### PR TITLE
Add AI agent configuration: AGENTS.md, copilot-instructions, and instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,9 +122,9 @@ The repo is at 0.1.0-preview so breaking changes are acceptable, but:
 
 - **Framework**: xUnit v2.9.3
 - **Naming**: `MethodName_Condition_ExpectedResult` or descriptive `[Fact]` names
-- **Location**: `src/{Product}/*.Tests/` or `src/{Product}/*.UnitTests/`
+- **Location**: `src/DevFlow/Microsoft.Maui.DevFlow.Tests/`
 - **Coverage**: coverlet.collector
-- **Fakes**: DevFlow tests use real Agent.Core code; Client tests use `FakeAndroidProvider`, `FakeJdkManager` etc.
+- **Approach**: DevFlow tests use real Agent.Core code — they instantiate actual services and test behavior
 
 ## Arcade SDK Gotchas
 
@@ -134,13 +134,13 @@ The repo is at 0.1.0-preview so breaking changes are acceptable, but:
 - **Signing**: configured in `eng/Signing.props`. New third-party DLLs need a `3PartySHA2` entry.
 - **Version**: defined in `eng/Versions.props` (`VersionPrefix` + `VersionSuffix`). Per-product overrides in `src/{Product}/Version.props`.
 
-## Maui.Client Conventions
+## Maui.Client Conventions (Future — Not Yet Present)
 
-The Client product (`src/Client/`) uses a DI-based architecture with provider interfaces:
+A Client product (`src/Client/`) is planned but not yet present in this repository. When added, it will use a DI-based architecture with provider interfaces:
 
 - `IAndroidProvider` — discovers and installs Android SDK components
 - `IJdkManager` — manages JDK installations
 - `IDeviceManager` — lists and manages Android emulators
 - `IDoctorService` — runs environment health checks
 
-When adding new functionality, define an interface first, implement it, register in `Program.Services`.
+Define an interface first, implement it, register in `Program.Services`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,146 @@
+# Copilot Instructions for maui-labs
+
+These instructions guide GitHub Copilot and other AI code generation tools when working with the maui-labs repository.
+
+## Platform-Specific Code
+
+DevFlow targets multiple platforms via multi-targeting. The pattern:
+
+- **`Microsoft.Maui.DevFlow.Agent.Core`** targets `net10.0` — all platform-agnostic code lives here.
+- **`Microsoft.Maui.DevFlow.Agent`** targets `net10.0-android`, `net10.0-ios`, `net10.0-maccatalyst`, `net10.0-macos`, `net10.0-windows10.0.19041.0` — platform-specific overrides.
+- **`Microsoft.Maui.DevFlow.Agent.Gtk`** targets `net10.0` — Linux/GTK-specific code.
+
+Use `#if` directives for platform code in multi-targeting projects:
+
+```csharp
+#if IOS || MACCATALYST
+    // iOS and Mac Catalyst share UIKit
+    return uiWindow.Screen.Scale;
+#elif ANDROID
+    return activity.Resources?.DisplayMetrics?.Density ?? 1.0;
+#elif WINDOWS
+    return xamlRoot.RasterizationScale;
+#elif MACOS
+    return nsWindow.BackingScaleFactor;
+#endif
+```
+
+**Important**: Both `.ios.cs` and `.maccatalyst.cs` files compile for Mac Catalyst. Use `#if IOS || MACCATALYST` when code applies to both.
+
+## Agent Architecture (Core/Platform Pattern)
+
+When adding new features to the DevFlow agent:
+
+1. **Add the virtual method in `Agent.Core/DevFlowAgentService.cs`** — this is the platform-agnostic base
+2. **Override in `Agent/DevFlowAgentService.cs`** with `#if` directives for platform-specific behavior
+3. **Override in `Agent.Gtk/GtkAgentService.cs`** for Linux/GTK if needed
+
+Example:
+```csharp
+// In Agent.Core/DevFlowAgentService.cs
+protected virtual Task<byte[]?> CaptureFullScreenAsync() => Task.FromResult<byte[]?>(null);
+
+// In Agent/DevFlowAgentService.cs
+#if IOS || MACCATALYST
+protected override Task<byte[]?> CaptureFullScreenAsync()
+    => DispatchAsync(() => CaptureAllWindowsComposited());
+#elif MACOS
+protected override async Task<byte[]?> CaptureFullScreenAsync() { /* AppKit capture */ }
+#endif
+```
+
+## MCP Tool Conventions
+
+MCP tools live in `src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/`. When creating a new tool:
+
+1. Create a new file in the `Tools/` directory
+2. Use `[McpServerToolType]` on the class, `[McpServerTool]` on the method
+3. **Every parameter must have a `[Description]`** — this is what AI agents see
+4. Tool names use the `maui_` prefix and snake_case: `maui_screenshot`, `maui_tap`
+5. First parameter is always `McpAgentSession session`
+6. Use `session.GetAgentClientAsync(agentPort)` for agent resolution
+7. **Register the tool** in `Mcp/McpServerHost.cs`: `.WithTools<YourTool>()`
+
+```csharp
+[McpServerToolType]
+public sealed class MyNewTool
+{
+    [McpServerTool(Name = "maui_my_action"),
+     Description("Clear description of what this tool does and when to use it.")]
+    public static async Task<string> MyAction(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+        [Description("Describe this parameter clearly")] string requiredParam,
+        [Description("Describe this optional parameter")] string? optionalParam = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        // Use agent.* methods
+        return "Result";
+    }
+}
+```
+
+## HTTP Endpoint Conventions
+
+Agent HTTP endpoints are defined in `DevFlowAgentService.cs` (in Agent.Core). When adding new endpoints:
+
+1. Register the route in the `ConfigureRoutes()` method: `_server.MapGet("/api/myendpoint", HandleMyEndpoint);`
+2. Implement the handler as `protected virtual async Task<HttpResponse> HandleMyEndpoint(HttpRequest request)`
+3. For POST endpoints that accept JSON bodies, define a DTO class at the bottom of the file
+4. **Add a corresponding method in `AgentClient`** (in `Microsoft.Maui.DevFlow.Driver`) — this is the public API
+
+```csharp
+// In DevFlowAgentService.cs — handler
+protected virtual async Task<HttpResponse> HandleMyEndpoint(HttpRequest request) { ... }
+
+// In AgentClient.cs — public API (this is what NuGet consumers use)
+public async Task<MyResult?> MyEndpointAsync(string param) { ... }
+```
+
+## CLI Command Conventions
+
+CLI commands use **System.CommandLine** in `Program.cs`:
+
+- Use `Option<T>` for named parameters, `Argument<T>` for positional
+- Support `--json` / `--no-json` output modes via `OutputWriter`
+- Use `SetHandler` with `InvocationContext` for commands with many options
+- Post-action flags: `--and-screenshot`, `--and-tree`, `--and-tree-depth` for verification after mutations
+
+## Driver Library (AgentClient)
+
+`Microsoft.Maui.DevFlow.Driver/AgentClient.cs` is the **public API for NuGet consumers**. Changes to method signatures are:
+
+- **Binary breaking** — existing compiled code stops working
+- **Source breaking** — existing source code fails to compile
+
+The repo is at 0.1.0-preview so breaking changes are acceptable, but:
+- Document breaking changes in the PR description
+- Add the `breaking-change` label to the PR
+- Update parameter defaults so existing callers keep working where possible (add new params with defaults at the end)
+
+## Test Patterns
+
+- **Framework**: xUnit v2.9.3
+- **Naming**: `MethodName_Condition_ExpectedResult` or descriptive `[Fact]` names
+- **Location**: `src/{Product}/*.Tests/` or `src/{Product}/*.UnitTests/`
+- **Coverage**: coverlet.collector
+- **Fakes**: DevFlow tests use real Agent.Core code; Client tests use `FakeAndroidProvider`, `FakeJdkManager` etc.
+
+## Arcade SDK Gotchas
+
+- **Never modify `eng/common/`** — auto-generated by Arcade SDK, overwritten by Dependency Flow
+- **Central Package Management**: specify package versions **only** in `Directory.Packages.props`, not in `.csproj` files
+- **`IsShipping` and `IsPackable`**: default `false` in `Directory.Build.props`. Shipped projects explicitly set `true`.
+- **Signing**: configured in `eng/Signing.props`. New third-party DLLs need a `3PartySHA2` entry.
+- **Version**: defined in `eng/Versions.props` (`VersionPrefix` + `VersionSuffix`). Per-product overrides in `src/{Product}/Version.props`.
+
+## Maui.Client Conventions
+
+The Client product (`src/Client/`) uses a DI-based architecture with provider interfaces:
+
+- `IAndroidProvider` — discovers and installs Android SDK components
+- `IJdkManager` — manages JDK installations
+- `IDeviceManager` — lists and manages Android emulators
+- `IDoctorService` — runs environment health checks
+
+When adding new functionality, define an interface first, implement it, register in `Program.Services`.

