### PR TITLE
Add CliJson and migrate CLI JSON handling

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -68,6 +68,59 @@ jobs:
           --prepareMachine
           --projects $(pwd)/${{ inputs.project-path }}
 
+      - name: NativeAOT publish smoke test (macOS)
+        if: matrix.os == 'macos-latest' && inputs.project-name == 'cli'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          arch="$(uname -m)"
+          case "$arch" in
+            arm64) rid="osx-arm64" ;;
+            x86_64) rid="osx-x64" ;;
+            *)
+              echo "Unsupported macOS architecture: $arch"
+              exit 1
+              ;;
+          esac
+
+          dotnet publish src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj \
+            -c Release \
+            -r "$rid" \
+            -p:PublishAot=true \
+            -p:PublishTrimmed=true \
+            -p:InvariantGlobalization=true \
+            -p:TreatWarningsAsErrors=true \
+            --self-contained true
+
+          publish_dir="artifacts/bin/Microsoft.Maui.Cli/Release/net10.0/$rid/publish"
+          cli_path="$publish_dir/maui"
+          commands_json="$(mktemp)"
+          agents_json="$(mktemp)"
+
+          "$cli_path" devflow version
+          "$cli_path" devflow commands --json > "$commands_json"
+          "$cli_path" devflow broker stop >/dev/null 2>&1 || true
+          "$cli_path" devflow list --json > "$agents_json"
+          "$cli_path" devflow broker stop >/dev/null 2>&1 || true
+
+          python - "$commands_json" "$agents_json" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as fp:
+              commands = json.load(fp)
+          with open(sys.argv[2], "r", encoding="utf-8") as fp:
+              agents = json.load(fp)
+
+          assert isinstance(commands, list), "Expected commands output to be a JSON array"
+          assert commands, "Expected at least one command description"
+          assert all("command" in item and "description" in item for item in commands), "Command entries must include command and description"
+          assert isinstance(agents, list), "Expected list --json output to be a JSON array"
+          PY
+
+          rm -f "$commands_json" "$agents_json"
+
       - name: Upload test results
         if: inputs.run-tests && always()
         uses: actions/upload-artifact@v7

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/AgentRegistration.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/AgentRegistration.cs
@@ -59,3 +59,27 @@ public record BrokerState
     [JsonPropertyName("startedAt")]
     public DateTime StartedAt { get; init; }
 }
+
+internal record RegistrationMessage
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "";
+
+    [JsonPropertyName("project")]
+    public string Project { get; init; } = "";
+
+    [JsonPropertyName("tfm")]
+    public string Tfm { get; init; } = "";
+
+    [JsonPropertyName("platform")]
+    public string Platform { get; init; } = "";
+
+    [JsonPropertyName("appName")]
+    public string AppName { get; init; } = "";
+
+    [JsonPropertyName("currentPort")]
+    public int? CurrentPort { get; init; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
@@ -38,7 +38,7 @@ public static class BrokerClient
         try
         {
             var response = await _http.GetStringAsync($"http://localhost:{brokerPort}/api/agents");
-            return JsonSerializer.Deserialize<AgentRegistration[]>(response);
+            return CliJson.Deserialize<AgentRegistration[]>(response);
         }
         catch
         {
@@ -125,7 +125,7 @@ public static class BrokerClient
         {
             if (!File.Exists(BrokerPaths.StateFile)) return null;
             var json = File.ReadAllText(BrokerPaths.StateFile);
-            var state = JsonSerializer.Deserialize<BrokerState>(json);
+            var state = CliJson.Deserialize<BrokerState>(json);
             return state?.Port;
         }
         catch
@@ -181,7 +181,7 @@ public static class BrokerClient
         if (!File.Exists(configPath)) return null;
         try
         {
-            var json = JsonSerializer.Deserialize<JsonElement>(File.ReadAllText(configPath));
+            var json = CliJson.ParseElement(File.ReadAllText(configPath));
             if (json.TryGetProperty("port", out var portEl) && portEl.TryGetInt32(out var p))
                 return p;
         }
@@ -195,7 +195,7 @@ public static class BrokerClient
         {
             if (!File.Exists(BrokerPaths.StateFile)) return;
             var json = File.ReadAllText(BrokerPaths.StateFile);
-            var state = JsonSerializer.Deserialize<BrokerState>(json);
+            var state = CliJson.Deserialize<BrokerState>(json);
             if (state == null) return;
 
             // Try to kill hung process
@@ -220,7 +220,7 @@ public static class BrokerClient
         try
         {
             // Find the CLI executable path
-            var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+            var exePath = Environment.ProcessPath;
             if (exePath == null) return null;
 
             string fileName;
@@ -228,11 +228,10 @@ public static class BrokerClient
 
             // If running via `dotnet run` or `dotnet <dll>`, exePath is the dotnet host.
             // In that case, use `dotnet <entryDll> broker start --foreground` instead.
-            var entryAsm = System.Reflection.Assembly.GetEntryAssembly();
             if (exePath.EndsWith("dotnet", StringComparison.OrdinalIgnoreCase)
                 || exePath.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
             {
-                var dllPath = entryAsm?.Location;
+                var dllPath = ResolveManagedEntryAssemblyPath();
                 if (string.IsNullOrEmpty(dllPath)) return null;
                 fileName = exePath;
                 arguments = $"\"{dllPath}\" broker start --foreground";
@@ -282,5 +281,15 @@ public static class BrokerClient
         {
             return null;
         }
+    }
+
+    private static string? ResolveManagedEntryAssemblyPath()
+    {
+        var assemblyName = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name;
+        if (string.IsNullOrEmpty(assemblyName))
+            return null;
+
+        var candidate = Path.Combine(AppContext.BaseDirectory, $"{assemblyName}.dll");
+        return File.Exists(candidate) ? candidate : null;
     }
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerServer.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Maui.Cli.DevFlow.Broker;
 
@@ -101,10 +101,17 @@ public class BrokerServer : IDisposable
             // HTTP endpoints for CLI
             var (statusCode, body) = (method, path) switch
             {
-                ("GET", "/api/health") => (200, JsonSerializer.Serialize(new { status = "ok", agents = _agents.Count })),
+                ("GET", "/api/health") => (200, CliJson.SerializeUntyped(new JsonObject
+                {
+                    ["status"] = "ok",
+                    ["agents"] = _agents.Count
+                }, indented: false)),
                 ("GET", "/api/agents") => (200, HandleListAgents()),
                 ("POST", "/api/shutdown") => HandleShutdown(),
-                _ => (404, JsonSerializer.Serialize(new { error = "Not found" }))
+                _ => (404, CliJson.SerializeUntyped(new JsonObject
+                {
+                    ["error"] = "Not found"
+                }, indented: false))
             };
 
             context.Response.StatusCode = statusCode;
@@ -147,7 +154,7 @@ public class BrokerServer : IDisposable
             if (result.MessageType == WebSocketMessageType.Close) return;
 
             var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
-            var registration = JsonSerializer.Deserialize<RegistrationMessage>(message);
+            var registration = CliJson.Deserialize<RegistrationMessage>(message);
             if (registration == null || registration.Type != "register")
             {
                 await ws.CloseAsync(WebSocketCloseStatus.InvalidPayloadData, "Expected register message", CancellationToken.None);
@@ -167,7 +174,11 @@ public class BrokerServer : IDisposable
                 var newPort = AssignPort();
                 if (newPort == null)
                 {
-                    var errorMsg = JsonSerializer.Serialize(new { type = "error", message = "No ports available" });
+                    var errorMsg = CliJson.SerializeUntyped(new JsonObject
+                    {
+                        ["type"] = "error",
+                        ["message"] = "No ports available"
+                    }, indented: false);
                     await ws.SendAsync(Encoding.UTF8.GetBytes(errorMsg), WebSocketMessageType.Text, true, CancellationToken.None);
                     await ws.CloseAsync(WebSocketCloseStatus.InternalServerError, "No ports available", CancellationToken.None);
                     return;
@@ -202,7 +213,12 @@ public class BrokerServer : IDisposable
             Log($"Agent connected: {agent.AppName}|{agent.Tfm} → port {assignedPort} (id: {id})");
 
             // Send registration response
-            var response = JsonSerializer.Serialize(new { type = "registered", id, port = assignedPort });
+            var response = CliJson.SerializeUntyped(new JsonObject
+            {
+                ["type"] = "registered",
+                ["id"] = id,
+                ["port"] = assignedPort
+            }, indented: false);
             await ws.SendAsync(Encoding.UTF8.GetBytes(response), WebSocketMessageType.Text, true, CancellationToken.None);
 
             // Keep connection alive — wait for disconnect
@@ -242,7 +258,7 @@ public class BrokerServer : IDisposable
     private string HandleListAgents()
     {
         var agents = _agents.Values.Select(c => c.Registration).ToArray();
-        return JsonSerializer.Serialize(agents, new JsonSerializerOptions { WriteIndented = true });
+        return CliJson.SerializeUntyped(agents, indented: true);
     }
 
     private (int, string) HandleShutdown()
@@ -253,7 +269,10 @@ public class BrokerServer : IDisposable
             await Task.Delay(100); // Let response send first
             _cts?.Cancel();
         });
-        return (200, JsonSerializer.Serialize(new { status = "shutting_down" }));
+        return (200, CliJson.SerializeUntyped(new JsonObject
+        {
+            ["status"] = "shutting_down"
+        }, indented: false));
     }
 
     private int? AssignPort()
@@ -344,7 +363,7 @@ public class BrokerServer : IDisposable
                 StartedAt = DateTime.UtcNow
             };
 
-            var json = JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true });
+            var json = CliJson.SerializeUntyped(state, indented: true);
             var tmpPath = BrokerPaths.StateFile + ".tmp";
             File.WriteAllText(tmpPath, json);
             File.Move(tmpPath, BrokerPaths.StateFile, overwrite: true);
@@ -388,30 +407,5 @@ public class BrokerServer : IDisposable
         try { _listener?.Close(); } catch { }
         _cts?.Dispose();
     }
