### PR TITLE
Add project version management commands

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -20,6 +20,31 @@ public class CommandConstructionTests
 	}
 
 	[Fact]
+	public void RootCommand_IncludesProjectVersionCommands()
+	{
+		var rootCommand = Program.BuildRootCommand();
+
+		var projectCommand = Assert.Single(rootCommand.Subcommands, command => command.Name == "project");
+		var versionCommand = Assert.Single(projectCommand.Subcommands, command => command.Name == "version");
+		Assert.Contains(versionCommand.Subcommands, command => command.Name == "show");
+		Assert.Contains(versionCommand.Subcommands, command => command.Name == "list");
+		Assert.Contains(versionCommand.Subcommands, command => command.Name == "set");
+		Assert.Contains(versionCommand.Subcommands, command => command.Name == "use-workload");
+
+		var showCommand = Assert.Single(versionCommand.Subcommands, command => command.Name == "show");
+		Assert.Contains("check", showCommand.Aliases);
+	}
+
+	[Fact]
+	public void VersionCommand_RemainsCliVersionCommand()
+	{
+		var rootCommand = Program.BuildRootCommand();
+
+		var versionCommand = Assert.Single(rootCommand.Subcommands, command => command.Name == "version");
+		Assert.Empty(versionCommand.Subcommands);
+	}
+
+	[Fact]
 	public void DevFlowCommand_AllOptionsHaveValidAliases()
 	{
 		var jsonOption = new Option<bool>("--json");

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiProjectVersionServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiProjectVersionServiceTests.cs
@@ -1,0 +1,438 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+using Microsoft.Maui.Cli.Services;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class MauiProjectVersionServiceTests
+{
+	[Fact]
+	public async Task GetVersionInfoAsync_UseMauiProjectWithoutPackageReferences_UsesWorkloadVersion()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var info = await service.GetVersionInfoAsync(projectPath);
+
+		Assert.True(info.IsMauiProject);
+		Assert.True(info.UsesMaui);
+		Assert.Equal("10.0.41", info.EffectiveVersion);
+		Assert.Empty(info.Packages);
+	}
+
+	[Fact]
+	public async Task GetVersionInfoAsync_UseMauiProjectWithoutPackageReferences_IgnoresCentralPackageVersions()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("Directory.Packages.props", """
+			<Project>
+			  <ItemGroup>
+			    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.30" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var info = await service.GetVersionInfoAsync(projectPath);
+
+		Assert.True(info.IsMauiProject);
+		Assert.Equal("10.0.41", info.EffectiveVersion);
+		Assert.Empty(info.Packages);
+	}
+
+	[Fact]
+	public async Task SetVersionAsync_UseMauiProject_AddsMauiVersionProperty()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetVersionAsync(projectPath, "10.0.60", dryRun: false);
+
+		Assert.True(result.Changed);
+		Assert.Contains("<MauiVersion>10.0.60</MauiVersion>", File.ReadAllText(projectPath));
+	}
+
+	[Fact]
+	public async Task SetVersionAsync_ConditionalFirstPropertyGroup_AddsMauiVersionToUnconditionalGroup()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetVersionAsync(projectPath, "10.0.60", dryRun: false);
+		var document = XDocument.Load(projectPath);
+		var mauiVersionGroup = Assert.Single(document.Root!.Elements(),
+			element => element.Elements().Any(child => child.Name.LocalName == "MauiVersion"));
+
+		Assert.True(result.Changed);
+		Assert.Null(mauiVersionGroup.Attribute("Condition"));
+	}
+
+	[Fact]
+	public async Task SetVersionAsync_ConditionalMauiVersion_UpdatesConditionalAndAddsUnconditionalVersion()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+			    <UseMaui>true</UseMaui>
+			    <MauiVersion>10.0.30</MauiVersion>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetVersionAsync(projectPath, "10.0.60", dryRun: false);
+		var document = XDocument.Load(projectPath);
+		var mauiVersionGroups = document.Root!.Elements()
+			.Where(element => element.Elements().Any(child => child.Name.LocalName == "MauiVersion"))
+			.ToList();
+
+		Assert.True(result.Changed);
+		Assert.Contains(mauiVersionGroups, element => element.Attribute("Condition") is null);
+		Assert.All(document.Descendants().Where(element => element.Name.LocalName == "MauiVersion"),
+			element => Assert.Equal("10.0.60", element.Value));
+	}
+
+	[Fact]
+	public async Task SetVersionAsync_ProjectPackageReference_UpdatesExplicitVersion()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetVersionAsync(projectPath, "10.0.60", dryRun: false);
+
+		Assert.True(result.Changed);
+		Assert.Contains("Version=\"10.0.60\"", File.ReadAllText(projectPath));
+	}
+
+	[Fact]
+	public async Task SetVersionAsync_CentralPackageVersion_UpdatesCentralFile()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("Directory.Packages.props", """
+			<Project>
+			  <PropertyGroup>
+			    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.41" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Controls" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetVersionAsync(projectPath, "10.0.60", dryRun: false);
+
+		Assert.True(result.Changed);
+		Assert.Contains("Version=\"10.0.60\"", File.ReadAllText(Path.Combine(directory.Path, "Directory.Packages.props")));
+	}
+
+	[Fact]
+	public async Task SetVersionAsync_ExplicitPackageAlreadyAtVersion_DoesNotUpdateCentralFile()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("Directory.Packages.props", """
+			<Project>
+			  <ItemGroup>
+			    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.30" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			    <MauiVersion>10.0.60</MauiVersion>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetVersionAsync(projectPath, "10.0.60", dryRun: false);
+		var centralContent = File.ReadAllText(Path.Combine(directory.Path, "Directory.Packages.props"));
+
+		Assert.False(result.Changed);
+		Assert.Contains("Version=\"10.0.30\"", centralContent);
+	}
+
+	[Fact]
+	public async Task SetVersionAsync_CentralPackageManagementWithoutPackageVersion_AddsCentralVersion()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("Directory.Packages.props", """
+			<Project>
+			  <PropertyGroup>
+			    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+			  </PropertyGroup>
+			  <ItemGroup />
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Controls" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetVersionAsync(projectPath, "10.0.60", dryRun: false);
+		var projectContent = File.ReadAllText(projectPath);
+		var centralContent = File.ReadAllText(Path.Combine(directory.Path, "Directory.Packages.props"));
+
+		Assert.True(result.Changed);
+		Assert.DoesNotContain("PackageReference Include=\"Microsoft.Maui.Controls\" Version=", projectContent);
+		Assert.Contains("<PackageVersion Include=\"Microsoft.Maui.Controls\" Version=\"10.0.60\" />", centralContent);
+	}
+
+	[Fact]
+	public async Task GetVersionInfoAsync_CentralPackageVersionWithProperty_ResolvesEffectiveVersion()
+	{
+		using var directory = TemporaryDirectory.Create();
+		Directory.CreateDirectory(Path.Combine(directory.Path, "eng"));
+		directory.WriteFile("eng/Versions.props", """
+			<Project>
+			  <PropertyGroup>
+			    <MicrosoftMauiControlsVersion>10.0.41</MicrosoftMauiControlsVersion>
+			    <MicrosoftAspNetCoreComponentsWebViewMauiVersion>$(MicrosoftMauiControlsVersion)</MicrosoftAspNetCoreComponentsWebViewMauiVersion>
+			  </PropertyGroup>
+			</Project>
+			""");
+		directory.WriteFile("Directory.Packages.props", """
+			<Project>
+			  <PropertyGroup>
+			    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MicrosoftMauiControlsVersion)" />
+			    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MicrosoftAspNetCoreComponentsWebViewMauiVersion)" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Controls" />
+			    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var info = await service.GetVersionInfoAsync(projectPath);
+
+		Assert.Equal("10.0.41", info.EffectiveVersion);
+		Assert.DoesNotContain(info.Packages, package => package.ResolvedVersion is not null && package.ResolvedVersion != "10.0.41");
+	}
+
+	[Fact]
+	public async Task GetVersionInfoAsync_NonMauiProjectWithCentralMauiVersions_IsNotMauiProject()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("Directory.Packages.props", """
+			<Project>
+			  <ItemGroup>
+			    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.41" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("Tool.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <TargetFramework>net10.0</TargetFramework>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var info = await service.GetVersionInfoAsync(projectPath);
+
+		Assert.False(info.IsMauiProject);
+		Assert.Empty(info.Packages);
+	}
+
+	[Fact]
+	public async Task GetVersionInfoAsync_CentralPackageVersions_OnlyIncludesPackagesReferencedByProject()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("Directory.Packages.props", """
+			<Project>
+			  <PropertyGroup>
+			    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.41" />
+			    <PackageVersion Include="Microsoft.Maui.Essentials" Version="10.0.41" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <TargetFramework>net10.0</TargetFramework>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Controls" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var info = await service.GetVersionInfoAsync(projectPath);
+
+		Assert.True(info.IsMauiProject);
+		Assert.Contains(info.Packages, package => package.PackageId == "Microsoft.Maui.Controls" && package.Source == "central");
+		Assert.DoesNotContain(info.Packages, package => package.PackageId == "Microsoft.Maui.Essentials");
+	}
+
+	[Fact]
+	public async Task UseWorkloadVersionAsync_RemovesProjectMauiVersionAndUsesWorkloadExpressionForPackages()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			    <MauiVersion>10.0.60</MauiVersion>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.UseWorkloadVersionAsync(projectPath, dryRun: false);
+		var content = File.ReadAllText(projectPath);
+
+		Assert.True(result.Changed);
+		Assert.DoesNotContain("<MauiVersion>", content);
+		Assert.Contains("Version=\"$(MauiVersion)\"", content);
+	}
+
+	[Fact]
+	public async Task UseWorkloadVersionAsync_PackageOnlyProject_Throws()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <TargetFramework>net10.0</TargetFramework>
+			    <MauiVersion>10.0.60</MauiVersion>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			service.UseWorkloadVersionAsync(projectPath, dryRun: false));
+
+		Assert.Contains("<UseMaui>true</UseMaui>", exception.Message);
+		Assert.Contains("<MauiVersion>10.0.60</MauiVersion>", File.ReadAllText(projectPath));
+	}
+
+	[Fact]
+	public void DiscoverProjectFile_MultipleProjects_ReturnsNull()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("App1.csproj", "<Project />");
+		directory.WriteFile("App2.csproj", "<Project />");
+		var service = CreateService("10.0.41");
+
+		var projectPath = service.DiscoverProjectFile(directory.Path);
+
+		Assert.Null(projectPath);
+	}
+
+	static MauiProjectVersionService CreateService(string workloadVersion) =>
+		new(_ => Task.FromResult<string?>(workloadVersion));
+
+	sealed class TemporaryDirectory : IDisposable
+	{
+		public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "maui-cli-tests", Guid.NewGuid().ToString("N"));
+
+		TemporaryDirectory()
+		{
+			Directory.CreateDirectory(Path);
+		}
+
+		public static TemporaryDirectory Create() => new();
+
+		public string WriteFile(string relativePath, string contents)
+		{
+			var path = System.IO.Path.Combine(Path, relativePath);
+			Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+			File.WriteAllText(path, contents);
+			return path;
+		}
+
+		public void Dispose()
+		{
+			if (Directory.Exists(Path))
+				Directory.Delete(Path, recursive: true);
+		}
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiVersionFeedServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiVersionFeedServiceTests.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using Microsoft.Maui.Cli.Services;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class MauiVersionFeedServiceTests
+{
+	[Fact]
+	public async Task GetVersionsAsync_StableWithoutPrerelease_FiltersAndSortsVersions()
+	{
+		var service = CreateService("""
+			{"versions":["10.0.5","11.0.0-preview.1.1","10.0.60","10.0.12"]}
+			""");
+
+		var versions = await service.GetVersionsAsync(MauiVersionChannel.Stable, includePrerelease: false);
+
+		Assert.Equal(["10.0.5", "10.0.12", "10.0.60"], versions.Select(version => version.Version).ToArray());
+	}
+
+	[Fact]
+	public async Task GetLatestVersionAsync_Nightly_SortsCiVersions()
+	{
+		var service = CreateService("""
+			{"versions":["9.0.90-ci.main.25354.1","9.0.90-ci.main.25353.3","9.0.90-ci.main.25354.2"]}
+			""");
+
+		var version = await service.GetLatestVersionAsync(MauiVersionChannel.Nightly, includePrerelease: true);
+
+		Assert.NotNull(version);
+		Assert.Equal("9.0.90-ci.main.25354.2", version.Version);
+	}
+
+	static MauiVersionFeedService CreateService(string response) =>
+		new(new HttpClient(new StubHandler(response)));
+
+	sealed class StubHandler(string response) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(response),
+			});
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
@@ -27,6 +27,8 @@ public class ServiceConfigurationTests
 		Assert.NotNull(provider.GetService<IDoctorService>());
 		Assert.NotNull(provider.GetService<IDeviceManager>());
 		Assert.NotNull(provider.GetService<IDevFlowOutputWriter>());
+		Assert.NotNull(provider.GetService<IMauiVersionFeedService>());
+		Assert.NotNull(provider.GetService<IMauiProjectVersionService>());
 	}
 
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.Version.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.Version.cs
@@ -1,0 +1,416 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Cli.Output;
+using Microsoft.Maui.Cli.Services;
+
+namespace Microsoft.Maui.Cli.Commands;
+
+public static partial class ProjectCommands
+{
+	static Command CreateVersionCommand()
+	{
+		var command = new Command("version", "Show and manage the .NET MAUI version used by a project")
+		{
+			ProjectOption,
+		};
+
+		SetHandledAction(command, ShowVersionAsync);
+		command.Add(CreateVersionShowCommand());
+		command.Add(CreateVersionListCommand());
+		command.Add(CreateVersionSetCommand());
+		command.Add(CreateVersionUseWorkloadCommand());
+
+		return command;
+	}
+
+	static Command CreateVersionShowCommand()
+	{
+		var command = new Command("show", "Show the .NET MAUI version used by a project");
+		command.Aliases.Add("check");
+		SetHandledAction(command, ShowVersionAsync);
+		return command;
+	}
+
+	static Command CreateVersionListCommand()
+	{
+		var channelOption = new Option<string>("--channel", "-c")
+		{
+			Description = "Version feed to query: stable or nightly.",
+			DefaultValueFactory = _ => "stable",
+		};
+		var prereleaseOption = new Option<bool>("--prerelease")
+		{
+			Description = "Include prerelease versions when querying the stable feed.",
+		};
+		var takeOption = new Option<int>("--take", "-t")
+		{
+			Description = "Number of versions to display.",
+			DefaultValueFactory = _ => 10,
+		};
+
+		var command = new Command("list", "List available .NET MAUI package versions")
+		{
+			channelOption,
+			prereleaseOption,
+			takeOption,
+		};
+
+		SetHandledAction(command, async (parseResult, cancellationToken) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			var channel = ParseChannel(parseResult.GetValue(channelOption));
+			var take = parseResult.GetValue(takeOption);
+			if (take <= 0)
+				throw new InvalidOperationException("--take must be a positive number.");
+
+			var includePrerelease = parseResult.GetValue(prereleaseOption) || channel == MauiVersionChannel.Nightly;
+			var feedService = Program.Services.GetRequiredService<IMauiVersionFeedService>();
+			var versions = await feedService.GetVersionsAsync(channel, includePrerelease, cancellationToken);
+			var displayVersions = versions.TakeLast(take).Reverse().ToList();
+
+			if (useJson)
+			{
+				formatter.Write(new MauiVersionListResult
+				{
+					Channel = channel.ToString().ToLowerInvariant(),
+					Feed = feedService.GetFeedUrl(channel),
+					TotalAvailable = versions.Count,
+					Versions = displayVersions,
+				});
+			}
+			else
+			{
+				formatter.WriteTable(displayVersions,
+					("Version", version => version.Version),
+					("Prerelease", version => version.IsPrerelease ? "Yes" : "No"));
+				formatter.WriteInfo($"Showing {displayVersions.Count} of {versions.Count} versions from the {channel.ToString().ToLowerInvariant()} feed.");
+			}
+
+			return 0;
+		});
+
+		return command;
+	}
+
+	static Command CreateVersionSetCommand()
+	{
+		var versionArgument = new Argument<string?>("version")
+		{
+			Description = "Specific .NET MAUI version to use. Omit when using --latest or --latest-nightly.",
+			Arity = ArgumentArity.ZeroOrOne,
+		};
+		var latestOption = new Option<bool>("--latest")
+		{
+			Description = "Set the project to the latest stable Microsoft.Maui.Controls version.",
+		};
+		var latestNightlyOption = new Option<bool>("--latest-nightly")
+		{
+			Description = "Set the project to the latest version from the MAUI nightly feed.",
+		};
+		var nugetConfigOption = new Option<bool>("--nuget-config")
+		{
+			Description = "Add or update a NuGet.config source for the selected feed.",
+		};
+		var sourceOption = new Option<string>("--source")
+		{
+			Description = "NuGet v3 source URL to add to NuGet.config, useful for PR or custom builds.",
+		};
+		var sourceNameOption = new Option<string>("--source-name")
+		{
+			Description = "Name to use when adding --source to NuGet.config.",
+			DefaultValueFactory = _ => ".NET MAUI Packages",
+		};
+		var noRestoreOption = new Option<bool>("--no-restore")
+		{
+			Description = "Do not run dotnet restore after updating files.",
+		};
+
+		var command = new Command("set", "Set the .NET MAUI version used by a project")
+		{
+			versionArgument,
+			latestOption,
+			latestNightlyOption,
+			nugetConfigOption,
+			sourceOption,
+			sourceNameOption,
+			noRestoreOption,
+		};
+
+		SetHandledAction(command, async (parseResult, cancellationToken) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+			var dryRun = Program.IsDryRun(parseResult);
+			var projectService = Program.Services.GetRequiredService<IMauiProjectVersionService>();
+			var feedService = Program.Services.GetRequiredService<IMauiVersionFeedService>();
+			var projectPath = ResolveProjectPath(parseResult, projectService);
+			var explicitVersion = parseResult.GetValue(versionArgument);
+			var latest = parseResult.GetValue(latestOption);
+			var latestNightly = parseResult.GetValue(latestNightlyOption);
+			var noRestore = parseResult.GetValue(noRestoreOption);
+			var nugetConfig = parseResult.GetValue(nugetConfigOption);
+			var source = parseResult.GetValue(sourceOption);
+			var sourceName = parseResult.GetValue(sourceNameOption) ?? ".NET MAUI Packages";
+			var sourceSpecified = parseResult.GetResult(sourceOption)?.Tokens.Count > 0;
+			var sourceNameSpecified = parseResult.GetResult(sourceNameOption)?.Tokens.Count > 0;
+
+			var sourceCount = (string.IsNullOrWhiteSpace(explicitVersion) ? 0 : 1) + (latest ? 1 : 0) + (latestNightly ? 1 : 0);
+			if (sourceCount == 0)
+				throw new InvalidOperationException("Specify a version, --latest, or --latest-nightly.");
+			if (sourceCount > 1)
+				throw new InvalidOperationException("Specify only one of version, --latest, or --latest-nightly.");
+			if (!nugetConfig && (sourceSpecified || sourceNameSpecified))
+				throw new InvalidOperationException("--source and --source-name require --nuget-config.");
+
+			string version;
+			string? sourceForConfig = source;
+			string sourceNameForConfig = sourceName;
+			if (latest)
+			{
+				var latestStable = await feedService.GetLatestVersionAsync(MauiVersionChannel.Stable, includePrerelease: false, cancellationToken);
+				version = latestStable?.Version ?? throw new InvalidOperationException("Could not determine the latest stable MAUI version.");
+			}
+			else if (latestNightly)
+			{
+				var latestNightlyVersion = await feedService.GetLatestVersionAsync(MauiVersionChannel.Nightly, includePrerelease: true, cancellationToken);
+				version = latestNightlyVersion?.Version ?? throw new InvalidOperationException("Could not determine the latest nightly MAUI version.");
+				sourceForConfig ??= feedService.GetFeedUrl(MauiVersionChannel.Nightly);
+				sourceNameForConfig = sourceName == ".NET MAUI Packages" ? ".NET MAUI Nightly" : sourceName;
+			}
+			else
+			{
+				version = explicitVersion!;
+			}
+
+			var versionResult = await projectService.SetVersionAsync(projectPath, version, dryRun: true, cancellationToken);
+			var changes = new List<MauiProjectVersionChange>();
+			if (nugetConfig)
+			{
+				if (string.IsNullOrWhiteSpace(sourceForConfig))
+					throw new InvalidOperationException("--nuget-config requires --source unless --latest-nightly is used.");
+				var nugetConfigChange = await projectService.EnsureNuGetSourceAsync(
+					projectPath, sourceNameForConfig, sourceForConfig, dryRun, cancellationToken);
+				if (nugetConfigChange is not null)
+					changes.Add(nugetConfigChange);
+			}
+
+			var result = dryRun
+				? versionResult
+				: await projectService.SetVersionAsync(projectPath, version, dryRun: false, cancellationToken);
+			changes.AddRange(result.Changes);
+
+			MauiProjectRestoreResult? restoreResult = null;
+			if (!dryRun && !noRestore && changes.Count > 0)
+				restoreResult = await projectService.RestoreAsync(projectPath, cancellationToken);
+
+			WriteUpdateResult(formatter, parseResult, result with { Changes = changes }, restoreResult);
+			return 0;
+		});
+
+		return command;
+	}
+
+	static Command CreateVersionUseWorkloadCommand()
+	{
+		var noRestoreOption = new Option<bool>("--no-restore")
+		{
+			Description = "Do not run dotnet restore after updating files.",
+		};
+		var command = new Command("use-workload", "Use the installed MAUI workload version instead of a pinned project version")
+		{
+			noRestoreOption,
+		};
+
+		SetHandledAction(command, async (parseResult, cancellationToken) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+			var dryRun = Program.IsDryRun(parseResult);
+			var projectService = Program.Services.GetRequiredService<IMauiProjectVersionService>();
+			var projectPath = ResolveProjectPath(parseResult, projectService);
+			var result = await projectService.UseWorkloadVersionAsync(projectPath, dryRun, cancellationToken);
+
+			MauiProjectRestoreResult? restoreResult = null;
+			if (!dryRun && !parseResult.GetValue(noRestoreOption) && result.Changed)
+				restoreResult = await projectService.RestoreAsync(projectPath, cancellationToken);
+
+			WriteUpdateResult(formatter, parseResult, result, restoreResult);
+			return 0;
+		});
+
+		return command;
+	}
+
+	static void SetHandledAction(Command command, Func<ParseResult, CancellationToken, Task<int>> action)
+	{
+		command.SetAction((parseResult, cancellationToken) =>
+			ExecuteHandledActionAsync(parseResult, cancellationToken, action));
+	}
+
+	static async Task<int> ExecuteHandledActionAsync(
+		ParseResult parseResult,
+		CancellationToken cancellationToken,
+		Func<ParseResult, CancellationToken, Task<int>> action)
+	{
+		try
+		{
+			return await action(parseResult, cancellationToken);
+		}
+		catch (Exception exception)
+		{
+			var formatter = Program.GetFormatter(parseResult);
+			return Program.HandleCommandException(formatter, exception);
+		}
+	}
+
+	static async Task<int> ShowVersionAsync(ParseResult parseResult, CancellationToken cancellationToken)
+	{
+		var formatter = Program.GetFormatter(parseResult);
+		var projectService = Program.Services.GetRequiredService<IMauiProjectVersionService>();
+		var projectPath = ResolveProjectPath(parseResult, projectService);
+		var info = await projectService.GetVersionInfoAsync(projectPath, cancellationToken);
+
+		if (!info.IsMauiProject)
+			throw new InvalidOperationException($"No .NET MAUI project markers found in {Path.GetFileName(projectPath)}.");
+
+		if (parseResult.GetValue(GlobalOptions.JsonOption))
+		{
+			formatter.Write(info);
+		}
+		else
+		{
+			WriteProjectVersionInfo(formatter, info);
+		}
+
+		return 0;
+	}
+
+	static string ResolveProjectPath(ParseResult parseResult, IMauiProjectVersionService projectService)
+	{
+		var projectPath = parseResult.GetValue(ProjectOption);
+		var resolvedProjectPath = projectService.DiscoverProjectFile(projectPath);
+		if (resolvedProjectPath is null)
+		{
+			throw new InvalidOperationException(
+				string.IsNullOrWhiteSpace(projectPath)
+					? "No single .csproj file found. Run from a project directory or pass --project."
+					: $"Project file not found or ambiguous: {projectPath}");
+		}
+
+		if (!File.Exists(resolvedProjectPath))
+			throw new FileNotFoundException($"Project file not found: {resolvedProjectPath}", resolvedProjectPath);
+
+		return resolvedProjectPath;
+	}
+
+	static MauiVersionChannel ParseChannel(string? channel) =>
+		channel?.ToLowerInvariant() switch
+		{
+			null or "" or "stable" => MauiVersionChannel.Stable,
+			"nightly" => MauiVersionChannel.Nightly,
+			_ => throw new InvalidOperationException($"Invalid channel '{channel}'. Valid values: stable, nightly."),
+		};
+
+	static void WriteProjectVersionInfo(IOutputFormatter formatter, MauiProjectVersionInfo info)
+	{
+		formatter.WriteInfo($"Project: {Path.GetFileName(info.ProjectPath)}");
+		formatter.WriteInfo($"MAUI project: {(info.UsesMaui ? "yes (<UseMaui>true</UseMaui>)" : "yes")}");
+
+		if (info.MauiVersion is not null)
+			formatter.WriteInfo($"MauiVersion property: {info.MauiVersion}");
+		if (info.WorkloadVersion is not null)
+			formatter.WriteInfo($"Installed workload version: {info.WorkloadVersion}");
+		if (info.EffectiveVersion is not null)
+			formatter.WriteSuccess($"Effective MAUI version: {info.EffectiveVersion}");
+		else
+			formatter.WriteWarning("No explicit MAUI version was found; the project will use the installed workload defaults.");
+
+		if (info.HasMixedPackageVersions)
+			formatter.WriteWarning("Mixed MAUI package versions detected.");
+
+		if (info.Packages.Count > 0)
+		{
+			formatter.WriteTable(info.Packages,
+				("Package", package => package.PackageId),
+				("Version", FormatPackageVersion),
+				("Source", package => package.Source),
+				("File", package => Path.GetFileName(package.FilePath)));
+		}
+	}
+
+	static string FormatPackageVersion(MauiProjectPackageVersion package)
+	{
+		if (package.Version is null)
+			return "(implicit)";
+		if (package.ResolvedVersion is null ||
+			string.Equals(package.Version, package.ResolvedVersion, StringComparison.OrdinalIgnoreCase))
+		{
+			return package.Version;
+		}
+
+		return $"{package.Version} => {package.ResolvedVersion}";
+	}
+
+	static void WriteUpdateResult(
+		IOutputFormatter formatter,
+		ParseResult parseResult,
+		MauiProjectVersionUpdateResult result,
+		MauiProjectRestoreResult? restoreResult)
+	{
+		if (parseResult.GetValue(GlobalOptions.JsonOption))
+		{
+			formatter.Write(new MauiProjectVersionCommandResult
+			{
+				ProjectPath = result.ProjectPath,
+				Version = result.Version,
+				DryRun = result.DryRun,
+				Changed = result.Changed,
+				Changes = result.Changes,
+				Restored = restoreResult?.Success,
+			});
+			return;
+		}
+
+		if (result.DryRun)
+			formatter.WriteInfo($"[dry-run] Would set MAUI version to {result.Version}");
+
+		if (result.Changes.Count == 0)
+		{
+			formatter.WriteSuccess($"Project already uses MAUI version {result.Version}.");
+			return;
+		}
+
+		foreach (var change in result.Changes)
+		{
+			var oldValue = change.OldValue is null ? "(none)" : change.OldValue;
+			var newValue = change.NewValue is null ? "(removed)" : change.NewValue;
+			formatter.WriteInfo($"{change.Description}: {oldValue} -> {newValue} ({Path.GetFileName(change.FilePath)})");
+		}
+
+		if (restoreResult is not null)
+			formatter.WriteSuccess("dotnet restore completed.");
+		else if (!result.DryRun)
+			formatter.WriteSuccess($"Updated MAUI version to {result.Version}.");
+	}
+}
+
+public sealed record MauiVersionListResult
+{
+	public required string Channel { get; init; }
+	public required string Feed { get; init; }
+	public int TotalAvailable { get; init; }
+	public List<MauiPackageFeedVersion> Versions { get; init; } = [];
+}
+
+public sealed record MauiProjectVersionCommandResult
+{
+	public required string ProjectPath { get; init; }
+	public required string Version { get; init; }
+	public bool DryRun { get; init; }
+	public bool Changed { get; init; }
+	public bool? Restored { get; init; }
+	public List<MauiProjectVersionChange> Changes { get; init; } = [];
+}

--- a/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+
+namespace Microsoft.Maui.Cli.Commands;
+
+public static partial class ProjectCommands
+{
+	internal static readonly Option<string> ProjectOption = new("--project", "-p")
+	{
+		Description = "Path to a .csproj file. If omitted, the current directory is searched.",
+		Recursive = true,
+	};
+
+	public static Command Create()
+	{
+		var command = new Command("project", "Project-level .NET MAUI commands");
+		command.Add(CreateVersionCommand());
+		return command;
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
@@ -3,9 +3,11 @@
 
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Microsoft.Maui.Cli.Commands;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.Providers.Apple;
+using Microsoft.Maui.Cli.Services;
 
 namespace Microsoft.Maui.Cli.Output;
 
@@ -46,6 +48,15 @@ namespace Microsoft.Maui.Cli.Output;
 [JsonSerializable(typeof(StatusMessageResult))]
 [JsonSerializable(typeof(VersionResult))]
 [JsonSerializable(typeof(CliCommandResult))]
+[JsonSerializable(typeof(MauiPackageFeedVersion))]
+[JsonSerializable(typeof(List<MauiPackageFeedVersion>))]
+[JsonSerializable(typeof(MauiProjectPackageVersion))]
+[JsonSerializable(typeof(List<MauiProjectPackageVersion>))]
+[JsonSerializable(typeof(MauiProjectVersionChange))]
+[JsonSerializable(typeof(List<MauiProjectVersionChange>))]
+[JsonSerializable(typeof(MauiProjectVersionCommandResult))]
+[JsonSerializable(typeof(MauiProjectVersionInfo))]
+[JsonSerializable(typeof(MauiVersionListResult))]
 [JsonSerializable(typeof(SimulatorCreateResult))]
 [JsonSerializable(typeof(SimulatorEraseResult))]
 [JsonSerializable(typeof(SimulatorAppResult))]

--- a/src/Cli/Microsoft.Maui.Cli/Program.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Program.cs
@@ -101,6 +101,7 @@ public class Program
 		rootCommand.Add(DoctorCommand.Create());
 		rootCommand.Add(DeviceCommand.Create());
 		rootCommand.Add(ProfileCommand.Create());
+		rootCommand.Add(ProjectCommands.Create());
 		rootCommand.Add(VersionCommand.Create());
 
 		// Platform-specific command groups

--- a/src/Cli/Microsoft.Maui.Cli/ServiceConfiguration.cs
+++ b/src/Cli/Microsoft.Maui.Cli/ServiceConfiguration.cs
@@ -41,6 +41,9 @@ public static class ServiceConfiguration
 		// Core services
 		services.AddSingleton<IDoctorService, DoctorService>();
 		services.AddSingleton<IDeviceManager, DeviceManager>();
+		services.AddSingleton<HttpClient>();
+		services.AddSingleton<IMauiVersionFeedService, MauiVersionFeedService>();
+		services.AddSingleton<IMauiProjectVersionService, MauiProjectVersionService>();
 
 		// DevFlow output
 		services.AddSingleton<IDevFlowOutputWriter, DevFlowOutputWriter>();
@@ -59,7 +62,9 @@ public static class ServiceConfiguration
 		IJdkManager? jdkManager = null,
 		IDoctorService? doctorService = null,
 		IDeviceManager? deviceManager = null,
-		IDevFlowOutputWriter? devFlowOutputWriter = null)
+		IDevFlowOutputWriter? devFlowOutputWriter = null,
+		IMauiVersionFeedService? mauiVersionFeedService = null,
+		IMauiProjectVersionService? mauiProjectVersionService = null)
 	{
 		var services = new ServiceCollection();
 
@@ -93,6 +98,18 @@ public static class ServiceConfiguration
 			services.AddSingleton(devFlowOutputWriter);
 		else
 			services.AddSingleton<IDevFlowOutputWriter, DevFlowOutputWriter>();
+
+		services.AddSingleton<HttpClient>();
+
+		if (mauiVersionFeedService != null)
+			services.AddSingleton(mauiVersionFeedService);
+		else
+			services.AddSingleton<IMauiVersionFeedService, MauiVersionFeedService>();
+
+		if (mauiProjectVersionService != null)
+			services.AddSingleton(mauiProjectVersionService);
+		else
+			services.AddSingleton<IMauiProjectVersionService, MauiProjectVersionService>();
 
 		return services.BuildServiceProvider();
 	}

--- a/src/Cli/Microsoft.Maui.Cli/Services/MauiProjectVersionService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/MauiProjectVersionService.cs
@@ -1,0 +1,820 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+using Microsoft.Maui.Cli.Utils;
+
+namespace Microsoft.Maui.Cli.Services;
+
+public sealed record MauiProjectPackageVersion
+{
+	public required string PackageId { get; init; }
+	public string? Version { get; init; }
+	public string? ResolvedVersion { get; init; }
+	public required string Source { get; init; }
+	public required string FilePath { get; init; }
+}
+
+public sealed record MauiProjectVersionInfo
+{
+	public required string ProjectPath { get; init; }
+	public bool UsesMaui { get; init; }
+	public bool IsMauiProject { get; init; }
+	public string? MauiVersion { get; init; }
+	public string? WorkloadVersion { get; init; }
+	public string? EffectiveVersion { get; init; }
+	public bool HasMixedPackageVersions { get; init; }
+	public string? CentralPackageFilePath { get; init; }
+	public List<MauiProjectPackageVersion> Packages { get; init; } = [];
+}
+
+public sealed record MauiProjectVersionChange
+{
+	public required string FilePath { get; init; }
+	public required string Description { get; init; }
+	public string? OldValue { get; init; }
+	public string? NewValue { get; init; }
+}
+
+public sealed record MauiProjectVersionUpdateResult
+{
+	public required string ProjectPath { get; init; }
+	public required string Version { get; init; }
+	public bool DryRun { get; init; }
+	public bool Changed => Changes.Count > 0;
+	public List<MauiProjectVersionChange> Changes { get; init; } = [];
+}
+
+public sealed record MauiProjectRestoreResult
+{
+	public bool Success { get; init; }
+	public string? Output { get; init; }
+	public string? Error { get; init; }
+}
+
+public interface IMauiProjectVersionService
+{
+	string? DiscoverProjectFile(string? path = null);
+	Task<MauiProjectVersionInfo> GetVersionInfoAsync(string projectPath, CancellationToken cancellationToken = default);
+	Task<MauiProjectVersionUpdateResult> SetVersionAsync(string projectPath, string version, bool dryRun, CancellationToken cancellationToken = default);
+	Task<MauiProjectVersionUpdateResult> UseWorkloadVersionAsync(string projectPath, bool dryRun, CancellationToken cancellationToken = default);
+	Task<MauiProjectVersionChange?> EnsureNuGetSourceAsync(string projectPath, string sourceName, string sourceUrl, bool dryRun, CancellationToken cancellationToken = default);
+	Task<MauiProjectRestoreResult> RestoreAsync(string projectPath, CancellationToken cancellationToken = default);
+}
+
+public sealed class MauiProjectVersionService : IMauiProjectVersionService
+{
+	internal const string MauiVersionProperty = "MauiVersion";
+	internal const string WorkloadVersionExpression = "$(MauiVersion)";
+
+	static readonly HashSet<string> s_mauiPackageIds = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"Microsoft.Maui.Controls",
+		"Microsoft.Maui.Controls.Compatibility",
+		"Microsoft.Maui.Controls.Maps",
+		"Microsoft.Maui.Core",
+		"Microsoft.Maui.Essentials",
+		"Microsoft.Maui.Graphics",
+		"Microsoft.AspNetCore.Components.WebView.Maui",
+	};
+
+	readonly Func<CancellationToken, Task<string?>> _workloadVersionResolver;
+
+	public MauiProjectVersionService(Func<CancellationToken, Task<string?>>? workloadVersionResolver = null)
+	{
+		_workloadVersionResolver = workloadVersionResolver ?? ResolveMauiVersionFromWorkloadAsync;
+	}
+
+	public string? DiscoverProjectFile(string? path = null)
+	{
+		path = string.IsNullOrWhiteSpace(path) ? Environment.CurrentDirectory : path;
+
+		if (File.Exists(path))
+			return Path.GetFullPath(path);
+
+		if (!Directory.Exists(path))
+			return null;
+
+		var directProjects = Directory.GetFiles(path, "*.csproj", SearchOption.TopDirectoryOnly);
+		if (directProjects.Length == 1)
+			return Path.GetFullPath(directProjects[0]);
+
+		var recursiveProjects = EnumerateProjectFiles(path).Take(2).ToList();
+		return recursiveProjects.Count == 1 ? Path.GetFullPath(recursiveProjects[0]) : null;
+	}
+
+	public async Task<MauiProjectVersionInfo> GetVersionInfoAsync(string projectPath, CancellationToken cancellationToken = default)
+	{
+		projectPath = Path.GetFullPath(projectPath);
+		var document = LoadXml(projectPath);
+		var usesMaui = HasTrueProperty(document, "UseMaui");
+		var centralPackageFile = FindCentralPackageFile(Path.GetDirectoryName(projectPath) ?? Environment.CurrentDirectory);
+		var properties = LoadKnownProperties(projectPath, centralPackageFile);
+		var mauiVersion = ResolvePropertyExpression(GetPropertyValue(document, MauiVersionProperty), properties);
+
+		var packages = new List<MauiProjectPackageVersion>();
+		var projectPackages = GetProjectPackageVersions(document, projectPath, properties).ToList();
+		packages.AddRange(projectPackages);
+		var projectPackageIds = projectPackages
+			.Select(package => package.PackageId)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		var hasProjectMauiMarker = usesMaui || mauiVersion is not null || projectPackages.Count > 0;
+		var centralPackageManagementEnabled = IsCentralPackageManagementEnabled(properties);
+
+		if (centralPackageFile is not null && hasProjectMauiMarker && centralPackageManagementEnabled)
+		{
+			var centralDocument = LoadXml(centralPackageFile);
+			packages.AddRange(GetCentralPackageVersions(centralDocument, centralPackageFile, properties)
+				.Where(package => projectPackageIds.Contains(package.PackageId)));
+		}
+
+		var isMauiProject = hasProjectMauiMarker;
+		var rawVersions = packages
+			.Select(package => package.ResolvedVersion ?? package.Version)
+			.Where(version => !string.IsNullOrWhiteSpace(version))
+			.Select(version => version!)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToList();
+		var needsWorkloadVersion = isMauiProject && (rawVersions.Count == 0 || rawVersions.Contains(WorkloadVersionExpression, StringComparer.OrdinalIgnoreCase));
+		var workloadVersion = needsWorkloadVersion ? await _workloadVersionResolver(cancellationToken) : null;
+		var effectiveVersion = GetEffectiveVersion(mauiVersion, workloadVersion, rawVersions);
+
+		return new MauiProjectVersionInfo
+		{
+			ProjectPath = projectPath,
+			UsesMaui = usesMaui,
+			IsMauiProject = isMauiProject,
+			MauiVersion = mauiVersion,
+			WorkloadVersion = workloadVersion,
+			EffectiveVersion = effectiveVersion,
+			HasMixedPackageVersions = rawVersions.Count > 1,
+			CentralPackageFilePath = centralPackageFile,
+			Packages = packages,
+		};
+	}
+
+	public Task<MauiProjectVersionUpdateResult> SetVersionAsync(
+		string projectPath,
+		string version,
+		bool dryRun,
+		CancellationToken cancellationToken = default)
+	{
+		ValidateVersionValue(version, allowWorkloadExpression: false);
+		return UpdateVersionAsync(projectPath, version, removeMauiVersionProperty: false, dryRun, cancellationToken);
+	}
+
+	public Task<MauiProjectVersionUpdateResult> UseWorkloadVersionAsync(
+		string projectPath,
+		bool dryRun,
+		CancellationToken cancellationToken = default)
+	{
+		return UseWorkloadVersionCoreAsync(projectPath, dryRun, cancellationToken);
+	}
+
+	async Task<MauiProjectVersionUpdateResult> UseWorkloadVersionCoreAsync(
+		string projectPath,
+		bool dryRun,
+		CancellationToken cancellationToken)
+	{
+		var info = await GetVersionInfoAsync(projectPath, cancellationToken);
+		if (!info.UsesMaui)
+			throw new InvalidOperationException("use-workload requires <UseMaui>true</UseMaui> so $(MauiVersion) is supplied by the installed MAUI workload.");
+
+		return await UpdateVersionAsync(projectPath, WorkloadVersionExpression, removeMauiVersionProperty: true, dryRun, cancellationToken);
+	}
+
+	public async Task<MauiProjectVersionChange?> EnsureNuGetSourceAsync(
+		string projectPath,
+		string sourceName,
+		string sourceUrl,
+		bool dryRun,
+		CancellationToken cancellationToken = default)
+	{
+		if (string.IsNullOrWhiteSpace(sourceName))
+			throw new ArgumentException("NuGet source name cannot be empty.", nameof(sourceName));
+		if (!Uri.TryCreate(sourceUrl, UriKind.Absolute, out _))
+			throw new ArgumentException($"NuGet source must be an absolute URL: {sourceUrl}", nameof(sourceUrl));
+
+		projectPath = Path.GetFullPath(projectPath);
+		var projectDirectory = Path.GetDirectoryName(projectPath) ?? Environment.CurrentDirectory;
+		var configPath = Directory.GetFiles(projectDirectory, "NuGet.config", SearchOption.TopDirectoryOnly).FirstOrDefault()
+			?? Directory.GetFiles(projectDirectory, "nuget.config", SearchOption.TopDirectoryOnly).FirstOrDefault()
+			?? Path.Combine(projectDirectory, "NuGet.config");
+
+		XDocument document;
+		if (File.Exists(configPath))
+		{
+			document = LoadXml(configPath);
+		}
+		else
+		{
+			document = new XDocument(
+				new XElement("configuration",
+					new XElement("packageSources")));
+		}
+
+		var packageSources = document.Root?.Elements().FirstOrDefault(e => e.Name.LocalName == "packageSources");
+		if (packageSources is null)
+		{
+			packageSources = new XElement("packageSources");
+			document.Root?.Add(packageSources);
+		}
+
+		var source = packageSources.Elements()
+			.FirstOrDefault(e =>
+				e.Name.LocalName == "add" &&
+				string.Equals(e.Attribute("key")?.Value, sourceName, StringComparison.OrdinalIgnoreCase));
+
+		if (source is null)
+		{
+			var change = new MauiProjectVersionChange
+			{
+				FilePath = configPath,
+				Description = $"Add NuGet source '{sourceName}'",
+				NewValue = sourceUrl,
+			};
+
+			if (!dryRun)
+			{
+				packageSources.Add(new XElement("add",
+					new XAttribute("key", sourceName),
+					new XAttribute("value", sourceUrl)));
+				await SaveXmlAsync(document, configPath, cancellationToken);
+			}
+
+			return change;
+		}
+
+		var valueAttribute = source.Attribute("value");
+		var oldValue = valueAttribute?.Value;
+		if (string.Equals(oldValue, sourceUrl, StringComparison.OrdinalIgnoreCase))
+			return null;
+
+		var updateChange = new MauiProjectVersionChange
+		{
+			FilePath = configPath,
+			Description = $"Update NuGet source '{sourceName}'",
+			OldValue = oldValue,
+			NewValue = sourceUrl,
+		};
+
+		if (!dryRun)
+		{
+			if (valueAttribute is null)
+				source.Add(new XAttribute("value", sourceUrl));
+			else
+				valueAttribute.Value = sourceUrl;
+			await SaveXmlAsync(document, configPath, cancellationToken);
+		}
+
+		return updateChange;
+	}
+
+	public async Task<MauiProjectRestoreResult> RestoreAsync(string projectPath, CancellationToken cancellationToken = default)
+	{
+		projectPath = Path.GetFullPath(projectPath);
+		var result = await ProcessRunner.RunAsync(
+			"dotnet",
+			["restore", projectPath],
+			workingDirectory: Path.GetDirectoryName(projectPath),
+			cancellationToken: cancellationToken);
+
+		if (!result.Success)
+		{
+			throw new InvalidOperationException(
+				$"'dotnet restore {projectPath}' failed with exit code {result.ExitCode}: {result.StandardError.Trim()}");
+		}
+
+		return new MauiProjectRestoreResult
+		{
+			Success = true,
+			Output = result.StandardOutput.Trim(),
+			Error = string.IsNullOrWhiteSpace(result.StandardError) ? null : result.StandardError.Trim(),
+		};
+	}
+
+	async Task<MauiProjectVersionUpdateResult> UpdateVersionAsync(
+		string projectPath,
+		string version,
+		bool removeMauiVersionProperty,
+		bool dryRun,
+		CancellationToken cancellationToken)
+	{
+		ValidateVersionValue(version, allowWorkloadExpression: true);
+		projectPath = Path.GetFullPath(projectPath);
+
+		if (!File.Exists(projectPath))
+			throw new FileNotFoundException($"Project file not found: {projectPath}", projectPath);
+
+		var info = await GetVersionInfoAsync(projectPath, cancellationToken);
+		if (!info.IsMauiProject)
+			throw new InvalidOperationException($"No .NET MAUI project markers found in {Path.GetFileName(projectPath)}.");
+
+		var changes = new List<MauiProjectVersionChange>();
+		var projectDocument = LoadXml(projectPath);
+		var projectChanged = false;
+		var projectReferencePackageIds = GetProjectPackageReferences(projectDocument)
+			.Where(element => IsMauiPackage(GetPackageId(element)))
+			.Select(element => GetPackageId(element)!)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+		var projectPackageReferencesWithoutVersion = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var packageReference in GetProjectPackageReferences(projectDocument).Where(element => IsMauiPackage(GetPackageId(element))))
+		{
+			var packageId = GetPackageId(packageReference)!;
+			var packageVersion = GetVersionValue(packageReference);
+			if (TryUpdateVersionOnElement(packageReference, projectPath, packageId, version, changes, addIfMissing: false))
+			{
+				projectChanged = true;
+			}
+			else if (packageVersion is null)
+			{
+				projectPackageReferencesWithoutVersion.Add(packageId);
+			}
+		}
+
+		var centralChanged = false;
+		XDocument? centralDocument = null;
+		var centralFilePath = info.CentralPackageFilePath;
+		var centralPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var centralPackageManagementEnabled = false;
+		if (centralFilePath is not null)
+		{
+			centralDocument = LoadXml(centralFilePath);
+			centralPackageManagementEnabled = IsCentralPackageManagementEnabled(projectPath, centralFilePath);
+			if (centralPackageManagementEnabled)
+			{
+				foreach (var packageVersion in GetCentralPackageVersionElements(centralDocument).Where(element => IsMauiPackage(GetPackageId(element))))
+				{
+					var packageId = GetPackageId(packageVersion)!;
+					centralPackageIds.Add(packageId);
+					if (projectPackageReferencesWithoutVersion.Contains(packageId) &&
+						TryUpdateVersionOnElement(packageVersion, centralFilePath, packageId, version, changes, addIfMissing: true))
+					{
+						centralChanged = true;
+					}
+				}
+			}
+		}
+
+		foreach (var packageId in projectPackageReferencesWithoutVersion.Where(packageId => !centralPackageIds.Contains(packageId)))
+		{
+			if (centralPackageManagementEnabled && centralDocument is not null && centralFilePath is not null)
+			{
+				if (AddCentralPackageVersion(centralDocument, centralFilePath, packageId, version, changes))
+					centralChanged = true;
+			}
+			else
+			{
+				var packageReference = GetProjectPackageReferences(projectDocument)
+					.First(element => string.Equals(GetPackageId(element), packageId, StringComparison.OrdinalIgnoreCase));
+				if (TryUpdateVersionOnElement(packageReference, projectPath, packageId, version, changes, addIfMissing: true))
+				{
+					projectChanged = true;
+				}
+			}
+		}
+
+		if (removeMauiVersionProperty)
+		{
+			if (RemoveMauiVersionProperty(projectDocument, projectPath, changes))
+				projectChanged = true;
+		}
+		else if (info.UsesMaui || info.MauiVersion is not null || projectReferencePackageIds.Count == 0)
+		{
+			if (SetMauiVersionProperty(projectDocument, projectPath, version, changes))
+				projectChanged = true;
+		}
+
+		if (!dryRun)
+		{
+			if (projectChanged)
+				await SaveXmlAsync(projectDocument, projectPath, cancellationToken);
+			if (centralChanged && centralDocument is not null && centralFilePath is not null)
+				await SaveXmlAsync(centralDocument, centralFilePath, cancellationToken);
+		}
+
+		return new MauiProjectVersionUpdateResult
+		{
+			ProjectPath = projectPath,
+			Version = version,
+			DryRun = dryRun,
+			Changes = changes,
+		};
+	}
+
+	static IEnumerable<string> EnumerateProjectFiles(string directory)
+	{
+		var pending = new Queue<string>();
+		pending.Enqueue(directory);
+
+		while (pending.Count > 0)
+		{
+			var current = pending.Dequeue();
+			foreach (var project in Directory.GetFiles(current, "*.csproj", SearchOption.TopDirectoryOnly))
+				yield return project;
+
+			foreach (var child in Directory.GetDirectories(current))
+			{
+				var name = Path.GetFileName(child);
+				if (name is "bin" or "obj" or ".git" or ".vs")
+					continue;
+				pending.Enqueue(child);
+			}
+		}
+	}
+
+	static string? GetEffectiveVersion(string? mauiVersion, string? workloadVersion, List<string> rawPackageVersions)
+	{
+		var expandedVersions = rawPackageVersions
+			.Select(version => string.Equals(version, WorkloadVersionExpression, StringComparison.OrdinalIgnoreCase)
+				? mauiVersion ?? workloadVersion ?? version
+				: version)
+			.Where(version => !string.IsNullOrWhiteSpace(version))
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToList();
+
+		if (expandedVersions.Count == 1)
+			return expandedVersions[0];
+		if (mauiVersion is not null)
+			return mauiVersion;
+		return workloadVersion;
+	}
+
+	static bool HasTrueProperty(XDocument document, string propertyName) =>
+		document.Descendants()
+			.Any(element =>
+				element.Name.LocalName == propertyName &&
+				string.Equals(element.Value.Trim(), "true", StringComparison.OrdinalIgnoreCase));
+
+	static string? GetPropertyValue(XDocument document, string propertyName) =>
+		document.Descendants()
+			.FirstOrDefault(element =>
+				element.Name.LocalName == propertyName &&
+				IsUnconditionalProperty(element))
+			?.Value
+			.Trim();
+
+	static IEnumerable<MauiProjectPackageVersion> GetProjectPackageVersions(
+		XDocument document,
+		string filePath,
+		IReadOnlyDictionary<string, string> properties) =>
+		GetProjectPackageReferences(document)
+			.Where(element => IsMauiPackage(GetPackageId(element)))
+			.Select(element => new MauiProjectPackageVersion
+			{
+				PackageId = GetPackageId(element)!,
+				Version = GetVersionValue(element),
+				ResolvedVersion = ResolvePropertyExpression(GetVersionValue(element), properties),
+				Source = "project",
+				FilePath = filePath,
+			});
+
+	static IEnumerable<MauiProjectPackageVersion> GetCentralPackageVersions(
+		XDocument document,
+		string filePath,
+		IReadOnlyDictionary<string, string> properties) =>
+		GetCentralPackageVersionElements(document)
+			.Where(element => IsMauiPackage(GetPackageId(element)))
+			.Select(element => new MauiProjectPackageVersion
+			{
+				PackageId = GetPackageId(element)!,
+				Version = GetVersionValue(element),
+				ResolvedVersion = ResolvePropertyExpression(GetVersionValue(element), properties),
+				Source = "central",
+				FilePath = filePath,
+			});
+
+	static IEnumerable<XElement> GetProjectPackageReferences(XDocument document) =>
+		document.Descendants().Where(element => element.Name.LocalName == "PackageReference");
+
+	static IEnumerable<XElement> GetCentralPackageVersionElements(XDocument document) =>
+		document.Descendants().Where(element => element.Name.LocalName == "PackageVersion");
+
+	static string? GetPackageId(XElement element) =>
+		element.Attribute("Include")?.Value ?? element.Attribute("Update")?.Value;
+
+	static string? GetVersionValue(XElement element) =>
+		element.Attribute("Version")?.Value ??
+		element.Attribute("VersionOverride")?.Value ??
+		element.Elements().FirstOrDefault(child => child.Name.LocalName == "Version")?.Value.Trim();
+
+	static bool TryUpdateVersionOnElement(
+		XElement element,
+		string filePath,
+		string packageId,
+		string version,
+		List<MauiProjectVersionChange> changes,
+		bool addIfMissing)
+	{
+		var versionAttribute = element.Attribute("Version");
+		var versionOverrideAttribute = element.Attribute("VersionOverride");
+		var versionElement = element.Elements().FirstOrDefault(child => child.Name.LocalName == "Version");
+		var oldValue = versionAttribute?.Value ?? versionOverrideAttribute?.Value ?? versionElement?.Value.Trim();
+
+		if (oldValue is null && !addIfMissing)
+			return false;
+		if (string.Equals(oldValue, version, StringComparison.OrdinalIgnoreCase))
+			return false;
+
+		changes.Add(new MauiProjectVersionChange
+		{
+			FilePath = filePath,
+			Description = oldValue is null
+				? $"Set {packageId} version"
+				: $"Update {packageId} version",
+			OldValue = oldValue,
+			NewValue = version,
+		});
+
+		if (versionAttribute is not null)
+			versionAttribute.Value = version;
+		else if (versionOverrideAttribute is not null)
+			versionOverrideAttribute.Value = version;
+		else if (versionElement is not null)
+			versionElement.Value = version;
+		else
+			element.Add(new XAttribute("Version", version));
+
+		return true;
+	}
+
+	static bool SetMauiVersionProperty(
+		XDocument document,
+		string projectPath,
+		string version,
+		List<MauiProjectVersionChange> changes)
+	{
+		var changed = false;
+		var properties = document.Descendants()
+			.Where(element => element.Name.LocalName == MauiVersionProperty)
+			.ToList();
+		var hasUnconditionalProperty = properties.Any(IsUnconditionalProperty);
+
+		foreach (var property in properties)
+		{
+			var oldValue = property.Value.Trim();
+			if (string.Equals(oldValue, version, StringComparison.OrdinalIgnoreCase))
+				continue;
+
+			changes.Add(new MauiProjectVersionChange
+			{
+				FilePath = projectPath,
+				Description = "Update MauiVersion property",
+				OldValue = oldValue,
+				NewValue = version,
+			});
+			property.Value = version;
+			changed = true;
+		}
+
+		if (hasUnconditionalProperty)
+			return changed;
+
+		changes.Add(new MauiProjectVersionChange
+		{
+			FilePath = projectPath,
+			Description = "Set MauiVersion property",
+			NewValue = version,
+		});
+
+		var root = document.Root ?? throw new InvalidOperationException("Project file does not have a root element.");
+		var ns = root.Name.Namespace;
+		var propertyGroup = root.Elements().FirstOrDefault(element =>
+			element.Name.LocalName == "PropertyGroup" &&
+			element.Attribute("Condition") is null);
+		if (propertyGroup is null)
+		{
+			propertyGroup = new XElement(ns + "PropertyGroup");
+			root.AddFirst(propertyGroup);
+		}
+
+		propertyGroup.Add(new XElement(ns + MauiVersionProperty, version));
+		return true;
+	}
+
+	static bool AddCentralPackageVersion(
+		XDocument document,
+		string filePath,
+		string packageId,
+		string version,
+		List<MauiProjectVersionChange> changes)
+	{
+		changes.Add(new MauiProjectVersionChange
+		{
+			FilePath = filePath,
+			Description = $"Set {packageId} version",
+			NewValue = version,
+		});
+
+		var root = document.Root ?? throw new InvalidOperationException("Central package file does not have a root element.");
+		var ns = root.Name.Namespace;
+		var itemGroup = root.Elements().FirstOrDefault(element =>
+			element.Name.LocalName == "ItemGroup" &&
+			element.Attribute("Condition") is null);
+		if (itemGroup is null)
+		{
+			itemGroup = new XElement(ns + "ItemGroup");
+			root.Add(itemGroup);
+		}
+
+		itemGroup.Add(new XElement(ns + "PackageVersion",
+			new XAttribute("Include", packageId),
+			new XAttribute("Version", version)));
+		return true;
+	}
+
+	static bool RemoveMauiVersionProperty(
+		XDocument document,
+		string projectPath,
+		List<MauiProjectVersionChange> changes)
+	{
+		var properties = document.Descendants().Where(element => element.Name.LocalName == MauiVersionProperty).ToList();
+		if (properties.Count == 0)
+			return false;
+
+		foreach (var property in properties)
+		{
+			changes.Add(new MauiProjectVersionChange
+			{
+				FilePath = projectPath,
+				Description = "Remove MauiVersion property",
+				OldValue = property.Value.Trim(),
+			});
+			property.Remove();
+		}
+
+		return true;
+	}
+
+	static string? FindCentralPackageFile(string startDirectory)
+	{
+		var directory = new DirectoryInfo(startDirectory);
+		while (directory is not null)
+		{
+			var candidate = Path.Combine(directory.FullName, "Directory.Packages.props");
+			if (File.Exists(candidate))
+				return candidate;
+			directory = directory.Parent;
+		}
+
+		return null;
+	}
+
+	static bool IsMauiPackage(string? packageId) =>
+		packageId is not null && s_mauiPackageIds.Contains(packageId);
+
+	static IReadOnlyDictionary<string, string> LoadKnownProperties(string projectPath, string? centralPackageFile)
+	{
+		var files = new List<string>();
+		var directory = new DirectoryInfo(Path.GetDirectoryName(projectPath) ?? Environment.CurrentDirectory);
+		var ancestors = new Stack<DirectoryInfo>();
+		for (var current = directory; current is not null; current = current.Parent)
+			ancestors.Push(current);
+
+		foreach (var ancestor in ancestors)
+		{
+			var versionsProps = Path.Combine(ancestor.FullName, "eng", "Versions.props");
+			if (File.Exists(versionsProps))
+				files.Add(versionsProps);
+
+			var directoryBuildProps = Path.Combine(ancestor.FullName, "Directory.Build.props");
+			if (File.Exists(directoryBuildProps))
+				files.Add(directoryBuildProps);
+		}
+
+		if (centralPackageFile is not null)
+			files.Add(centralPackageFile);
+		files.Add(projectPath);
+
+		var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var file in files.Distinct(StringComparer.OrdinalIgnoreCase))
+		{
+			foreach (var property in LoadProperties(file))
+				properties[property.Key] = ResolvePropertyExpression(property.Value, properties) ?? property.Value;
+		}
+
+		return properties;
+	}
+
+	static IEnumerable<KeyValuePair<string, string>> LoadProperties(string filePath)
+	{
+		var document = LoadXml(filePath);
+
+		foreach (var propertyGroup in document.Descendants().Where(element =>
+			element.Name.LocalName == "PropertyGroup" &&
+			element.Attribute("Condition") is null))
+		{
+			foreach (var property in propertyGroup.Elements())
+			{
+				if (property.HasElements || property.Attribute("Condition") is not null)
+					continue;
+				yield return new KeyValuePair<string, string>(property.Name.LocalName, property.Value.Trim());
+			}
+		}
+	}
+
+	static bool IsCentralPackageManagementEnabled(string projectPath, string centralPackageFile)
+	{
+		var properties = LoadKnownProperties(projectPath, centralPackageFile);
+		return IsCentralPackageManagementEnabled(properties);
+	}
+
+	static bool IsCentralPackageManagementEnabled(IReadOnlyDictionary<string, string> properties)
+	{
+		return properties.TryGetValue("ManagePackageVersionsCentrally", out var value) &&
+			string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+	}
+
+	static bool IsUnconditionalProperty(XElement element) =>
+		element.Attribute("Condition") is null &&
+		element.Parent?.Name.LocalName == "PropertyGroup" &&
+		element.Parent.Attribute("Condition") is null;
+
+	static string? ResolvePropertyExpression(string? value, IReadOnlyDictionary<string, string> properties)
+	{
+		if (string.IsNullOrWhiteSpace(value))
+			return value;
+
+		var resolved = value;
+		for (var pass = 0; pass < 10 && resolved.Contains("$(", StringComparison.Ordinal); pass++)
+		{
+			var before = resolved;
+			foreach (var property in properties)
+				resolved = resolved.Replace($"$({property.Key})", property.Value, StringComparison.OrdinalIgnoreCase);
+
+			if (string.Equals(before, resolved, StringComparison.Ordinal))
+				break;
+		}
+
+		return resolved;
+	}
+
+	static void ValidateVersionValue(string version, bool allowWorkloadExpression)
+	{
+		if (string.IsNullOrWhiteSpace(version))
+			throw new ArgumentException("Version cannot be empty.", nameof(version));
+
+		if (allowWorkloadExpression && string.Equals(version, WorkloadVersionExpression, StringComparison.OrdinalIgnoreCase))
+			return;
+
+		if (!char.IsDigit(version[0]) || version.Any(character =>
+			!(char.IsLetterOrDigit(character) || character is '.' or '-' or '+')))
+		{
+			throw new ArgumentException($"'{version}' is not a valid NuGet-style MAUI version.", nameof(version));
+		}
+	}
+
+	static XDocument LoadXml(string path) =>
+		XDocument.Load(path, LoadOptions.PreserveWhitespace);
+
+	static async Task SaveXmlAsync(XDocument document, string path, CancellationToken cancellationToken)
+	{
+		var directory = Path.GetDirectoryName(path) ?? Environment.CurrentDirectory;
+		var tempPath = Path.Combine(directory, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+		var moved = false;
+
+		try
+		{
+			await using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+			{
+				await document.SaveAsync(stream, SaveOptions.DisableFormatting, cancellationToken);
+				await stream.FlushAsync(cancellationToken);
+			}
+
+			File.Move(tempPath, path, overwrite: true);
+			moved = true;
+		}
+		finally
+		{
+			if (!moved && File.Exists(tempPath))
+				File.Delete(tempPath);
+		}
+	}
+
+	static async Task<string?> ResolveMauiVersionFromWorkloadAsync(CancellationToken cancellationToken)
+	{
+		var result = await ProcessRunner.RunAsync("dotnet", ["workload", "--info"], cancellationToken: cancellationToken);
+		if (!result.Success || !result.StandardOutput.Contains("[maui]", StringComparison.OrdinalIgnoreCase))
+			return null;
+
+		var mauiSection = result.StandardOutput[result.StandardOutput.IndexOf("[maui]", StringComparison.OrdinalIgnoreCase)..];
+		var manifestIndex = mauiSection.IndexOf("Manifest Version:", StringComparison.OrdinalIgnoreCase);
+		if (manifestIndex < 0)
+			return null;
+
+		var afterLabel = mauiSection[(manifestIndex + "Manifest Version:".Length)..];
+		var slashIndex = afterLabel.IndexOf('/');
+		var newlineIndex = afterLabel.IndexOf('\n');
+		var endIndex = (slashIndex >= 0 && newlineIndex >= 0)
+			? Math.Min(slashIndex, newlineIndex)
+			: slashIndex >= 0
+				? slashIndex
+				: newlineIndex >= 0
+					? newlineIndex
+					: afterLabel.Length;
+
+		return afterLabel[..endIndex].Trim();
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/Services/MauiVersionFeedService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/MauiVersionFeedService.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Microsoft.Maui.Cli.Services;
+
+public enum MauiVersionChannel
+{
+	Stable,
+	Nightly,
+}
+
+public sealed record MauiPackageFeedVersion
+{
+	public required string Version { get; init; }
+	public bool IsPrerelease { get; init; }
+}
+
+public interface IMauiVersionFeedService
+{
+	Task<IReadOnlyList<MauiPackageFeedVersion>> GetVersionsAsync(
+		MauiVersionChannel channel,
+		bool includePrerelease,
+		CancellationToken cancellationToken = default);
+
+	Task<MauiPackageFeedVersion?> GetLatestVersionAsync(
+		MauiVersionChannel channel,
+		bool includePrerelease,
+		CancellationToken cancellationToken = default);
+
+	string GetFeedUrl(MauiVersionChannel channel);
+}
+
+public sealed class MauiVersionFeedService : IMauiVersionFeedService
+{
+	internal const string PackageId = "Microsoft.Maui.Controls";
+	internal const string StableFeedUrl = "https://api.nuget.org/v3/index.json";
+	internal const string StableFlatContainerUrl = "https://api.nuget.org/v3-flatcontainer";
+	internal const string NightlyFeedUrl = "https://pkgs.dev.azure.com/xamarin/public/_packaging/maui-nightly/nuget/v3/index.json";
+	internal const string NightlyFlatContainerUrl = "https://pkgs.dev.azure.com/xamarin/public/_packaging/maui-nightly/nuget/v3/flat2";
+
+	readonly HttpClient _httpClient;
+
+	public MauiVersionFeedService(HttpClient? httpClient = null)
+	{
+		_httpClient = httpClient ?? new HttpClient();
+	}
+
+	public string GetFeedUrl(MauiVersionChannel channel) => channel switch
+	{
+		MauiVersionChannel.Nightly => NightlyFeedUrl,
+		_ => StableFeedUrl,
+	};
+
+	public async Task<MauiPackageFeedVersion?> GetLatestVersionAsync(
+		MauiVersionChannel channel,
+		bool includePrerelease,
+		CancellationToken cancellationToken = default)
+	{
+		var versions = await GetVersionsAsync(channel, includePrerelease, cancellationToken);
+		return versions.LastOrDefault();
+	}
+
+	public async Task<IReadOnlyList<MauiPackageFeedVersion>> GetVersionsAsync(
+		MauiVersionChannel channel,
+		bool includePrerelease,
+		CancellationToken cancellationToken = default)
+	{
+		var flatContainerUrl = channel switch
+		{
+			MauiVersionChannel.Nightly => NightlyFlatContainerUrl,
+			_ => StableFlatContainerUrl,
+		};
+
+		var url = $"{flatContainerUrl.TrimEnd('/')}/{PackageId.ToLowerInvariant()}/index.json";
+		using var stream = await _httpClient.GetStreamAsync(url, cancellationToken);
+		using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+
+		if (!document.RootElement.TryGetProperty("versions", out var versionsElement) ||
+			versionsElement.ValueKind != JsonValueKind.Array)
+		{
+			throw new InvalidOperationException($"The MAUI package feed did not return a versions array: {url}");
+		}
+
+		var versions = new List<MauiPackageFeedVersion>();
+		foreach (var versionElement in versionsElement.EnumerateArray())
+		{
+			var version = versionElement.GetString();
+			if (string.IsNullOrWhiteSpace(version))
+				continue;
+
+			var isPrerelease = IsPrerelease(version);
+			if (channel == MauiVersionChannel.Stable && !includePrerelease && isPrerelease)
+				continue;
+
+			versions.Add(new MauiPackageFeedVersion
+			{
+				Version = version,
+				IsPrerelease = isPrerelease,
+			});
+		}
+
+		versions.Sort((left, right) => MauiVersionComparer.Compare(left.Version, right.Version));
+		return versions;
+	}
+
+	static bool IsPrerelease(string version) => version.Contains('-', StringComparison.Ordinal);
+
+	internal static class MauiVersionComparer
+	{
+		public static int Compare(string? left, string? right)
+		{
+			if (ReferenceEquals(left, right))
+				return 0;
+			if (left is null)
+				return -1;
+			if (right is null)
+				return 1;
+
+			var leftVersion = ParsedVersion.Parse(left);
+			var rightVersion = ParsedVersion.Parse(right);
+
+			var coreComparison = CompareCore(leftVersion.Core, rightVersion.Core);
+			if (coreComparison != 0)
+				return coreComparison;
+
+			if (leftVersion.Prerelease.Length == 0 && rightVersion.Prerelease.Length == 0)
+				return 0;
+			if (leftVersion.Prerelease.Length == 0)
+				return 1;
+			if (rightVersion.Prerelease.Length == 0)
+				return -1;
+
+			return ComparePrerelease(leftVersion.Prerelease, rightVersion.Prerelease);
+		}
+
+		static int CompareCore(int[] left, int[] right)
+		{
+			var count = Math.Max(left.Length, right.Length);
+			for (var i = 0; i < count; i++)
+			{
+				var leftValue = i < left.Length ? left[i] : 0;
+				var rightValue = i < right.Length ? right[i] : 0;
+				var comparison = leftValue.CompareTo(rightValue);
+				if (comparison != 0)
+					return comparison;
+			}
+
+			return 0;
+		}
+
+		static int ComparePrerelease(string[] left, string[] right)
+		{
+			var count = Math.Max(left.Length, right.Length);
+			for (var i = 0; i < count; i++)
+			{
+				if (i >= left.Length)
+					return -1;
+				if (i >= right.Length)
+					return 1;
+
+				var leftIsNumber = int.TryParse(left[i], out var leftNumber);
+				var rightIsNumber = int.TryParse(right[i], out var rightNumber);
+
+				int comparison;
+				if (leftIsNumber && rightIsNumber)
+					comparison = leftNumber.CompareTo(rightNumber);
+				else if (leftIsNumber)
+					comparison = -1;
+				else if (rightIsNumber)
+					comparison = 1;
+				else
+					comparison = string.Compare(left[i], right[i], StringComparison.OrdinalIgnoreCase);
+
+				if (comparison != 0)
+					return comparison;
+			}
+
+			return 0;
+		}
+
+		readonly record struct ParsedVersion(int[] Core, string[] Prerelease)
+		{
+			public static ParsedVersion Parse(string version)
+			{
+				var withoutMetadata = version.Split('+', 2)[0];
+				var parts = withoutMetadata.Split('-', 2);
+				var core = parts[0]
+					.Split('.', StringSplitOptions.RemoveEmptyEntries)
+					.Select(part => int.TryParse(part, out var value) ? value : 0)
+					.ToArray();
+				var prerelease = parts.Length > 1
+					? parts[1].Split('.', StringSplitOptions.RemoveEmptyEntries)
+					: Array.Empty<string>();
+
+				return new ParsedVersion(core, prerelease);
+			}
+		}
+	}
+}

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -28,7 +28,29 @@ maui doctor
 maui device list
 ```
 
-### 3. Set up Android development
+### 3. Manage a project's .NET MAUI version
+
+```bash
+# Show the effective MAUI version for the current project
+maui project version
+maui project version --project ./src/MyApp/MyApp.csproj
+
+# List available versions
+maui project version list
+maui project version list --channel nightly --take 20
+
+# Pin a specific version and restore
+maui project version set 10.0.60
+
+# Use the latest stable or nightly package version
+maui project version set --latest
+maui project version set --latest-nightly --nuget-config
+
+# Switch back to the installed workload version
+maui project version use-workload
+```
+
+### 4. Set up Android development
 
 ```bash
 # Full interactive Android setup (JDK + SDK + emulator)
@@ -46,7 +68,7 @@ maui android emulator create --name MyEmulator
 maui android emulator start --name MyEmulator
 ```
 
-### 4. Set up Apple development (macOS only)
+### 5. Set up Apple development (macOS only)
 
 ```bash
 # List installed Xcode versions
@@ -69,6 +91,10 @@ maui apple simulator delete "iPhone 16 Pro"
 |---------|-------------|
 | `maui doctor` | Run environment diagnostics and auto-fix issues |
 | `maui device list` | List connected devices and emulators |
+| `maui project version` | Show the effective .NET MAUI version for a project |
+| `maui project version list` | List available .NET MAUI package versions |
+| `maui project version set` | Pin a project to a specific, latest stable, nightly, or custom-source MAUI version |
+| `maui project version use-workload` | Use the installed MAUI workload version instead of a pinned project version |
 | `maui version` | Display version information |
 | **Android** | |
 | `maui android install` | Full interactive Android environment setup |


### PR DESCRIPTION
## Summary

Adds project-scoped MAUI version management under `maui project version` while keeping bare `maui version` as the CLI version command.

### New commands

| Command | Description |
|---------|-------------|
| `maui project version show` / `check` | Inspect the effective MAUI version for a project |
| `maui project version list` | List available stable or nightly MAUI package versions |
| `maui project version set` | Set an explicit, latest stable, latest nightly, or custom-source/PR build version |
| `maui project version use-workload` | Remove project-pinned MAUI package versions and fall back to the installed workload version |

### Implementation notes

- Uses AOT-safe NuGet flat-container queries instead of `NuGet.Protocol`.
- Handles `<UseMaui>true</UseMaui>`, `<MauiVersion>`, MAUI `PackageReference`s, and central package management via `Directory.Packages.props` when CPM is enabled.
- Updates project XML with safe temp-file replacement and places new `<MauiVersion>` values in an unconditional `PropertyGroup`.
- Can add or update `NuGet.config` package sources for nightly/custom/PR feeds.
- Wraps command validation errors through the existing CLI error formatter for consistent text and JSON output.

### Validation

- CLI unit tests: 523 passed.
- NativeAOT publish passed for the CLI tool.
- Functional on-disk validation passed with the published tool, covering temp MAUI projects, repo sample projects, CPM and non-CPM central package files, workload fallback, validation failures, ambiguous/non-MAUI project failures, custom PR feed dry-runs, and live `dotnet/maui` PR dry-runs.