--- a/.github/instructions/devflow-architecture.instructions.md
+++ b/.github/instructions/devflow-architecture.instructions.md
@@ -9,24 +9,27 @@ applyTo: "src/DevFlow/**"
 DevFlow uses a three-tier architecture:
 
 ```
-┌──────────────┐     HTTP      ┌──────────────┐     HTTP      ┌──────────────────────────┐
-│  CLI / MCP   │ ◄──────────►  │    Broker     │ ◄──────────►  │  Agent (in-app)          │
-│  (maui-devflow)│             │  (port 19223) │               │  (dynamic port)          │
-└──────────────┘               └──────────────┘               └──────────────────────────┘
-      ▲                                                               │
-      │ MCP (stdio)                                                   │ Platform APIs
-      ▼                                                               ▼
-┌──────────────┐                                              ┌──────────────────────────┐
-│  AI Agent    │                                              │  MAUI App Runtime        │
-│  (Copilot,   │                                              │  (Visual Tree, Pages,    │
-│   Claude,    │                                              │   Navigation, CDP)       │
-│   etc.)      │                                              └──────────────────────────┘
+┌──────────────┐                ┌──────────────┐                ┌──────────────────────────┐
+│  CLI / MCP   │  HTTP (direct) │    Broker     │  WebSocket     │  Agent (in-app)          │
+│  (maui-devflow)│ ◄──────────► │  (port 19223) │ ◄───────────── │  (dynamic port)          │
+└──────────────┘  (after port   └──────────────┘  (registration) └──────────────────────────┘
+      │            discovery)          │                                │
+      │ HTTP (direct, after discovery) │                                │ Platform APIs
+      └────────────────────────────────┼────────────────────────────────┘
+      ▲                                                               
+      │ MCP (stdio)                                                   
+      ▼                                                               
+┌──────────────┐                                              
+│  AI Agent    │                                              
+│  (Copilot,   │                                              
+│   Claude,    │                                              
+│   etc.)      │                                              
 └──────────────┘
 ```
 
-1. **Agent** runs inside the MAUI app process (added via NuGet package). Exposes HTTP API on a dynamic port. Has direct access to the visual tree, pages, platform views.
-2. **Broker** runs on the developer machine (port 19223). Agents register with it. CLI discovers agents through it.
-3. **CLI** (`maui-devflow`) communicates with agents via the broker. Also hosts the MCP server for AI agent integration.
+1. **Agent** runs inside the MAUI app process (added via NuGet package). Exposes HTTP API on a dynamic port. Registers with the Broker over WebSocket. Has direct access to the visual tree, pages, platform views.
+2. **Broker** runs on the developer machine (port 19223). Agents register with it via WebSocket. CLI discovers agent ports through the broker's HTTP API.
+3. **CLI** (`maui-devflow`) discovers agents via the broker, then communicates **directly** with agents over HTTP. Also hosts the MCP server for AI agent integration.
 
 ## Package Dependency Graph
 
@@ -35,13 +38,13 @@ Microsoft.Maui.DevFlow.CLI (global tool)
 ├── Microsoft.Maui.DevFlow.Driver (AgentClient — public API)
 ├── ModelContextProtocol (MCP server)
 ├── System.CommandLine (CLI framework)
-└── Spectre.Console (terminal UI)
+├── Spectre.Console (terminal UI)
+└── Websocket.Client (broker transport)
 
 Microsoft.Maui.DevFlow.Agent (NuGet package for app developers)
 ├── Microsoft.Maui.DevFlow.Agent.Core (HTTP server, visual tree, interactions)
 │   ├── Fizzler (CSS selector parsing)
-│   ├── SkiaSharp (screenshot capture/resize)
-│   └── Websocket.Client
+│   └── SkiaSharp (screenshot capture/resize)
 └── Microsoft.Maui.DevFlow.Blazor (optional — CDP bridge for Blazor WebViews)
 
 Microsoft.Maui.DevFlow.Agent.Gtk (NuGet package for GTK/Linux apps)