-
-    private record RegistrationMessage
-    {
-        [System.Text.Json.Serialization.JsonPropertyName("type")]
-        public string Type { get; init; } = "";
-
-        [System.Text.Json.Serialization.JsonPropertyName("project")]
-        public string Project { get; init; } = "";
-
-        [System.Text.Json.Serialization.JsonPropertyName("tfm")]
-        public string Tfm { get; init; } = "";
-
-        [System.Text.Json.Serialization.JsonPropertyName("platform")]
-        public string Platform { get; init; } = "";
-
-        [System.Text.Json.Serialization.JsonPropertyName("appName")]
-        public string AppName { get; init; } = "";
-
-        [System.Text.Json.Serialization.JsonPropertyName("currentPort")]
-        public int? CurrentPort { get; init; }
-
-        [System.Text.Json.Serialization.JsonPropertyName("version")]
-        public string? Version { get; init; }
-    }
-
     private record AgentConnection(AgentRegistration Registration, WebSocket WebSocket);
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/CliJson.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/CliJson.cs
@@ -1,0 +1,67 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.Maui.Cli.DevFlow;
+
+internal static class CliJson
+{
+    private static readonly JsonSerializerOptions s_nodeIndentedOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private static readonly JsonSerializerOptions s_nodeCompactOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    public static T? Deserialize<T>(string json) where T : class
+        => (T?)JsonSerializer.Deserialize(json, typeof(T), DevFlowCliJsonContext.Default);
+
+    public static string SerializeUntyped(object? value, bool indented = true)
+    {
+        if (value is null)
+            return "null";
+
+        return value switch
+        {
+            JsonNode node => node.ToJsonString(indented ? s_nodeIndentedOptions : s_nodeCompactOptions),
+            JsonElement element => PrettyPrint(element, indented),
+            JsonDocument document => PrettyPrint(document.RootElement, indented),
+            _ => SerializeTyped(value, indented),
+        };
+    }
+
+    public static JsonElement ParseElement(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    public static JsonNode? ParseNode(string json) => JsonNode.Parse(json);
+
+    public static string PrettyPrint(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return PrettyPrint(document.RootElement, indented: true);
+    }
+
+    public static string PrettyPrint(JsonElement element, bool indented = true)
+    {
+        if (!indented)
+            return element.GetRawText();
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+        element.WriteTo(writer);
+        writer.Flush();
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string SerializeTyped(object value, bool indented)
+    {
+        var json = JsonSerializer.Serialize(value, value.GetType(), DevFlowCliJsonContext.Default);
+        return indented ? PrettyPrint(json) : json;
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/CliJson.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/CliJson.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Maui.Cli.DevFlow;
 
@@ -8,12 +9,14 @@ internal static class CliJson
 {
     private static readonly JsonSerializerOptions s_nodeIndentedOptions = new()
     {
-        WriteIndented = true
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
     private static readonly JsonSerializerOptions s_nodeCompactOptions = new()
     {
-        WriteIndented = false
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
     public static T? Deserialize<T>(string json) where T : class

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/CommandDescription.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/CommandDescription.cs
@@ -1,3 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace Microsoft.Maui.Cli.DevFlow;
 
-internal sealed record CommandDescription(string Command, string Description, bool Mutating);
+internal sealed record CommandDescription(
+    [property: JsonPropertyName("command")] string Command,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("mutating")] bool Mutating);

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/CommandDescription.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/CommandDescription.cs
@@ -1,0 +1,3 @@
+namespace Microsoft.Maui.Cli.DevFlow;
+
+internal sealed record CommandDescription(string Command, string Description, bool Mutating);

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+using Microsoft.Maui.Cli.DevFlow.Broker;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.Cli.DevFlow;
+
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(CommandDescription))]
+[JsonSerializable(typeof(List<CommandDescription>))]
+[JsonSerializable(typeof(AgentStatus))]
+[JsonSerializable(typeof(ElementInfo))]
+[JsonSerializable(typeof(List<ElementInfo>))]
+[JsonSerializable(typeof(NetworkRequest))]
+[JsonSerializable(typeof(List<NetworkRequest>))]
+[JsonSerializable(typeof(AgentRegistration))]
+[JsonSerializable(typeof(List<AgentRegistration>))]
+[JsonSerializable(typeof(AgentRegistration[]))]
+[JsonSerializable(typeof(BrokerState))]
+[JsonSerializable(typeof(RegistrationMessage))]
+internal sealed partial class DevFlowCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -3818,7 +3818,7 @@ public class DevFlowCommands
             Output.WriteError("Broker unavailable", json);
             if (json)
             {
-                Console.WriteLine("[]");
+                Output.WriteResult(new JsonArray(), json);
             }
             _errorOccurred = true;
             return;
@@ -3832,15 +3832,12 @@ public class DevFlowCommands
             
             if (json)
             {
-                var projectsArray = new JsonArray();
-                foreach (var p in projects)
-                    projectsArray.Add((JsonNode?)JsonValue.Create(p));
-
-                Output.WriteResult(new JsonObject
+                Output.WriteResult(new JsonArray(), json);
+                // Log project scan info to stderr so it doesn't pollute JSON output
+                if (projects.Length > 0)
                 {
-                    ["agents"] = new JsonArray(),
-                    ["projects"] = projectsArray
-                }, json);
+                    Console.Error.WriteLine($"DevFlow-enabled projects found: {string.Join(", ", projects)}");
+                }
             }
             else
             {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -3816,6 +3816,10 @@ public class DevFlowCommands
         if (port == null)
         {
             Output.WriteError("Broker unavailable", json);
+            if (json)
+            {
+                Console.WriteLine("[]");
+            }
             _errorOccurred = true;
             return;
         }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Maui.Cli.DevFlow;
 public class DevFlowCommands
 {
     private static Command? _devflowCommand;
-    [ThreadStatic] private static bool _errorOccurred;
-    [ThreadStatic] private static IDevFlowOutputWriter? s_output;
+    private static bool _errorOccurred;
+    private static IDevFlowOutputWriter? s_output;
 
     private static IDevFlowOutputWriter Output => s_output ?? throw new InvalidOperationException("DevFlowCommands not initialized. Call CreateDevFlowCommand first.");
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Cli.Utils;
 
@@ -877,7 +878,12 @@ public class DevFlowCommands
             var type = ctx.GetValue(prefsSetTypeOption)!;
             var sharedName = ctx.GetValue(prefsSetSharedNameOption);
             var isJson = output.ResolveJsonMode(json, noJson);
-            var body = new { value, type, sharedName };
+            var body = new JsonObject
+            {
+                ["value"] = value,
+                ["type"] = type,
+                ["sharedName"] = sharedName
+            };
             await SimplePostAsync(host, port, $"/api/preferences/{Uri.EscapeDataString(key)}", body, isJson);
         });
         prefsCommand.Add(prefsSetCmd);
@@ -945,7 +951,10 @@ public class DevFlowCommands
             var key = ctx.GetValue(secureSetKeyArg)!;
             var value = ctx.GetValue(secureSetValueArg)!;
             var isJson = output.ResolveJsonMode(json, noJson);
-            await SimplePostAsync(host, port, $"/api/secure-storage/{Uri.EscapeDataString(key)}", new { value }, isJson);
+            await SimplePostAsync(host, port, $"/api/secure-storage/{Uri.EscapeDataString(key)}", new JsonObject
+            {
+                ["value"] = value
+            }, isJson);
         });
         secureCommand.Add(secureSetCmd);
 
@@ -1310,22 +1319,19 @@ public class DevFlowCommands
     
     // ===== CDP Helper: Send command via AgentClient =====
 
-    private static async Task<JsonElement?> SendCdpCommandAsync(string host, int port, string method, object? parameters = null, string? webview = null)
+    private static async Task<JsonElement?> SendCdpCommandAsync(string host, int port, string method, JsonNode? parameters = null, string? webview = null)
     {
         using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
-        JsonElement? paramsEl = parameters != null
-            ? JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(parameters))
-            : null;
-        var result = await client.SendCdpCommandAsync(method, paramsEl, webview);
+        var result = await client.SendCdpCommandAsync(method, parameters, webview);
         return result;
     }
 
     private static async Task<string> CdpEvaluateAsync(string host, int port, string expression, string? webview = null)
     {
-        var result = await SendCdpCommandAsync(host, port, "Runtime.evaluate", new
+        var result = await SendCdpCommandAsync(host, port, "Runtime.evaluate", new JsonObject
         {
-            expression,
-            returnByValue = true
+            ["expression"] = expression,
+            ["returnByValue"] = true
         }, webview);
 
         if (result == null) return "null";
@@ -1340,7 +1346,7 @@ public class DevFlowCommands
                     if (value.ValueKind == JsonValueKind.String)
                         return value.GetString() ?? "null";
                     if (value.ValueKind == JsonValueKind.Object || value.ValueKind == JsonValueKind.Array)
-                        return JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true });
+                        return CliJson.PrettyPrint(value);
                     return value.ToString();
                 }
             }
