### PR TITLE
Fix CLI crash on startup and reduce package size by ~244MB

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -36,7 +36,7 @@ public class CommandConstructionTests
 	{
 		foreach (var option in command.Options)
 		{
-			Assert.DoesNotContain(option.Name, " ");
+			Assert.DoesNotContain(' ', option.Name);
 			foreach (var alias in option.Aliases)
 			{
 				Assert.False(alias.Contains(' '), $"Option alias contains whitespace: \"{alias}\" in command '{command.Name}'");

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.Maui.Cli.Commands;
+using Microsoft.Maui.Cli.DevFlow;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class CommandConstructionTests
+{
+	[Fact]
+	public void BuildRootCommand_DoesNotThrow()
+	{
+		// Verifies all commands and options can be constructed without errors.
+		// Catches issues like descriptions passed as aliases (which throws
+		// ArgumentException for whitespace in alias names).
+		var rootCommand = Program.BuildRootCommand();
+
+		Assert.NotNull(rootCommand);
+		Assert.NotEmpty(rootCommand.Subcommands);
+	}
+
+	[Fact]
+	public void DevFlowCommand_AllOptionsHaveValidAliases()
+	{
+		var jsonOption = new Option<bool>("--json");
+		var devflowCommand = DevFlowCommands.CreateDevFlowCommand(jsonOption);
+
+		// Recursively verify every option in the command tree has no whitespace in aliases
+		AssertNoWhitespaceAliases(devflowCommand);
+	}
+
+	private static void AssertNoWhitespaceAliases(Command command)
+	{
+		foreach (var option in command.Options)
+		{
+			Assert.DoesNotContain(option.Name, " ");
+			foreach (var alias in option.Aliases)
+			{
+				Assert.False(alias.Contains(' '), $"Option alias contains whitespace: \"{alias}\" in command '{command.Name}'");
+			}
+		}
+
+		foreach (var subcommand in command.Subcommands)
+		{
+			AssertNoWhitespaceAliases(subcommand);
+		}
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -36,10 +36,10 @@ public class CommandConstructionTests
 	{
 		foreach (var option in command.Options)
 		{
-			Assert.DoesNotContain(' ', option.Name);
+			Assert.False(option.Name.Any(char.IsWhiteSpace), $"Option name contains whitespace: \"{option.Name}\" in command '{command.Name}'");
 			foreach (var alias in option.Aliases)
 			{
-				Assert.False(alias.Contains(' '), $"Option alias contains whitespace: \"{alias}\" in command '{command.Name}'");
+				Assert.False(alias.Any(char.IsWhiteSpace), $"Option alias contains whitespace: \"{alias}\" in command '{command.Name}'");
 			}
 		}
 

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -1,6 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System.CommandLine;
 using Microsoft.Maui.Cli.Commands;
 using Microsoft.Maui.Cli.DevFlow;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -301,7 +301,7 @@ public class DevFlowCommands
         var queryTypeOption = new Option<string?>("--type") { Description = "Filter by element type" };
         var queryAutoIdOption = new Option<string?>("--automationId") { Description = "Filter by AutomationId" };
         var queryTextOption = new Option<string?>("--text") { Description = "Filter by text content" };
-        var querySelectorOption = new Option<string?>("--selector", "CSS selector (e.g. 'Button:visible', 'StackLayout > Label[Text^=\"Hello\"]')");
+        var querySelectorOption = new Option<string?>("--selector") { Description = "CSS selector (e.g. 'Button:visible', 'StackLayout > Label[Text^=\"Hello\"]')" };
         var queryFieldsOption = new Option<string?>("--fields") { Description = "Comma-separated fields to include (e.g. id,type,text,automationId,bounds)" };
         var queryFormatOption = new Option<string?>("--format") { Description = "Output format: compact (id,type,text,automationId,bounds only)" };
         var queryWaitUntilOption = new Option<string?>("--wait-until") { Description = "Wait condition: exists or gone" };

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -28,9 +28,14 @@
   </ItemGroup>
 
   <!-- Exclude native debug symbols (e.g. SkiaSharp PDBs) from the tool package to reduce size -->
-  <ItemGroup>
-    <Content Remove="runtimes\**\*.pdb" />
-  </ItemGroup>
+  <Target Name="ExcludeNativeRuntimePdbsFromPack" BeforeTargets="Pack;Publish">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
+                             Condition="'%(Extension)' == '.pdb' and $([System.String]::Copy('%(RelativePath)').StartsWith('runtimes'))" />
+      <RuntimeTargetsCopyLocalItems Remove="@(RuntimeTargetsCopyLocalItems)"
+                                    Condition="'%(Extension)' == '.pdb' and $([System.String]::Copy('%(DestinationSubPath)').StartsWith('runtimes'))" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\..\DevFlow\Microsoft.Maui.DevFlow.Driver\Microsoft.Maui.DevFlow.Driver.csproj" />

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -28,10 +28,11 @@
   </ItemGroup>
 
   <!-- Exclude native debug symbols (e.g. SkiaSharp PDBs) from the tool package to reduce size.
-       PackTool globs everything from PublishDir — delete PDBs from there before the glob runs. -->
+       PackTool globs everything from PublishDir — delete PDBs from there before the glob runs.
+       Only runs during 'dotnet pack', not standalone 'dotnet publish'. -->
   <Target Name="RemoveNativeRuntimePdbsBeforeToolPack"
-          AfterTargets="Publish"
           BeforeTargets="PackTool"
+          DependsOnTargets="Publish"
           Condition="'$(PackAsTool)' == 'true' and '$(IsPackable)' != 'false'">
     <ItemGroup>
       <_PdbsToRemove Include="$(PublishDir)runtimes/**/*.pdb" />

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -27,6 +27,11 @@
     <PackageReference Include="XenoAtom.Terminal.UI" />
   </ItemGroup>
 
+  <!-- Exclude native debug symbols (e.g. SkiaSharp PDBs) from the tool package to reduce size -->
+  <ItemGroup>
+    <Content Remove="runtimes\**\*.pdb" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\DevFlow\Microsoft.Maui.DevFlow.Driver\Microsoft.Maui.DevFlow.Driver.csproj" />
   </ItemGroup>

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -29,9 +29,10 @@
 
   <!-- Exclude native debug symbols (e.g. SkiaSharp PDBs) from the tool package to reduce size.
        PackTool globs everything from PublishDir — delete PDBs from there before the glob runs. -->
-  <Target Name="ExcludeNativeRuntimePdbsFromToolPack"
+  <Target Name="RemoveNativeRuntimePdbsBeforeToolPack"
           AfterTargets="Publish"
-          BeforeTargets="PackTool">
+          BeforeTargets="PackTool"
+          Condition="'$(PackAsTool)' == 'true' and '$(IsPackable)' != 'false'">
     <ItemGroup>
       <_PdbsToRemove Include="$(PublishDir)runtimes/**/*.pdb" />
     </ItemGroup>

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -27,14 +27,15 @@
     <PackageReference Include="XenoAtom.Terminal.UI" />
   </ItemGroup>
 
-  <!-- Exclude native debug symbols (e.g. SkiaSharp PDBs) from the tool package to reduce size -->
-  <Target Name="ExcludeNativeRuntimePdbsFromPack" BeforeTargets="Pack;Publish">
+  <!-- Exclude native debug symbols (e.g. SkiaSharp PDBs) from the tool package to reduce size.
+       PackTool globs everything from PublishDir — delete PDBs from there before the glob runs. -->
+  <Target Name="ExcludeNativeRuntimePdbsFromToolPack"
+          AfterTargets="Publish"
+          BeforeTargets="PackTool">
     <ItemGroup>
-      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
-                             Condition="'%(Extension)' == '.pdb' and $([System.String]::Copy('%(RelativePath)').StartsWith('runtimes'))" />
-      <RuntimeTargetsCopyLocalItems Remove="@(RuntimeTargetsCopyLocalItems)"
-                                    Condition="'%(Extension)' == '.pdb' and $([System.String]::Copy('%(DestinationSubPath)').StartsWith('runtimes'))" />
+      <_PdbsToRemove Include="$(PublishDir)runtimes/**/*.pdb" />
     </ItemGroup>
+    <Delete Files="@(_PdbsToRemove)" />
   </Target>
 
   <ItemGroup>

--- a/src/Cli/Microsoft.Maui.Cli/Program.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Program.cs
@@ -72,7 +72,7 @@ public class Program
 		}
 	}
 
-	static RootCommand BuildRootCommand()
+	internal static RootCommand BuildRootCommand()
 	{
 		var rootCommand = new RootCommand("MAUI Development Tools - Device management and environment setup");
 


### PR DESCRIPTION
## Fixes

### 1. CLI crashes on every command
```
System.ArgumentException: Names and aliases cannot contain whitespace:
"CSS selector (e.g. 'Button:visible', 'StackLayout > Label[Text^="Hello"]')"
```
The `--selector` option in `DevFlowCommands.cs` passed its description string as a constructor alias argument. Moved to `{ Description = "..." }` property initializer.

 24MB
The tool package included three SkiaSharp native PDB files (~80MB each, 244MB total uncompressed). These are C++ debug symbols for Skia's rendering  not needed at runtime. Excluded via an MSBuild target (`RemoveNativeRuntimePdbsBeforeToolPack`) that deletes PDBs from the publish directory before `PackTool` globs it. Scoped to only run when packing the tool (`PackAsTool=true`).engine 

 24MB, zero PDBs in package, all native DLLs/dylibs and managed assemblies intact. Managed debug symbols are embedded (`DebugType=embedded`).

### 3. Regression tests
- `BuildRootCommand_ constructs the full command tree, catches constructor crashesDoesNotThrow` 
- `DevFlowCommand_ recursively verifies no option name or alias contains any whitespace characterAllOptionsHaveValidAliases` 

121 tests pass (119 existing + 2 new).