### PR TITLE
Complete DevFlow CLI merge: unify output, DI, and process execution

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,6 @@
     <FizzlerVersion>1.3.1</FizzlerVersion>
     <SkiaSharpVersion>3.119.2</SkiaSharpVersion>
     <SpectreConsoleVersion>0.54.0</SpectreConsoleVersion>
-    <SystemCommandLineVersion>2.0.0-beta4.22272.1</SystemCommandLineVersion>
     <SystemCommandLineStableVersion>2.0.5</SystemCommandLineStableVersion>
     <WebsocketClientVersion>5.3.0</WebsocketClientVersion>
     <XenoAtomTerminalUIVersion>1.7.1</XenoAtomTerminalUIVersion>

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Cli.DevFlow;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.Services;
 using Microsoft.Maui.Cli.UnitTests.Fakes;
@@ -22,6 +23,7 @@ public class ServiceConfigurationTests
 		Assert.NotNull(provider.GetService<IAndroidProvider>());
 		Assert.NotNull(provider.GetService<IDoctorService>());
 		Assert.NotNull(provider.GetService<IDeviceManager>());
+		Assert.NotNull(provider.GetService<IDevFlowOutputWriter>());
 	}
 
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -4,6 +4,8 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Cli.Utils;
 
 namespace Microsoft.Maui.Cli.DevFlow;
 
@@ -15,6 +17,7 @@ public class DevFlowCommands
 {
     private static Command? _devflowCommand;
     [ThreadStatic] private static bool _errorOccurred;
+    private static IDevFlowOutputWriter s_output = null!;
 
     /// <summary>
     /// Creates the "devflow" command with all subcommands for integration into the MAUI CLI.
@@ -22,6 +25,8 @@ public class DevFlowCommands
     /// <param name="parentJsonOption">The parent CLI's --json option (recursive/global). Used instead of a local --json to avoid duplicates.</param>
     public static Command CreateDevFlowCommand(Option<bool> parentJsonOption)
     {
+        var output = Program.Services.GetRequiredService<IDevFlowOutputWriter>();
+        s_output = output;
         var devflowCommand = new Command("devflow", "Automate MAUI apps via Agent API and Blazor WebViews via CDP");
         
         // Alias parent's --json so all existing handler bindings work
@@ -242,7 +247,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await CdpWebViewsAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson));
+            await CdpWebViewsAsync(host, port, output.ResolveJsonMode(json, noJson));
         });
         cdpCommand.Add(webviewsCmd);
 
@@ -274,7 +279,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var window = ctx.GetValue(windowOption);
-            await MauiStatusAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), window);
+            await MauiStatusAsync(host, port, output.ResolveJsonMode(json, noJson), window);
         });
         mauiCommand.Add(mauiStatusCmd);
 
@@ -293,7 +298,7 @@ public class DevFlowCommands
             var window = ctx.GetValue(windowOption);
             var fields = ctx.GetValue(treeFieldsOption);
             var format = ctx.GetValue(treeFormatOption);
-            await MauiTreeAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), depth, window, fields, format);
+            await MauiTreeAsync(host, port, output.ResolveJsonMode(json, noJson), depth, window, fields, format);
         });
         mauiCommand.Add(mauiTreeCmd);
 
@@ -311,7 +316,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(
+            var isJson = output.ResolveJsonMode(
                 ctx.GetValue(jsonOption),
                 ctx.GetValue(noJsonOption));
             var type = ctx.GetValue(queryTypeOption);
@@ -339,7 +344,7 @@ public class DevFlowCommands
             var x = ctx.GetValue(hitTestXArg);
             var y = ctx.GetValue(hitTestYArg);
             var window = ctx.GetValue(windowOption);
-            await MauiHitTestAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), x, y, window);
+            await MauiHitTestAsync(host, port, output.ResolveJsonMode(json, noJson), x, y, window);
         });
         mauiCommand.Add(mauiHitTestCmd);
 
@@ -360,7 +365,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
             var id = ctx.GetValue(tapIdArg);
             var autoId = ctx.GetValue(resolveAutoIdOption);
             var type = ctx.GetValue(resolveTypeOption);
@@ -385,7 +390,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
             var id = ctx.GetValue(fillIdArg);
             var fillText = ctx.GetValue(fillTextArg2)!;
             var autoId = ctx.GetValue(resolveAutoIdOption);
@@ -410,7 +415,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
             var id = ctx.GetValue(clearIdArg);
             var autoId = ctx.GetValue(resolveAutoIdOption);
             var type = ctx.GetValue(resolveTypeOption);
@@ -439,7 +444,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
             await MauiScreenshotAsync(host, port, isJson,
                 ctx.GetValue(screenshotOutputOption),
                 ctx.GetValue(windowOption),
@@ -496,7 +501,7 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var id = ctx.GetValue(propIdArg)!;
             var name = ctx.GetValue(propNameArg)!;
-            await MauiPropertyAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), id, name);
+            await MauiPropertyAsync(host, port, output.ResolveJsonMode(json, noJson), id, name);
         });
         mauiCommand.Add(mauiPropertyCmd);
 
@@ -514,7 +519,7 @@ public class DevFlowCommands
             var id = ctx.GetValue(setPropIdArg)!;
             var name = ctx.GetValue(setPropNameArg)!;
             var value = ctx.GetValue(setPropValueArg)!;
-            await MauiSetPropertyAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), id, name, value);
+            await MauiSetPropertyAsync(host, port, output.ResolveJsonMode(json, noJson), id, name, value);
         });
         mauiCommand.Add(mauiSetPropertyCmd);
 
@@ -528,7 +533,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var id = ctx.GetValue(elementIdArg)!;
-            await MauiElementAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), id);
+            await MauiElementAsync(host, port, output.ResolveJsonMode(json, noJson), id);
         });
         mauiCommand.Add(mauiElementCmd);
 
@@ -542,7 +547,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var route = ctx.GetValue(navRouteArg)!;
-            await MauiNavigateAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), route);
+            await MauiNavigateAsync(host, port, output.ResolveJsonMode(json, noJson), route);
         });
         mauiCommand.Add(mauiNavigateCmd);
 
@@ -559,7 +564,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
             await MauiScrollAsync(host, port, isJson,
                 ctx.GetValue(scrollElementIdOption),
                 ctx.GetValue(scrollDeltaXOption),
@@ -579,7 +584,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
             var id = ctx.GetValue(focusIdArg);
             var autoId = ctx.GetValue(resolveAutoIdOption);
             var type = ctx.GetValue(resolveTypeOption);
@@ -604,7 +609,7 @@ public class DevFlowCommands
             var w = ctx.GetValue(resizeWidthArg);
             var h = ctx.GetValue(resizeHeightArg);
             var window = ctx.GetValue(windowOption);
-            await MauiResizeAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), w, h, window);
+            await MauiResizeAsync(host, port, output.ResolveJsonMode(json, noJson), w, h, window);
         });
         mauiCommand.Add(mauiResizeCmd);
 
@@ -623,7 +628,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await AlertDetectAsync(udid, pid, host, port, OutputWriter.ResolveJsonMode(json, noJson));
+            await AlertDetectAsync(udid, pid, host, port, output.ResolveJsonMode(json, noJson));
         });
         alertCommand.Add(alertDetectCmd);
 
@@ -641,7 +646,7 @@ public class DevFlowCommands
             var button = ctx.GetValue(dismissButtonArg);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await AlertDismissAsync(udid, pid, host, port, button, OutputWriter.ResolveJsonMode(json, noJson));
+            await AlertDismissAsync(udid, pid, host, port, button, output.ResolveJsonMode(json, noJson));
         });
         alertCommand.Add(alertDismissCmd);
 
@@ -657,7 +662,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await AlertTreeAsync(udid, pid, host, port, OutputWriter.ResolveJsonMode(json, noJson));
+            await AlertTreeAsync(udid, pid, host, port, output.ResolveJsonMode(json, noJson));
         });
         alertCommand.Add(alertTreeCmd);
 
@@ -673,7 +678,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
             var id = ctx.GetValue(assertIdOption);
             var autoId = ctx.GetValue(assertAutoIdOption);
             var prop = ctx.GetValue(assertPropertyArg)!;
@@ -737,7 +742,7 @@ public class DevFlowCommands
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
-            var isJson = OutputWriter.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
             var follow = ctx.GetValue(logsFollowOption);
             if (follow)
                 await MauiLogsFollowAsync(host, port, ctx.GetValue(logsSourceOption), isJson, ctx.GetValue(logsReplayOption));
@@ -763,7 +768,7 @@ public class DevFlowCommands
             var limit = ctx.GetValue(networkLimitOption);
             var filterHost = ctx.GetValue(networkHostOption);
             var filterMethod = ctx.GetValue(networkMethodOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             if (isJson)
                 await MauiNetworkMonitorAsync(host, port, isJson, limit, filterHost, filterMethod);
             else
@@ -783,7 +788,7 @@ public class DevFlowCommands
             var limit = ctx.GetValue(networkLimitOption);
             var filterHost = ctx.GetValue(networkHostOption);
             var filterMethod = ctx.GetValue(networkMethodOption);
-            await MauiNetworkListAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), limit, filterHost, filterMethod);
+            await MauiNetworkListAsync(host, port, output.ResolveJsonMode(json, noJson), limit, filterHost, filterMethod);
         });
         networkCommand.Add(networkListCmd);
 