@@ -1400,7 +1406,7 @@ public class DevFlowCommands
         {
             var result = await CdpEvaluateAsync(host, port, $@"
                 JSON.stringify((function() {{
-                    const el = document.querySelector({JsonSerializer.Serialize(selector)}, webview);
+                    const el = document.querySelector({CliJson.SerializeUntyped(selector, indented: false)}, webview);
                     if (!el) return null;
                     return {{
                         tagName: el.tagName.toLowerCase(),
@@ -1421,7 +1427,7 @@ public class DevFlowCommands
         {
             var result = await CdpEvaluateAsync(host, port, $@"
                 JSON.stringify((function() {{
-                    const els = document.querySelectorAll({JsonSerializer.Serialize(selector)}, webview);
+                    const els = document.querySelectorAll({CliJson.SerializeUntyped(selector, indented: false)}, webview);
                     return Array.from(els).map((el, i) => ({{
                         index: i,
                         tagName: el.tagName.toLowerCase(),
@@ -1440,7 +1446,7 @@ public class DevFlowCommands
     {
         try
         {
-            var result = await CdpEvaluateAsync(host, port, $@"document.querySelector({JsonSerializer.Serialize(selector)})?.outerHTML || null", webview);
+            var result = await CdpEvaluateAsync(host, port, $@"document.querySelector({CliJson.SerializeUntyped(selector, indented: false)})?.outerHTML || null", webview);
             Console.WriteLine(result);
         }
         catch (Exception ex) { WriteError(ex.Message); }
@@ -1452,7 +1458,10 @@ public class DevFlowCommands
     {
         try
         {
-            await SendCdpCommandAsync(host, port, "Page.navigate", new { url }, webview);
+            await SendCdpCommandAsync(host, port, "Page.navigate", new JsonObject
+            {
+                ["url"] = url
+            }, webview);
             Console.WriteLine($"Navigated to: {url}");
         }
         catch (Exception ex) { WriteError(ex.Message); }
@@ -1495,7 +1504,7 @@ public class DevFlowCommands
         {
             var result = await CdpEvaluateAsync(host, port, $@"
                 (function() {{
-                    const el = document.querySelector({JsonSerializer.Serialize(selector)}, webview);
+                    const el = document.querySelector({CliJson.SerializeUntyped(selector, indented: false)}, webview);
                     if (!el) return 'Error: Element not found';
                     el.click();
                     return 'Clicked: ' + el.tagName.toLowerCase() + (el.id ? '#' + el.id : '');
@@ -1510,7 +1519,10 @@ public class DevFlowCommands
     {
         try
         {
-            var result = await SendCdpCommandAsync(host, port, "Input.insertText", new { text }, webview);
+            await SendCdpCommandAsync(host, port, "Input.insertText", new JsonObject
+            {
+                ["text"] = text
+            }, webview);
             Console.WriteLine($"Inserted: {text.Length} characters");
         }
         catch (Exception ex) { WriteError(ex.Message); }
@@ -1522,10 +1534,10 @@ public class DevFlowCommands
         {
             var result = await CdpEvaluateAsync(host, port, $@"
                 (function() {{
-                    const el = document.querySelector({JsonSerializer.Serialize(selector)}, webview);
+                    const el = document.querySelector({CliJson.SerializeUntyped(selector, indented: false)}, webview);
                     if (!el) return 'Error: Element not found';
                     
-                    const text = {JsonSerializer.Serialize(text)};
+                    const text = {CliJson.SerializeUntyped(text, indented: false)};
                     if (el.isContentEditable) {{
                         el.textContent = text;
                     }} else {{
@@ -1682,7 +1694,7 @@ public class DevFlowCommands
     
     private static string FormatJson(JsonElement element)
     {
-        return JsonSerializer.Serialize(element, new JsonSerializerOptions { WriteIndented = true });
+        return CliJson.PrettyPrint(element);
     }
 
     // ===== Generic agent HTTP helpers (for preferences, platform, sensors, etc.) =====
@@ -1703,8 +1715,7 @@ public class DevFlowCommands
             {
                 try
                 {
-                    var doc = JsonDocument.Parse(body);
-                    Console.WriteLine(JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true }));
+                    Console.WriteLine(CliJson.PrettyPrint(body));
                 }
                 catch
                 {
@@ -1720,7 +1731,7 @@ public class DevFlowCommands
         }
     }
 
-    private static async Task SimplePostAsync(string host, int port, string path, object? bodyObj, bool json)
+    private static async Task SimplePostAsync(string host, int port, string path, JsonNode? bodyObj, bool json)
     {
         try
         {
@@ -1729,8 +1740,8 @@ public class DevFlowCommands
             HttpResponseMessage response;
             if (bodyObj != null)
             {
-                var content = new StringContent(
-                    JsonSerializer.Serialize(bodyObj),
+                using var content = new StringContent(
+                    CliJson.SerializeUntyped(bodyObj, indented: false),
                     Encoding.UTF8,
                     "application/json");
                 response = await http.PostAsync($"http://{host}:{port}{path}", content);
@@ -1919,7 +1930,14 @@ public class DevFlowCommands
             var passed = string.Equals(actualValue, expectedValue, StringComparison.Ordinal);
             if (json)
             {
-                Output.WriteResult(new { passed, property = propertyName, expected = expectedValue, actual = actualValue, elementId = resolvedId }, json);
+                Output.WriteResult(new JsonObject
+                {
+                    ["passed"] = passed,
+                    ["property"] = propertyName,
+                    ["expected"] = expectedValue,
+                    ["actual"] = actualValue,
+                    ["elementId"] = resolvedId
+                }, json);
             }
             else
             {
@@ -1937,8 +1955,6 @@ public class DevFlowCommands
     }
 
     // ===== Command Descriptions (Schema Discovery) =====
-
-    private record CommandDescription(string Command, string Description, bool Mutating);
 
     private static List<CommandDescription> GetCommandDescriptions() => new()
     {
@@ -2114,15 +2130,14 @@ public class DevFlowCommands
             var sha = await GetRemoteSkillCommitShaAsync(http, branch);
             if (sha == null) return;
 
-            var versionInfo = new
+            var versionInfo = new JsonObject
             {
-                commit = sha,
-                updatedAt = DateTime.UtcNow.ToString("o"),
-                branch
+                ["commit"] = sha,
+                ["updatedAt"] = DateTime.UtcNow.ToString("o"),
+                ["branch"] = branch
             };
             var versionPath = Path.Combine(destBase, ".skill-version");
-            await File.WriteAllTextAsync(versionPath,
-                JsonSerializer.Serialize(versionInfo, new JsonSerializerOptions { WriteIndented = true }));
+            await File.WriteAllTextAsync(versionPath, CliJson.SerializeUntyped(versionInfo, indented: true));
         }
         catch { /* non-fatal — version tracking is best-effort */ }
     }
@@ -2131,7 +2146,7 @@ public class DevFlowCommands
     {
         var url = $"https://api.github.com/repos/{SkillRepo}/commits?path={SkillBasePath}&sha={branch}&per_page=1";
         var json = await http.GetStringAsync(url);
-        var commits = JsonSerializer.Deserialize<JsonElement>(json);
+        var commits = CliJson.ParseElement(json);
         foreach (var commit in commits.EnumerateArray())
             return commit.GetProperty("sha").GetString();
         return null;
@@ -2152,7 +2167,7 @@ public class DevFlowCommands
             try
             {
                 var json = await File.ReadAllTextAsync(versionPath);
-                var doc = JsonSerializer.Deserialize<JsonElement>(json);
+                var doc = CliJson.ParseElement(json);
                 localSha = doc.TryGetProperty("commit", out var c) ? c.GetString() : null;
                 localDate = doc.TryGetProperty("updatedAt", out var d) ? d.GetString() : null;
                 localBranch = doc.TryGetProperty("branch", out var b) ? b.GetString() : null;
@@ -2210,7 +2225,7 @@ public class DevFlowCommands
         var apiPath = string.IsNullOrEmpty(relativePath) ? basePath : $"{basePath}/{relativePath}";
         var url = $"https://api.github.com/repos/{SkillRepo}/contents/{apiPath}?ref={branch}";
         var json = await http.GetStringAsync(url);
-        var items = JsonSerializer.Deserialize<JsonElement>(json);
+        var items = CliJson.ParseElement(json);
 
         foreach (var item in items.EnumerateArray())
         {
@@ -2259,7 +2274,7 @@ public class DevFlowCommands
             if (json)
             {
                 var projected = ProjectElements(tree, fields, format);
-                Console.WriteLine(JsonSerializer.Serialize(projected, new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull }));
+                Console.WriteLine(CliJson.SerializeUntyped(projected, indented: true));
             }
             else
             {
@@ -2330,7 +2345,7 @@ public class DevFlowCommands
         if (json)
         {
             var projected = ProjectElements(results, fields, format);
-            Console.WriteLine(JsonSerializer.Serialize(projected, new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull }));
+            Console.WriteLine(CliJson.SerializeUntyped(projected, indented: true));
         }
         else
         {
@@ -2458,7 +2473,13 @@ public class DevFlowCommands
             var fullPath = Path.GetFullPath(filename);
             if (json)
             {
-                Output.WriteResult(new { path = fullPath, size = data.Length, maxWidth = maxWidth, scale = scale ?? "auto" }, json);
+                Output.WriteResult(new JsonObject
+                {
+                    ["path"] = fullPath,
+                    ["size"] = data.Length,
+                    ["maxWidth"] = maxWidth,
+                    ["scale"] = scale ?? "auto"
+                }, json);
             }
             else
             {
@@ -2615,7 +2636,11 @@ public class DevFlowCommands
             var value = await client.GetPropertyAsync(elementId, propertyName);
             if (json)
             {
-                Output.WriteResult(new { property = propertyName, value }, json);
+                Output.WriteResult(new JsonObject
+                {
+                    ["property"] = propertyName,
+                    ["value"] = value
+                }, json);
             }
             else
             {
@@ -3001,7 +3026,7 @@ public class DevFlowCommands
             if (json)
             {
                 foreach (var r in requests)
-                    Console.WriteLine(JsonSerializer.Serialize(r, new JsonSerializerOptions { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull }));
+                    Console.WriteLine(CliJson.SerializeUntyped(r, indented: false));
             }
             else
             {
@@ -3157,8 +3182,7 @@ public class DevFlowCommands
             // Try to pretty-print JSON
             try
             {
-                using var doc = JsonDocument.Parse(body);
-                Console.WriteLine(JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true }));
+                Console.WriteLine(CliJson.PrettyPrint(body));
             }
             catch
             {
@@ -3244,12 +3268,16 @@ public class DevFlowCommands
         if (fieldSet == null)
             return elements;
 
-        return elements.Select(el => ProjectElement(el, fieldSet)).ToList();
+        var projected = new JsonArray();
+        foreach (var element in elements)
+            projected.Add((JsonNode)ProjectElement(element, fieldSet));
+
+        return projected;
     }
 
-    private static Dictionary<string, object?> ProjectElement(Microsoft.Maui.DevFlow.Driver.ElementInfo el, HashSet<string> fields)
+    private static JsonObject ProjectElement(Microsoft.Maui.DevFlow.Driver.ElementInfo el, HashSet<string> fields)
     {
-        var dict = new Dictionary<string, object?>();
+        var dict = new JsonObject();
         if (fields.Contains("id")) dict["id"] = el.Id;
         if (fields.Contains("parentId")) dict["parentId"] = el.ParentId;
         if (fields.Contains("type")) dict["type"] = el.Type;
@@ -3261,12 +3289,37 @@ public class DevFlowCommands
         if (fields.Contains("isFocused")) dict["isFocused"] = el.IsFocused;
         if (fields.Contains("opacity")) dict["opacity"] = el.Opacity;
         if (fields.Contains("bounds") && el.Bounds != null)
-            dict["bounds"] = new { el.Bounds.X, el.Bounds.Y, el.Bounds.Width, el.Bounds.Height };
-        if (fields.Contains("gestures") && el.Gestures != null) dict["gestures"] = el.Gestures;
+        {
+            dict["bounds"] = new JsonObject
+            {
+                ["x"] = el.Bounds.X,
+                ["y"] = el.Bounds.Y,
+                ["width"] = el.Bounds.Width,
+                ["height"] = el.Bounds.Height
+            };
+        }
+        if (fields.Contains("gestures") && el.Gestures != null)
+        {
+            var gestures = new JsonArray();
+            foreach (var gesture in el.Gestures)
+                gestures.Add((JsonNode?)JsonValue.Create(gesture));
+            dict["gestures"] = gestures;
+        }
         if (fields.Contains("nativeType")) dict["nativeType"] = el.NativeType;
-        if (fields.Contains("nativeProperties") && el.NativeProperties != null) dict["nativeProperties"] = el.NativeProperties;
+        if (fields.Contains("nativeProperties") && el.NativeProperties != null)
+        {
+            var nativeProperties = new JsonObject();
+            foreach (var (key, value) in el.NativeProperties)
+                nativeProperties[key] = value;
+            dict["nativeProperties"] = nativeProperties;
+        }
         if (fields.Contains("children") && el.Children != null && el.Children.Count > 0)
-            dict["children"] = el.Children.Select(c => ProjectElement(c, fields)).ToList();
+        {
+            var children = new JsonArray();
+            foreach (var child in el.Children)
+                children.Add((JsonNode)ProjectElement(child, fields));
+            dict["children"] = children;
+        }
         return dict;
     }
 
@@ -3457,11 +3510,30 @@ public class DevFlowCommands
 
             if (alert is null)
             {
-                Output.WriteResult(new { detected = false }, json, _ => Console.WriteLine("No alert detected"));
+                Output.WriteResult(new JsonObject
+                {
+                    ["detected"] = false
+                }, json, _ => Console.WriteLine("No alert detected"));
                 return;
             }
 
-            Output.WriteResult(new { detected = true, title = alert.Title, buttons = alert.Buttons.Select(b => new { label = b.Label, centerX = b.CenterX, centerY = b.CenterY }) }, json, _ =>
+            var buttons = new JsonArray();
+            foreach (var button in alert.Buttons)
+            {
+                buttons.Add((JsonNode)new JsonObject
+                {
+                    ["label"] = button.Label,
+                    ["centerX"] = button.CenterX,
+                    ["centerY"] = button.CenterY
+                });
+            }
+
+            Output.WriteResult(new JsonObject
+            {
+                ["detected"] = true,
+                ["title"] = alert.Title,
+                ["buttons"] = buttons
+            }, json, _ =>
             {
                 Console.WriteLine($"Alert: {alert.Title ?? "(no title)"}");
                 foreach (var btn in alert.Buttons)
@@ -3503,9 +3575,16 @@ public class DevFlowCommands
             }
 
             if (alert is null)
-                Output.WriteResult(new { dismissed = false }, json, _ => Console.WriteLine("No alert to dismiss"));
+                Output.WriteResult(new JsonObject
+                {
+                    ["dismissed"] = false
+                }, json, _ => Console.WriteLine("No alert to dismiss"));
             else
-                Output.WriteResult(new { dismissed = true, title = alert.Title }, json, _ => Console.WriteLine($"Dismissed: {alert.Title ?? "(alert)"}"));
+                Output.WriteResult(new JsonObject
+                {
+                    ["dismissed"] = true,
+                    ["title"] = alert.Title
+                }, json, _ => Console.WriteLine($"Dismissed: {alert.Title ?? "(alert)"}"));
         }
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
@@ -3546,12 +3625,14 @@ public class DevFlowCommands
                 // Try to parse as JSON and output directly; if not valid JSON, wrap as string
                 try
                 {
-                    using var doc = JsonDocument.Parse(treeResult);
-                    Console.WriteLine(JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true }));
+                    Console.WriteLine(CliJson.PrettyPrint(treeResult));
                 }
                 catch (JsonException)
                 {
-                    Output.WriteResult(new { tree = treeResult }, json);
+                    Output.WriteResult(new JsonObject
+                    {
+                        ["tree"] = treeResult
+                    }, json);
                 }
             }
             else
@@ -3667,13 +3748,22 @@ public class DevFlowCommands
                 var response = await http.GetStringAsync($"http://localhost:{Broker.BrokerServer.DefaultPort}/api/health");
                 var doc = JsonDocument.Parse(response);
                 var agents = doc.RootElement.GetProperty("agents").GetInt32();
-                Output.WriteResult(new { running = true, port = Broker.BrokerServer.DefaultPort, agents, stateFile = false }, json,
+                Output.WriteResult(new JsonObject
+                {
+                    ["running"] = true,
+                    ["port"] = Broker.BrokerServer.DefaultPort,
+                    ["agents"] = agents,
+                    ["stateFile"] = false
+                }, json,
                     _ => Console.WriteLine($"Broker: running on port {Broker.BrokerServer.DefaultPort} ({agents} agent(s) connected) [no state file]"));
                 return;
             }
             catch { }
 
-            Output.WriteResult(new { running = false }, json,
+            Output.WriteResult(new JsonObject
+            {
+                ["running"] = false
+            }, json,
                 _ => Console.WriteLine("Broker: not running"));
             return;
         }
@@ -3684,12 +3774,22 @@ public class DevFlowCommands
             var response = await http.GetStringAsync($"http://localhost:{port}/api/health");
             var doc = JsonDocument.Parse(response);
             var agents = doc.RootElement.GetProperty("agents").GetInt32();
-            Output.WriteResult(new { running = true, port, agents }, json,
+            Output.WriteResult(new JsonObject
+            {
+                ["running"] = true,
+                ["port"] = port,
+                ["agents"] = agents
+            }, json,
                 _ => Console.WriteLine($"Broker: running on port {port} ({agents} agent(s) connected)"));
         }
         catch
         {
-            Output.WriteResult(new { running = false, port, stale = true }, json,
+            Output.WriteResult(new JsonObject
+            {
+                ["running"] = false,
+                ["port"] = port,
+                ["stale"] = true
+            }, json,
                 _ => Console.WriteLine($"Broker: not responding on port {port} (stale state file?)"));
         }
     }
@@ -3728,8 +3828,15 @@ public class DevFlowCommands
             
             if (json)
             {
-                var result = new { agents = Array.Empty<object>(), projects };
-                Output.WriteResult(result, json);
+                var projectsArray = new JsonArray();
+                foreach (var p in projects)
+                    projectsArray.Add((JsonNode?)JsonValue.Create(p));
+
+                Output.WriteResult(new JsonObject
+                {
+                    ["agents"] = new JsonArray(),
+                    ["projects"] = projectsArray
+                }, json);
             }
             else
             {
@@ -3907,7 +4014,7 @@ public class DevFlowCommands
 
         if (json)
         {
-            Console.WriteLine(JsonSerializer.Serialize(matched));
+            Console.WriteLine(CliJson.SerializeUntyped(matched, indented: false));
         }
         else
         {
@@ -3960,7 +4067,12 @@ public class DevFlowCommands
                     }
                     else
                     {
-                        var errJson = JsonSerializer.Serialize(new { command = rawCmd, exit_code = 1, output = $"Error: {errMsg}" });
+                        var errJson = CliJson.SerializeUntyped(new JsonObject
+                        {
+                            ["command"] = rawCmd,
+                            ["exit_code"] = 1,
+                            ["output"] = $"Error: {errMsg}"
+                        }, indented: false);
                         originalOut.WriteLine(errJson);
                         originalOut.Flush();
                     }
@@ -4006,7 +4118,12 @@ public class DevFlowCommands
                 }
                 else
                 {
-                    var jsonResponse = JsonSerializer.Serialize(new { command = rawCmd, exit_code = exitCode, output = combinedOutput });
+                    var jsonResponse = CliJson.SerializeUntyped(new JsonObject
+                    {
+                        ["command"] = rawCmd,
+                        ["exit_code"] = exitCode,
+                        ["output"] = combinedOutput
+                    }, indented: false);
                     originalOut.WriteLine(jsonResponse);
                     originalOut.Flush();
                 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
 using Microsoft.Maui.Cli.DevFlow.Broker;
@@ -10,13 +10,6 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class AgentTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-        WriteIndented = false
-    };
-
     [McpServerTool(Name = "maui_list_agents"), Description("List all connected MAUI DevFlow agents (running apps). Shows app name, platform, port, and uptime.")]
     public static async Task<string> ListAgents(McpAgentSession session)
     {
@@ -24,18 +17,22 @@ public sealed class AgentTools
         if (agents == null || agents.Length == 0)
             return "No agents connected. Build and run a MAUI app with Microsoft.Maui.DevFlow.Agent configured.";
 
-        var result = agents.Select(a => new
+        var result = new JsonArray();
+        foreach (var agent in agents)
         {
-            a.Id,
-            a.AppName,
-            a.Platform,
-            a.Tfm,
-            a.Port,
-            a.Version,
-            uptime = (DateTime.UtcNow - a.ConnectedAt).ToString(@"hh\:mm\:ss")
-        });
+            result.Add((JsonNode)new JsonObject
+            {
+                ["id"] = agent.Id,
+                ["appName"] = agent.AppName,
+                ["platform"] = agent.Platform,
+                ["tfm"] = agent.Tfm,
+                ["port"] = agent.Port,
+                ["version"] = agent.Version,
+                ["uptime"] = (DateTime.UtcNow - agent.ConnectedAt).ToString(@"hh\:mm\:ss")
+            });
+        }
 
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return CliJson.SerializeUntyped(result, indented: false);
     }
 
     [McpServerTool(Name = "maui_status"), Description("Get detailed status of a connected MAUI DevFlow agent including platform, device type, app name, and version.")]
@@ -49,7 +46,7 @@ public sealed class AgentTools
         if (status == null)
             return "Agent not responding. Is the app running?";
 
-        return JsonSerializer.Serialize(status, JsonOptions);
+        return CliJson.SerializeUntyped(status, indented: false);
     }
 
     [McpServerTool(Name = "maui_wait"), Description("Wait for a MAUI DevFlow agent to connect. Blocks until an agent registers with the broker or timeout is reached.")]
@@ -73,15 +70,15 @@ public sealed class AgentTools
                 if (match != null)
                 {
                     session.DefaultAgentPort = match.Port;
-                    return JsonSerializer.Serialize(new
+                    return CliJson.SerializeUntyped(new JsonObject
                     {
-                        match.Id,
-                        match.AppName,
-                        match.Platform,
-                        match.Tfm,
-                        match.Port,
-                        match.Version
-                    }, JsonOptions);
+                        ["id"] = match.Id,
+                        ["appName"] = match.AppName,
+                        ["platform"] = match.Platform,
+                        ["tfm"] = match.Tfm,
+                        ["port"] = match.Port,
+                        ["version"] = match.Version
+                    }, indented: false);
                 }
             }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/CdpTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/CdpTools.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 using ModelContextProtocol.Protocol;
@@ -18,9 +18,11 @@ public sealed class CdpTools
         [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
     {
         var agent = await session.GetAgentClientAsync(agentPort);
-        var paramsEl = JsonSerializer.Deserialize<JsonElement>(
-            JsonSerializer.Serialize(new { expression, returnByValue = true }));
-        var content = await agent.SendCdpCommandAsync("Runtime.evaluate", paramsEl, webviewId);
+        var content = await agent.SendCdpCommandAsync("Runtime.evaluate", new JsonObject
+        {
+            ["expression"] = expression,
+            ["returnByValue"] = true
+        }, webviewId);
 
         try
         {
@@ -45,9 +47,10 @@ public sealed class CdpTools
         [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
     {
         var agent = await session.GetAgentClientAsync(agentPort);
-        var paramsEl = JsonSerializer.Deserialize<JsonElement>(
-            JsonSerializer.Serialize(new { format = "png" }));
-        var json = await agent.SendCdpCommandAsync("Page.captureScreenshot", paramsEl, webviewId);
+        var json = await agent.SendCdpCommandAsync("Page.captureScreenshot", new JsonObject
+        {
+            ["format"] = "png"
+        }, webviewId);
 
         if (json.TryGetProperty("result", out var result) &&
             result.TryGetProperty("data", out var data))

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/LogsTool.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/LogsTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
 
@@ -32,20 +33,19 @@ public sealed class LogsTool
 		if (!levelOrder.TryGetValue(minLevel, out var minOrd))
 			return response;
 
-		var entries = JsonSerializer.Deserialize<JsonElement>(response);
+		var entries = CliJson.ParseElement(response);
 		if (entries.ValueKind != JsonValueKind.Array)
 			return response;
 
-		var filtered = entries.EnumerateArray()
-			.Where(e =>
-			{
-				var level = e.TryGetProperty("l", out var l) ? l.GetString() :
-				            e.TryGetProperty("level", out var lv) ? lv.GetString() : null;
-				if (level == null) return true;
-				return levelOrder.TryGetValue(level, out var ord) && ord >= minOrd;
-			})
-			.ToList();
+		var filtered = new JsonArray();
+		foreach (var entry in entries.EnumerateArray())
+		{
+			var level = entry.TryGetProperty("l", out var l) ? l.GetString() :
+			            entry.TryGetProperty("level", out var lv) ? lv.GetString() : null;
+			if (level == null || (levelOrder.TryGetValue(level, out var ord) && ord >= minOrd))
+				filtered.Add(JsonNode.Parse(entry.GetRawText()));
+		}
 
-		return JsonSerializer.Serialize(filtered);
+		return CliJson.SerializeUntyped(filtered, indented: false);
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NetworkTool.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NetworkTool.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text.Json;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
 using Microsoft.Maui.DevFlow.Driver;
@@ -9,13 +8,6 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class NetworkTool
 {
-	private static readonly JsonSerializerOptions JsonOptions = new()
-	{
-		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-		DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-		WriteIndented = false
-	};
-
 	[McpServerTool(Name = "maui_network"), Description("List captured HTTP network requests from the running app. Returns structured data with method, URL, status code, duration, and sizes.")]
 	public static async Task<string> NetworkList(
 		McpAgentSession session,
@@ -43,7 +35,7 @@ public sealed class NetworkTool
 			};
 		}
 
-		return JsonSerializer.Serialize(requests, JsonOptions);
+		return CliJson.SerializeUntyped(requests, indented: false);
 	}
 
 	[McpServerTool(Name = "maui_network_detail"), Description("Get full details of a captured HTTP request including headers and body.")]
@@ -57,7 +49,7 @@ public sealed class NetworkTool
 		if (detail == null)
 			return $"Network request '{requestId}' not found.";
 
-		return JsonSerializer.Serialize(detail, JsonOptions);
+		return CliJson.SerializeUntyped(detail, indented: false);
 	}
 
 	[McpServerTool(Name = "maui_network_clear"), Description("Clear all captured network requests from the buffer.")]

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/QueryTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/QueryTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text.Json;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
 using Microsoft.Maui.DevFlow.Driver;
@@ -9,13 +8,6 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class QueryTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-        WriteIndented = false
-    };
-
     [McpServerTool(Name = "maui_query"), Description("Query visual tree elements by type, AutomationId, or text content. Returns matching elements with their IDs and properties.")]
     public static async Task<string> Query(
         McpAgentSession session,
@@ -32,7 +24,7 @@ public sealed class QueryTools
         if (results == null || results.Count == 0)
             return "No matching elements found.";
 
-        return JsonSerializer.Serialize(results, JsonOptions);
+        return CliJson.SerializeUntyped(results, indented: false);
     }
 
     [McpServerTool(Name = "maui_query_css"), Description("Query Blazor WebView elements using CSS selectors. Returns matching elements.")]
@@ -46,7 +38,7 @@ public sealed class QueryTools
         if (results == null || results.Count == 0)
             return $"No elements matching selector '{selector}'.";
 
-        return JsonSerializer.Serialize(results, JsonOptions);
+        return CliJson.SerializeUntyped(results, indented: false);
     }
 
     [McpServerTool(Name = "maui_element"), Description("Get detailed info about a single element by its visual tree ID.")]
@@ -60,7 +52,7 @@ public sealed class QueryTools
         if (element == null)
             return $"Element '{elementId}' not found.";
 
-        return JsonSerializer.Serialize(element, JsonOptions);
+        return CliJson.SerializeUntyped(element, indented: false);
     }
 
     [McpServerTool(Name = "maui_hittest"), Description("Find which element is at specific screen coordinates (hit test).")]

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/TreeTool.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/TreeTool.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text.Json;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
 using Microsoft.Maui.DevFlow.Driver;
@@ -9,13 +8,6 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class TreeTool
 {
-	private static readonly JsonSerializerOptions JsonOptions = new()
-	{
-		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-		DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-		WriteIndented = false
-	};
-
 	[McpServerTool(Name = "maui_tree"), Description("Inspect the visual tree of the running MAUI app. Returns structured JSON element hierarchy with IDs, types, bounds, visibility, and properties. Use element IDs from this tree for tap, fill, scroll, and other interaction commands.")]
 	public static async Task<string> Tree(
 		McpAgentSession session,
@@ -47,7 +39,7 @@ public sealed class TreeTool
 				return $"No elements of type '{filter}' found in the visual tree.";
 		}
 
-		return JsonSerializer.Serialize(result, JsonOptions);
+		return CliJson.SerializeUntyped(result, indented: false);
 	}
 
 	private static ElementInfo? FindElement(IEnumerable<ElementInfo> elements, string id)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/NetworkMonitorTui.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/NetworkMonitorTui.cs
@@ -298,8 +298,7 @@ public static class NetworkMonitorTui
     {
         try
         {
-            using var doc = JsonDocument.Parse(text);
-            return JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true });
+            return CliJson.PrettyPrint(text);
         }
         catch { return text; }
     }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/OutputWriter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/OutputWriter.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Maui.Cli.DevFlow;
 
@@ -10,20 +10,6 @@ namespace Microsoft.Maui.Cli.DevFlow;
 /// </summary>
 class DevFlowOutputWriter : IDevFlowOutputWriter
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    };
-
-    private static readonly JsonSerializerOptions s_compactJsonOptions = new()
-    {
-        WriteIndented = false,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    };
-
     /// <summary>
     /// Resolves whether JSON output mode is active.
     /// Priority: --no-json flag > --json flag > MAUIDEVFLOW_OUTPUT env var > TTY auto-detection.
@@ -51,7 +37,7 @@ class DevFlowOutputWriter : IDevFlowOutputWriter
     {
         if (json)
         {
-            Console.WriteLine(JsonSerializer.Serialize(data, s_jsonOptions));
+            Console.WriteLine(CliJson.SerializeUntyped(data, indented: true));
         }
         else if (humanFormatter != null)
         {
@@ -59,7 +45,7 @@ class DevFlowOutputWriter : IDevFlowOutputWriter
         }
         else
         {
-            Console.WriteLine(JsonSerializer.Serialize(data, s_jsonOptions));
+            Console.WriteLine(CliJson.SerializeUntyped(data, indented: true));
         }
     }
 
@@ -83,7 +69,7 @@ class DevFlowOutputWriter : IDevFlowOutputWriter
         }
         else
         {
-            Console.WriteLine(JsonSerializer.Serialize(element, s_jsonOptions));
+            Console.WriteLine(CliJson.PrettyPrint(element));
         }
     }
 
@@ -94,8 +80,12 @@ class DevFlowOutputWriter : IDevFlowOutputWriter
     {
         if (json)
         {
-            var result = new ActionResult { Success = success, Action = action, ElementId = elementId };
-            Console.WriteLine(JsonSerializer.Serialize(result, s_compactJsonOptions));
+            Console.WriteLine(CliJson.SerializeUntyped(new JsonObject
+            {
+                ["success"] = success,
+                ["action"] = action,
+                ["elementId"] = elementId
+            }, indented: false));
         }
         else
         {
@@ -112,14 +102,21 @@ class DevFlowOutputWriter : IDevFlowOutputWriter
     {
         if (json)
         {
-            var error = new ErrorResult
+            var error = new JsonObject
             {
-                Error = message,
-                Type = errorType,
-                Retryable = retryable,
-                Suggestions = suggestions
+                ["error"] = message,
+                ["type"] = errorType,
+                ["retryable"] = retryable
             };
-            Console.Error.WriteLine(JsonSerializer.Serialize(error, s_compactJsonOptions));
+            if (suggestions is { Length: > 0 })
+            {
+                var suggestionArray = new JsonArray();
+                foreach (var suggestion in suggestions)
+                    suggestionArray.Add((JsonNode?)JsonValue.Create(suggestion));
+                error["suggestions"] = suggestionArray;
+            }
+
+            Console.Error.WriteLine(CliJson.SerializeUntyped(error, indented: false));
         }
         else
         {
@@ -132,7 +129,7 @@ class DevFlowOutputWriter : IDevFlowOutputWriter
     /// </summary>
     public void WriteJsonLine<T>(T data)
     {
-        Console.WriteLine(JsonSerializer.Serialize(data, s_compactJsonOptions));
+        Console.WriteLine(CliJson.SerializeUntyped(data, indented: false));
     }
 
     /// <summary>
@@ -140,35 +137,6 @@ class DevFlowOutputWriter : IDevFlowOutputWriter
     /// </summary>
     public string FormatJson<T>(T data)
     {
-        return JsonSerializer.Serialize(data, s_jsonOptions);
-    }
-
-    // DTOs for structured output
-
-    private class ActionResult
-    {
-        [JsonPropertyName("success")]
-        public bool Success { get; set; }
-
-        [JsonPropertyName("action")]
-        public string? Action { get; set; }
-
-        [JsonPropertyName("elementId")]
-        public string? ElementId { get; set; }
-    }
-
-    private class ErrorResult
-    {
-        [JsonPropertyName("error")]
-        public string? Error { get; set; }
-
-        [JsonPropertyName("type")]
-        public string? Type { get; set; }
-
-        [JsonPropertyName("retryable")]
-        public bool Retryable { get; set; }
-
-        [JsonPropertyName("suggestions")]
-        public string[]? Suggestions { get; set; }
+        return CliJson.SerializeUntyped(data, indented: true);
     }
 }

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -13,6 +13,9 @@
     <IsShipping>true</IsShipping>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1572;CS1573</NoWarn>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>
@@ -46,6 +49,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Maui.Cli.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.Maui.DevFlow.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputFormatter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputFormatter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Maui.Cli.Models;
@@ -10,6 +11,8 @@ namespace Microsoft.Maui.Cli.Output;
 /// <summary>
 /// JSON output formatter for machine-readable output.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "General-purpose CLI output formatter; full AOT migration tracked separately.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "General-purpose CLI output formatter; full AOT migration tracked separately.")]
 public class JsonOutputFormatter : IOutputFormatter
 {
 	static readonly JsonSerializerOptions s_options = new()
@@ -17,7 +20,13 @@ public class JsonOutputFormatter : IOutputFormatter
 		WriteIndented = true,
 		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
 		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-		Converters = { new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower) }
+		Converters =
+		{
+			new JsonStringEnumConverter<DeviceType>(JsonNamingPolicy.SnakeCaseLower),
+			new JsonStringEnumConverter<DeviceState>(JsonNamingPolicy.SnakeCaseLower),
+			new JsonStringEnumConverter<HealthStatus>(JsonNamingPolicy.SnakeCaseLower),
+			new JsonStringEnumConverter<CheckStatus>(JsonNamingPolicy.SnakeCaseLower),
+		}
 	};
 
 	readonly TextWriter _output;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Maui.DevFlow.Driver;
 
@@ -72,14 +73,14 @@ public class AgentClient : IDisposable
         var url = $"{_baseUrl}/api/query?selector={Uri.EscapeDataString(selector)}";
         var response = await _http.GetAsync(url);
         var body = await response.Content.ReadAsStringAsync();
-        var json = JsonSerializer.Deserialize<JsonElement>(body);
+        var json = DriverJson.ParseElement(body);
         if (json.ValueKind == JsonValueKind.Object &&
             json.TryGetProperty("success", out var s) && !s.GetBoolean())
         {
             var msg = json.TryGetProperty("error", out var e) ? e.GetString() : "Query failed";
             throw new InvalidOperationException(msg);
         }
-        return json.Deserialize<List<ElementInfo>>() ?? new();
+        return DriverJson.Deserialize<List<ElementInfo>>(json.GetRawText()) ?? new();
     }
 
     /// <summary>
@@ -87,7 +88,10 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> TapAsync(string elementId)
     {
-        return await PostActionAsync("/api/action/tap", new { elementId });
+        return await PostActionAsync("/api/action/tap", new JsonObject
+        {
+            ["elementId"] = elementId
+        });
     }
 
     /// <summary>
@@ -95,7 +99,11 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> FillAsync(string elementId, string text)
     {
-        return await PostActionAsync("/api/action/fill", new { elementId, text });
+        return await PostActionAsync("/api/action/fill", new JsonObject
+        {
+            ["elementId"] = elementId,
+            ["text"] = text
+        });
     }
 
     /// <summary>
@@ -103,7 +111,10 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> ClearAsync(string elementId)
     {
-        return await PostActionAsync("/api/action/clear", new { elementId });
+        return await PostActionAsync("/api/action/clear", new JsonObject
+        {
+            ["elementId"] = elementId
+        });
     }
 
     /// <summary>
@@ -111,7 +122,10 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> FocusAsync(string elementId)
     {
-        return await PostActionAsync("/api/action/focus", new { elementId });
+        return await PostActionAsync("/api/action/focus", new JsonObject
+        {
+            ["elementId"] = elementId
+        });
     }
 
     /// <summary>
@@ -119,7 +133,10 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> NavigateAsync(string route)
     {
-        return await PostActionAsync("/api/action/navigate", new { route });
+        return await PostActionAsync("/api/action/navigate", new JsonObject
+        {
+            ["route"] = route
+        });
     }
 
     /// <summary>
@@ -129,7 +146,16 @@ public class AgentClient : IDisposable
     {
         var url = "/api/action/scroll";
         if (window != null) url += $"?window={window}";
-        return await PostActionAsync(url, new { elementId, deltaX, deltaY, animated, itemIndex, groupIndex, scrollToPosition });
+        return await PostActionAsync(url, new JsonObject
+        {
+            ["elementId"] = elementId,
+            ["deltaX"] = deltaX,
+            ["deltaY"] = deltaY,
+            ["animated"] = animated,
+            ["itemIndex"] = itemIndex,
+            ["groupIndex"] = groupIndex,
+            ["scrollToPosition"] = scrollToPosition
+        });
     }
 
     /// <summary>
@@ -139,7 +165,11 @@ public class AgentClient : IDisposable
     {
         var url = "/api/action/resize";
         if (window != null) url += $"?window={window}";
-        return await PostActionAsync(url, new { width, height });
+        return await PostActionAsync(url, new JsonObject
+        {
+            ["width"] = width,
+            ["height"] = height
+        });
     }
 
     /// <summary>
@@ -186,8 +216,10 @@ public class AgentClient : IDisposable
     {
         try
         {
-            var json = JsonSerializer.Serialize(new { value });
-            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            using var content = DriverJson.CreateJsonContent(new JsonObject
+            {
+                ["value"] = value
+            });
             var response = await _http.PostAsync($"{_baseUrl}/api/property/{elementId}/{propertyName}", content);
             return response.IsSuccessStatusCode;
         }
@@ -208,21 +240,23 @@ public class AgentClient : IDisposable
     /// <summary>
     /// Send a CDP command to a Blazor WebView.
     /// </summary>
-    public async Task<JsonElement> SendCdpCommandAsync(string method, JsonElement? @params = null, string? webviewId = null)
+    public async Task<JsonElement> SendCdpCommandAsync(string method, JsonNode? @params = null, string? webviewId = null)
     {
         var path = "/api/cdp";
         if (!string.IsNullOrEmpty(webviewId))
             path += $"?webview={Uri.EscapeDataString(webviewId)}";
 
-        var body = new Dictionary<string, object> { ["method"] = method };
-        if (@params.HasValue && @params.Value.ValueKind != JsonValueKind.Undefined)
-            body["params"] = @params.Value;
+        var body = new JsonObject
+        {
+            ["method"] = method
+        };
+        if (@params != null)
+            body["params"] = @params;
 
-        var json = JsonSerializer.Serialize(body);
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var content = DriverJson.CreateJsonContent(body);
         var response = await _http.PostAsync($"{_baseUrl}{path}", content);
         var responseBody = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+        return DriverJson.ParseElement(responseBody);
     }
 
     /// <summary>
@@ -256,16 +290,17 @@ public class AgentClient : IDisposable
 
     public async Task<ProfilerSessionInfo?> StartProfilerAsync(int? sampleIntervalMs = null)
     {
-        object payload = sampleIntervalMs.HasValue
-            ? new { sampleIntervalMs = sampleIntervalMs.Value }
-            : new { };
+        var payload = new JsonObject();
+        if (sampleIntervalMs.HasValue)
+            payload["sampleIntervalMs"] = sampleIntervalMs.Value;
+
         var response = await PostJsonAsync<ProfilerSessionEnvelope>("/api/profiler/start", payload);
         return response?.Session;
     }
 
     public async Task<ProfilerSessionInfo?> StopProfilerAsync()
     {
-        var response = await PostJsonAsync<ProfilerSessionEnvelope>("/api/profiler/stop", new { });
+        var response = await PostJsonAsync<ProfilerSessionEnvelope>("/api/profiler/stop", new JsonObject());
         return response?.Session;
     }
 
@@ -284,7 +319,12 @@ public class AgentClient : IDisposable
         string type = "user.action",
         string? payloadJson = null)
     {
-        return await PostActionAsync("/api/profiler/marker", new { name, type, payloadJson });
+        return await PostActionAsync("/api/profiler/marker", new JsonObject
+        {
+            ["name"] = name,
+            ["type"] = type,
+            ["payloadJson"] = payloadJson
+        });
     }
 
     public async Task<List<ProfilerHotspot>> GetProfilerHotspotsAsync(
@@ -306,7 +346,7 @@ public class AgentClient : IDisposable
         try
         {
             var response = await _http.GetStringAsync($"{_baseUrl}{path}");
-            return JsonSerializer.Deserialize<T>(response);
+            return DriverJson.Deserialize<T>(response);
         }
         catch { return null; }
     }
@@ -320,38 +360,36 @@ public class AgentClient : IDisposable
             if (string.IsNullOrWhiteSpace(body))
                 return default;
 
-            return JsonSerializer.Deserialize<JsonElement>(body);
+            return DriverJson.ParseElement(body);
         }
         catch { return default; }
     }
 
-    private async Task<bool> PostActionAsync(string path, object body)
+    private async Task<bool> PostActionAsync(string path, JsonNode body)
     {
         try
         {
-            var json = JsonSerializer.Serialize(body);
-            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            using var content = DriverJson.CreateJsonContent(body);
             var response = await _http.PostAsync($"{_baseUrl}{path}", content);
             if (!response.IsSuccessStatusCode) return false;
 
             var responseBody = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<JsonElement>(responseBody);
-            return result.TryGetProperty("success", out var success) && success.GetBoolean();
+            var result = DriverJson.Deserialize<ActionResponse>(responseBody);
+            return result?.Success == true;
         }
         catch { return false; }
     }
 
-    private async Task<T?> PostJsonAsync<T>(string path, object body) where T : class
+    private async Task<T?> PostJsonAsync<T>(string path, JsonNode body) where T : class
     {
         try
         {
-            var json = JsonSerializer.Serialize(body);
-            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            using var content = DriverJson.CreateJsonContent(body);
             var response = await _http.PostAsync($"{_baseUrl}{path}", content);
             if (!response.IsSuccessStatusCode)
                 return null;
             var responseBody = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<T>(responseBody);
+            return DriverJson.Deserialize<T>(responseBody);
         }
         catch
         {
@@ -381,14 +419,17 @@ public class AgentClient : IDisposable
 
     public async Task<JsonElement> SetPreferenceAsync(string key, string value, string? type = null, string? sharedName = null)
     {
-        var body = new Dictionary<string, object?> { ["value"] = value };
+        var body = new JsonObject
+        {
+            ["value"] = value
+        };
         if (!string.IsNullOrEmpty(type)) body["type"] = type;
         if (!string.IsNullOrEmpty(sharedName)) body["sharedName"] = sharedName;
-        var json = JsonSerializer.Serialize(body);
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var content = DriverJson.CreateJsonContent(body);
         var response = await _http.PostAsync($"{_baseUrl}/api/preferences/{Uri.EscapeDataString(key)}", content);
         var responseBody = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+        return DriverJson.ParseElement(responseBody);
     }
 
     public async Task<JsonElement> DeletePreferenceAsync(string key, string? sharedName = null)
@@ -398,7 +439,7 @@ public class AgentClient : IDisposable
             path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
         var response = await _http.DeleteAsync($"{_baseUrl}{path}");
         var responseBody = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+        return DriverJson.ParseElement(responseBody);
     }
 
     public async Task<bool> ClearPreferencesAsync(string? sharedName = null)
@@ -406,7 +447,7 @@ public class AgentClient : IDisposable
         var path = "/api/preferences/clear";
         if (!string.IsNullOrEmpty(sharedName))
             path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
-        return await PostActionAsync(path, new { });
+        return await PostActionAsync(path, new JsonObject());
     }
 
     // ── Secure Storage ──
@@ -418,23 +459,25 @@ public class AgentClient : IDisposable
 
     public async Task<JsonElement> SetSecureStorageAsync(string key, string value)
     {
-        var json = JsonSerializer.Serialize(new { value });
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var content = DriverJson.CreateJsonContent(new JsonObject
+        {
+            ["value"] = value
+        });
         var response = await _http.PostAsync($"{_baseUrl}/api/secure-storage/{Uri.EscapeDataString(key)}", content);
         var responseBody = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+        return DriverJson.ParseElement(responseBody);
     }
 
     public async Task<JsonElement> DeleteSecureStorageAsync(string key)
     {
         var response = await _http.DeleteAsync($"{_baseUrl}/api/secure-storage/{Uri.EscapeDataString(key)}");
         var responseBody = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<JsonElement>(responseBody);
+        return DriverJson.ParseElement(responseBody);
     }
 
     public async Task<bool> ClearSecureStorageAsync()
     {
-        return await PostActionAsync("/api/secure-storage/clear", new { });
+        return await PostActionAsync("/api/secure-storage/clear", new JsonObject());
     }
 
     // ── Platform info ──
@@ -466,12 +509,12 @@ public class AgentClient : IDisposable
         var path = $"/api/sensors/{Uri.EscapeDataString(sensor)}/start";
         if (!string.IsNullOrEmpty(speed))
             path += $"?speed={Uri.EscapeDataString(speed)}";
-        return await PostActionAsync(path, new { });
+        return await PostActionAsync(path, new JsonObject());
     }
 
     public async Task<bool> StopSensorAsync(string sensor)
     {
-        return await PostActionAsync($"/api/sensors/{Uri.EscapeDataString(sensor)}/stop", new { });
+        return await PostActionAsync($"/api/sensors/{Uri.EscapeDataString(sensor)}/stop", new JsonObject());
     }
 
     public void Dispose()
@@ -493,7 +536,7 @@ public class AgentClient : IDisposable
             if (!string.IsNullOrEmpty(method)) url += $"&method={Uri.EscapeDataString(method)}";
 
             var response = await _http.GetStringAsync(url);
-            return JsonSerializer.Deserialize<List<NetworkRequest>>(response) ?? new();
+            return DriverJson.Deserialize<List<NetworkRequest>>(response) ?? new();
         }
         catch { return new(); }
     }
@@ -503,14 +546,14 @@ public class AgentClient : IDisposable
         try
         {
             var response = await _http.GetStringAsync($"{_baseUrl}/api/network/{Uri.EscapeDataString(id)}");
-            return JsonSerializer.Deserialize<NetworkRequest>(response);
+            return DriverJson.Deserialize<NetworkRequest>(response);
         }
         catch { return null; }
     }
 
     public async Task<bool> ClearNetworkRequestsAsync()
     {
-        return await PostActionAsync("/api/network/clear", new { });
+        return await PostActionAsync("/api/network/clear", new JsonObject());
     }
 
     /// <summary>
@@ -522,10 +565,16 @@ public class AgentClient : IDisposable
         return $"{wsBase}/ws/network";
     }
 
-    private sealed class ProfilerSessionEnvelope
+    internal sealed class ProfilerSessionEnvelope
     {
         [System.Text.Json.Serialization.JsonPropertyName("session")]
         public ProfilerSessionInfo? Session { get; set; }
+    }
+
+    internal sealed class ActionResponse
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("success")]
+        public bool Success { get; set; }
     }
 }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/DevFlowDriverJson.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/DevFlowDriverJson.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.DevFlow.Driver;
+
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(AgentStatus))]
+[JsonSerializable(typeof(ElementInfo))]
+[JsonSerializable(typeof(List<ElementInfo>))]
+[JsonSerializable(typeof(NetworkRequest))]
+[JsonSerializable(typeof(List<NetworkRequest>))]
+[JsonSerializable(typeof(ProfilerCapabilities))]
+[JsonSerializable(typeof(ProfilerSessionInfo))]
+[JsonSerializable(typeof(ProfilerBatch))]
+[JsonSerializable(typeof(List<ProfilerHotspot>))]
+[JsonSerializable(typeof(RecordingState))]
+[JsonSerializable(typeof(AgentClient.ProfilerSessionEnvelope))]
+[JsonSerializable(typeof(AgentClient.ActionResponse))]
+internal sealed partial class DevFlowDriverJsonContext : JsonSerializerContext;
+
+internal static class DriverJson
+{
+    private static readonly JsonSerializerOptions s_nodeIndentedOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private static readonly JsonSerializerOptions s_nodeCompactOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    public static T? Deserialize<T>(string json) where T : class
+        => (T?)JsonSerializer.Deserialize(json, typeof(T), DevFlowDriverJsonContext.Default);
+
+    public static string SerializeUntyped(object? value, bool indented = false)
+    {
+        if (value is null)
+            return "null";
+
+        return value switch
+        {
+            JsonNode node => node.ToJsonString(indented ? s_nodeIndentedOptions : s_nodeCompactOptions),
+            JsonElement element => PrettyPrint(element, indented),
+            JsonDocument document => PrettyPrint(document.RootElement, indented),
+            _ => SerializeTyped(value, indented),
+        };
+    }
+
+    public static StringContent CreateJsonContent(JsonNode body)
+        => new(SerializeUntyped(body), Encoding.UTF8, "application/json");
+
+    public static JsonElement ParseElement(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    public static string PrettyPrint(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return PrettyPrint(document.RootElement, indented: true);
+    }
+
+    public static string PrettyPrint(JsonElement element, bool indented = true)
+    {
+        if (!indented)
+            return element.GetRawText();
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+        element.WriteTo(writer);
+        writer.Flush();
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string SerializeTyped(object value, bool indented)
+    {
+        var json = JsonSerializer.Serialize(value, value.GetType(), DevFlowDriverJsonContext.Default);
+        return indented ? PrettyPrint(json) : json;
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Microsoft.Maui.DevFlow.Driver.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Microsoft.Maui.DevFlow.Driver.csproj
@@ -7,6 +7,7 @@
          as a ProjectReference but the DevFlow job owns the package. -->
     <IsPackable>false</IsPackable>
     <IsPackable Condition="'$(PackDriverNuGet)' == 'true'">true</IsPackable>
+    <IsAotCompatible>true</IsAotCompatible>
 
     <PackageId>Microsoft.Maui.DevFlow.Driver</PackageId>
     <IsShipping>true</IsShipping>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Properties/InternalsVisibleTo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Maui.DevFlow.Tests")]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/RecordingState.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/RecordingState.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Maui.DevFlow.Driver;
@@ -50,15 +49,10 @@ public static class RecordingStateManager
 
     private static readonly string StateFile = Path.Combine(StateDir, "recording-state.json");
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true
-    };
-
     public static void Save(RecordingState state)
     {
         Directory.CreateDirectory(StateDir);
-        var json = JsonSerializer.Serialize(state, JsonOptions);
+        var json = DriverJson.SerializeUntyped(state, indented: true);
         File.WriteAllText(StateFile, json);
     }
 
@@ -68,7 +62,7 @@ public static class RecordingStateManager
         try
         {
             var json = File.ReadAllText(StateFile);
-            return JsonSerializer.Deserialize<RecordingState>(json);
+            return DriverJson.Deserialize<RecordingState>(json);
         }
         catch
         {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AotCompatibilityTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AotCompatibilityTests.cs
@@ -17,6 +17,9 @@ public class AotCompatibilityTests
         var json = CliJson.SerializeUntyped(commands, indented: false);
         var deserialized = CliJson.Deserialize<List<CommandDescription>>(json);
 
+        Assert.Contains("\"command\":\"MAUI status\"", json);
+        Assert.Contains("\"description\":\"Check agent connection and app info\"", json);
+        Assert.Contains("\"mutating\":false", json);
         Assert.NotNull(deserialized);
         var command = Assert.Single(deserialized);
         Assert.Equal("MAUI status", command.Command);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AotCompatibilityTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AotCompatibilityTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json.Nodes;
+using Microsoft.Maui.Cli.DevFlow;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class AotCompatibilityTests
+{
+    [Fact]
+    public void CliJson_Serializes_And_Deserializes_CommandDescriptions()
+    {
+        var commands = new List<CommandDescription>
+        {
+            new("MAUI status", "Check agent connection and app info", false)
+        };
+
+        var json = CliJson.SerializeUntyped(commands, indented: false);
+        var deserialized = CliJson.Deserialize<List<CommandDescription>>(json);
+
+        Assert.NotNull(deserialized);
+        var command = Assert.Single(deserialized);
+        Assert.Equal("MAUI status", command.Command);
+        Assert.Equal("Check agent connection and app info", command.Description);
+        Assert.False(command.Mutating);
+    }
+
+    [Fact]
+    public void CliJson_Serializes_JsonNode_Payloads()
+    {
+        var payload = new JsonObject
+        {
+            ["status"] = "ok",
+            ["agents"] = 2
+        };
+
+        var json = CliJson.SerializeUntyped(payload, indented: false);
+
+        Assert.Equal("{\"status\":\"ok\",\"agents\":2}", json);
+    }
+
+    [Fact]
+    public void DriverJson_Serializes_And_Deserializes_NetworkRequests()
+    {
+        var requests = new List<NetworkRequest>
+        {
+            new()
+            {
+                Id = "req-1",
+                Method = "GET",
+                Url = "https://example.com/api",
+                Host = "example.com",
+                Path = "/api",
+                StatusCode = 200,
+                DurationMs = 42,
+                Timestamp = DateTimeOffset.Parse("2026-01-01T00:00:00Z")
+            }
+        };
+
+        var json = DriverJson.SerializeUntyped(requests);
+        var deserialized = DriverJson.Deserialize<List<NetworkRequest>>(json);
+
+        Assert.NotNull(deserialized);
+        var request = Assert.Single(deserialized);
+        Assert.Equal("req-1", request.Id);
+        Assert.Equal("GET", request.Method);
+        Assert.Equal("https://example.com/api", request.Url);
+        Assert.Equal(200, request.StatusCode);
+        Assert.Equal(42, request.DurationMs);
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/Microsoft.Maui.DevFlow.Tests.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/Microsoft.Maui.DevFlow.Tests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Cli\Microsoft.Maui.Cli\Microsoft.Maui.Cli.csproj" />
     <ProjectReference Include="..\Microsoft.Maui.DevFlow.Agent.Core\Microsoft.Maui.DevFlow.Agent.Core.csproj" />
     <ProjectReference Include="..\Microsoft.Maui.DevFlow.Driver\Microsoft.Maui.DevFlow.Driver.csproj" />
     <ProjectReference Include="..\Microsoft.Maui.DevFlow.Logging\Microsoft.Maui.DevFlow.Logging.csproj" />


### PR DESCRIPTION
Introduce a CliJson helper and generated JsonContext to centralize JSON parsing/serialization and pretty-printing across the CLI. Migrate broker, MCP tools, output formatting, CDP helpers and many Program APIs to use JsonNode/JsonObject and CliJson.Serialize/Deserialize/Parse/PrettyPrint instead of ad-hoc JsonSerializer usage and custom options. Add CommandDescription and RegistrationMessage records, improve broker client/server logic (entry assembly resolution), and enable AOT/single-file/trim analyzers in the CLI csproj. Also add a macOS NativeAOT publish smoke test to the GitHub Actions workflow to catch publish/runtime regressions.