### PR TITLE
fix: broken symlinks and pipeline variable expansion

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -114,9 +114,9 @@ extends:
         parameters:
           pool: ${{ parameters.WindowsPool }}
           macPool: ${{ parameters.MacOSPool }}
-          buildConfig: $(_BuildConfig)
-          solutionFilter: $(_SolutionFilter)
-          productName: $(_ProductName)
+          buildConfig: ${{ variables._BuildConfig }}
+          solutionFilter: ${{ variables._SolutionFilter }}
+          productName: ${{ variables._ProductName }}
           signType: $(_SignType)
           sign: $(_Sign)
 

--- a/samples/DevFlow.Sample.Linux/Components
+++ b/samples/DevFlow.Sample.Linux/Components
@@ -1,1 +1,1 @@
-../SampleMauiApp/Components
+../DevFlow.Sample/Components

--- a/samples/DevFlow.Sample.Linux/Resources
+++ b/samples/DevFlow.Sample.Linux/Resources
@@ -1,1 +1,1 @@
-../SampleMauiApp/Resources
+../DevFlow.Sample/Resources

--- a/samples/DevFlow.Sample.Linux/wwwroot
+++ b/samples/DevFlow.Sample.Linux/wwwroot
@@ -1,1 +1,1 @@
-../SampleMauiApp/wwwroot
+../DevFlow.Sample/wwwroot


### PR DESCRIPTION
## Fixes

### 1. Broken symlinks causing UseDotNet@2 failure
`samples/DevFlow.Sample.Linux/` had 3 symlinks pointing to `../SampleMauiApp/` (the original repo name). Fixed to point to `../DevFlow.Sample/`:
- `Components` → `../DevFlow.Sample/Components`
- `Resources` → `../DevFlow.Sample/Resources`
- `wwwroot` → `../DevFlow.Sample/wwwroot`

This caused: `ENOENT: no such file or directory, stat .../Components`

### 2. Pipeline variable expansion
Template parameters need compile-time expressions (`${{ variables.X }}`) not runtime macros (`$(X)`). Runtime macros pass through as literal strings, causing display names like `Build & Test ($(_ProductName) macOS)` instead of `Build & Test (DevFlow macOS)`.

Changed `buildConfig`, `solutionFilter`, and `productName` to use `${{ variables. }}`. Left `signType`/`sign` as `$()` since they are conditional variables.