### PR TITLE
Improve DevFlow AI agent reliability: diagnose command, project scanning, agent logging

### DIFF
--- a/.claude/skills/maui-ai-debugging/SKILL.md
+++ b/.claude/skills/maui-ai-debugging/SKILL.md
@@ -45,6 +45,43 @@ For complete setup instructions, see [references/setup.md](references/setup.md).
 
 ## Core Workflow
 
+### 0. Verify DevFlow Availability
+
+Before building or launching anything, determine if DevFlow is available for the current project.
+
+**Check integration (project files — the source of truth):**
+```bash
+# Check if any csproj in the project has DevFlow packages
+grep -rl "MauiDevFlow\|Maui\.DevFlow" --include="*.csproj" .
+```
+
+If grep returns results, DevFlow IS integrated — even if `maui-devflow list` shows nothing.
+
+**Check runtime connection:**
+```bash
+maui-devflow list                          # shows connected agents
+maui-devflow broker status                 # shows broker health
+maui-devflow diagnose                      # full end-to-end health check (recommended)
+```
+
+**Decision tree — what to do based on results:**
+
+| Project has DevFlow packages? | Agent in `list`? | Action |
+|-------------------------------|------------------|--------|
+| ✅ Yes | ✅ Yes | Ready — proceed to inspection/interaction |
+| ✅ Yes | ❌ No | App not running in Debug, or broker issue. Launch app, then `maui-devflow wait` |
+| ❌ No | — | Need to integrate DevFlow (see "Integrating MauiDevFlow into a MAUI App") |
+
+**⚠️ CRITICAL:** `maui-devflow list` shows RUNTIME state (connected agents), NOT project integration.
+An empty list does NOT mean "DevFlow is not installed." Always check project files first.
+
+**After launching the app (via `dotnet build -t:Run` or through Aspire):**
+```bash
+maui-devflow wait                          # blocks until agent connects (default 120s)
+maui-devflow wait --project path/to/App.csproj  # filter to specific project
+```
+ALWAYS run `wait` after launching. Never assume the agent is connected — verify it.
+
 ### 1. Ensure a Device/Simulator/Emulator is Running
 
 **⚠️ Multi-project conflict avoidance:** When multiple projects may run simultaneously
@@ -52,7 +89,7 @@ For complete setup instructions, see [references/setup.md](references/setup.md).
 prevent apps from replacing each other. Check what's already in use first:
 
 ```bash
-maui-devflow list                                             # see all registered agents
+maui-devflow list     # check if any agents are already connected (runtime state only — see Step 0 for integration check)
 ```
 
 If another iOS or Android agent is already registered, **create a new simulator/emulator**
@@ -139,7 +176,8 @@ maui-devflow wait --project path/to/App.csproj   # filter to specific project
 ```
 
 `maui-devflow wait` prints the assigned port as soon as the agent connects. Exit code 1
-means timeout — check async shell output for build errors.
+means timeout. If `wait` times out, run `maui-devflow diagnose` to identify the issue.
+Check async shell output for build errors.
 
 **Android only** — set up port forwarding after the agent connects:
 ```bash
@@ -524,6 +562,10 @@ their input.
 
 ## Tips
 
+- **`maui-devflow list` shows runtime state, not project integration.** Empty list ≠ "not installed."
+  Always check project files (`grep -r MauiDevFlow *.csproj`) before concluding DevFlow is unavailable.
+- **`maui-devflow diagnose`** is the fastest way to check the entire chain: CLI → broker → agents → projects.
+- After launching through Aspire, always run `maui-devflow wait` before attempting any interaction.
 - **Use `maui-devflow batch`** for multi-step interactions — resolves port once, adds delays,
   returns structured JSONL. See [references/batch.md](references/batch.md).
 - **Always use `maui-devflow MAUI screenshot`** — captures in-process, app does NOT need

