### PR TITLE
Add fullscreen screenshot mode for safe area and edge verification

### DIFF
--- a/.claude/skills/maui-ai-debugging/SKILL.md
+++ b/.claude/skills/maui-ai-debugging/SKILL.md
@@ -200,6 +200,7 @@ if the build fails.
 7. `maui-devflow MAUI screenshot --output screen.png` — visual verification (auto-scaled to 1x on HiDPI)
 8. `maui-devflow MAUI screenshot --id <elementId> --output el.png` — element-only screenshot
 9. `maui-devflow MAUI screenshot --selector "Button" --output btn.png` — screenshot by CSS selector
+10. `maui-devflow MAUI screenshot --fullscreen --output full.png` — full device display including status bar and safe areas
 
 **Property inspection** is more reliable than screenshots for verifying exact runtime values:
 ```bash
@@ -430,7 +431,7 @@ resolution options are provided.
 | `MAUI clear [elementId] [--automationId A] [--type T] [--text T] [--index N] [--and-screenshot [path]] [--and-tree]` | Clear text. elementId optional when using resolution options |
 | `MAUI focus [elementId] [--automationId A] [--type T] [--text T] [--index N]` | Set focus. elementId optional when using resolution options |
 | `MAUI assert [--id ID] [--automationId A] <property> <expected>` | Assert element property value. Exit 0 if match, 1 if mismatch. Ideal for verification without screenshots |
-| `MAUI screenshot [--output path.png] [--window W] [--id ID] [--selector SEL] [--overwrite] [--max-width N] [--scale native]` | PNG screenshot. Auto-scales to 1x logical resolution on HiDPI displays (2x, 3x). Use `--scale native` for full resolution. `--max-width N` overrides auto-scaling with explicit width. `--overwrite` replaces existing file |
+| `MAUI screenshot [--output path.png] [--window W] [--id ID] [--selector SEL] [--fullscreen] [--overwrite] [--max-width N] [--scale native]` | PNG screenshot. Default captures **Page content area only** (excludes status bar, home indicator, safe areas). `--fullscreen` captures the complete device display including system chrome and safe area regions. Auto-scales to 1x logical resolution on HiDPI displays (2x, 3x). Use `--scale native` for full resolution. `--max-width N` overrides auto-scaling with explicit width. `--overwrite` replaces existing file |
 | `MAUI property <elementId> <prop>` | Read property (Text, IsVisible, FontSize, etc.) |
 | `MAUI set-property <elementId> <prop> <value>` | Set property (live editing — colors, text, sizes, etc.) |
 | `MAUI element <elementId>` | Full element JSON (type, bounds, children, etc.) |
@@ -597,6 +598,7 @@ their input.
 - Use **`--format compact`** for minimal tree output (id, type, text, automationId, bounds).
 - **Prefer `MAUI query --automationId`** over full tree traversal — much smaller response.
 - Use **element-level screenshots** (`--id <elementId>`) when you only need to see one control.
+- Use **`--fullscreen`** when verifying layout near screen edges, safe areas, or device chrome — default screenshots exclude these.
 
 ### Adaptive Depth Learning
 MAUI app trees vary in depth — a simple app might have controls at depth 8, while a complex app
@@ -622,6 +624,38 @@ the screenshot dimensions accordingly. This happens server-side before transfer.
   ```bash
   maui-devflow MAUI screenshot --output screen.png --max-width 600
   ```
+
+### Safe Area & Edge Verification
+Default screenshots capture the **Page content area only** — they do NOT include the device
+status bar, home indicator, notch, Dynamic Island, or navigation bar chrome. This means layout
+issues near screen edges are invisible in default screenshots.
+
+**When to use `--fullscreen`:** Use fullscreen mode whenever the user mentions or you need to
+verify anything related to:
+- Safe areas, safe area insets, or `UseSafeArea`
+- Content being cut off, clipped, or hidden at screen edges
+- Status bar overlap, notch clearance, or Dynamic Island avoidance
+- Home indicator area, bottom bar, or navigation bar overlap
+- Layout near the top or bottom of the screen
+- Rounded corner clipping on modern devices
+- Toolbar or tab bar positioning relative to device chrome
+- Keyboard avoiding behavior and content shifting
+- Screen edge gestures conflicting with swipe-based UI
+
+```bash
+# Full device display — shows status bar, safe areas, home indicator
+maui-devflow MAUI screenshot --fullscreen --output full-device.png
+
+# Compare: default captures Page content only
+maui-devflow MAUI screenshot --output page-only.png
+```
+
+**Verify safe area padding via properties** (complement to fullscreen screenshots):
+```bash
+maui-devflow MAUI property <id> Padding      # check if padding accounts for safe area
+maui-devflow MAUI property <id> Margin        # check margins near edges
+maui-devflow MAUI platform display            # get screen density, size, orientation
+```
 
 ### Eliminating Round-Trips
 - **Use implicit resolution** instead of query-then-act:

--- a/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/ScreenshotTool.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/ScreenshotTool.cs
@@ -20,12 +20,15 @@ public sealed class ScreenshotTool
 		[Description("Resize screenshot to this max width in pixels (overrides auto-scaling)")] int? maxWidth = null,
 		[Description("Scale mode: 'native' keeps full HiDPI resolution, default auto-scales to 1x logical pixels")] string? scale = null)
 	{
+		if (fullscreen && (!string.IsNullOrWhiteSpace(elementId) || !string.IsNullOrWhiteSpace(selector)))
+			throw new McpException("'fullscreen' and 'elementId'/'selector' are mutually exclusive. Omit elementId/selector for a fullscreen screenshot, or set fullscreen=false to capture a specific element.");
+
 		var agent = await session.GetAgentClientAsync(agentPort);
 		var bytes = await agent.ScreenshotAsync(window, elementId, selector, maxWidth, scale, fullscreen);
 		if (bytes == null || bytes.Length == 0)
 			throw new McpException("Screenshot failed — no image data returned. Is the agent connected and the app visible?");
 
-		var modeLabel = fullscreen ? "fullscreen" : (elementId ?? selector) != null ? "element" : "page";
+		var modeLabel = fullscreen ? "fullscreen" : !string.IsNullOrWhiteSpace(elementId) || !string.IsNullOrWhiteSpace(selector) ? "element" : "page";
 		return [
 			new TextContentBlock { Text = $"Screenshot captured ({bytes.Length} bytes, PNG, mode: {modeLabel})" },
 			ImageContentBlock.FromBytes(bytes, "image/png")

--- a/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/ScreenshotTool.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/ScreenshotTool.cs
@@ -9,23 +9,25 @@ namespace Microsoft.Maui.DevFlow.CLI.Mcp.Tools;
 [McpServerToolType]
 public sealed class ScreenshotTool
 {
-	[McpServerTool(Name = "maui_screenshot"), Description("Capture a screenshot of the running MAUI app. Returns the image directly for visual verification of layout, colors, contrast, and rendering.")]
+	[McpServerTool(Name = "maui_screenshot"), Description("Capture a screenshot of the running MAUI app. Returns the image directly for visual verification of layout, colors, contrast, and rendering. By default captures the Page content area only. Use fullscreen=true to capture the complete device display including status bar, navigation bar, and safe area regions — use this when verifying layout near screen edges, notch/Dynamic Island areas, or safe area insets.")]
 	public static async Task<ContentBlock[]> Screenshot(
 		McpAgentSession session,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
 		[Description("Window index for multi-window apps (default: 0)")] int? window = null,
 		[Description("Element ID to capture a specific element")] string? elementId = null,
 		[Description("CSS selector to capture (first match, Blazor WebViews only)")] string? selector = null,
+		[Description("Capture the complete device display including status bar, home indicator, and safe area regions. Use when verifying edge layout, safe areas, notch clearance, or content near screen boundaries. Default: false (captures Page content area only)")] bool fullscreen = false,
 		[Description("Resize screenshot to this max width in pixels (overrides auto-scaling)")] int? maxWidth = null,
 		[Description("Scale mode: 'native' keeps full HiDPI resolution, default auto-scales to 1x logical pixels")] string? scale = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var bytes = await agent.ScreenshotAsync(window, elementId, selector, maxWidth, scale);
+		var bytes = await agent.ScreenshotAsync(window, elementId, selector, maxWidth, scale, fullscreen);
 		if (bytes == null || bytes.Length == 0)
 			throw new McpException("Screenshot failed — no image data returned. Is the agent connected and the app visible?");
 
+		var modeLabel = fullscreen ? "fullscreen" : (elementId ?? selector) != null ? "element" : "page";
 		return [
-			new TextContentBlock { Text = $"Screenshot captured ({bytes.Length} bytes, PNG)" },
+			new TextContentBlock { Text = $"Screenshot captured ({bytes.Length} bytes, PNG, mode: {modeLabel})" },
 			ImageContentBlock.FromBytes(bytes, "image/png")
 		];
 	}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.CLI/Program.cs
@@ -308,7 +308,8 @@ class Program
         var screenshotOverwriteOption = new Option<bool>("--overwrite", () => false, "Overwrite existing file (default: fail if exists)");
         var screenshotMaxWidthOption = new Option<int?>("--max-width", "Resize screenshot to this max width (overrides auto-scaling)");
         var screenshotScaleOption = new Option<string?>("--scale", "Scale mode: 'native' keeps full HiDPI resolution, default auto-scales to 1x logical pixels");
-        var mauiScreenshotCmd = new Command("screenshot", "Take screenshot") { screenshotOutputOption, windowOption, screenshotIdOption, screenshotSelectorOption, screenshotOverwriteOption, screenshotMaxWidthOption, screenshotScaleOption };
+        var screenshotFullscreenOption = new Option<bool>("--fullscreen", () => false, "Capture complete device display including status bar and safe areas");
+        var mauiScreenshotCmd = new Command("screenshot", "Take screenshot") { screenshotOutputOption, windowOption, screenshotIdOption, screenshotSelectorOption, screenshotOverwriteOption, screenshotMaxWidthOption, screenshotScaleOption, screenshotFullscreenOption };
         mauiScreenshotCmd.SetHandler(async (ctx) =>
         {
             var host = ctx.ParseResult.GetValueForOption(agentHostOption)!;
@@ -321,7 +322,8 @@ class Program
                 ctx.ParseResult.GetValueForOption(screenshotSelectorOption),
                 ctx.ParseResult.GetValueForOption(screenshotOverwriteOption),
                 ctx.ParseResult.GetValueForOption(screenshotMaxWidthOption),
-                ctx.ParseResult.GetValueForOption(screenshotScaleOption));
+                ctx.ParseResult.GetValueForOption(screenshotScaleOption),
+                ctx.ParseResult.GetValueForOption(screenshotFullscreenOption));
         });
         mauiCommand.Add(mauiScreenshotCmd);
 
@@ -2010,7 +2012,7 @@ class Program
         catch (Exception ex) { OutputWriter.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
-    private static async Task MauiScreenshotAsync(string host, int port, bool json, string? output, int? window, string? id, string? selector, bool overwrite = false, int? maxWidth = null, string? scale = null)
+    private static async Task MauiScreenshotAsync(string host, int port, bool json, string? output, int? window, string? id, string? selector, bool overwrite = false, int? maxWidth = null, string? scale = null, bool fullscreen = false)
     {
         try
         {
@@ -2044,7 +2046,7 @@ class Program
             // Fall back to agent-based screenshot (or used for element-scoped captures)
             if (data == null)
             {
-                data = await client.ScreenshotAsync(window, id, selector, maxWidth, scale);
+                data = await client.ScreenshotAsync(window, id, selector, maxWidth, scale, fullscreen);
             }
 
             if (data == null)
@@ -2064,11 +2066,11 @@ class Program
             var fullPath = Path.GetFullPath(filename);
             if (json)
             {
-                OutputWriter.WriteResult(new { path = fullPath, size = data.Length, maxWidth = maxWidth, scale = scale ?? "auto" }, json);
+                OutputWriter.WriteResult(new { path = fullPath, size = data.Length, maxWidth = maxWidth, scale = scale ?? "auto", fullscreen }, json);
             }
             else
             {
-                var target = id != null ? $" (element: {id})" : selector != null ? $" (selector: {selector})" : "";
+                var target = id != null ? $" (element: {id})" : selector != null ? $" (selector: {selector})" : fullscreen ? " (fullscreen)" : "";
                 var scaleInfo = scale?.Equals("native", StringComparison.OrdinalIgnoreCase) == true ? " (native resolution)" :
                                 maxWidth != null ? $" (max-width: {maxWidth}px)" : " (auto-scaled to 1x)";
                 Console.WriteLine($"Screenshot saved: {fullPath} ({data.Length} bytes){target}{scaleInfo}");

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -145,13 +145,15 @@ public class AgentClient : IDisposable
     /// <summary>
     /// Take a screenshot (returns PNG bytes).
     /// Optionally target a specific element by ID or CSS selector.
+    /// When fullscreen is true, captures the complete device display including status bar and safe areas.
     /// </summary>
-    public async Task<byte[]?> ScreenshotAsync(int? window = null, string? elementId = null, string? selector = null, int? maxWidth = null, string? scale = null)
+    public async Task<byte[]?> ScreenshotAsync(int? window = null, string? elementId = null, string? selector = null, int? maxWidth = null, string? scale = null, bool fullscreen = false)
     {
         try
         {
             var queryParams = new List<string>();
             if (window != null) queryParams.Add($"window={window}");
+            if (fullscreen) queryParams.Add("fullscreen=true");
             if (elementId != null) queryParams.Add($"id={Uri.EscapeDataString(elementId)}");
             if (selector != null) queryParams.Add($"selector={Uri.EscapeDataString(selector)}");
             if (maxWidth != null) queryParams.Add($"maxWidth={maxWidth}");


### PR DESCRIPTION
## Problem

When an AI agent uses DevFlow to verify layout near screen edges, it takes a default screenshot that captures only the **Page content area** — excluding the status bar, home indicator, notch/Dynamic Island, and safe area regions. The agent then concludes the layout "looks fine" because it literally cannot see the device chrome the content may be overlapping with.

The in-app HTTP API already has a `fullscreen=true` query parameter on `/api/screenshot` that triggers composited full-device capture (all UIWindows on iOS, CGWindowListCreateImage on macOS), but this parameter was **never wired through** to:
- `AgentClient.ScreenshotAsync()`
- The `maui_screenshot` MCP tool
- The CLI `MAUI screenshot` command

The CLI had a separate workaround for iOS (`simctl io screenshot` fallback), but the MCP tool path — which is what AI agents use — had no way to request a full-device capture.

## Changes

### Code (parameter threading)
| Layer | Change |
|-------|--------|
| **AgentClient** | New `bool fullscreen = false` parameter on `ScreenshotAsync()`, sends `fullscreen=true` query param |
| **MCP Tool** | New `fullscreen` parameter with rich description guiding agents to use it for edge/safe area checks |
| **CLI** | New `--fullscreen` option on `MAUI screenshot` command |
| **Output** | JSON output includes `fullscreen` field; text output shows `(fullscreen)` label; MCP returns mode label |

`fullscreen` defaults to `false` to preserve token efficiency — full-device screenshots are larger and most verification doesn't need them.

### Skill file (AI agent guidance)
- **New "Safe Area & Edge Verification" section** — explains the default vs fullscreen difference and lists trigger keywords for when agents should automatically use fullscreen:
  - Safe areas, insets, `UseSafeArea`
  - Content clipping/cutoff at screen edges
  - Status bar overlap, notch clearance, Dynamic Island
  - Home indicator, bottom bar, navigation bar overlap
  - Rounded corner clipping
  - Toolbar/tab bar positioning relative to device chrome
  - Keyboard avoiding behavior
- **Updated command reference table** — documents both modes
- **Token usage tips** — mentions `--fullscreen` alongside element-level screenshots
- **Inspection flow** — added fullscreen example

## Testing

The `fullscreen=true` HTTP API parameter already worked end-to-end (it's been in `DevFlowAgentService.HandleScreenshot` since inception). This PR only wires it through the public API layers. CI will validate compilation.