--- a/.github/instructions/devflow-architecture.instructions.md
+++ b/.github/instructions/devflow-architecture.instructions.md
@@ -1,0 +1,96 @@
+---
+applyTo: "src/DevFlow/**"
+---
+
+# DevFlow Architecture
+
+## Communication Model
+
+DevFlow uses a three-tier architecture:
+
+```
+┌──────────────┐     HTTP      ┌──────────────┐     HTTP      ┌──────────────────────────┐
+│  CLI / MCP   │ ◄──────────►  │    Broker     │ ◄──────────►  │  Agent (in-app)          │
+│  (maui-devflow)│             │  (port 19223) │               │  (dynamic port)          │
+└──────────────┘               └──────────────┘               └──────────────────────────┘
+      ▲                                                               │
+      │ MCP (stdio)                                                   │ Platform APIs
+      ▼                                                               ▼
+┌──────────────┐                                              ┌──────────────────────────┐
+│  AI Agent    │                                              │  MAUI App Runtime        │
+│  (Copilot,   │                                              │  (Visual Tree, Pages,    │
+│   Claude,    │                                              │   Navigation, CDP)       │
+│   etc.)      │                                              └──────────────────────────┘
+└──────────────┘
+```
+
+1. **Agent** runs inside the MAUI app process (added via NuGet package). Exposes HTTP API on a dynamic port. Has direct access to the visual tree, pages, platform views.
+2. **Broker** runs on the developer machine (port 19223). Agents register with it. CLI discovers agents through it.
+3. **CLI** (`maui-devflow`) communicates with agents via the broker. Also hosts the MCP server for AI agent integration.
+
+## Package Dependency Graph
+
+```
+Microsoft.Maui.DevFlow.CLI (global tool)
+├── Microsoft.Maui.DevFlow.Driver (AgentClient — public API)
+├── ModelContextProtocol (MCP server)
+├── System.CommandLine (CLI framework)
+└── Spectre.Console (terminal UI)
+
+Microsoft.Maui.DevFlow.Agent (NuGet package for app developers)
+├── Microsoft.Maui.DevFlow.Agent.Core (HTTP server, visual tree, interactions)
+│   ├── Fizzler (CSS selector parsing)
+│   ├── SkiaSharp (screenshot capture/resize)
+│   └── Websocket.Client
+└── Microsoft.Maui.DevFlow.Blazor (optional — CDP bridge for Blazor WebViews)
+
+Microsoft.Maui.DevFlow.Agent.Gtk (NuGet package for GTK/Linux apps)
+├── Microsoft.Maui.DevFlow.Agent.Core
+└── Microsoft.Maui.DevFlow.Blazor.Gtk (optional — WebKitGTK CDP)
+
+Microsoft.Maui.DevFlow.Logging (standalone — no MAUI dependency)
+```
+
+## Key Extension Points
+
+### Adding a New HTTP Endpoint
+
+1. Add route in `Agent.Core/DevFlowAgentService.cs` → `ConfigureRoutes()`:
+   ```csharp
+   _server.MapGet("/api/myfeature", HandleMyFeature);
+   ```
+2. Implement handler (virtual for platform override):
+   ```csharp
+   protected virtual async Task<HttpResponse> HandleMyFeature(HttpRequest request) { ... }
+   ```
+3. Add DTO class at bottom of `DevFlowAgentService.cs` if needed
+4. Add client method in `Driver/AgentClient.cs`
+5. Optionally expose as MCP tool and/or CLI command
+
+### Adding a New MCP Tool
+
+See `mcp-tools.instructions.md`.
+
+### Adding Platform-Specific Behavior
+
+Override virtual methods from `Agent.Core/DevFlowAgentService.cs`:
+
+- In `Agent/DevFlowAgentService.cs` with `#if` directives for iOS/Android/macOS/Windows
+- In `Agent.Gtk/GtkAgentService.cs` for Linux/GTK
+- Always call `await DispatchAsync(() => ...)` to run on the UI thread
+
+## Visual Tree and Element Resolution
+
+- `VisualTreeWalker` recursively walks MAUI's `IVisualTreeElement` hierarchy
+- Each element gets a unique ID (ephemeral, regenerated on tree changes)
+- Elements are resolved by: element ID, AutomationId, type, text content, CSS selector
+- `ElementInfo` captures: Id, Type, AutomationId, Text, IsVisible, IsEnabled, Bounds, WindowBounds
+- CSS selectors (Fizzler) work in Blazor WebViews via CDP
+
+## Screenshot Capture Flow
+
+1. **Default** (no params): captures `window.Page` via `VisualDiagnostics.CaptureAsPngAsync` — page content only
+2. **Element** (`--id` or `--selector`): captures specific element bounds
+3. **Fullscreen** (`--fullscreen`): platform-specific composited capture including status bar and safe areas
+4. **iOS CLI fallback**: `simctl io screenshot` for full simulator display
+5. All screenshots auto-scale to 1x logical resolution (configurable via `--scale native`)

--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -1,0 +1,91 @@
+---
+applyTo: "src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/**"
+---
+
+# MCP Tool Development Guide
+
+## Adding a New MCP Tool
+
+### Step 1: Create the Tool File
+
+Create `src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/MyNewTool.cs`:
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Protocol;
+using Microsoft.Maui.DevFlow.CLI.Mcp;
+
+namespace Microsoft.Maui.DevFlow.CLI.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class MyNewTool
+{
+    [McpServerTool(Name = "maui_my_action"),
+     Description("Clear, complete description of what this tool does. Mention when an AI agent should use it.")]
+    public static async Task<string> MyAction(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+        [Description("Describe what this parameter controls")] string requiredParam,
+        [Description("Describe this optional parameter and its default behavior")] bool optionalFlag = false)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        // Call agent.* methods to interact with the running app
+        var result = await agent.SomeMethodAsync(requiredParam);
+        return result ?? "No result";
+    }
+}
+```
+
+### Step 2: Register the Tool
+
+Add to `src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/McpServerHost.cs`:
+
+```csharp
+.WithTools<MyNewTool>()
+```
+
+### Step 3: Add the Corresponding AgentClient Method (if needed)
+
+If the tool calls a new agent endpoint, add the client method in `Microsoft.Maui.DevFlow.Driver/AgentClient.cs`.
+
+## Naming Conventions
+
+- Tool names: `maui_` prefix + snake_case action: `maui_screenshot`, `maui_tap`, `maui_network`
+- Class names: PascalCase + `Tool` suffix: `ScreenshotTool`, `InteractionTools`, `NetworkTool`
+- One file can contain multiple related tools (e.g., `InteractionTools` has tap, fill, clear)
+
+## Parameter Rules
+
+- **Every parameter must have `[Description]`** — AI agents only see the description to decide how to use the tool
+- Descriptions should explain: what the parameter does, valid values, default behavior
+- `McpAgentSession session` is always the first parameter (injected by the MCP framework)
+- `int? agentPort = null` should be the second parameter for most tools (enables multi-app scenarios)
+- Use nullable types with defaults for optional parameters
+
+## Return Types
+
+- `Task<string>` — simple text result (most tools)
+- `Task<ContentBlock[]>` — when returning images (screenshot tools)
+- Throw `McpException` for errors that should be reported to the AI agent
+
+## Existing Tools Reference
+
+| File | Tools | Pattern |
+|------|-------|---------|
+| `AgentTools.cs` | `maui_agents` | List/discovery |
+| `TreeTool.cs` | `maui_tree` | Visual tree inspection |
+| `QueryTools.cs` | `maui_query` | Element search |
+| `InteractionTools.cs` | `maui_tap`, `maui_fill`, `maui_clear`, `maui_scroll`, `maui_focus` | User interactions |
+| `NavigationTools.cs` | `maui_navigate` | Navigation |
+| `ScreenshotTool.cs` | `maui_screenshot` | Image capture |
+| `AssertTool.cs` | `maui_assert` | Property assertions |
+| `PropertyTools.cs` | `maui_property`, `maui_set_property` | Property read/write |
+| `LogsTool.cs` | `maui_logs` | Log retrieval |
+| `NetworkTool.cs` | `maui_network`, `maui_network_detail` | Network inspection |
+| `CdpTools.cs` | `maui_cdp`, `maui_cdp_screenshot` | Blazor WebView CDP |
+| `RecordingTools.cs` | `maui_recording_start`, `maui_recording_stop`, `maui_recording_status` | Screen recording |
+| `SensorTools.cs` | `maui_sensors` | Device sensors |
+| `PlatformTools.cs` | `maui_platform_*` | Device/app info |
+| `PreferencesTools.cs` | `maui_preferences_*`, `maui_secure_storage_*` | Storage |

--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -26,9 +26,9 @@ public sealed class MyNewTool
      Description("Clear, complete description of what this tool does. Mention when an AI agent should use it.")]
     public static async Task<string> MyAction(
         McpAgentSession session,
-        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
         [Description("Describe what this parameter controls")] string requiredParam,
-        [Description("Describe this optional parameter and its default behavior")] bool optionalFlag = false)
+        [Description("Describe this optional parameter and its default behavior")] bool optionalFlag = false,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
     {
         var agent = await session.GetAgentClientAsync(agentPort);
         // Call agent.* methods to interact with the running app
@@ -53,7 +53,8 @@ If the tool calls a new agent endpoint, add the client method in `Microsoft.Maui
 ## Naming Conventions
 
 - Tool names: `maui_` prefix + snake_case action: `maui_screenshot`, `maui_tap`, `maui_network`
-- Class names: PascalCase + `Tool` suffix: `ScreenshotTool`, `InteractionTools`, `NetworkTool`
+- Class names: PascalCase with a `Tool` or `Tools` suffix: `ScreenshotTool`, `InteractionTools`, `NetworkTool`
+- Use plural `*Tools` when grouping multiple related actions in one file (e.g., `InteractionTools` has tap, fill, clear)
 - One file can contain multiple related tools (e.g., `InteractionTools` has tap, fill, clear)
 
 ## Parameter Rules