--- a/.claude/skills/maui-ai-debugging/SKILL.md
+++ b/.claude/skills/maui-ai-debugging/SKILL.md
@@ -563,7 +563,7 @@ their input.
 ## Tips
 
 - **`maui-devflow list` shows runtime state, not project integration.** Empty list ≠ "not installed."
-  Always check project files (`grep -r MauiDevFlow *.csproj`) before concluding DevFlow is unavailable.
+  Always check project files (`grep -rl "MauiDevFlow" --include="*.csproj" .`) before concluding DevFlow is unavailable.
 - **`maui-devflow diagnose`** is the fastest way to check the entire chain: CLI → broker → agents → projects.
 - After launching through Aspire, always run `maui-devflow wait` before attempting any interaction.
 - **Use `maui-devflow batch`** for multi-step interactions — resolves port once, adds delays,

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BrokerRegistration.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BrokerRegistration.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui.DevFlow.Agent.Core;
 
@@ -25,6 +26,8 @@ public class BrokerRegistration : IDisposable
     private readonly string _appName;
     private int _brokerPort;
     private int? _assignedPort;
+    private ILogger? _logger;
+    private static ILogger? _staticLogger;
 
     /// <summary>
     /// The port assigned by the broker, or null if not registered.
@@ -42,13 +45,19 @@ public class BrokerRegistration : IDisposable
     /// </summary>
     public bool IsConnected => _ws?.State == WebSocketState.Open;
 
-    public BrokerRegistration(string project, string tfm, string platform, string appName, int brokerPort = DefaultBrokerPort)
+    /// <summary>
+    /// Sets the static logger to be used by all BrokerRegistration instances that don't have an instance logger.
+    /// </summary>
+    public static void SetLogger(ILogger logger) => _staticLogger = logger;
+
+    public BrokerRegistration(string project, string tfm, string platform, string appName, int brokerPort = DefaultBrokerPort, ILogger? logger = null)
     {
         _project = project;
         _tfm = tfm;
         _platform = platform;
         _appName = appName;
         _brokerPort = brokerPort;
+        _logger = logger;
     }
 
     /// <summary>
