### PR TITLE
Split Microsoft.Maui.Client into separate solution filter

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      install-workloads:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whether to install MAUI workloads and Android SDK (not needed for pure net10.0 projects)'
 
 jobs:
   build:
@@ -34,15 +39,16 @@ jobs:
           global-json-file: global.json
 
       - name: Install workloads
+        if: inputs.install-workloads
         run: dotnet workload install maui macos maui-tizen
 
       - name: Install Android SDK dependencies (Windows)
-        if: matrix.os == 'windows-latest'
+        if: inputs.install-workloads && matrix.os == 'windows-latest'
         run: dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
         shell: cmd
 
       - name: Install Android SDK dependencies (macOS)
-        if: matrix.os == 'macos-latest'
+        if: inputs.install-workloads && matrix.os == 'macos-latest'
         run: dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="$ANDROID_HOME" -p:AcceptAndroidSDKLicenses=true src/DevFlow/Microsoft.Maui.DevFlow.Agent/Microsoft.Maui.DevFlow.Agent.csproj
 
       - name: Build, Test and Pack (Windows)

--- a/.github/workflows/ci-devflow.yml
+++ b/.github/workflows/ci-devflow.yml
@@ -25,10 +25,53 @@ on:
       - 'NuGet.config'
 
 jobs:
-  build:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      devflow: ${{ steps.combine.outputs.devflow }}
+      client: ${{ steps.combine.outputs.client }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shared:
+              - 'eng/**'
+              - 'Directory.Build.props'
+              - 'Directory.Build.targets'
+              - 'Directory.Packages.props'
+              - 'global.json'
+              - 'NuGet.config'
+            devflow:
+              - 'src/DevFlow/**'
+            client:
+              - 'src/Client/**'
+      - id: combine
+        run: |
+          shared="${{ steps.filter.outputs.shared }}"
+          devflow="${{ steps.filter.outputs.devflow }}"
+          client="${{ steps.filter.outputs.client }}"
+          echo "devflow=$([ "$shared" = 'true' ] || [ "$devflow" = 'true' ] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+          echo "client=$([ "$shared" = 'true' ] || [ "$client" = 'true' ] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+
+  devflow:
+    needs: changes
+    if: needs.changes.outputs.devflow == 'true'
     uses: ./.github/workflows/_build.yml
     with:
       project-path: src/DevFlow/DevFlow.slnf
       project-name: devflow
       run-tests: true
       pack: true
+
+  client:
+    needs: changes
+    if: needs.changes.outputs.client == 'true'
+    uses: ./.github/workflows/_build.yml
+    with:
+      project-path: src/Client/Client.slnf
+      project-name: client
+      run-tests: true
+      pack: true
+      install-workloads: false

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -57,6 +57,7 @@ extends:
           enableTelemetry: true
           jobs:
           - job: Windows
+            displayName: DevFlow - Windows
             pool:
               name: NetCore1ESPool-Internal
               demands: ImageOverride -equals windows.vs2026preview.scout.amd64
@@ -81,7 +82,31 @@ extends:
                 -prepareMachine
                 -projects $(Build.SourcesDirectory)\src\DevFlow\DevFlow.slnf
                 $(_OfficialBuildArgs)
-              displayName: Build and Test
+              displayName: Build and Test DevFlow
+
+          - job: Client
+            displayName: Client - Windows
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+                  _OfficialBuildArgs: /p:DotNetSignType=$(_SignType)
+                    /p:TeamName=$(_TeamName)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            steps:
+            - task: UseDotNet@2
+              displayName: Install .NET SDK
+              inputs:
+                useGlobalJson: true
+            - script: eng\common\cibuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                -projects $(Build.SourcesDirectory)\src\Client\Client.slnf
+                $(_OfficialBuildArgs)
+              displayName: Build and Test Client
        
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:

--- a/src/Client/Client.slnf
+++ b/src/Client/Client.slnf
@@ -1,0 +1,9 @@
+{
+  "solution": {
+    "path": "../../MauiLabs.sln",
+    "projects": [
+      "src\\Client\\Microsoft.Maui.Client\\Microsoft.Maui.Client.csproj",
+      "src\\Client\\Microsoft.Maui.Client.UnitTests\\Microsoft.Maui.Client.UnitTests.csproj"
+    ]
+  }
+}

--- a/src/DevFlow/DevFlow.slnf
+++ b/src/DevFlow/DevFlow.slnf
@@ -10,9 +10,7 @@
       "src\\DevFlow\\Microsoft.Maui.DevFlow.CLI\\Microsoft.Maui.DevFlow.CLI.csproj",
       "src\\DevFlow\\Microsoft.Maui.DevFlow.Driver\\Microsoft.Maui.DevFlow.Driver.csproj",
       "src\\DevFlow\\Microsoft.Maui.DevFlow.Logging\\Microsoft.Maui.DevFlow.Logging.csproj",
-      "src\\DevFlow\\Microsoft.Maui.DevFlow.Tests\\Microsoft.Maui.DevFlow.Tests.csproj",
-      "src\\Client\\Microsoft.Maui.Client\\Microsoft.Maui.Client.csproj",
-      "src\\Client\\Microsoft.Maui.Client.UnitTests\\Microsoft.Maui.Client.UnitTests.csproj"
+      "src\\DevFlow\\Microsoft.Maui.DevFlow.Tests\\Microsoft.Maui.DevFlow.Tests.csproj"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Create independent build infrastructure for the Client and DevFlow products so they can be built, tested, and released independently.

## Changes

- **`src/Client/Client.slnf`** — New solution filter with only Client + UnitTests projects
- **`src/DevFlow/DevFlow.slnf`** — Removed Client project entries (DevFlow-only now)
- **`.github/workflows/_build.yml`** — Added `install-workloads` input (default: `true`); workload/Android SDK steps gated behind it
- **`.github/workflows/ci-devflow.yml`** — Split into `changes` → `devflow` + `client` jobs with path filtering (shared infra changes trigger both)
- **`eng/pipelines/devflow-official.yml`** — Added parallel `Client` build job (no workloads — just SDK + cibuild)

## Design decisions

- **Option A** for AzDO (issue #32) — both products in the same pipeline, separate jobs
- Client builds skip MAUI workloads + Android SDK (`net10.0` only)
- GitHub CI uses `dorny/paths-filter` so Client-only changes skip the heavy DevFlow build, and vice versa
- Shared infra changes (`eng/`, `Directory.Build.props`, etc.) trigger both builds

Fixes #32