@@ -796,7 +801,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var id = ctx.GetValue(networkDetailId)!;
-            await MauiNetworkDetailAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson), id);
+            await MauiNetworkDetailAsync(host, port, output.ResolveJsonMode(json, noJson), id);
         });
         networkCommand.Add(networkDetailCmd);
 
@@ -807,7 +812,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await MauiNetworkClearAsync(host, port, OutputWriter.ResolveJsonMode(json, noJson));
+            await MauiNetworkClearAsync(host, port, output.ResolveJsonMode(json, noJson));
         });
         networkCommand.Add(networkClearCmd);
 
@@ -826,7 +831,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var sharedName = ctx.GetValue(prefsSharedNameOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             var qs = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
             await SimpleGetAsync(host, port, $"/api/preferences{qs}", isJson);
         });
@@ -844,7 +849,7 @@ public class DevFlowCommands
             var key = ctx.GetValue(prefsGetKeyArg)!;
             var type = ctx.GetValue(prefsGetTypeOption)!;
             var sharedName = ctx.GetValue(prefsSharedNameOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             var qs = $"?type={Uri.EscapeDataString(type)}";
             if (sharedName != null) qs += $"&sharedName={Uri.EscapeDataString(sharedName)}";
             await SimpleGetAsync(host, port, $"/api/preferences/{Uri.EscapeDataString(key)}{qs}", isJson);
@@ -866,7 +871,7 @@ public class DevFlowCommands
             var value = ctx.GetValue(prefsSetValueArg)!;
             var type = ctx.GetValue(prefsSetTypeOption)!;
             var sharedName = ctx.GetValue(prefsSetSharedNameOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             var body = new { value, type, sharedName };
             await SimplePostAsync(host, port, $"/api/preferences/{Uri.EscapeDataString(key)}", body, isJson);
         });
@@ -883,7 +888,7 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var key = ctx.GetValue(prefsDeleteKeyArg)!;
             var sharedName = ctx.GetValue(prefsDeleteSharedNameOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             var qs = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
             await SimpleDeleteAsync(host, port, $"/api/preferences/{Uri.EscapeDataString(key)}{qs}", isJson);
         });
@@ -898,7 +903,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var sharedName = ctx.GetValue(prefsClearSharedNameOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             var qs = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
             await SimplePostAsync(host, port, $"/api/preferences/clear{qs}", null, isJson);
         });
@@ -918,7 +923,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var key = ctx.GetValue(secureGetKeyArg)!;
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             await SimpleGetAsync(host, port, $"/api/secure-storage/{Uri.EscapeDataString(key)}", isJson);
         });
         secureCommand.Add(secureGetCmd);
@@ -934,7 +939,7 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var key = ctx.GetValue(secureSetKeyArg)!;
             var value = ctx.GetValue(secureSetValueArg)!;
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             await SimplePostAsync(host, port, $"/api/secure-storage/{Uri.EscapeDataString(key)}", new { value }, isJson);
         });
         secureCommand.Add(secureSetCmd);
@@ -948,7 +953,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var key = ctx.GetValue(secureDeleteKeyArg)!;
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             await SimpleDeleteAsync(host, port, $"/api/secure-storage/{Uri.EscapeDataString(key)}", isJson);
         });
         secureCommand.Add(secureDeleteCmd);
@@ -960,7 +965,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             await SimplePostAsync(host, port, "/api/secure-storage/clear", null, isJson);
         });
         secureCommand.Add(secureClearCmd);
@@ -977,7 +982,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/app-info", OutputWriter.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/platform/app-info", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformAppInfoCmd);
 
@@ -988,7 +993,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/device-info", OutputWriter.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/platform/device-info", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformDeviceInfoCmd);
 
@@ -999,7 +1004,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/device-display", OutputWriter.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/platform/device-display", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformDisplayCmd);
 
@@ -1010,7 +1015,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/battery", OutputWriter.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/platform/battery", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformBatteryCmd);
 
@@ -1021,7 +1026,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/connectivity", OutputWriter.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/platform/connectivity", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformConnectivityCmd);
 
@@ -1032,7 +1037,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/version-tracking", OutputWriter.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/platform/version-tracking", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformVersionTrackingCmd);
 
@@ -1045,7 +1050,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var permName = ctx.GetValue(platformPermsNameArg);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             var path = permName != null
             ? $"/api/platform/permissions/{Uri.EscapeDataString(permName)}"
             : "/api/platform/permissions";
@@ -1064,7 +1069,7 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var accuracy = ctx.GetValue(platformGeoAccuracyOption)!;
             var timeout = ctx.GetValue(platformGeoTimeoutOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             await SimpleGetAsync(host, port, $"/api/platform/geolocation?accuracy={Uri.EscapeDataString(accuracy)}&timeout={timeout}", isJson);
         });
         platformCommand.Add(platformGeoCmd);
@@ -1081,7 +1086,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/sensors", OutputWriter.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/sensors", output.ResolveJsonMode(json, noJson));
         });
         sensorsCommand.Add(sensorsListCmd);
 
@@ -1096,7 +1101,7 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var sensor = ctx.GetValue(sensorsStartSensorArg)!;
             var speed = ctx.GetValue(sensorsStartSpeedOption)!;
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             await SimplePostAsync(host, port, $"/api/sensors/{Uri.EscapeDataString(sensor)}/start?speed={Uri.EscapeDataString(speed)}", null, isJson);
         });
         sensorsCommand.Add(sensorsStartCmd);
@@ -1110,7 +1115,7 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var sensor = ctx.GetValue(sensorsStopSensorArg)!;
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             await SimplePostAsync(host, port, $"/api/sensors/{Uri.EscapeDataString(sensor)}/stop", null, isJson);
         });
         sensorsCommand.Add(sensorsStopCmd);
@@ -1130,7 +1135,7 @@ public class DevFlowCommands
             var speed = ctx.GetValue(sensorsStreamSpeedOption)!;
             var duration = ctx.GetValue(sensorsStreamDurationOption);
             var throttle = ctx.GetValue(sensorsStreamThrottleOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             await SensorStreamAsync(host, port, sensor, speed, duration, throttle, isJson);
         });
         sensorsCommand.Add(sensorsStreamCmd);
@@ -1192,7 +1197,7 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await BrokerStatusAsync(OutputWriter.ResolveJsonMode(json, noJson));
+            await BrokerStatusAsync(output.ResolveJsonMode(json, noJson));
         });
         brokerCommand.Add(brokerStatusCmd);
 
@@ -1208,7 +1213,7 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await ListAgentsCommandAsync(OutputWriter.ResolveJsonMode(json, noJson));
+            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson));
         });
         devflowCommand.Add(listCmd);
 
@@ -1218,7 +1223,7 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await DiagnoseCommandAsync(OutputWriter.ResolveJsonMode(json, noJson));
+            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson));
         });
         devflowCommand.Add(diagnoseCmd);
 
@@ -1237,7 +1242,7 @@ public class DevFlowCommands
             var waitPlatform = ctx.GetValue(waitPlatformOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await WaitForAgentCommandAsync(timeout, project, waitPlatform, OutputWriter.ResolveJsonMode(json, noJson));
+            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson));
         });
         devflowCommand.Add(waitCmd);
 
@@ -1276,9 +1281,9 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            var isJson = OutputWriter.ResolveJsonMode(json, noJson);
+            var isJson = output.ResolveJsonMode(json, noJson);
             var cmds = GetCommandDescriptions();
-            OutputWriter.WriteResult(cmds, isJson, list =>
+            output.WriteResult(cmds, isJson, list =>
             {
                 Console.WriteLine($"{"Command",-35} {"Mutating",-10} {"Description"}");
                 Console.WriteLine(new string('-', 85));
@@ -1705,7 +1710,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            OutputWriter.WriteError(ex.Message, json);
+            s_output.WriteError(ex.Message, json);
             _errorOccurred = true;
         }
     }
@@ -1735,7 +1740,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            OutputWriter.WriteError(ex.Message, json);
+            s_output.WriteError(ex.Message, json);
             _errorOccurred = true;
         }
     }
@@ -1753,7 +1758,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            OutputWriter.WriteError(ex.Message, json);
+            s_output.WriteError(ex.Message, json);
             _errorOccurred = true;
         }
     }
@@ -1789,7 +1794,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            OutputWriter.WriteError(ex.Message, json);
+            s_output.WriteError(ex.Message, json);
             _errorOccurred = true;
         }
     }
@@ -1813,7 +1818,7 @@ public class DevFlowCommands
         // Need at least one resolution option
         if (string.IsNullOrWhiteSpace(automationId) && string.IsNullOrWhiteSpace(type) && string.IsNullOrWhiteSpace(text))
         {
-            OutputWriter.WriteError("Provide an element ID or use --automationId, --type, or --text to resolve", json, "InvocationError");
+            s_output.WriteError("Provide an element ID or use --automationId, --type, or --text to resolve", json, "InvocationError");
             _errorOccurred = true;
             return null;
         }