@@ -59,6 +68,9 @@ public class BrokerRegistration : IDisposable
     {
         timeout ??= TimeSpan.FromSeconds(3);
         _cts = new CancellationTokenSource();
+        
+        var logger = _logger ?? _staticLogger;
+        logger?.LogInformation("DevFlow agent connecting to broker at ws://localhost:{BrokerPort}/ws/agent", _brokerPort);
 
         try
         {
@@ -80,6 +92,7 @@ public class BrokerRegistration : IDisposable
             if (response?.Type == "registered" && response.Port > 0)
             {
                 _assignedPort = response.Port;
+                logger?.LogInformation("DevFlow agent registered. Broker assigned port: {Port}", _assignedPort);
 
                 // Start background task to keep connection alive
                 _ = Task.Run(() => MonitorConnectionAsync(_cts.Token));
@@ -88,14 +101,16 @@ public class BrokerRegistration : IDisposable
             }
 
             // Registration failed
+            logger?.LogWarning("DevFlow agent failed to register with broker: Invalid response");
             _ws.Dispose();
             _ws = null;
             StartReconnection();
             return null;
         }
-        catch
+        catch (Exception ex)
         {
             // Broker unavailable — start background retries so we register when it comes up
+            logger?.LogDebug("Broker unavailable at ws://localhost:{BrokerPort}/ws/agent — starting background reconnection: {Message}", _brokerPort, ex.Message);
             _ws?.Dispose();
             _ws = null;
             StartReconnection();
@@ -119,7 +134,11 @@ public class BrokerRegistration : IDisposable
 
         // Connection lost — start reconnection
         if (!_disposed && !ct.IsCancellationRequested)
+        {
+            var logger = _logger ?? _staticLogger;
+            logger?.LogWarning("DevFlow agent lost broker connection — starting reconnection");
             StartReconnection();
+        }
     }
 
     private void StartReconnection()
@@ -128,10 +147,14 @@ public class BrokerRegistration : IDisposable
 
         var delays = new[] { 2000, 5000, 10000, 15000 };
         var attempt = 0;
+        var logger = _logger ?? _staticLogger;
 
         _reconnectTimer = new Timer(async _ =>
         {
             if (_disposed) return;
+
+            attempt++;
+            logger?.LogDebug("DevFlow agent reconnection attempt {Attempt} to broker...", attempt);
 
             try
             {
@@ -153,16 +176,19 @@ public class BrokerRegistration : IDisposable
                 if (response?.Type == "registered")
                 {
                     _assignedPort = response.Port;
+                    logger?.LogInformation("DevFlow agent reconnected to broker after {Attempt} attempts", attempt);
                     _reconnectTimer?.Dispose();
                     _reconnectTimer = null;
                     _ = Task.Run(() => MonitorConnectionAsync(_cts?.Token ?? CancellationToken.None));
                     return;
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                logger?.LogDebug("DevFlow agent reconnection attempt {Attempt} failed — retrying: {Message}", attempt, ex.Message);
+            }
 
             // Keep retrying with backoff up to 15s, indefinitely
-            attempt++;
             var delay = delays[Math.Min(attempt, delays.Length - 1)];
             try { _reconnectTimer?.Change(delay, Timeout.Infinite); } catch { }
         }, null, 2000, Timeout.Infinite);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/GtkAgentServiceExtensions.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/GtkAgentServiceExtensions.cs
@@ -25,28 +25,29 @@ public static class GtkAgentServiceExtensions
         var project = ReadAssemblyMetadata("Microsoft.Maui.DevFlowProject") ?? "unknown";
         var tfm = ReadAssemblyMetadata("Microsoft.Maui.DevFlowTfm") ?? "unknown";
 
-        // Try broker for port assignment first
+        // Always register with the broker for discoverability. When a custom port is
+        // set, we tell the broker our port so it uses it instead of assigning from the pool.
         BrokerRegistration? brokerReg = null;
-        if (options.Port == AgentOptions.DefaultPort)
+        bool hasCustomPort = options.Port != AgentOptions.DefaultPort;
+        try
         {
-            try
+            var platform = "Linux";
+            var appName = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown";
+            brokerReg = new BrokerRegistration(project, tfm, platform, appName);
+            if (hasCustomPort)
+                brokerReg.CurrentPort = options.Port;
+            var assignedPort = Task.Run(() => brokerReg.TryRegisterAsync(TimeSpan.FromSeconds(5))).GetAwaiter().GetResult();
+            if (assignedPort.HasValue)
             {
-                var platform = "Linux";
-                var appName = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown";
-                brokerReg = new BrokerRegistration(project, tfm, platform, appName);
-                var assignedPort = Task.Run(() => brokerReg.TryRegisterAsync(TimeSpan.FromSeconds(5))).GetAwaiter().GetResult();
-                if (assignedPort.HasValue)
-                {
-                    options.Port = assignedPort.Value;
-                    Console.WriteLine($"[Microsoft.Maui.DevFlow] Broker assigned port {assignedPort.Value}");
-                }
+                options.Port = assignedPort.Value;
+                Console.WriteLine($"[Microsoft.Maui.DevFlow] Broker assigned port {assignedPort.Value}");
             }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"[Microsoft.Maui.DevFlow] Broker registration failed: {ex.Message}");
-                brokerReg?.Dispose();
-                brokerReg = null;
-            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Microsoft.Maui.DevFlow] Broker registration failed: {ex.Message}");
+            brokerReg?.Dispose();
+            brokerReg = null;
         }
 
         // Fall back to assembly metadata port if broker didn't assign one

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/AgentServiceExtensions.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/AgentServiceExtensions.cs
@@ -28,48 +28,53 @@ public static class AgentServiceExtensions
         var project = ReadAssemblyMetadataProject() ?? "unknown";
         var tfm = ReadAssemblyMetadataTfm() ?? "unknown";
 