@@ -74,18 +75,18 @@ If the tool calls a new agent endpoint, add the client method in `Microsoft.Maui
 
 | File | Tools | Pattern |
 |------|-------|---------|
-| `AgentTools.cs` | `maui_agents` | List/discovery |
+| `AgentTools.cs` | `maui_list_agents`, `maui_select_agent`, `maui_wait` | Agent discovery |
 | `TreeTool.cs` | `maui_tree` | Visual tree inspection |
-| `QueryTools.cs` | `maui_query` | Element search |
+| `QueryTools.cs` | `maui_query`, `maui_query_css` | Element search |
 | `InteractionTools.cs` | `maui_tap`, `maui_fill`, `maui_clear`, `maui_scroll`, `maui_focus` | User interactions |
-| `NavigationTools.cs` | `maui_navigate` | Navigation |
+| `NavigationTools.cs` | `maui_navigate`, `maui_resize` | Navigation & window |
 | `ScreenshotTool.cs` | `maui_screenshot` | Image capture |
 | `AssertTool.cs` | `maui_assert` | Property assertions |
-| `PropertyTools.cs` | `maui_property`, `maui_set_property` | Property read/write |
+| `PropertyTools.cs` | `maui_get_property`, `maui_set_property` | Property read/write |
 | `LogsTool.cs` | `maui_logs` | Log retrieval |
-| `NetworkTool.cs` | `maui_network`, `maui_network_detail` | Network inspection |
-| `CdpTools.cs` | `maui_cdp`, `maui_cdp_screenshot` | Blazor WebView CDP |
+| `NetworkTool.cs` | `maui_network`, `maui_network_detail`, `maui_network_clear` | Network inspection |
+| `CdpTools.cs` | `maui_cdp_evaluate`, `maui_cdp_screenshot`, `maui_cdp_source`, `maui_cdp_webviews` | Blazor WebView CDP |
 | `RecordingTools.cs` | `maui_recording_start`, `maui_recording_stop`, `maui_recording_status` | Screen recording |
-| `SensorTools.cs` | `maui_sensors` | Device sensors |
-| `PlatformTools.cs` | `maui_platform_*` | Device/app info |
-| `PreferencesTools.cs` | `maui_preferences_*`, `maui_secure_storage_*` | Storage |
+| `SensorTools.cs` | `maui_sensors_list`, `maui_sensors_start`, `maui_sensors_stop` | Device sensors |
+| `PlatformTools.cs` | `maui_app_info`, `maui_device_info`, `maui_display_info`, `maui_battery_info`, `maui_connectivity`, `maui_geolocation`, `maui_status` | Device/app info |
+| `PreferencesTools.cs` | `maui_preferences_list`, `maui_preferences_get`, `maui_preferences_set`, `maui_preferences_delete`, `maui_preferences_clear`, `maui_secure_storage_get`, `maui_secure_storage_set`, `maui_secure_storage_delete`, `maui_secure_storage_clear` | Storage |

--- a/.github/instructions/packaging.instructions.md
+++ b/.github/instructions/packaging.instructions.md
@@ -43,7 +43,7 @@ All NuGet package versions are defined in **`Directory.Packages.props`** at the 
    <FileSignInfo Include="ThirdParty.dll" CertificateName="3PartySHA2" />
    ```
 6. Add the project to the solution: `MauiLabs.sln` and the product's `.slnf`
-7. Add to `DevFlow.slnf` (or `Client.slnf`) if it should be built by CI
+7. Add to `DevFlow.slnf` if it should be built by CI
 
 ## Version Management
 
@@ -78,7 +78,7 @@ When adding a new third-party dependency that gets bundled into a NuGet package,
 - `dotnet-public` (dnceng) — public .NET packages
 - `dotnet-tools` — internal tooling
 - `dotnet-eng` — engineering infrastructure
-- `dotnet10`, `dotnet11` — version-specific feeds
+- `dotnet10` — version-specific feed
 
 **Do NOT add `nuget.org` as a direct source.** All public packages are available through the dnceng proxy feeds.
 

