### PR TITLE
fix: use Microsoft-hosted agents for Azure DevOps pipeline

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -60,9 +60,8 @@ parameters:
 - name: WindowsPool
   type: object
   default:
-    name: NetCore1ESPool-Internal
-    demands:
-      - ImageOverride -equals 1es-windows-2022
+    name: Azure Pipelines
+    vmImage: windows-latest
     os: windows
 
 - name: MacOSPool


### PR DESCRIPTION
Switch Windows pool from `NetCore1ESPool-Internal` to Microsoft-hosted `windows-latest` until the internal pool is authorized for this project.

Once `NetCore1ESPool-Internal` access is granted, revert this to use the internal pool (required for 1ES Official template signing/security features).