-        // Try broker for port assignment first (must run on thread pool to avoid deadlock
-        // with SynchronizationContext — AddMauiDevFlowAgent runs on the main thread)
+        // Always register with the broker for discoverability (must run on thread pool
+        // to avoid deadlock with SynchronizationContext — AddMauiDevFlowAgent runs on
+        // the main thread). When a custom port is set, we tell the broker our port so it
+        // uses it instead of assigning from the pool; the agent stays discoverable via
+        // `maui-devflow list` regardless of port configuration.
         BrokerRegistration? brokerReg = null;
-        if (options.Port == AgentOptions.DefaultPort)
+        bool hasCustomPort = options.Port != AgentOptions.DefaultPort;
+        try
         {
+            string platform;
+            string appName;
             try
             {
-                string platform;
-                string appName;
-                try
-                {
-                    platform = DeviceInfo.Platform.ToString();
-                    appName = AppInfo.Name ?? "unknown";
-                }
-                catch
-                {
-                    // MAUI not fully initialized yet during DI registration
-                    platform = OperatingSystem.IsAndroid() ? "Android"
-                        : OperatingSystem.IsIOS() ? "iOS"
-                        : OperatingSystem.IsMacCatalyst() ? "MacCatalyst"
-                        : OperatingSystem.IsMacOS() ? "macOS"
-                        : OperatingSystem.IsWindows() ? "Windows"
-                        : "Unknown";
-                    appName = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown";
-                }
-                brokerReg = new BrokerRegistration(project, tfm, platform, appName);
-                // Task.Run avoids deadlock: TryRegisterAsync uses await internally,
-                // and the main thread has a SynchronizationContext that would deadlock
-                // if we called .GetAwaiter().GetResult() directly.
-                var assignedPort = Task.Run(() => brokerReg.TryRegisterAsync(TimeSpan.FromSeconds(5))).GetAwaiter().GetResult();
-                if (assignedPort.HasValue)
-                {
-                    options.Port = assignedPort.Value;
-                    Console.WriteLine($"[Microsoft.Maui.DevFlow] Broker assigned port {assignedPort.Value}");
-                }
+                platform = DeviceInfo.Platform.ToString();
+                appName = AppInfo.Name ?? "unknown";
             }
-            catch (Exception ex)
+            catch
             {
-                Console.WriteLine($"[Microsoft.Maui.DevFlow] Broker registration failed: {ex.Message}");
-                brokerReg?.Dispose();
-                brokerReg = null;
+                // MAUI not fully initialized yet during DI registration
+                platform = OperatingSystem.IsAndroid() ? "Android"
+                    : OperatingSystem.IsIOS() ? "iOS"
+                    : OperatingSystem.IsMacCatalyst() ? "MacCatalyst"
+                    : OperatingSystem.IsMacOS() ? "macOS"
+                    : OperatingSystem.IsWindows() ? "Windows"
+                    : "Unknown";
+                appName = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown";
             }
+            brokerReg = new BrokerRegistration(project, tfm, platform, appName);
+            // If the user set a custom port, tell the broker upfront so it registers
+            // with that port instead of assigning one from the pool.
+            if (hasCustomPort)
+                brokerReg.CurrentPort = options.Port;
+            // Task.Run avoids deadlock: TryRegisterAsync uses await internally,
+            // and the main thread has a SynchronizationContext that would deadlock
+            // if we called .GetAwaiter().GetResult() directly.
+            var assignedPort = Task.Run(() => brokerReg.TryRegisterAsync(TimeSpan.FromSeconds(5))).GetAwaiter().GetResult();
+            if (assignedPort.HasValue)
+            {
+                options.Port = assignedPort.Value;
+                Console.WriteLine($"[Microsoft.Maui.DevFlow] Broker assigned port {assignedPort.Value}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Microsoft.Maui.DevFlow] Broker registration failed: {ex.Message}");
+            brokerReg?.Dispose();
+            brokerReg = null;
         }
 
         // Fall back to assembly metadata port if broker didn't assign one

--- a/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
@@ -3453,8 +3453,9 @@ class Program
             foreach (var agent in agents!)
             {
                 var uptime = DateTime.UtcNow - agent.ConnectedAt;
+                var totalHours = (int)uptime.TotalHours;
                 var uptimeStr = uptime.TotalHours >= 1
-                    ? $"{uptime.Hours}h {uptime.Minutes}m"
+                    ? $"{totalHours}h {uptime.Minutes}m"
                     : $"{uptime.Minutes}m {uptime.Seconds}s";
                 Console.WriteLine($"   • {agent.AppName} ({agent.Platform}, port {agent.Port}, uptime {uptimeStr})");
             }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
@@ -3718,37 +3718,64 @@ class Program
     /// Scans the current directory for csproj files containing DevFlow package references.
     /// Returns relative paths to projects that have DevFlow enabled.
     /// </summary>
+    private static readonly HashSet<string> _scanExcludedDirs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "bin", "obj", "node_modules", ".git", ".vs", ".idea", "packages"
+    };
+
     private static string[] ScanForDevFlowProjects()
     {
         var cwd = Directory.GetCurrentDirectory();
         var projects = new List<string>();
-        
+
         try
         {
-            var csprojFiles = Directory.EnumerateFiles(cwd, "*.csproj", SearchOption.AllDirectories);
-            
-            foreach (var csproj in csprojFiles)
+            var pending = new Queue<string>();
+            pending.Enqueue(cwd);
+
+            while (pending.Count > 0)
             {
-                // Skip bin, obj, node_modules, .git directories for performance
-                var relativePath = Path.GetRelativePath(cwd, csproj);
-                if (relativePath.Contains("/bin/") || relativePath.Contains("\\bin\\") ||
-                    relativePath.Contains("/obj/") || relativePath.Contains("\\obj\\") ||
-                    relativePath.Contains("/node_modules/") || relativePath.Contains("\\node_modules\\") ||
-                    relativePath.Contains("/.git/") || relativePath.Contains("\\.git\\"))
-                    continue;
-                
+                var dir = pending.Dequeue();
+
+                // Search for .csproj files in this directory only (not recursive)
                 try
                 {
-                    var content = File.ReadAllText(csproj);
-                    if (content.Contains("Redth.MauiDevFlow.Agent") || 
-                        content.Contains("Microsoft.Maui.DevFlow.Agent"))
+                    foreach (var csproj in Directory.EnumerateFiles(dir, "*.csproj", SearchOption.TopDirectoryOnly))
                     {
-                        projects.Add(relativePath);
+                        try
+                        {
+                            var content = File.ReadAllText(csproj);
+                            if (content.Contains("Redth.MauiDevFlow.Agent") ||
+                                content.Contains("Microsoft.Maui.DevFlow.Agent"))
+                            {
+                                projects.Add(Path.GetRelativePath(cwd, csproj));
+                            }
+                        }
+                        catch
+                        {
+                            // Skip files we can't read
+                        }
                     }
                 }
                 catch
                 {
-                    // Skip files we can't read
+                    // Skip directories we can't enumerate
+                    continue;
+                }
+
+                // Enqueue subdirectories, pruning excluded ones before recursing
+                try
+                {
+                    foreach (var subDir in Directory.EnumerateDirectories(dir, "*", SearchOption.TopDirectoryOnly))
+                    {
+                        var dirName = Path.GetFileName(subDir);
+                        if (!_scanExcludedDirs.Contains(dirName))
+                            pending.Enqueue(subDir);
+                    }
+                }
+                catch
+                {
+                    // Skip directories we can't enumerate
                 }
             }
         }
@@ -3756,7 +3783,8 @@ class Program
         {
             // If scanning fails, return empty array
         }
-        
+
+        projects.Sort(StringComparer.OrdinalIgnoreCase);
         return projects.ToArray();
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
@@ -3480,7 +3480,7 @@ class Program
                 Console.WriteLine();
                 Console.WriteLine("💡 Suggestion: Your project has DevFlow but no agent is connected.");
                 Console.WriteLine("   1. Ensure the app is running in Debug configuration");
-                Console.WriteLine($"   2. Run: maui-devflow wait --project {projects[0]}");
+                Console.WriteLine($"   2. Run: maui-devflow wait --project \"{projects[0].Replace("\"", "\\\"")}\"");
             }
         }
         else