--- a/.github/instructions/packaging.instructions.md
+++ b/.github/instructions/packaging.instructions.md
@@ -1,0 +1,91 @@
+---
+applyTo: "eng/**,Directory.Build.props,Directory.Build.targets,Directory.Packages.props,**/*.csproj,global.json,NuGet.config"
+---
+
+# Packaging and Build Infrastructure
+
+## Arcade SDK
+
+This repo uses the [Microsoft.DotNet.Arcade.Sdk](https://github.com/dotnet/arcade) for build infrastructure. Key rules:
+
+- **Never modify files in `eng/common/`** — they are auto-generated and overwritten by Dependency Flow updates
+- Arcade version is pinned in `global.json` under `msbuild-sdks`
+- CI scripts: `eng/common/cibuild.sh` (macOS/Linux) and `eng\common\cibuild.cmd` (Windows)
+
+## Central Package Management
+
+All NuGet package versions are defined in **`Directory.Packages.props`** at the repo root.
+
+- `.csproj` files reference packages **without versions**: `<PackageReference Include="xunit" />`
+- To add a new dependency: add `<PackageVersion Include="Package.Name" Version="X.Y.Z" />` to `Directory.Packages.props`
+- To override a version in a specific project: use `VersionOverride="X.Y.Z"` on the `PackageReference`
+- MAUI and runtime package versions flow via Dependency Flow (Maestro/DARC) and are defined in `eng/Versions.props`
+
+## Adding a New NuGet Package
+
+1. **Create the project** in `src/{Product}/`:
+   ```xml
+   <Project Sdk="Microsoft.NET.Sdk">
+     <PropertyGroup>
+       <TargetFramework>net10.0</TargetFramework>
+       <IsPackable>true</IsPackable>
+       <IsShipping>true</IsShipping>
+       <PackageId>Microsoft.Maui.DevFlow.NewPackage</PackageId>
+       <Description>What this package does</Description>
+     </PropertyGroup>
+   </Project>
+   ```
+2. Set `IsPackable` and `IsShipping` to `true` (defaults are `false` in `Directory.Build.props`)
+3. For CLI tools, also set `PackAsTool=true` and `ToolCommandName=your-command`
+4. Add any new third-party dependencies to `Directory.Packages.props`
+5. Add signing entries in `eng/Signing.props` for third-party DLLs:
+   ```xml
+   <FileSignInfo Include="ThirdParty.dll" CertificateName="3PartySHA2" />
+   ```
+6. Add the project to the solution: `MauiLabs.sln` and the product's `.slnf`
+7. Add to `DevFlow.slnf` (or `Client.slnf`) if it should be built by CI
+
+## Version Management
+
+```
+eng/Versions.props              ← Product version (VersionPrefix + VersionSuffix)
+src/{Product}/Version.props     ← Per-product override (if needed)
+Directory.Packages.props        ← NuGet dependency versions
+eng/Version.Details.xml         ← Dependency Flow tracking (auto-managed by DARC)
+```
+
+- **Product version**: `eng/Versions.props` defines `VersionPrefix` (e.g., `0.1.0`) and `VersionSuffix` (e.g., `preview.3`)
+- **Bump version**: Update `VersionPrefix` or `VersionSuffix` in `eng/Versions.props`
+- **Per-product override**: `src/{Product}/Version.props` can override for independent versioning
+
+## Signing Configuration
+
+`eng/Signing.props` controls code signing:
+
+| Certificate | Used For |
+|------------|----------|
+| `UseDotNetCertificate` | First-party Microsoft DLLs (default for all projects) |
+| `3PartySHA2` | Third-party dependency DLLs bundled in packages |
+| `NuGet` | `.nupkg` files |
+| `None` | Static assets (JS, CSS files) |
+
+When adding a new third-party dependency that gets bundled into a NuGet package, add a `<FileSignInfo>` entry.
+
+## NuGet Feed Configuration
+
+`NuGet.config` defines package sources. **Only use approved internal feeds:**
+
+- `dotnet-public` (dnceng) — public .NET packages
+- `dotnet-tools` — internal tooling
+- `dotnet-eng` — engineering infrastructure
+- `dotnet10`, `dotnet11` — version-specific feeds
+
+**Do NOT add `nuget.org` as a direct source.** All public packages are available through the dnceng proxy feeds.
+
+## Publishing Flow
+
+1. **GitHub Actions CI**: Build + test on PR (no publishing)
+2. **Azure DevOps official build**: Build → Sign (MicroBuild) → Validate → Publish to internal feeds via DARC
+3. **NuGet.org release**: Separate pipeline (`eng/pipelines/release-publish-nuget.yml`) with `networkIsolationPolicy: Permissive`
+
+The official build pipeline (`eng/pipelines/devflow-official.yml`) has `enableMicrobuild: true` which enforces CFS network isolation — this is why NuGet.org publishing must happen in a separate pipeline.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,88 @@
+---
+applyTo: "**/*Tests*/**,**/*.Tests.*"
+---
+
+# Testing Guide
+
+## Test Framework
+
+- **xUnit** v2.9.3 with `Microsoft.NET.Test.Sdk`
+- **coverlet.collector** for code coverage
+- No quarantine, outerloop, or flaky test infrastructure (unlike dotnet/aspire or dotnet/maui)
+
+## Test Projects
+
+| Product | Test Project | Target |
+|---------|-------------|--------|
+| DevFlow | `src/DevFlow/Microsoft.Maui.DevFlow.Tests/` | `net10.0` |
+| Maui.Client | `src/Client/Microsoft.Maui.Client.UnitTests/` | `net10.0` |
+
+## Running Tests
+
+```bash
+# All tests
+dotnet test MauiLabs.sln
+
+# Per-product
+dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/
+dotnet test src/Client/Microsoft.Maui.Client.UnitTests/
+
+# Specific test
+dotnet test --filter "FullyQualifiedName~MyTestClass.MyTestMethod"
+
+# With verbose output
+dotnet test --logger "console;verbosity=detailed"
+```
+
+## CI Matrix
+
+Tests run on **macOS and Windows** in CI (`.github/workflows/_build.yml`):
+
+- **macOS**: `./eng/common/cibuild.sh --configuration Release --prepareMachine`
+- **Windows**: `eng\common\cibuild.cmd -configuration Release -prepareMachine`
+
+Test results are uploaded as artifacts: `artifacts/TestResults/**/*.xml`
+
+## Test Patterns
+
+### DevFlow Tests
+
+DevFlow tests use **real Agent.Core code** — they instantiate actual services and test behavior:
+
+```csharp
+[Fact]
+public void VisualTreeWalker_FindsElementById()
+{
+    var walker = new VisualTreeWalker();
+    // Test with real MAUI types where possible
+}
+```
+
+### Maui.Client Tests
+
+Client tests use **fake providers** to avoid real filesystem/SDK dependencies:
+
+```csharp
+[Fact]
+public async Task Doctor_DetectsMissingJdk()
+{
+    var fakeJdk = new FakeJdkManager(installed: false);
+    var doctor = new DoctorService(fakeJdk, ...);
+    var result = await doctor.RunAsync();
+    Assert.Contains(result.Issues, i => i.Component == "JDK");
+}
+```
+
+### Naming Convention
+
+Use descriptive names that communicate the scenario:
+
+- `MethodName_Condition_ExpectedResult` — e.g., `ParseVersion_InvalidInput_ThrowsArgumentException`
+- Or descriptive `[Fact]` — e.g., `Should_return_all_connected_agents_when_multiple_registered`
+
+### What to Test
+
+- **Do test**: Public API methods, edge cases, error handling, serialization/deserialization
+- **Do test**: AgentClient methods (they're the public NuGet API surface)
+- **Don't test**: Platform-specific overrides (require actual devices/simulators)
+- **Don't test**: MCP tool registration (covered by integration at runtime)

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -15,7 +15,6 @@ applyTo: "**/*Tests*/**,**/*.Tests.*"
 | Product | Test Project | Target |
 |---------|-------------|--------|
 | DevFlow | `src/DevFlow/Microsoft.Maui.DevFlow.Tests/` | `net10.0` |
-| Maui.Client | `src/Client/Microsoft.Maui.Client.UnitTests/` | `net10.0` |
 
 ## Running Tests
 
@@ -23,9 +22,8 @@ applyTo: "**/*Tests*/**,**/*.Tests.*"
 # All tests
 dotnet test MauiLabs.sln
 
-# Per-product
+# DevFlow tests
 dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/
-dotnet test src/Client/Microsoft.Maui.Client.UnitTests/
 
 # Specific test
 dotnet test --filter "FullyQualifiedName~MyTestClass.MyTestMethod"
@@ -38,8 +36,8 @@ dotnet test --logger "console;verbosity=detailed"
 
 Tests run on **macOS and Windows** in CI (`.github/workflows/_build.yml`):
 
-- **macOS**: `./eng/common/cibuild.sh --configuration Release --prepareMachine`
-- **Windows**: `eng\common\cibuild.cmd -configuration Release -prepareMachine`
+- **macOS**: `./eng/common/cibuild.sh --configuration Release --prepareMachine --projects src/DevFlow/DevFlow.slnf`
+- **Windows**: `eng\common\cibuild.cmd -configuration Release -prepareMachine -projects src/DevFlow/DevFlow.slnf`
 
 Test results are uploaded as artifacts: `artifacts/TestResults/**/*.xml`
 
@@ -55,21 +53,6 @@ public void VisualTreeWalker_FindsElementById()
 {
     var walker = new VisualTreeWalker();
     // Test with real MAUI types where possible
-}
-```
-
-### Maui.Client Tests
-
-Client tests use **fake providers** to avoid real filesystem/SDK dependencies:
-
-```csharp
-[Fact]
-public async Task Doctor_DetectsMissingJdk()
-{
-    var fakeJdk = new FakeJdkManager(installed: false);
-    var doctor = new DoctorService(fakeJdk, ...);
-    var result = await doctor.RunAsync();
-    Assert.Contains(result.Issues, i => i.Component == "JDK");
 }
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,7 @@ This repository hosts experimental .NET MAUI packages. It is a **multi-product m
 
 | Product | Package / Tool | Description |
 |---------|---------------|-------------|
-| **DevFlow** | `Microsoft.Maui.DevFlow.*` (9 packages), `maui-devflow` CLI | Runtime MAUI automation toolkit. In-app agent with HTTP API, visual tree inspection, CDP bridge for Blazor WebViews, MCP server for AI agents, cross-platform driver library. |
-| **Maui.Client** | `Microsoft.Maui.Client`, `maui` CLI | Environment setup CLI. Android SDK management, JDK installation, emulator creation, `doctor` diagnostics. |
+| **DevFlow** | `Microsoft.Maui.DevFlow.*` (8 packages), `maui-devflow` CLI | Runtime MAUI automation toolkit. In-app agent with HTTP API, visual tree inspection, CDP bridge for Blazor WebViews, MCP server for AI agents, cross-platform driver library. |
 
 ### Technology Stack
 
@@ -20,7 +19,7 @@ This repository hosts experimental .NET MAUI packages. It is a **multi-product m
 - **Microsoft.DotNet.Arcade.Sdk** for build infrastructure
 - **Central Package Management** — all versions in `Directory.Packages.props`
 - **xUnit** v2.9.3 for testing, **coverlet** for coverage
-- **System.CommandLine** for CLI tooling (beta4 for DevFlow, 2.0.5 stable for Client)
+- **System.CommandLine** 2.0.0-beta4 for CLI tooling
 
 ## Building
 
@@ -37,13 +36,12 @@ dotnet build MauiLabs.sln
 
 # Build a single product (recommended for focused development)
 dotnet build src/DevFlow/DevFlow.slnf
-dotnet build src/Client/Client.slnf
 
-# Build via Arcade CI scripts (matches what CI runs)
+# Build via Arcade CI scripts (matches what CI runs for DevFlow)
 # macOS/Linux:
-./eng/common/cibuild.sh --configuration Release --prepareMachine
+./eng/common/cibuild.sh --configuration Release --prepareMachine --projects src/DevFlow/DevFlow.slnf
 # Windows:
-eng\common\cibuild.cmd -configuration Release -prepareMachine
+eng\common\cibuild.cmd -configuration Release -prepareMachine -projects src/DevFlow/DevFlow.slnf
 ```
 
 ### Build Troubleshooting
@@ -60,7 +58,6 @@ dotnet test MauiLabs.sln
 
 # Per-product
 dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/
-dotnet test src/Client/Microsoft.Maui.Client.UnitTests/
 ```
 
 - Tests run in CI on **macOS and Windows** (matrix build)
@@ -73,7 +70,7 @@ dotnet test src/Client/Microsoft.Maui.Client.UnitTests/
 - **Nullable**: enabled repo-wide (`#nullable enable` is implicit)
 - **File-scoped namespaces**: all files use `namespace X.Y.Z;` (not block-scoped)
 - **No strong naming**: `SignAssembly: false`
-- **Namespace pattern**: `Microsoft.Maui.DevFlow.{Component}.{SubComponent}` or `Microsoft.Maui.Client.{Component}`
+- **Namespace pattern**: `Microsoft.Maui.DevFlow.{Component}.{SubComponent}`
 - **No .editorconfig**: relies on Arcade SDK defaults
 - **TreatWarningsAsErrors**: false (not enforced)
 
@@ -82,23 +79,19 @@ dotnet test src/Client/Microsoft.Maui.Client.UnitTests/
 ```
 maui-labs/
 ├── src/
-│   ├── DevFlow/                          # DevFlow product
-│   │   ├── Microsoft.Maui.DevFlow.Agent.Core/   # Platform-agnostic agent (HTTP server, visual tree)
-│   │   ├── Microsoft.Maui.DevFlow.Agent/         # Platform-specific overrides (iOS/Android/macOS/Windows)
-│   │   ├── Microsoft.Maui.DevFlow.Agent.Gtk/     # GTK/Linux agent
-│   │   ├── Microsoft.Maui.DevFlow.Blazor/        # Blazor WebView CDP bridge
-│   │   ├── Microsoft.Maui.DevFlow.Blazor.Gtk/    # WebKitGTK CDP bridge
-│   │   ├── Microsoft.Maui.DevFlow.CLI/           # CLI global tool (maui-devflow)
-│   │   │   ├── Broker/                           # Connection management
-│   │   │   └── Mcp/Tools/                        # 17 MCP tool implementations
-│   │   ├── Microsoft.Maui.DevFlow.Driver/        # Cross-platform driver (AgentClient)
-│   │   ├── Microsoft.Maui.DevFlow.Logging/       # JSONL file logger
-│   │   ├── Microsoft.Maui.DevFlow.Tests/         # xUnit tests
-│   │   └── DevFlow.slnf                          # Solution filter
-│   └── Client/                           # Maui.Client product
-│       ├── Microsoft.Maui.Client/                # CLI tool (maui)
-│       ├── Microsoft.Maui.Client.UnitTests/      # xUnit tests
-│       └── Client.slnf                           # Solution filter
+│   └── DevFlow/                          # DevFlow product
+│       ├── Microsoft.Maui.DevFlow.Agent.Core/   # Platform-agnostic agent (HTTP server, visual tree)
+│       ├── Microsoft.Maui.DevFlow.Agent/         # Platform-specific overrides (iOS/Android/macOS/Windows)
+│       ├── Microsoft.Maui.DevFlow.Agent.Gtk/     # GTK/Linux agent
+│       ├── Microsoft.Maui.DevFlow.Blazor/        # Blazor WebView CDP bridge
+│       ├── Microsoft.Maui.DevFlow.Blazor.Gtk/    # WebKitGTK CDP bridge
+│       ├── Microsoft.Maui.DevFlow.CLI/           # CLI global tool (maui-devflow)
+│       │   ├── Broker/                           # Connection management
+│       │   └── Mcp/Tools/                        # MCP tool implementations
+│       ├── Microsoft.Maui.DevFlow.Driver/        # Cross-platform driver (AgentClient)
+│       ├── Microsoft.Maui.DevFlow.Logging/       # JSONL file logger
+│       ├── Microsoft.Maui.DevFlow.Tests/         # xUnit tests
+│       └── DevFlow.slnf                          # Solution filter
 ├── samples/                              # Sample MAUI apps (not shipped)
 ├── playground/                           # Manual test/scratch apps
 ├── eng/                                  # Shared build infrastructure
@@ -154,7 +147,7 @@ maui-labs/
 ### NuGet Feed Configuration
 
 NuGet.config uses **internal dnceng proxy feeds only** — no direct nuget.org reference:
-- `dotnet-public`, `dotnet-tools`, `dotnet-eng`, `dotnet10`, `dotnet11`
+- `dotnet-public`, `dotnet-tools`, `dotnet-eng`, `dotnet10`
 
 **Do not** add `nuget.org` as a direct feed source. Package versions flow via Dependency Flow (Maestro/DARC).
 
@@ -168,31 +161,59 @@ NuGet.config uses **internal dnceng proxy feeds only** — no direct nuget.org r
 
 ## DevFlow MCP Tools
 
-DevFlow exposes 17 MCP tools for AI agent integration (in `src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/`):
+DevFlow exposes 49 MCP tools for AI agent integration (in `src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/`):
 
 | Tool | Purpose |
 |------|---------|
-| `maui_agents` | List connected MAUI DevFlow agents (running apps) |
+| `maui_list_agents` | List connected MAUI DevFlow agents (running apps) |
+| `maui_select_agent` | Select a specific agent for subsequent commands |
+| `maui_wait` | Wait for an agent to connect |
+| `maui_status` | Agent connection status, platform, app name |
 | `maui_tree` | Inspect visual tree — structured JSON hierarchy with IDs, types, bounds |
 | `maui_query` | Query elements by type, AutomationId, or text |
+| `maui_query_css` | Query elements by CSS selector |
 | `maui_element` | Get full element details |
+| `maui_hittest` | Find elements at screen coordinates |
 | `maui_tap` | Tap a UI element |
 | `maui_fill` | Fill text into Entry/Editor |
+| `maui_clear` | Clear text from an element |
 | `maui_scroll` | Scroll by delta, item index, or into view |
+| `maui_focus` | Set focus to an element |
 | `maui_navigate` | Shell navigation to a route |
+| `maui_resize` | Resize the app window |
 | `maui_screenshot` | Capture screenshot (page, element, or fullscreen) |
 | `maui_assert` | Assert element property equals expected value |
-| `maui_property` | Read any element property |
+| `maui_get_property` | Read any element property |
 | `maui_set_property` | Live-edit element properties |
 | `maui_logs` | Retrieve app logs (ILogger + WebView console) |
 | `maui_network` | List captured HTTP requests |
-| `maui_cdp` | Execute JavaScript in Blazor WebView via CDP |
+| `maui_network_detail` | Full request/response details |
+| `maui_network_clear` | Clear captured request buffer |
+| `maui_cdp_evaluate` | Execute JavaScript in Blazor WebView via CDP |
 | `maui_cdp_screenshot` | WebView screenshot via CDP |
-| `maui_recording` | Start/stop screen recording |
-| `maui_sensors` | List and stream device sensor data |
-| `maui_preferences` | Read/write app preferences |
-| `maui_secure_storage` | Read/write secure storage |
-| `maui_platform` | App info, device info, display, battery, connectivity |
+| `maui_cdp_source` | Get WebView page source |
+| `maui_cdp_webviews` | List available WebViews |
+| `maui_recording_start` | Start screen recording |
+| `maui_recording_stop` | Stop screen recording |
+| `maui_recording_status` | Check recording status |
+| `maui_sensors_list` | List available device sensors |
+| `maui_sensors_start` | Start a sensor |
+| `maui_sensors_stop` | Stop a sensor |
+| `maui_app_info` | App name, version, package, theme |
+| `maui_device_info` | Device manufacturer, model, OS |
+| `maui_display_info` | Screen density, size, orientation |
+| `maui_battery_info` | Battery level, state, power source |
+| `maui_connectivity` | Network access and connection profiles |
+| `maui_geolocation` | GPS coordinates |
+| `maui_preferences_list` | List preference keys |
+| `maui_preferences_get` | Read a preference value |
+| `maui_preferences_set` | Write a preference value |
+| `maui_preferences_delete` | Delete a preference |
+| `maui_preferences_clear` | Clear all preferences |
+| `maui_secure_storage_get` | Read secure storage value |
+| `maui_secure_storage_set` | Write secure storage value |
+| `maui_secure_storage_delete` | Delete secure storage entry |
+| `maui_secure_storage_clear` | Clear all secure storage |
 
 ## Important Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,202 @@
+# Agent Instructions
+
+Instructions for GitHub Copilot and other AI coding agents working with the maui-labs repository.
+
+## Repository Overview
+
+This repository hosts experimental .NET MAUI packages. It is a **multi-product mono-repo** — each product lives under `src/{Product}/` with its own version, solution filter, and CI workflow.
+
+### Products
+
+| Product | Package / Tool | Description |
+|---------|---------------|-------------|
+| **DevFlow** | `Microsoft.Maui.DevFlow.*` (9 packages), `maui-devflow` CLI | Runtime MAUI automation toolkit. In-app agent with HTTP API, visual tree inspection, CDP bridge for Blazor WebViews, MCP server for AI agents, cross-platform driver library. |
+| **Maui.Client** | `Microsoft.Maui.Client`, `maui` CLI | Environment setup CLI. Android SDK management, JDK installation, emulator creation, `doctor` diagnostics. |
+
+### Technology Stack
+
+- **.NET 10** (SDK version pinned in `global.json`, `rollForward: latestMinor`)
+- **C#** with `LangVersion: latest`, file-scoped namespaces
+- **Microsoft.DotNet.Arcade.Sdk** for build infrastructure
+- **Central Package Management** — all versions in `Directory.Packages.props`
+- **xUnit** v2.9.3 for testing, **coverlet** for coverage
+- **System.CommandLine** for CLI tooling (beta4 for DevFlow, 2.0.5 stable for Client)
+
+## Building
+
+### Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (see `global.json` for exact version)
+- MAUI workload: `dotnet workload install maui`
+
+### Build Commands
+
+```bash
+# Build everything
+dotnet build MauiLabs.sln
+
+# Build a single product (recommended for focused development)
+dotnet build src/DevFlow/DevFlow.slnf
+dotnet build src/Client/Client.slnf
+
+# Build via Arcade CI scripts (matches what CI runs)
+# macOS/Linux:
+./eng/common/cibuild.sh --configuration Release --prepareMachine
+# Windows:
+eng\common\cibuild.cmd -configuration Release -prepareMachine
+```
+
+### Build Troubleshooting
+
+- If restore fails, check `NuGet.config` — feeds are internal dnceng proxies, not nuget.org
+- If workload errors occur: `dotnet workload install maui macos maui-tizen`
+- SDK version mismatch: check `global.json` vs `dotnet --version`
+
+## Testing
+
+```bash
+# All tests
+dotnet test MauiLabs.sln
+
+# Per-product
+dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/
+dotnet test src/Client/Microsoft.Maui.Client.UnitTests/
+```
+
+- Tests run in CI on **macOS and Windows** (matrix build)
+- Test results: `artifacts/TestResults/**/*.xml`
+- No quarantine or outerloop test attributes are used in this repo
+
+## Code Conventions
+
+- **ImplicitUsings**: enabled repo-wide
+- **Nullable**: enabled repo-wide (`#nullable enable` is implicit)
+- **File-scoped namespaces**: all files use `namespace X.Y.Z;` (not block-scoped)
+- **No strong naming**: `SignAssembly: false`
+- **Namespace pattern**: `Microsoft.Maui.DevFlow.{Component}.{SubComponent}` or `Microsoft.Maui.Client.{Component}`
+- **No .editorconfig**: relies on Arcade SDK defaults
+- **TreatWarningsAsErrors**: false (not enforced)
+
+## Project Layout
+
+```
+maui-labs/
+├── src/
+│   ├── DevFlow/                          # DevFlow product
+│   │   ├── Microsoft.Maui.DevFlow.Agent.Core/   # Platform-agnostic agent (HTTP server, visual tree)
+│   │   ├── Microsoft.Maui.DevFlow.Agent/         # Platform-specific overrides (iOS/Android/macOS/Windows)
+│   │   ├── Microsoft.Maui.DevFlow.Agent.Gtk/     # GTK/Linux agent
+│   │   ├── Microsoft.Maui.DevFlow.Blazor/        # Blazor WebView CDP bridge
+│   │   ├── Microsoft.Maui.DevFlow.Blazor.Gtk/    # WebKitGTK CDP bridge
+│   │   ├── Microsoft.Maui.DevFlow.CLI/           # CLI global tool (maui-devflow)
+│   │   │   ├── Broker/                           # Connection management
+│   │   │   └── Mcp/Tools/                        # 17 MCP tool implementations
+│   │   ├── Microsoft.Maui.DevFlow.Driver/        # Cross-platform driver (AgentClient)
+│   │   ├── Microsoft.Maui.DevFlow.Logging/       # JSONL file logger
+│   │   ├── Microsoft.Maui.DevFlow.Tests/         # xUnit tests
+│   │   └── DevFlow.slnf                          # Solution filter
+│   └── Client/                           # Maui.Client product
+│       ├── Microsoft.Maui.Client/                # CLI tool (maui)
+│       ├── Microsoft.Maui.Client.UnitTests/      # xUnit tests
+│       └── Client.slnf                           # Solution filter
+├── samples/                              # Sample MAUI apps (not shipped)
+├── playground/                           # Manual test/scratch apps
+├── eng/                                  # Shared build infrastructure
+│   ├── pipelines/                        # Azure DevOps pipeline definitions
+│   ├── Versions.props                    # Central version definitions
+│   ├── Signing.props                     # Code signing configuration
+│   ├── Publishing.props                  # NuGet publishing config
+│   └── common/                           # Arcade SDK (DO NOT MODIFY)
+├── Directory.Build.props                 # Global MSBuild properties
+├── Directory.Build.targets               # Global MSBuild targets
+├── Directory.Packages.props              # Central Package Management
+├── global.json                           # SDK version pinning
+├── NuGet.config                          # NuGet feed configuration
+└── MauiLabs.sln                          # Full solution
+```
+
+### Key Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `global.json` | .NET SDK version and Arcade SDK version |
+| `Directory.Build.props` | Global properties: TFMs, nullable, implicit usings, platform versions |
+| `Directory.Packages.props` | All NuGet package versions (Central Package Management) |
+| `eng/Versions.props` | Product version (`0.1.0-preview`), dependency versions |
+| `eng/Signing.props` | Code signing: Microsoft cert for first-party, 3PartySHA2 for third-party |
+| `eng/Publishing.props` | Arcade publishing version |
+| `src/{Product}/Version.props` | Per-product version override |
+
+## Packaging and Signing
+
+- Packages are built by the Arcade SDK's `Pack` target
+- **PackAsTool**: Both CLIs (`maui-devflow`, `maui`) set `PackAsTool=true`
+- **IsShipping/IsPackable**: Default `false` in `Directory.Build.props`; shipped projects override to `true`
+- **Signing**: `eng/Signing.props` configures Microsoft .NET certificate for first-party DLLs, `3PartySHA2` for third-party dependencies, `NuGet` certificate for `.nupkg` files
+- **Version flow**: `eng/Versions.props` defines `VersionPrefix`/`VersionSuffix`, Arcade SDK applies them
+
+## CI/CD
+
+### GitHub Actions (PR validation)
+
+- Workflow: `.github/workflows/ci-devflow.yml` → calls `_build.yml`
+- **Matrix**: macOS + Windows
+- **Path-filtered**: only triggers for changed product paths
+- Steps: restore → build → test → upload test results + packages
+
+### Azure DevOps (official builds)
+
+- Pipeline: `eng/pipelines/devflow-official.yml`
+- Builds, signs, and publishes to internal feeds via Maestro/DARC
+- **MicroBuild signing** enabled (`enableMicrobuild: true`) — this enforces CFS network isolation
+- NuGet.org publishing: separate pipeline (`eng/pipelines/release-publish-nuget.yml`) with `networkIsolationPolicy: Permissive`
+
+### NuGet Feed Configuration
+
+NuGet.config uses **internal dnceng proxy feeds only** — no direct nuget.org reference:
+- `dotnet-public`, `dotnet-tools`, `dotnet-eng`, `dotnet10`, `dotnet11`
+
+**Do not** add `nuget.org` as a direct feed source. Package versions flow via Dependency Flow (Maestro/DARC).
+
+## Adding a New Product
+
+1. Create `src/{NewProduct}/` with `Version.props`, project folders, test project, `{NewProduct}.slnf`
+2. Add projects to `MauiLabs.sln`
+3. Add package versions to `Directory.Packages.props`
+4. Add path filter in `.github/workflows/ci.yml`
+5. Add signing entries in `eng/Signing.props` for any new third-party DLLs
+
+## DevFlow MCP Tools
+
+DevFlow exposes 17 MCP tools for AI agent integration (in `src/DevFlow/Microsoft.Maui.DevFlow.CLI/Mcp/Tools/`):
+
+| Tool | Purpose |
+|------|---------|
+| `maui_agents` | List connected MAUI DevFlow agents (running apps) |
+| `maui_tree` | Inspect visual tree — structured JSON hierarchy with IDs, types, bounds |
+| `maui_query` | Query elements by type, AutomationId, or text |
+| `maui_element` | Get full element details |
+| `maui_tap` | Tap a UI element |
+| `maui_fill` | Fill text into Entry/Editor |
+| `maui_scroll` | Scroll by delta, item index, or into view |
+| `maui_navigate` | Shell navigation to a route |
+| `maui_screenshot` | Capture screenshot (page, element, or fullscreen) |
+| `maui_assert` | Assert element property equals expected value |
+| `maui_property` | Read any element property |
+| `maui_set_property` | Live-edit element properties |
+| `maui_logs` | Retrieve app logs (ILogger + WebView console) |
+| `maui_network` | List captured HTTP requests |
+| `maui_cdp` | Execute JavaScript in Blazor WebView via CDP |
+| `maui_cdp_screenshot` | WebView screenshot via CDP |
+| `maui_recording` | Start/stop screen recording |
+| `maui_sensors` | List and stream device sensor data |
+| `maui_preferences` | Read/write app preferences |
+| `maui_secure_storage` | Read/write secure storage |
+| `maui_platform` | App info, device info, display, battery, connectivity |
+
+## Important Notes
+
+- **`eng/common/` is auto-generated by Arcade SDK** — never modify files in this directory manually.
+- **`AgentClient`** (in `Microsoft.Maui.DevFlow.Driver`) is the public API consumed by NuGet users. Method signature changes are **binary and source breaking** for consumers.
+- The repo is at version **0.1.0-preview** — breaking changes are acceptable but should be documented.
+- **Platform conditionals**: Use `#if IOS`, `#if ANDROID`, `#if MACCATALYST`, `#if MACOS`, `#if WINDOWS` for platform-specific code in multi-targeting projects.


### PR DESCRIPTION
## What

Adds comprehensive AI augmentation to the repository — 6 new files totaling 714 lines that guide AI coding agents (GitHub Copilot, Claude, Cursor, etc.) when working with this codebase.

## Why

maui-labs had **zero repo-level AI configuration** while sibling repos have extensive setups:
- **dotnet/aspire**: AGENTS.md (397 lines) + 5 instruction files + 12 skills
- **dotnet/maui**: copilot-instructions (345 lines) + 9 instruction files + 14 skills

Without guidance, AI agents don't know about the multi-product architecture, Arcade SDK conventions, MCP tool patterns, or the Core/Platform agent split — leading to incorrect code suggestions and wasted iteration cycles.

## Files Added

### `AGENTS.md` (root) — Centralized agent instructions
The first file every AI tool reads. Covers:
- Repository overview and multi-product architecture
- Both products: DevFlow (9 packages, CLI, MCP server) and Maui.Client (environment setup CLI)
- Technology stack (.NET 10, Arcade SDK, Central Package Management)
- Build and test commands with troubleshooting
- Code conventions (nullable, implicit usings, file-scoped namespaces)
- Full project layout with directory tree
- Packaging, signing, and CI/CD pipeline details
- NuGet feed rules (internal dnceng only, no direct nuget.org)
- Complete MCP tools reference table (17 tools)

### `.github/copilot-instructions.md` — Code generation patterns
GitHub Copilot-specific guidance:
- Platform multi-targeting patterns (`#if IOS`, `#if ANDROID`, etc.)
- Core/Platform agent architecture (where new features go)
- MCP tool conventions (naming, parameters, registration)
- HTTP endpoint and CLI command patterns
- Driver library breaking change awareness
- Test patterns (real code for DevFlow, fakes for Client)
- Arcade SDK gotchas (`eng/common/` is read-only, Central Package Management rules)

### `.github/instructions/` — 4 scoped instruction files
Activate based on file paths being edited:

| File | Scope | Content |
|------|-------|---------|
| `devflow-architecture.instructions.md` | `src/DevFlow/**` | CLI↔Broker↔Agent communication model, package dependency graph, extension points, screenshot capture flow |
| `mcp-tools.instructions.md` | `Mcp/**` | Step-by-step MCP tool creation guide, naming conventions, parameter rules, existing tools reference |
| `testing.instructions.md` | `*Tests*/**` | xUnit patterns, CI matrix (macOS+Windows), fake provider patterns |
| `packaging.instructions.md` | `eng/**`, build props, csproj | Arcade SDK rules, Central Package Management, signing config, version management, publishing flow |

## Note on `.claude/skills/`
The existing `.claude/skills/maui-ai-debugging/` is an **end-user skill** delivered through the DevFlow CLI to people building MAUI apps — it is NOT repo-level AI config and is intentionally left as-is.