### PR TITLE
Avoid rewriting DevFlow port file on no-op builds

### DIFF
--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
@@ -25,7 +25,8 @@
     </PropertyGroup>
     <WriteLinesToFile File="$(_MauiDevFlowPortFile)"
                      Lines="$(_MauiDevFlowMetadata)"
-                     Overwrite="true" />
+                     Overwrite="true"
+                     WriteOnlyWhenDifferent="true" />
     <ItemGroup>
       <Compile Include="$(_MauiDevFlowPortFile)" />
     </ItemGroup>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
@@ -25,7 +25,8 @@
     </PropertyGroup>
     <WriteLinesToFile File="$(_MauiDevFlowPortFile)"
                      Lines="$(_MauiDevFlowMetadata)"
-                     Overwrite="true" />
+                     Overwrite="true"
+                     WriteOnlyWhenDifferent="true" />
     <ItemGroup>
       <Compile Include="$(_MauiDevFlowPortFile)" />
     </ItemGroup>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics;
+using System.Security;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public sealed class MauiDevFlowAgentTargetsTests : IDisposable
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+    private readonly string _projectDirectory;
+
+    public MauiDevFlowAgentTargetsTests()
+    {
+        _projectDirectory = Path.Combine(Path.GetTempPath(), $"mauidevflow-msbuild-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_projectDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_projectDirectory))
+            Directory.Delete(_projectDirectory, true);
+    }
+
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void SetMauiDevFlowPort_DoesNotRewriteGeneratedFile_WhenInputsAreUnchanged(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath);
+
+        RunSetMauiDevFlowPortTarget("/p:MauiDevFlowPort=9225");
+
+        Assert.True(File.Exists(GeneratedFilePath), $"Expected generated file at '{GeneratedFilePath}'.");
+        Assert.Contains("\"Microsoft.Maui.DevFlowPort\", \"9225\"", File.ReadAllText(GeneratedFilePath));
+
+        File.SetLastWriteTimeUtc(GeneratedFilePath, SentinelTimestampUtc);
+
+        RunSetMauiDevFlowPortTarget("/p:MauiDevFlowPort=9225");
+
+        Assert.Equal(SentinelTimestampUtc, File.GetLastWriteTimeUtc(GeneratedFilePath));
+    }
+
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void SetMauiDevFlowPort_RewritesGeneratedFile_WhenPortPropertyChanges(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath);
+
+        RunSetMauiDevFlowPortTarget("/p:MauiDevFlowPort=9225");
+        File.SetLastWriteTimeUtc(GeneratedFilePath, SentinelTimestampUtc);
+
+        RunSetMauiDevFlowPortTarget("/p:MauiDevFlowPort=9333");
+
+        Assert.NotEqual(SentinelTimestampUtc, File.GetLastWriteTimeUtc(GeneratedFilePath));
+
+        var contents = File.ReadAllText(GeneratedFilePath);
+        Assert.Contains("\"Microsoft.Maui.DevFlowPort\", \"9333\"", contents);
+        Assert.DoesNotContain("\"Microsoft.Maui.DevFlowPort\", \"9225\"", contents);
+    }
+
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void ReadMauiDevFlowConfig_RewritesGeneratedFile_WhenConfigChanges(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath);
+        File.WriteAllText(ConfigFilePath, """
+            {
+              "port": 9225
+            }
+            """);
+
+        RunSetMauiDevFlowPortTarget();
+        File.SetLastWriteTimeUtc(GeneratedFilePath, SentinelTimestampUtc);
+
+        File.WriteAllText(ConfigFilePath, """
+            {
+              "port": 9333
+            }
+            """);
+
+        RunSetMauiDevFlowPortTarget();
+
+        Assert.NotEqual(SentinelTimestampUtc, File.GetLastWriteTimeUtc(GeneratedFilePath));
+
+        var contents = File.ReadAllText(GeneratedFilePath);
+        Assert.Contains("\"Microsoft.Maui.DevFlowPort\", \"9333\"", contents);
+        Assert.DoesNotContain("\"Microsoft.Maui.DevFlowPort\", \"9225\"", contents);
+    }
+
+    private string ProjectFilePath => Path.Combine(_projectDirectory, "Test.csproj");
+
+    private string ConfigFilePath => Path.Combine(_projectDirectory, ".mauidevflow");
+
+    private string GeneratedFilePath => Path.Combine(_projectDirectory, "obj", "Debug", "net10.0", "Microsoft.Maui.DevFlowPort.g.cs");
+
+    private static DateTime SentinelTimestampUtc { get; } = new(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private void CreateTestProject(string relativeTargetPath)
+    {
+        var targetFilePath = Path.Combine(
+            RepoRoot,
+            "src",
+            "DevFlow",
+            "Microsoft.Maui.DevFlow.Agent",
+            relativeTargetPath.Replace('/', Path.DirectorySeparatorChar));
+
+        var escapedTargetFilePath = SecurityElement.Escape(targetFilePath) ?? targetFilePath;
+
+        File.WriteAllText(ProjectFilePath, $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <Import Project="{{escapedTargetFilePath}}" />
+            </Project>
+            """);
+    }
+
+    private void RunSetMauiDevFlowPortTarget(params string[] properties)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = _projectDirectory,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+
+        startInfo.ArgumentList.Add("msbuild");
+        startInfo.ArgumentList.Add(ProjectFilePath);
+        startInfo.ArgumentList.Add("/t:_SetMauiDevFlowPort");
+        startInfo.ArgumentList.Add("/nologo");
+        startInfo.ArgumentList.Add("/v:minimal");
+
+        foreach (var property in properties)
+            startInfo.ArgumentList.Add(property);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+
+        process.WaitForExit();
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet msbuild failed with exit code {process.ExitCode}.{Environment.NewLine}{output}{error}");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "MauiLabs.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from test output directory.");
+    }
+}


### PR DESCRIPTION
## Summary
- avoid rewriting `Microsoft.Maui.DevFlowPort.g.cs` when the generated metadata content is unchanged
- apply the fix in both packaged Agent target files (`build` and `buildTransitive`)
- add regression tests that exercise the targets from a temporary SDK project and verify unchanged, changed-port, and changed-config behavior

## Testing
- `cd /tmp && dotnet test /Users/vitekkaras/dotnet/maui-labs/src/DevFlow/Microsoft.Maui.DevFlow.Tests/Microsoft.Maui.DevFlow.Tests.csproj --no-restore --results-directory /tmp/maui-devflow-fullsuite --logger "trx;LogFileName=fullsuite.trx" -m:1 -nr:false`
- `cd /tmp && dotnet test /Users/vitekkaras/dotnet/maui-labs/src/DevFlow/Microsoft.Maui.DevFlow.Tests/Microsoft.Maui.DevFlow.Tests.csproj --no-build --no-restore --filter FullyQualifiedName~MauiDevFlowAgentTargetsTests --results-directory /tmp/maui-devflow-test-results --logger "trx;LogFileName=maui-devflow-agent-targets.trx" -m:1 -nr:false`