--- a/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
@@ -3768,8 +3768,8 @@ class Program
                 {
                     foreach (var subDir in Directory.EnumerateDirectories(dir, "*", SearchOption.TopDirectoryOnly))
                     {
-                        var dirName = Path.GetFileName(subDir);
-                        if (!_scanExcludedDirs.Contains(dirName))
+                        var dirName = Path.GetFileName(subDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                        if (!string.IsNullOrEmpty(dirName) && !_scanExcludedDirs.Contains(dirName))
                             pending.Enqueue(subDir);
                     }
                 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
@@ -834,6 +834,11 @@ class Program
         listCmd.SetHandler(async (json, noJson) => await ListAgentsCommandAsync(OutputWriter.ResolveJsonMode(json, noJson)), jsonOption, noJsonOption);
         rootCommand.Add(listCmd);
 
+        // ===== diagnose command (end-to-end diagnostics) =====
+        var diagnoseCmd = new Command("diagnose", "Check DevFlow health: broker, agents, and project integration");
+        diagnoseCmd.SetHandler(async (json, noJson) => await DiagnoseCommandAsync(OutputWriter.ResolveJsonMode(json, noJson)), jsonOption, noJsonOption);
+        rootCommand.Add(diagnoseCmd);
+
         // ===== wait command (wait for agent to connect) =====
         var waitTimeoutOption = new Option<int>(
             ["--timeout", "-t"],
@@ -3343,7 +3348,34 @@ class Program
         var agents = await Broker.BrokerClient.ListAgentsAsync(port.Value);
         if (agents == null || agents.Length == 0)
         {
-            OutputWriter.WriteResult(Array.Empty<object>(), json, _ => Console.WriteLine("No agents connected"));
+            // Scan current directory for devflow-enabled projects
+            var projects = ScanForDevFlowProjects();
+            
+            if (json)
+            {
+                var result = new { agents = Array.Empty<object>(), projects };
+                OutputWriter.WriteResult(result, json);
+            }
+            else
+            {
+                Console.WriteLine("No agents connected.");
+                
+                if (projects.Length > 0)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine("DevFlow-enabled projects found:");
+                    foreach (var proj in projects)
+                    {
+                        Console.WriteLine($"  📦 {proj}");
+                    }
+                    Console.WriteLine();
+                    Console.WriteLine("Hint: Launch your app in Debug mode, then run 'maui-devflow wait'");
+                }
+                else
+                {
+                    Console.WriteLine("No DevFlow-enabled projects found in current directory.");
+                }
+            }
             return;
         }
 
@@ -3364,6 +3396,95 @@ class Program
                 var version = a.Version ?? "-";
                 Console.WriteLine($"{a.Id,-14} {a.AppName,-20} {a.Platform,-14} {a.Tfm,-24} {a.Port,-6} {version,-12} {uptimeStr}");
             }
+        }
+    }
+
+    private static async Task DiagnoseCommandAsync(bool json)
+    {
+        var diagnostics = new Dictionary<string, object>();
+        
+        // Get CLI version
+        var version = typeof(Program).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+        diagnostics["cli_version"] = version;
+        
+        // Check broker status
+        var brokerPort = await Broker.BrokerClient.EnsureBrokerRunningAsync();
+        var brokerRunning = brokerPort != null;
+        diagnostics["broker_running"] = brokerRunning;
+        if (brokerRunning)
+            diagnostics["broker_port"] = brokerPort!.Value;
+        
+        // List connected agents
+        var agents = brokerRunning ? await Broker.BrokerClient.ListAgentsAsync(brokerPort!.Value) : null;
+        var agentCount = agents?.Length ?? 0;
+        diagnostics["agent_count"] = agentCount;
+        diagnostics["agents"] = agents ?? Array.Empty<object>();
+        
+        // Scan for devflow-enabled projects
+        var projects = ScanForDevFlowProjects();
+        diagnostics["projects"] = projects;
+        
+        if (json)
+        {
+            OutputWriter.WriteResult(diagnostics, json);
+            return;
+        }
+        
+        // Human-readable output
+        Console.WriteLine("DevFlow Diagnostics");
+        Console.WriteLine("━━━━━━━━━━━━━━━━━━");
+        Console.WriteLine($"✅ CLI version:     {version}");
+        
+        if (brokerRunning)
+        {
+            Console.WriteLine($"✅ Broker:          Running on port {brokerPort} ({agentCount} agent(s) connected)");
+        }
+        else
+        {
+            Console.WriteLine($"❌ Broker:          Not running → Run 'maui-devflow broker start'");
+        }
+        
+        Console.WriteLine();
+        
+        if (agentCount > 0)
+        {
+            Console.WriteLine("✅ Connected agents:");
+            foreach (var agent in agents!)
+            {
+                var uptime = DateTime.UtcNow - agent.ConnectedAt;
+                var uptimeStr = uptime.TotalHours >= 1
+                    ? $"{uptime.Hours}h {uptime.Minutes}m"
+                    : $"{uptime.Minutes}m {uptime.Seconds}s";
+                Console.WriteLine($"   • {agent.AppName} ({agent.Platform}, port {agent.Port}, uptime {uptimeStr})");
+            }
+        }
+        else
+        {
+            Console.WriteLine("⚠️  No agents connected");
+        }
+        
+        Console.WriteLine();
+        
+        if (projects.Length > 0)
+        {
+            Console.WriteLine("📦 DevFlow-enabled projects:");
+            foreach (var proj in projects)
+            {
+                Console.WriteLine($"   • {proj}");
+            }
+            
+            if (agentCount == 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine("💡 Suggestion: Your project has DevFlow but no agent is connected.");
+                Console.WriteLine("   1. Ensure the app is running in Debug configuration");
+                Console.WriteLine($"   2. Run: maui-devflow wait --project {projects[0]}");
+            }
+        }
+        else
+        {
+            Console.WriteLine("📦 DevFlow-enabled projects: (none found in current directory)");
         }
     }
 