@@ -1829,7 +1834,7 @@ public class DevFlowCommands
                 if (automationId != null) criteria.Add($"automationId=\"{automationId}\"");
                 if (type != null) criteria.Add($"type=\"{type}\"");
                 if (text != null) criteria.Add($"text=\"{text}\"");
-                OutputWriter.WriteError($"No elements found matching {string.Join(", ", criteria)}", json,
+                s_output.WriteError($"No elements found matching {string.Join(", ", criteria)}", json,
                     suggestions: new[] { "Run 'MAUI tree' to see available elements", "Check automationId spelling" });
                 _errorOccurred = true;
                 return null;
@@ -1837,7 +1842,7 @@ public class DevFlowCommands
 
             if (index >= results.Count)
             {
-                OutputWriter.WriteError($"Index {index} out of range (found {results.Count} element(s))", json, "RuntimeError",
+                s_output.WriteError($"Index {index} out of range (found {results.Count} element(s))", json, "RuntimeError",
                     suggestions: new[] { $"Use --index 0 through {results.Count - 1}" });
                 _errorOccurred = true;
                 return null;
@@ -1847,7 +1852,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            OutputWriter.WriteError(ex.Message, json);
+            s_output.WriteError(ex.Message, json);
             _errorOccurred = true;
             return null;
         }
@@ -1860,14 +1865,14 @@ public class DevFlowCommands
     {
         if (id.Any(c => c < 0x20))
         {
-            OutputWriter.WriteError($"Element ID contains control characters: '{id}'", json, "InvocationError",
+            s_output.WriteError($"Element ID contains control characters: '{id}'", json, "InvocationError",
                 suggestions: new[] { "Element IDs should not contain control characters", "Run 'MAUI tree' to get valid IDs" });
             _errorOccurred = true;
             return;
         }
         if (id.Contains('?') || id.Contains('#'))
         {
-            OutputWriter.WriteError($"Element ID contains '?' or '#': '{id}' — this looks like a URL fragment, not an element ID", json, "InvocationError",
+            s_output.WriteError($"Element ID contains '?' or '#': '{id}' — this looks like a URL fragment, not an element ID", json, "InvocationError",
                 suggestions: new[] { "Run 'MAUI tree' to get valid element IDs" });
             _errorOccurred = true;
             return;
@@ -1909,7 +1914,7 @@ public class DevFlowCommands
             var passed = string.Equals(actualValue, expectedValue, StringComparison.Ordinal);
             if (json)
             {
-                OutputWriter.WriteResult(new { passed, property = propertyName, expected = expectedValue, actual = actualValue, elementId = resolvedId }, json);
+                s_output.WriteResult(new { passed, property = propertyName, expected = expectedValue, actual = actualValue, elementId = resolvedId }, json);
             }
             else
             {
@@ -1923,7 +1928,7 @@ public class DevFlowCommands
             }
             if (!passed) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     // ===== Command Descriptions (Schema Discovery) =====
@@ -2225,11 +2230,11 @@ public class DevFlowCommands
             var status = await client.GetStatusAsync(window);
             if (status == null)
             {
-                OutputWriter.WriteError($"Cannot connect to agent at {host}:{port}", json);
+                s_output.WriteError($"Cannot connect to agent at {host}:{port}", json);
                 _errorOccurred = true;
                 return;
             }
-            OutputWriter.WriteResult(status, json, s =>
+            s_output.WriteResult(status, json, s =>
             {
                 Console.WriteLine($"Agent: {s.Agent} v{s.Version}");
                 Console.WriteLine($"Platform: {s.Platform}");
@@ -2237,7 +2242,7 @@ public class DevFlowCommands
                 Console.WriteLine($"App: {s.AppName}");
             });
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiTreeAsync(string host, int port, bool json, int depth, int? window, string? fields, string? format)
@@ -2256,7 +2261,7 @@ public class DevFlowCommands
                 PrintTree(tree, 0);
             }
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiQueryAsync(string host, int port, bool json, string? type, string? autoId, string? text, string? selector, string? fields, string? format, string? waitUntil, int timeout)
@@ -2270,7 +2275,7 @@ public class DevFlowCommands
                 var condition = waitUntil.ToLowerInvariant();
                 if (condition != "exists" && condition != "gone")
                 {
-                    OutputWriter.WriteError("--wait-until must be 'exists' or 'gone'", json, "InvocationError");
+                    s_output.WriteError("--wait-until must be 'exists' or 'gone'", json, "InvocationError");
                     _errorOccurred = true;
                     return;
                 }
@@ -2289,7 +2294,7 @@ public class DevFlowCommands
                     if (condition == "gone" && results.Count == 0) break;
                     if (DateTime.UtcNow >= deadline)
                     {
-                        OutputWriter.WriteError(
+                        s_output.WriteError(
                             $"Timeout after {timeout}s: condition '{waitUntil}' not met",
                             json, "RuntimeError", retryable: true,
                             suggestions: new[] { "Increase --timeout", "Check element identifiers with 'MAUI tree'" });
@@ -2312,7 +2317,7 @@ public class DevFlowCommands
 
             WriteQueryResults(queryResults, json, fields, format);
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static void WriteQueryResults(List<Microsoft.Maui.DevFlow.Driver.ElementInfo> results, bool json, string? fields, string? format)
@@ -2352,7 +2357,7 @@ public class DevFlowCommands
             else
                 Console.WriteLine(result);
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiTapAsync(string host, int port, bool json, string elementId)
@@ -2361,11 +2366,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.TapAsync(elementId);
-            OutputWriter.WriteActionResult(success, "Tapped", elementId, json,
+            s_output.WriteActionResult(success, "Tapped", elementId, json,
                 success ? $"Tapped: {elementId}" : $"Failed to tap: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiFillAsync(string host, int port, bool json, string elementId, string text)
@@ -2374,11 +2379,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.FillAsync(elementId, text);
-            OutputWriter.WriteActionResult(success, "Filled", elementId, json,
+            s_output.WriteActionResult(success, "Filled", elementId, json,
                 success ? $"Filled: {elementId}" : $"Failed to fill: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiClearAsync(string host, int port, bool json, string elementId)
@@ -2387,11 +2392,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.ClearAsync(elementId);
-            OutputWriter.WriteActionResult(success, "Cleared", elementId, json,
+            s_output.WriteActionResult(success, "Cleared", elementId, json,
                 success ? $"Cleared: {elementId}" : $"Failed to clear: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiScreenshotAsync(string host, int port, bool json, string? output, int? window, string? id, string? selector, bool overwrite = false, int? maxWidth = null, string? scale = null)
@@ -2401,7 +2406,7 @@ public class DevFlowCommands
             var filename = output ?? $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png";
             if (!overwrite && File.Exists(filename))
             {
-                OutputWriter.WriteError($"File already exists: {Path.GetFullPath(filename)} (use --overwrite to replace)", json, "InvocationError");
+                s_output.WriteError($"File already exists: {Path.GetFullPath(filename)} (use --overwrite to replace)", json, "InvocationError");
                 _errorOccurred = true;
                 return;
             }
@@ -2433,7 +2438,7 @@ public class DevFlowCommands
 
             if (data == null)
             {
-                OutputWriter.WriteError("Failed to capture screenshot", json);
+                s_output.WriteError("Failed to capture screenshot", json);
                 _errorOccurred = true;
                 return;
             }
@@ -2448,7 +2453,7 @@ public class DevFlowCommands
             var fullPath = Path.GetFullPath(filename);
             if (json)
             {
-                OutputWriter.WriteResult(new { path = fullPath, size = data.Length, maxWidth = maxWidth, scale = scale ?? "auto" }, json);
+                s_output.WriteResult(new { path = fullPath, size = data.Length, maxWidth = maxWidth, scale = scale ?? "auto" }, json);
             }
             else
             {
@@ -2458,7 +2463,7 @@ public class DevFlowCommands
                 Console.WriteLine($"Screenshot saved: {fullPath} ({data.Length} bytes){target}{scaleInfo}");
             }
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     /// <summary>
@@ -2475,18 +2480,10 @@ public class DevFlowCommands
             var tempFile = Path.Combine(Path.GetTempPath(), $"devflow-simctl-{Guid.NewGuid():N}.png");
             try
             {
-                var psi = new System.Diagnostics.ProcessStartInfo("xcrun",
-                    $"simctl io {udid} screenshot --type png \"{tempFile}\"")
-                {
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false
-                };
-                using var proc = System.Diagnostics.Process.Start(psi)
-                    ?? throw new InvalidOperationException("Failed to start xcrun");
-                await proc.WaitForExitAsync();
+                var result = await ProcessRunner.RunAsync("xcrun",
+                    new[] { "simctl", "io", udid, "screenshot", "--type", "png", tempFile });
 
-                if (proc.ExitCode == 0 && File.Exists(tempFile))
+                if (result.ExitCode == 0 && File.Exists(tempFile))
                 {
                     var bytes = await File.ReadAllBytesAsync(tempFile);
                     if (bytes.Length > 0)
@@ -2613,14 +2610,14 @@ public class DevFlowCommands
             var value = await client.GetPropertyAsync(elementId, propertyName);
             if (json)
             {
-                OutputWriter.WriteResult(new { property = propertyName, value }, json);
+                s_output.WriteResult(new { property = propertyName, value }, json);
             }
             else
             {
                 Console.WriteLine(value != null ? $"{propertyName}: {value}" : $"Property '{propertyName}' not found");
             }
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiSetPropertyAsync(string host, int port, bool json, string elementId, string propertyName, string value)
@@ -2631,16 +2628,16 @@ public class DevFlowCommands
             var success = await client.SetPropertyAsync(elementId, propertyName, value);
             if (success)
             {
-                OutputWriter.WriteActionResult(true, "SetProperty", elementId, json,
+                s_output.WriteActionResult(true, "SetProperty", elementId, json,
                     $"Set {propertyName} = {value}");
             }
             else
             {
-                OutputWriter.WriteError($"Failed to set {propertyName}", json);
+                s_output.WriteError($"Failed to set {propertyName}", json);
                 _errorOccurred = true;
             }
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiElementAsync(string host, int port, bool json, string elementId)
@@ -2651,14 +2648,14 @@ public class DevFlowCommands
             var el = await client.GetElementAsync(elementId);
             if (el == null)
             {
-                OutputWriter.WriteError($"Element '{elementId}' not found", json,
+                s_output.WriteError($"Element '{elementId}' not found", json,
                     suggestions: new[] { "Run 'MAUI tree' to refresh element IDs", "Element IDs are ephemeral — re-query after navigation" });
                 _errorOccurred = true;
                 return;
             }
-            OutputWriter.WriteResult(el, json);
+            s_output.WriteResult(el, json);
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiNavigateAsync(string host, int port, bool json, string route)
@@ -2667,11 +2664,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.NavigateAsync(route);
-            OutputWriter.WriteActionResult(success, "Navigated", route, json,
+            s_output.WriteActionResult(success, "Navigated", route, json,
                 success ? $"Navigated to: {route}" : $"Failed to navigate to: {route}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiScrollAsync(string host, int port, bool json, string? elementId, double dx, double dy, bool animated, int? window, int? itemIndex = null, int? groupIndex = null, string? scrollToPosition = null)
@@ -2682,7 +2679,7 @@ public class DevFlowCommands
             var success = await client.ScrollAsync(elementId, dx, dy, animated, window, itemIndex, groupIndex, scrollToPosition);
             if (json)
             {
-                OutputWriter.WriteActionResult(success, "Scrolled", elementId, json);
+                s_output.WriteActionResult(success, "Scrolled", elementId, json);
             }
             else
             {
@@ -2695,7 +2692,7 @@ public class DevFlowCommands
             }
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiFocusAsync(string host, int port, bool json, string elementId)
@@ -2704,11 +2701,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.FocusAsync(elementId);
-            OutputWriter.WriteActionResult(success, "Focused", elementId, json,
+            s_output.WriteActionResult(success, "Focused", elementId, json,
                 success ? $"Focused: {elementId}" : $"Failed to focus: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiResizeAsync(string host, int port, bool json, int width, int height, int? window)
@@ -2718,12 +2715,12 @@ public class DevFlowCommands
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.ResizeAsync(width, height, window);
             if (json)
-                OutputWriter.WriteActionResult(success, "Resized", $"{width}x{height}", json);
+                s_output.WriteActionResult(success, "Resized", $"{width}x{height}", json);
             else
                 Console.WriteLine(success ? $"Resized to: {width}x{height}" : $"Failed to resize");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiLogsAsync(string host, int port, bool json, int limit, int skip, string? source)
@@ -2751,7 +2748,7 @@ public class DevFlowCommands
                 PrintLogEntry(entry);
             }
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiLogsFollowAsync(string host, int port, string? source, bool json, int replay)
@@ -3031,14 +3028,14 @@ public class DevFlowCommands
 
             if (req == null)
             {
-                OutputWriter.WriteError($"Network request '{id}' not found.", json);
+                s_output.WriteError($"Network request '{id}' not found.", json);
                 _errorOccurred = true;
                 return;
             }
 
             if (json)
             {
-                OutputWriter.WriteResult(req, json);
+                s_output.WriteResult(req, json);
                 return;
             }
 
@@ -3076,7 +3073,7 @@ public class DevFlowCommands
                 PrintBody(req.ResponseBody, req.ResponseBodyEncoding);
             }
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiNetworkClearAsync(string host, int port, bool json)
@@ -3085,11 +3082,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var result = await client.ClearNetworkRequestsAsync();
-            OutputWriter.WriteActionResult(result, "NetworkCleared", null, json,
+            s_output.WriteActionResult(result, "NetworkCleared", null, json,
                 result ? "Network request buffer cleared." : "Failed to clear.");
             if (!result) _errorOccurred = true;
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     // ── Network display helpers ──
@@ -3275,16 +3272,10 @@ public class DevFlowCommands
         if (!string.IsNullOrEmpty(udid)) return udid;
 
         // Auto-detect booted simulator
-        var psi = new System.Diagnostics.ProcessStartInfo("xcrun", "simctl list devices booted -j")
-        {
-            RedirectStandardOutput = true,
-            UseShellExecute = false
-        };
-        using var proc = System.Diagnostics.Process.Start(psi)!;
-        var output = await proc.StandardOutput.ReadToEndAsync();
-        await proc.WaitForExitAsync();
+        var result = await ProcessRunner.RunAsync("xcrun", new[] { "simctl", "list", "devices", "booted", "-j" });
+        var simOutput = result.StandardOutput;
 
-        using var doc = JsonDocument.Parse(output);
+        using var doc = JsonDocument.Parse(simOutput);
         if (doc.RootElement.TryGetProperty("devices", out var devices))
         {
             foreach (var runtime in devices.EnumerateObject())
@@ -3337,16 +3328,9 @@ public class DevFlowCommands
         {
             try
             {
-                var psi = new System.Diagnostics.ProcessStartInfo("xcrun", "simctl list devices booted -j")
-                {
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false
-                };
-                using var proc = System.Diagnostics.Process.Start(psi)!;
-                var output = await proc.StandardOutput.ReadToEndAsync();
-                await proc.WaitForExitAsync();
+                var simResult = await ProcessRunner.RunAsync("xcrun", new[] { "simctl", "list", "devices", "booted", "-j" });
 
-                using var doc = JsonDocument.Parse(output);
+                using var doc = JsonDocument.Parse(simResult.StandardOutput);
                 if (doc.RootElement.TryGetProperty("devices", out var devices))
                 {
                     foreach (var runtime in devices.EnumerateObject())
@@ -3379,16 +3363,8 @@ public class DevFlowCommands
             if (status?.AppName != null)
             {
                 // Find process by app name
-                var psi = new System.Diagnostics.ProcessStartInfo("pgrep", $"-f {status.AppName}")
-                {
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false
-                };
-                using var proc = System.Diagnostics.Process.Start(psi)!;
-                var output = await proc.StandardOutput.ReadToEndAsync();
-                await proc.WaitForExitAsync();
-                var lines = output.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                var pgrepResult = await ProcessRunner.RunAsync("pgrep", new[] { "-f", status.AppName });
+                var lines = pgrepResult.StandardOutput.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries);
                 if (lines.Length > 0 && int.TryParse(lines[0].Trim(), out var resolved))
                     return resolved;
             }
@@ -3460,18 +3436,18 @@ public class DevFlowCommands
 
             if (alert is null)
             {
-                OutputWriter.WriteResult(new { detected = false }, json, _ => Console.WriteLine("No alert detected"));
+                s_output.WriteResult(new { detected = false }, json, _ => Console.WriteLine("No alert detected"));
                 return;
             }
 
-            OutputWriter.WriteResult(new { detected = true, title = alert.Title, buttons = alert.Buttons.Select(b => new { label = b.Label, centerX = b.CenterX, centerY = b.CenterY }) }, json, _ =>
+            s_output.WriteResult(new { detected = true, title = alert.Title, buttons = alert.Buttons.Select(b => new { label = b.Label, centerX = b.CenterX, centerY = b.CenterY }) }, json, _ =>
             {
                 Console.WriteLine($"Alert: {alert.Title ?? "(no title)"}");
                 foreach (var btn in alert.Buttons)
                     Console.WriteLine($"  Button: \"{btn.Label}\"");
             });
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task AlertDismissAsync(string? udid, int? pid, string host, int port, string? buttonLabel, bool json)
@@ -3506,11 +3482,11 @@ public class DevFlowCommands
             }
 
             if (alert is null)
-                OutputWriter.WriteResult(new { dismissed = false }, json, _ => Console.WriteLine("No alert to dismiss"));
+                s_output.WriteResult(new { dismissed = false }, json, _ => Console.WriteLine("No alert to dismiss"));
             else
-                OutputWriter.WriteResult(new { dismissed = true, title = alert.Title }, json, _ => Console.WriteLine($"Dismissed: {alert.Title ?? "(alert)"}"));
+                s_output.WriteResult(new { dismissed = true, title = alert.Title }, json, _ => Console.WriteLine($"Dismissed: {alert.Title ?? "(alert)"}"));
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task AlertTreeAsync(string? udid, int? pid, string host, int port, bool json)
@@ -3554,7 +3530,7 @@ public class DevFlowCommands
                 }
                 catch (JsonException)
                 {
-                    OutputWriter.WriteResult(new { tree = treeResult }, json);
+                    s_output.WriteResult(new { tree = treeResult }, json);
                 }
             }
             else
@@ -3562,7 +3538,7 @@ public class DevFlowCommands
                 Console.WriteLine(treeResult);
             }
         }
-        catch (Exception ex) { OutputWriter.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task PermissionAsync(string action, string? udid, string? bundleId, string service)
@@ -3571,23 +3547,15 @@ public class DevFlowCommands
         {
             var resolved = await ResolveUdidAsync(udid);
             // Run xcrun simctl privacy directly (driver methods require BundleId which may not be set)
-            var args = string.IsNullOrEmpty(bundleId)
-                ? $"simctl privacy {resolved} {action} {service}"
-                : $"simctl privacy {resolved} {action} {service} {bundleId}";
+            var privacyArgs = string.IsNullOrEmpty(bundleId)
+                ? new[] { "simctl", "privacy", resolved, action, service }
+                : new[] { "simctl", "privacy", resolved, action, service, bundleId };
 
-            var psi = new System.Diagnostics.ProcessStartInfo("xcrun", args)
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-            using var proc = System.Diagnostics.Process.Start(psi)!;
-            await proc.WaitForExitAsync();
+            var privacyResult = await ProcessRunner.RunAsync("xcrun", privacyArgs);
 
-            if (proc.ExitCode != 0)
+            if (!privacyResult.Success)
             {
-                var stderr = await proc.StandardError.ReadToEndAsync();
-                WriteError($"simctl privacy failed: {stderr.Trim()}");
+                WriteError($"simctl privacy failed: {privacyResult.StandardError.Trim()}");
                 return;
             }
             Console.WriteLine($"Permission {action}: {service}" + (bundleId != null ? $" for {bundleId}" : ""));
@@ -3676,13 +3644,13 @@ public class DevFlowCommands
                 var response = await http.GetStringAsync($"http://localhost:{Broker.BrokerServer.DefaultPort}/api/health");
                 var doc = JsonDocument.Parse(response);
                 var agents = doc.RootElement.GetProperty("agents").GetInt32();
-                OutputWriter.WriteResult(new { running = true, port = Broker.BrokerServer.DefaultPort, agents, stateFile = false }, json,
+                s_output.WriteResult(new { running = true, port = Broker.BrokerServer.DefaultPort, agents, stateFile = false }, json,
                     _ => Console.WriteLine($"Broker: running on port {Broker.BrokerServer.DefaultPort} ({agents} agent(s) connected) [no state file]"));
                 return;
             }
             catch { }
 
-            OutputWriter.WriteResult(new { running = false }, json,
+            s_output.WriteResult(new { running = false }, json,
                 _ => Console.WriteLine("Broker: not running"));
             return;
         }
@@ -3693,12 +3661,12 @@ public class DevFlowCommands
             var response = await http.GetStringAsync($"http://localhost:{port}/api/health");
             var doc = JsonDocument.Parse(response);
             var agents = doc.RootElement.GetProperty("agents").GetInt32();
-            OutputWriter.WriteResult(new { running = true, port, agents }, json,
+            s_output.WriteResult(new { running = true, port, agents }, json,
                 _ => Console.WriteLine($"Broker: running on port {port} ({agents} agent(s) connected)"));
         }
         catch
         {
-            OutputWriter.WriteResult(new { running = false, port, stale = true }, json,
+            s_output.WriteResult(new { running = false, port, stale = true }, json,
                 _ => Console.WriteLine($"Broker: not responding on port {port} (stale state file?)"));
         }
     }
@@ -3724,7 +3692,7 @@ public class DevFlowCommands
         var port = await Broker.BrokerClient.EnsureBrokerRunningAsync();
         if (port == null)
         {
-            OutputWriter.WriteError("Broker unavailable", json);
+            s_output.WriteError("Broker unavailable", json);
             _errorOccurred = true;
             return;
         }
@@ -3738,7 +3706,7 @@ public class DevFlowCommands
             if (json)
             {
                 var result = new { agents = Array.Empty<object>(), projects };
-                OutputWriter.WriteResult(result, json);
+                s_output.WriteResult(result, json);
             }
             else
             {
@@ -3765,7 +3733,7 @@ public class DevFlowCommands
 
         if (json)
         {
-            OutputWriter.WriteResult(agents, json);
+            s_output.WriteResult(agents, json);
         }
         else
         {
@@ -3811,7 +3779,7 @@ public class DevFlowCommands
         
         if (json)
         {
-            OutputWriter.WriteResult(diagnostics, json);
+            s_output.WriteResult(diagnostics, json);
             return;
         }
         

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -17,7 +17,9 @@ public class DevFlowCommands
 {
     private static Command? _devflowCommand;
     [ThreadStatic] private static bool _errorOccurred;
-    private static IDevFlowOutputWriter s_output = null!;
+    [ThreadStatic] private static IDevFlowOutputWriter? s_output;
+
+    private static IDevFlowOutputWriter Output => s_output ?? throw new InvalidOperationException("DevFlowCommands not initialized. Call CreateDevFlowCommand first.");
 
     /// <summary>
     /// Creates the "devflow" command with all subcommands for integration into the MAUI CLI.
@@ -1710,7 +1712,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            s_output.WriteError(ex.Message, json);
+            Output.WriteError(ex.Message, json);
             _errorOccurred = true;
         }
     }
@@ -1740,7 +1742,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            s_output.WriteError(ex.Message, json);
+            Output.WriteError(ex.Message, json);
             _errorOccurred = true;
         }
     }
@@ -1758,7 +1760,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            s_output.WriteError(ex.Message, json);
+            Output.WriteError(ex.Message, json);
             _errorOccurred = true;
         }
     }
@@ -1794,7 +1796,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            s_output.WriteError(ex.Message, json);
+            Output.WriteError(ex.Message, json);
             _errorOccurred = true;
         }
     }
@@ -1818,7 +1820,7 @@ public class DevFlowCommands
         // Need at least one resolution option
         if (string.IsNullOrWhiteSpace(automationId) && string.IsNullOrWhiteSpace(type) && string.IsNullOrWhiteSpace(text))
         {
-            s_output.WriteError("Provide an element ID or use --automationId, --type, or --text to resolve", json, "InvocationError");
+            Output.WriteError("Provide an element ID or use --automationId, --type, or --text to resolve", json, "InvocationError");
             _errorOccurred = true;
             return null;
         }
@@ -1834,7 +1836,7 @@ public class DevFlowCommands
                 if (automationId != null) criteria.Add($"automationId=\"{automationId}\"");
                 if (type != null) criteria.Add($"type=\"{type}\"");
                 if (text != null) criteria.Add($"text=\"{text}\"");
-                s_output.WriteError($"No elements found matching {string.Join(", ", criteria)}", json,
+                Output.WriteError($"No elements found matching {string.Join(", ", criteria)}", json,
                     suggestions: new[] { "Run 'MAUI tree' to see available elements", "Check automationId spelling" });
                 _errorOccurred = true;
                 return null;
@@ -1842,7 +1844,7 @@ public class DevFlowCommands
 
             if (index >= results.Count)
             {
-                s_output.WriteError($"Index {index} out of range (found {results.Count} element(s))", json, "RuntimeError",
+                Output.WriteError($"Index {index} out of range (found {results.Count} element(s))", json, "RuntimeError",
                     suggestions: new[] { $"Use --index 0 through {results.Count - 1}" });
                 _errorOccurred = true;
                 return null;
@@ -1852,7 +1854,7 @@ public class DevFlowCommands
         }
         catch (Exception ex)
         {
-            s_output.WriteError(ex.Message, json);
+            Output.WriteError(ex.Message, json);
             _errorOccurred = true;
             return null;
         }
@@ -1865,14 +1867,14 @@ public class DevFlowCommands
     {
         if (id.Any(c => c < 0x20))
         {
-            s_output.WriteError($"Element ID contains control characters: '{id}'", json, "InvocationError",
+            Output.WriteError($"Element ID contains control characters: '{id}'", json, "InvocationError",
                 suggestions: new[] { "Element IDs should not contain control characters", "Run 'MAUI tree' to get valid IDs" });
             _errorOccurred = true;
             return;
         }
         if (id.Contains('?') || id.Contains('#'))
         {
-            s_output.WriteError($"Element ID contains '?' or '#': '{id}' — this looks like a URL fragment, not an element ID", json, "InvocationError",
+            Output.WriteError($"Element ID contains '?' or '#': '{id}' — this looks like a URL fragment, not an element ID", json, "InvocationError",
                 suggestions: new[] { "Run 'MAUI tree' to get valid element IDs" });
             _errorOccurred = true;
             return;
@@ -1914,7 +1916,7 @@ public class DevFlowCommands
             var passed = string.Equals(actualValue, expectedValue, StringComparison.Ordinal);
             if (json)
             {
-                s_output.WriteResult(new { passed, property = propertyName, expected = expectedValue, actual = actualValue, elementId = resolvedId }, json);
+                Output.WriteResult(new { passed, property = propertyName, expected = expectedValue, actual = actualValue, elementId = resolvedId }, json);
             }
             else
             {
@@ -1928,7 +1930,7 @@ public class DevFlowCommands
             }
             if (!passed) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     // ===== Command Descriptions (Schema Discovery) =====
@@ -2230,11 +2232,11 @@ public class DevFlowCommands
             var status = await client.GetStatusAsync(window);
             if (status == null)
             {
-                s_output.WriteError($"Cannot connect to agent at {host}:{port}", json);
+                Output.WriteError($"Cannot connect to agent at {host}:{port}", json);
                 _errorOccurred = true;
                 return;
             }
-            s_output.WriteResult(status, json, s =>
+            Output.WriteResult(status, json, s =>
             {
                 Console.WriteLine($"Agent: {s.Agent} v{s.Version}");
                 Console.WriteLine($"Platform: {s.Platform}");
@@ -2242,7 +2244,7 @@ public class DevFlowCommands
                 Console.WriteLine($"App: {s.AppName}");
             });
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiTreeAsync(string host, int port, bool json, int depth, int? window, string? fields, string? format)
@@ -2261,7 +2263,7 @@ public class DevFlowCommands
                 PrintTree(tree, 0);
             }
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiQueryAsync(string host, int port, bool json, string? type, string? autoId, string? text, string? selector, string? fields, string? format, string? waitUntil, int timeout)
@@ -2275,7 +2277,7 @@ public class DevFlowCommands
                 var condition = waitUntil.ToLowerInvariant();
                 if (condition != "exists" && condition != "gone")
                 {
-                    s_output.WriteError("--wait-until must be 'exists' or 'gone'", json, "InvocationError");
+                    Output.WriteError("--wait-until must be 'exists' or 'gone'", json, "InvocationError");
                     _errorOccurred = true;
                     return;
                 }
@@ -2294,7 +2296,7 @@ public class DevFlowCommands
                     if (condition == "gone" && results.Count == 0) break;
                     if (DateTime.UtcNow >= deadline)
                     {
-                        s_output.WriteError(
+                        Output.WriteError(
                             $"Timeout after {timeout}s: condition '{waitUntil}' not met",
                             json, "RuntimeError", retryable: true,
                             suggestions: new[] { "Increase --timeout", "Check element identifiers with 'MAUI tree'" });
@@ -2317,7 +2319,7 @@ public class DevFlowCommands
 
             WriteQueryResults(queryResults, json, fields, format);
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static void WriteQueryResults(List<Microsoft.Maui.DevFlow.Driver.ElementInfo> results, bool json, string? fields, string? format)
@@ -2357,7 +2359,7 @@ public class DevFlowCommands
             else
                 Console.WriteLine(result);
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiTapAsync(string host, int port, bool json, string elementId)
@@ -2366,11 +2368,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.TapAsync(elementId);
-            s_output.WriteActionResult(success, "Tapped", elementId, json,
+            Output.WriteActionResult(success, "Tapped", elementId, json,
                 success ? $"Tapped: {elementId}" : $"Failed to tap: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiFillAsync(string host, int port, bool json, string elementId, string text)
@@ -2379,11 +2381,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.FillAsync(elementId, text);
-            s_output.WriteActionResult(success, "Filled", elementId, json,
+            Output.WriteActionResult(success, "Filled", elementId, json,
                 success ? $"Filled: {elementId}" : $"Failed to fill: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiClearAsync(string host, int port, bool json, string elementId)
@@ -2392,11 +2394,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.ClearAsync(elementId);
-            s_output.WriteActionResult(success, "Cleared", elementId, json,
+            Output.WriteActionResult(success, "Cleared", elementId, json,
                 success ? $"Cleared: {elementId}" : $"Failed to clear: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiScreenshotAsync(string host, int port, bool json, string? output, int? window, string? id, string? selector, bool overwrite = false, int? maxWidth = null, string? scale = null)
@@ -2406,7 +2408,7 @@ public class DevFlowCommands
             var filename = output ?? $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png";
             if (!overwrite && File.Exists(filename))
             {
-                s_output.WriteError($"File already exists: {Path.GetFullPath(filename)} (use --overwrite to replace)", json, "InvocationError");
+                Output.WriteError($"File already exists: {Path.GetFullPath(filename)} (use --overwrite to replace)", json, "InvocationError");
                 _errorOccurred = true;
                 return;
             }
@@ -2438,7 +2440,7 @@ public class DevFlowCommands
 
             if (data == null)
             {
-                s_output.WriteError("Failed to capture screenshot", json);
+                Output.WriteError("Failed to capture screenshot", json);
                 _errorOccurred = true;
                 return;
             }
@@ -2453,7 +2455,7 @@ public class DevFlowCommands
             var fullPath = Path.GetFullPath(filename);
             if (json)
             {
-                s_output.WriteResult(new { path = fullPath, size = data.Length, maxWidth = maxWidth, scale = scale ?? "auto" }, json);
+                Output.WriteResult(new { path = fullPath, size = data.Length, maxWidth = maxWidth, scale = scale ?? "auto" }, json);
             }
             else
             {
@@ -2463,7 +2465,7 @@ public class DevFlowCommands
                 Console.WriteLine($"Screenshot saved: {fullPath} ({data.Length} bytes){target}{scaleInfo}");
             }
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     /// <summary>
@@ -2610,14 +2612,14 @@ public class DevFlowCommands
             var value = await client.GetPropertyAsync(elementId, propertyName);
             if (json)
             {
-                s_output.WriteResult(new { property = propertyName, value }, json);
+                Output.WriteResult(new { property = propertyName, value }, json);
             }
             else
             {
                 Console.WriteLine(value != null ? $"{propertyName}: {value}" : $"Property '{propertyName}' not found");
             }
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiSetPropertyAsync(string host, int port, bool json, string elementId, string propertyName, string value)
@@ -2628,16 +2630,16 @@ public class DevFlowCommands
             var success = await client.SetPropertyAsync(elementId, propertyName, value);
             if (success)
             {
-                s_output.WriteActionResult(true, "SetProperty", elementId, json,
+                Output.WriteActionResult(true, "SetProperty", elementId, json,
                     $"Set {propertyName} = {value}");
             }
             else
             {
-                s_output.WriteError($"Failed to set {propertyName}", json);
+                Output.WriteError($"Failed to set {propertyName}", json);
                 _errorOccurred = true;
             }
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiElementAsync(string host, int port, bool json, string elementId)
@@ -2648,14 +2650,14 @@ public class DevFlowCommands
             var el = await client.GetElementAsync(elementId);
             if (el == null)
             {
-                s_output.WriteError($"Element '{elementId}' not found", json,
+                Output.WriteError($"Element '{elementId}' not found", json,
                     suggestions: new[] { "Run 'MAUI tree' to refresh element IDs", "Element IDs are ephemeral — re-query after navigation" });
                 _errorOccurred = true;
                 return;
             }
-            s_output.WriteResult(el, json);
+            Output.WriteResult(el, json);
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiNavigateAsync(string host, int port, bool json, string route)
@@ -2664,11 +2666,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.NavigateAsync(route);
-            s_output.WriteActionResult(success, "Navigated", route, json,
+            Output.WriteActionResult(success, "Navigated", route, json,
                 success ? $"Navigated to: {route}" : $"Failed to navigate to: {route}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiScrollAsync(string host, int port, bool json, string? elementId, double dx, double dy, bool animated, int? window, int? itemIndex = null, int? groupIndex = null, string? scrollToPosition = null)
@@ -2679,7 +2681,7 @@ public class DevFlowCommands
             var success = await client.ScrollAsync(elementId, dx, dy, animated, window, itemIndex, groupIndex, scrollToPosition);
             if (json)
             {
-                s_output.WriteActionResult(success, "Scrolled", elementId, json);
+                Output.WriteActionResult(success, "Scrolled", elementId, json);
             }
             else
             {
@@ -2692,7 +2694,7 @@ public class DevFlowCommands
             }
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiFocusAsync(string host, int port, bool json, string elementId)
@@ -2701,11 +2703,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.FocusAsync(elementId);
-            s_output.WriteActionResult(success, "Focused", elementId, json,
+            Output.WriteActionResult(success, "Focused", elementId, json,
                 success ? $"Focused: {elementId}" : $"Failed to focus: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiResizeAsync(string host, int port, bool json, int width, int height, int? window)
@@ -2715,12 +2717,12 @@ public class DevFlowCommands
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var success = await client.ResizeAsync(width, height, window);
             if (json)
-                s_output.WriteActionResult(success, "Resized", $"{width}x{height}", json);
+                Output.WriteActionResult(success, "Resized", $"{width}x{height}", json);
             else
                 Console.WriteLine(success ? $"Resized to: {width}x{height}" : $"Failed to resize");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiLogsAsync(string host, int port, bool json, int limit, int skip, string? source)
@@ -2748,7 +2750,7 @@ public class DevFlowCommands
                 PrintLogEntry(entry);
             }
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiLogsFollowAsync(string host, int port, string? source, bool json, int replay)
@@ -3028,14 +3030,14 @@ public class DevFlowCommands
 
             if (req == null)
             {
-                s_output.WriteError($"Network request '{id}' not found.", json);
+                Output.WriteError($"Network request '{id}' not found.", json);
                 _errorOccurred = true;
                 return;
             }
 
             if (json)
             {
-                s_output.WriteResult(req, json);
+                Output.WriteResult(req, json);
                 return;
             }
 
@@ -3073,7 +3075,7 @@ public class DevFlowCommands
                 PrintBody(req.ResponseBody, req.ResponseBodyEncoding);
             }
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task MauiNetworkClearAsync(string host, int port, bool json)
@@ -3082,11 +3084,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var result = await client.ClearNetworkRequestsAsync();
-            s_output.WriteActionResult(result, "NetworkCleared", null, json,
+            Output.WriteActionResult(result, "NetworkCleared", null, json,
                 result ? "Network request buffer cleared." : "Failed to clear.");
             if (!result) _errorOccurred = true;
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     // ── Network display helpers ──
@@ -3273,7 +3275,17 @@ public class DevFlowCommands
 
         // Auto-detect booted simulator
         var result = await ProcessRunner.RunAsync("xcrun", new[] { "simctl", "list", "devices", "booted", "-j" });
+
+        if (!result.Success || result.ExitCode != 0)
+        {
+            var baseMessage = $"Failed to resolve simulator UDID. 'xcrun simctl list devices booted -j' exited with code {result.ExitCode}.";
+            var error = result.StandardError;
+            throw new InvalidOperationException(string.IsNullOrWhiteSpace(error) ? baseMessage : baseMessage + " Error: " + error.Trim());
+        }
+
         var simOutput = result.StandardOutput;
+        if (string.IsNullOrWhiteSpace(simOutput))
+            throw new InvalidOperationException("Failed to resolve simulator UDID: no output received from 'xcrun simctl list devices booted -j'.");
 
         using var doc = JsonDocument.Parse(simOutput);
         if (doc.RootElement.TryGetProperty("devices", out var devices))
@@ -3329,6 +3341,12 @@ public class DevFlowCommands
             try
             {
                 var simResult = await ProcessRunner.RunAsync("xcrun", new[] { "simctl", "list", "devices", "booted", "-j" });
+
+                if (!simResult.Success || simResult.ExitCode != 0)
+                    throw new InvalidOperationException($"xcrun simctl failed with exit code {simResult.ExitCode}: {simResult.StandardError}");
+
+                if (string.IsNullOrWhiteSpace(simResult.StandardOutput))
+                    throw new InvalidOperationException("xcrun simctl returned no output.");
 
                 using var doc = JsonDocument.Parse(simResult.StandardOutput);
                 if (doc.RootElement.TryGetProperty("devices", out var devices))
@@ -3436,18 +3454,18 @@ public class DevFlowCommands
 
             if (alert is null)
             {
-                s_output.WriteResult(new { detected = false }, json, _ => Console.WriteLine("No alert detected"));
+                Output.WriteResult(new { detected = false }, json, _ => Console.WriteLine("No alert detected"));
                 return;
             }
 
-            s_output.WriteResult(new { detected = true, title = alert.Title, buttons = alert.Buttons.Select(b => new { label = b.Label, centerX = b.CenterX, centerY = b.CenterY }) }, json, _ =>
+            Output.WriteResult(new { detected = true, title = alert.Title, buttons = alert.Buttons.Select(b => new { label = b.Label, centerX = b.CenterX, centerY = b.CenterY }) }, json, _ =>
             {
                 Console.WriteLine($"Alert: {alert.Title ?? "(no title)"}");
                 foreach (var btn in alert.Buttons)
                     Console.WriteLine($"  Button: \"{btn.Label}\"");
             });
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task AlertDismissAsync(string? udid, int? pid, string host, int port, string? buttonLabel, bool json)
@@ -3482,11 +3500,11 @@ public class DevFlowCommands
             }
 
             if (alert is null)
-                s_output.WriteResult(new { dismissed = false }, json, _ => Console.WriteLine("No alert to dismiss"));
+                Output.WriteResult(new { dismissed = false }, json, _ => Console.WriteLine("No alert to dismiss"));
             else
-                s_output.WriteResult(new { dismissed = true, title = alert.Title }, json, _ => Console.WriteLine($"Dismissed: {alert.Title ?? "(alert)"}"));
+                Output.WriteResult(new { dismissed = true, title = alert.Title }, json, _ => Console.WriteLine($"Dismissed: {alert.Title ?? "(alert)"}"));
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task AlertTreeAsync(string? udid, int? pid, string host, int port, bool json)
@@ -3530,7 +3548,7 @@ public class DevFlowCommands
                 }
                 catch (JsonException)
                 {
-                    s_output.WriteResult(new { tree = treeResult }, json);
+                    Output.WriteResult(new { tree = treeResult }, json);
                 }
             }
             else
@@ -3538,7 +3556,7 @@ public class DevFlowCommands
                 Console.WriteLine(treeResult);
             }
         }
-        catch (Exception ex) { s_output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     private static async Task PermissionAsync(string action, string? udid, string? bundleId, string service)
@@ -3644,13 +3662,13 @@ public class DevFlowCommands
                 var response = await http.GetStringAsync($"http://localhost:{Broker.BrokerServer.DefaultPort}/api/health");
                 var doc = JsonDocument.Parse(response);
                 var agents = doc.RootElement.GetProperty("agents").GetInt32();
-                s_output.WriteResult(new { running = true, port = Broker.BrokerServer.DefaultPort, agents, stateFile = false }, json,
+                Output.WriteResult(new { running = true, port = Broker.BrokerServer.DefaultPort, agents, stateFile = false }, json,
                     _ => Console.WriteLine($"Broker: running on port {Broker.BrokerServer.DefaultPort} ({agents} agent(s) connected) [no state file]"));
                 return;
             }
             catch { }
 
-            s_output.WriteResult(new { running = false }, json,
+            Output.WriteResult(new { running = false }, json,
                 _ => Console.WriteLine("Broker: not running"));
             return;
         }
@@ -3661,12 +3679,12 @@ public class DevFlowCommands
             var response = await http.GetStringAsync($"http://localhost:{port}/api/health");
             var doc = JsonDocument.Parse(response);
             var agents = doc.RootElement.GetProperty("agents").GetInt32();
-            s_output.WriteResult(new { running = true, port, agents }, json,
+            Output.WriteResult(new { running = true, port, agents }, json,
                 _ => Console.WriteLine($"Broker: running on port {port} ({agents} agent(s) connected)"));
         }
         catch
         {
-            s_output.WriteResult(new { running = false, port, stale = true }, json,
+            Output.WriteResult(new { running = false, port, stale = true }, json,
                 _ => Console.WriteLine($"Broker: not responding on port {port} (stale state file?)"));
         }
     }
@@ -3692,7 +3710,7 @@ public class DevFlowCommands
         var port = await Broker.BrokerClient.EnsureBrokerRunningAsync();
         if (port == null)
         {
-            s_output.WriteError("Broker unavailable", json);
+            Output.WriteError("Broker unavailable", json);
             _errorOccurred = true;
             return;
         }
@@ -3706,7 +3724,7 @@ public class DevFlowCommands
             if (json)
             {
                 var result = new { agents = Array.Empty<object>(), projects };
-                s_output.WriteResult(result, json);
+                Output.WriteResult(result, json);
             }
             else
             {
@@ -3733,7 +3751,7 @@ public class DevFlowCommands
 
         if (json)
         {
-            s_output.WriteResult(agents, json);
+            Output.WriteResult(agents, json);
         }
         else
         {
@@ -3779,7 +3797,7 @@ public class DevFlowCommands
         
         if (json)
         {
-            s_output.WriteResult(diagnostics, json);
+            Output.WriteResult(diagnostics, json);
             return;
         }
         

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -701,7 +701,8 @@ public class DevFlowCommands
             var udid = ctx.GetValue(permGrantUdid);
             var bundleId = ctx.GetValue(permGrantBundle);
             var service = ctx.GetValue(permGrantServiceArg)!;
-            await PermissionAsync("grant", udid, bundleId, service);
+            var isJson = Output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            await PermissionAsync("grant", udid, bundleId, service, isJson);
         });
         permissionCommand.Add(permGrantCmd);
 
@@ -714,7 +715,8 @@ public class DevFlowCommands
             var udid = ctx.GetValue(permRevokeUdid);
             var bundleId = ctx.GetValue(permRevokeBundle);
             var service = ctx.GetValue(permRevokeServiceArg)!;
-            await PermissionAsync("revoke", udid, bundleId, service);
+            var isJson = Output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            await PermissionAsync("revoke", udid, bundleId, service, isJson);
         });
         permissionCommand.Add(permRevokeCmd);
 
@@ -727,7 +729,8 @@ public class DevFlowCommands
             var udid = ctx.GetValue(permResetUdid);
             var bundleId = ctx.GetValue(permResetBundle);
             var service = ctx.GetValue(permResetServiceArg)!;
-            await PermissionAsync("reset", udid, bundleId, service);
+            var isJson = Output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            await PermissionAsync("reset", udid, bundleId, service, isJson);
         });
         permissionCommand.Add(permResetCmd);
 
@@ -3559,7 +3562,7 @@ public class DevFlowCommands
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
-    private static async Task PermissionAsync(string action, string? udid, string? bundleId, string service)
+    private static async Task PermissionAsync(string action, string? udid, string? bundleId, string service, bool json)
     {
         try
         {
@@ -3573,12 +3576,14 @@ public class DevFlowCommands
 
             if (!privacyResult.Success)
             {
-                WriteError($"simctl privacy failed: {privacyResult.StandardError.Trim()}");
+                Output.WriteError($"simctl privacy failed: {privacyResult.StandardError.Trim()}", json);
+                _errorOccurred = true;
                 return;
             }
-            Console.WriteLine($"Permission {action}: {service}" + (bundleId != null ? $" for {bundleId}" : ""));
+            var message = $"Permission {action}: {service}" + (bundleId != null ? $" for {bundleId}" : "");
+            Output.WriteActionResult(true, $"permission-{action}", service, json, message);
         }
-        catch (Exception ex) { WriteError(ex.Message); }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
     /// <summary>

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/IDevFlowOutputWriter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/IDevFlowOutputWriter.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+
+namespace Microsoft.Maui.Cli.DevFlow;
+
+/// <summary>
+/// Abstraction over DevFlow output formatting, enabling DI and testability.
+/// </summary>
+public interface IDevFlowOutputWriter
+{
+	bool ResolveJsonMode(bool jsonFlag, bool noJsonFlag);
+	void WriteResult<T>(T data, bool json, Action<T>? humanFormatter = null);
+	void WriteRawJson(string jsonString);
+	void WriteJsonElement(JsonElement element, bool json);
+	void WriteActionResult(bool success, string action, string? elementId, bool json, string? humanMessage = null);
+	void WriteError(string message, bool json, string errorType = "RuntimeError",
+		bool retryable = false, string[]? suggestions = null);
+	void WriteJsonLine<T>(T data);
+	string FormatJson<T>(T data);
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/OutputWriter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/OutputWriter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Cli.DevFlow;
 /// JSON mode: raw data on stdout, structured errors on stderr.
 /// Human mode: formatted text on stdout, plain errors on stderr.
 /// </summary>
-static class OutputWriter
+class DevFlowOutputWriter : IDevFlowOutputWriter
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -28,7 +28,7 @@ static class OutputWriter
     /// Resolves whether JSON output mode is active.
     /// Priority: --no-json flag > --json flag > MAUIDEVFLOW_OUTPUT env var > TTY auto-detection.
     /// </summary>
-    public static bool ResolveJsonMode(bool jsonFlag, bool noJsonFlag)
+    public bool ResolveJsonMode(bool jsonFlag, bool noJsonFlag)
     {
         if (noJsonFlag) return false;
         if (jsonFlag) return true;
@@ -47,7 +47,7 @@ static class OutputWriter
     /// Write a successful result to stdout.
     /// In JSON mode, serializes the data. In human mode, calls the humanFormatter.
     /// </summary>
-    public static void WriteResult<T>(T data, bool json, Action<T>? humanFormatter = null)
+    public void WriteResult<T>(T data, bool json, Action<T>? humanFormatter = null)
     {
         if (json)
         {
@@ -66,7 +66,7 @@ static class OutputWriter
     /// <summary>
     /// Write raw JSON string to stdout (for data already serialized or from HTTP responses).
     /// </summary>
-    public static void WriteRawJson(string jsonString)
+    public void WriteRawJson(string jsonString)
     {
         Console.WriteLine(jsonString);
     }
@@ -74,7 +74,7 @@ static class OutputWriter
     /// <summary>
     /// Write a JsonElement to stdout with indentation.
     /// </summary>
-    public static void WriteJsonElement(JsonElement element, bool json)
+    public void WriteJsonElement(JsonElement element, bool json)
     {
         if (json)
         {
@@ -89,7 +89,7 @@ static class OutputWriter
     /// <summary>
     /// Write a simple success action result (for tap, fill, clear, etc.).
     /// </summary>
-    public static void WriteActionResult(bool success, string action, string? elementId, bool json, string? humanMessage = null)
+    public void WriteActionResult(bool success, string action, string? elementId, bool json, string? humanMessage = null)
     {
         if (json)
         {
@@ -106,7 +106,7 @@ static class OutputWriter
     /// Write a structured error to stderr and set error state.
     /// In JSON mode, outputs structured error JSON. In human mode, plain text.
     /// </summary>
-    public static void WriteError(string message, bool json, string errorType = "RuntimeError",
+    public void WriteError(string message, bool json, string errorType = "RuntimeError",
         bool retryable = false, string[]? suggestions = null)
     {
         if (json)
@@ -129,7 +129,7 @@ static class OutputWriter
     /// <summary>
     /// Write a single JSONL line (for streaming commands).
     /// </summary>
-    public static void WriteJsonLine<T>(T data)
+    public void WriteJsonLine<T>(T data)
     {
         Console.WriteLine(JsonSerializer.Serialize(data, s_compactJsonOptions));
     }
@@ -137,7 +137,7 @@ static class OutputWriter
     /// <summary>
     /// Serialize an object to indented JSON string.
     /// </summary>
-    public static string FormatJson<T>(T data)
+    public string FormatJson<T>(T data)
     {
         return JsonSerializer.Serialize(data, s_jsonOptions);
     }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/OutputWriter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/OutputWriter.cs
@@ -72,7 +72,8 @@ class DevFlowOutputWriter : IDevFlowOutputWriter
     }
 
     /// <summary>
-    /// Write a JsonElement to stdout with indentation.
+    /// Write a <see cref="JsonElement"/> to stdout.
+    /// In JSON mode, writes the element's raw JSON text. In human mode, writes indented JSON.
     /// </summary>
     public void WriteJsonElement(JsonElement element, bool json)
     {

--- a/src/Cli/Microsoft.Maui.Cli/ServiceConfiguration.cs
+++ b/src/Cli/Microsoft.Maui.Cli/ServiceConfiguration.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Cli.DevFlow;
 using Microsoft.Maui.Cli.Output;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.Services;
@@ -37,6 +38,9 @@ public static class ServiceConfiguration
 		services.AddSingleton<IDoctorService, DoctorService>();
 		services.AddSingleton<IDeviceManager, DeviceManager>();
 
+		// DevFlow output
+		services.AddSingleton<IDevFlowOutputWriter, DevFlowOutputWriter>();
+
 		// Output formatters (transient - created per request with specific config)
 		services.AddTransient<JsonOutputFormatter>();
 		services.AddTransient<SpectreOutputFormatter>();
@@ -49,7 +53,8 @@ public static class ServiceConfiguration
 		IAndroidProvider? androidProvider = null,
 		IJdkManager? jdkManager = null,
 		IDoctorService? doctorService = null,
-		IDeviceManager? deviceManager = null)
+		IDeviceManager? deviceManager = null,
+		IDevFlowOutputWriter? devFlowOutputWriter = null)
 	{
 		var services = new ServiceCollection();
 
@@ -73,6 +78,11 @@ public static class ServiceConfiguration
 			services.AddSingleton(deviceManager);
 		else
 			services.AddSingleton<IDeviceManager, DeviceManager>();
+
+		if (devFlowOutputWriter != null)
+			services.AddSingleton(devFlowOutputWriter);
+		else
+			services.AddSingleton<IDevFlowOutputWriter, DevFlowOutputWriter>();
 
 		return services.BuildServiceProvider();
 	}


### PR DESCRIPTION
Closes #25

## Summary
Completes the remaining items from the DevFlow CLI merge plan (issue #25).

## Changes

### 1. Remove dead beta4 reference (Step 1)
`SystemCommandLineVersion` (beta4) was still in `eng/Versions.props` but  the build uses `SystemCommandLineStableVersion` (2.0.5). Removed.unused 

### 2. Unify output layer (Step 3)
- Created `IDevFlowOutputWriter` interface exposing all 8 public methods from `OutputWriter`
 `DevFlowOutputWriter : IDevFlowOutputWriter`
- Registered as singleton in DI (`ServiceConfiguration`)
- `DevFlowCommands` resolves from DI; all 120+ call sites migrated from static to instance calls
- Added to `CreateTestServiceProvider` for testability

### 3. Wire DevFlow services in DI (Step 7)
`IDevFlowOutputWriter` registered in `ServiceConfiguration.ConfigureServices()`.

### 4. Unify process execution (Step 4)
Replaced 5 raw `System.Diagnostics.Process.Start()` calls in DevFlowCommands with `ProcessRunner.RunAsync()`:
- xcrun screenshot capture
- 2 xcrun simctl list devices
- pgrep process lookup
- xcrun simctl privacy

`Process.GetProcessesByName()`/`GetProcesses()` left as-is (process enumeration has no ProcessRunner equivalent).

## Verification
- Build: 0 errors, 0 warnings
- Tests: 121 passed, 0 failed