### PR TITLE
Lower MAUI version floor to 10.0.20 for DevFlow shipping packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,6 +14,9 @@
   <!-- Dependencies flowing via darc/maestro (match Version.Details.xml) -->
   <PropertyGroup Label="Dotnet MAUI">
     <MicrosoftMauiControlsVersion>10.0.41</MicrosoftMauiControlsVersion>
+    <!-- Minimum MAUI version required by DevFlow shipping packages.
+         Kept low so consumers can use any compatible MAUI 10.0.x release. -->
+    <DevFlowMauiMinVersion>10.0.20</DevFlowMauiMinVersion>
     <MicrosoftMauiControlsCompatibilityVersion>$(MicrosoftMauiControlsVersion)</MicrosoftMauiControlsCompatibilityVersion>
     <MicrosoftMauiEssentialsVersion>$(MicrosoftMauiControlsVersion)</MicrosoftMauiEssentialsVersion>
     <MicrosoftAspNetCoreComponentsWebViewMauiVersion>$(MicrosoftMauiControlsVersion)</MicrosoftAspNetCoreComponentsWebViewMauiVersion>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/Microsoft.Maui.DevFlow.Agent.Core.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/Microsoft.Maui.DevFlow.Agent.Core.csproj
@@ -12,7 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Fizzler" />
-    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(DevFlowMauiMinVersion)" />
+    <PackageReference Include="Microsoft.Maui.Essentials" VersionOverride="$(DevFlowMauiMinVersion)" />
     <PackageReference Include="SkiaSharp" />
   </ItemGroup>
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Microsoft.Maui.DevFlow.Agent.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Microsoft.Maui.DevFlow.Agent.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(DevFlowMauiMinVersion)" />
   </ItemGroup>
 
   <!-- Include .targets files in NuGet package for MSBuild port configuration -->

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Blazor/Microsoft.Maui.DevFlow.Blazor.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Blazor/Microsoft.Maui.DevFlow.Blazor.csproj
@@ -25,8 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(DevFlowMauiMinVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" VersionOverride="$(DevFlowMauiMinVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- macOS AppKit backend -->


### PR DESCRIPTION
Use VersionOverride with DevFlowMauiMinVersion to set minimum MAUI dependency to 10.0.20 instead of the specific CI build version flowing via maestro. This allows consumers to use any compatible MAUI 10.0.x release without being forced to reference a build that may not be publicly available yet.