@@ -3590,5 +3711,51 @@ class Program
             tokens.Add(current.ToString());
 
         return tokens.ToArray();
+    }
+
+    /// <summary>
+    /// Scans the current directory for csproj files containing DevFlow package references.
+    /// Returns relative paths to projects that have DevFlow enabled.
+    /// </summary>
+    private static string[] ScanForDevFlowProjects()
+    {
+        var cwd = Directory.GetCurrentDirectory();
+        var projects = new List<string>();
+        
+        try
+        {
+            var csprojFiles = Directory.EnumerateFiles(cwd, "*.csproj", SearchOption.AllDirectories);
+            
+            foreach (var csproj in csprojFiles)
+            {
+                // Skip bin, obj, node_modules, .git directories for performance
+                var relativePath = Path.GetRelativePath(cwd, csproj);
+                if (relativePath.Contains("/bin/") || relativePath.Contains("\\bin\\") ||
+                    relativePath.Contains("/obj/") || relativePath.Contains("\\obj\\") ||
+                    relativePath.Contains("/node_modules/") || relativePath.Contains("\\node_modules\\") ||
+                    relativePath.Contains("/.git/") || relativePath.Contains("\\.git\\"))
+                    continue;
+                
+                try
+                {
+                    var content = File.ReadAllText(csproj);
+                    if (content.Contains("Redth.MauiDevFlow.Agent") || 
+                        content.Contains("Microsoft.Maui.DevFlow.Agent"))
+                    {
+                        projects.Add(relativePath);
+                    }
+                }
+                catch
+                {
+                    // Skip files we can't read
+                }
+            }
+        }
+        catch
+        {
+            // If scanning fails, return empty array
+        }
+        
+        return projects.ToArray();
     }
 }


### PR DESCRIPTION
## Fix: DevFlow Agent Always Registers with Broker

### Problem

When `AddMauiDevFlowAgent` is called with a custom port (e.g., `options.Port = 9224`), the agent **skipped broker registration entirely**. The agent's HTTP server started normally and was fully functional, but it was invisible to `maui-devflow list`.

This caused a real-world failure: an AI agent (Copilot CLI) ran `maui-devflow list`, didn't see SentenceStudio, and incorrectly concluded MauiDevFlow wasn't integrated — wasting multiple turns asking the human to do things the agent could have done itself.

### Root Cause

`AgentServiceExtensions.cs:34`:
```csharp
if (options.Port == AgentOptions.DefaultPort) // DefaultPort = 9223
{
    // Broker registration ONLY happens here
}
```

Any app with a non-default port (9224, 9225, etc.) bypassed the entire broker registration block. The design intent was "custom port = skip broker," but this silently broke discoverability.

### Fix (3 commits)

**Commit 1: SKILL.md intelligence** — Added Step 0 decision tree teaching AI agents to check project files before trusting `list` output.

**Commit 2: CLI observability** — Added `diagnose` command for end-to-end health checks, enhanced `list` with project scanning when no agents found, added ILogger throughout BrokerRegistration.cs (replaces empty `catch { }` blocks).

**Commit 3: The actual bug fix** — Removed the `if (options.Port == DefaultPort)` guard. Agents now ALWAYS register with the broker. When a custom port is set, `CurrentPort` is passed to the broker before registration so the broker uses the custom port (not one from the assignment pool). No broker-side changes needed — `BrokerServer.cs:161` already supports `currentPort`.

### Before / After

| Metric | Before | After |
|--------|--------|-------|
| SentenceStudio visible in `list` | ❌ Never | ✅ Always |
| Custom port preserved | ✅ 9224 | ✅ 9224 |
| Broker log shows connection | ❌ Zero entries ever | ✅ `Agent connected: SentenceStudio\|net10.0-ios → port 9224` |
| Agent HTTP API works | ✅ (via direct port) | ✅ (via broker discovery OR direct) |
| `MAUI screenshot` via broker | ❌ Must know port manually | ✅ Auto-discovered |
| BrokerRegistration has logging | ❌ All catch blocks empty | ✅ ILogger throughout |
| AI agent can find non-running apps | ❌ No project scanning | ✅ `diagnose` + `list` scan csproj |

### Reproduction

1. Create a MAUI app with `builder.AddMauiDevFlowAgent(o => o.Port = 9224)`
2. Build and run in Debug
3. Run `maui-devflow list` → agent missing (before fix)
4. Run `curl localhost:9224/api/status` → agent is alive
5. After fix: `maui-devflow list` shows the agent on port 9224

### Tested On

- SentenceStudio.iOS on iPhone 11 simulator (iOS 26.2)
- Custom agent package v0.24.0-dev built from this branch
- Broker 0.23.1, alongside Comet apps using agent v0.18.0
- Verified: screenshot, status, broker log all working
