### PR TITLE
Add Apple platform commands to CLI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
   <ItemGroup Label="Cli">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageVersion Include="Xamarin.Android.Tools.AndroidSdk" Version="$(XamarinAndroidToolsAndroidSdkVersion)" />
+    <PackageVersion Include="Xamarin.Apple.Tools.MaciOS" Version="$(XamarinAppleToolsMaciOSVersion)" />
   </ItemGroup>
 
   <!-- Platform extensions (pinned) -->

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A command-line tool for .NET MAUI development environment setup, device manageme
 - **Environment diagnostics** (`maui doctor`) with auto-fix capabilities
 - **Android SDK and JDK management** — install, update, and configure
 - **Emulator management** — create, start, stop, and delete Android emulators
-- **Device listing** across all connected platforms
+- **Apple platform management** (macOS) — Xcode, simulator, and runtime management
+- **Device listing** across all connected platforms (Android emulators + iOS simulators)
 - **DevFlow app automation** (`maui devflow`) — visual tree inspection, screenshots, CDP, MCP server
 - **JSON output** (`--json`) for CI pipelines and scripting
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -32,6 +32,10 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>73b3b5ac0e4a5658c7a0555b67d91a22ad39de4b</Sha>
     </Dependency>
+    <Dependency Name="Xamarin.Apple.Tools.MaciOS" Version="1.0.0-preview.1.26201.1">
+      <Uri>https://github.com/dotnet/macios-devtools</Uri>
+      <Sha>14efcb9735fab369066fa3c99130d076aa0dfdc9</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.26168.104">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,6 +44,10 @@
   <PropertyGroup Label="Android Tools">
     <XamarinAndroidToolsAndroidSdkVersion>1.0.143-preview.8</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
+  <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
+  <PropertyGroup Label="Apple Tools">
+    <XamarinAppleToolsMaciOSVersion>1.0.0-preview.1.26201.1</XamarinAppleToolsMaciOSVersion>
+  </PropertyGroup>
   <PropertyGroup Label="Platform Extensions">
     <PlatformMauiMacOSVersion>0.3.0</PlatformMauiMacOSVersion>
     <PlatformMauiMacOSBlazorWebViewVersion>$(PlatformMauiMacOSVersion)</PlatformMauiMacOSBlazorWebViewVersion>

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -34,6 +34,70 @@ public class DeviceManagerTests
 	}
 
 	[Fact]
+	public async Task GetAllDevicesAsync_ReturnsAppleSimulators()
+	{
+		// Arrange
+		var fakeApple = new FakeAppleProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device
+				{
+					Id = "sim-udid-1234",
+					Name = "iPhone 15 Pro",
+					Platforms = new[] { "ios" },
+					Type = DeviceType.Simulator,
+					State = DeviceState.Booted,
+					IsEmulator = true,
+					IsRunning = true,
+					EmulatorId = "sim-udid-1234",
+					Version = "18.0"
+				}
+			}
+		};
+
+		var manager = new DeviceManager(appleProvider: fakeApple);
+
+		// Act
+		var devices = await manager.GetAllDevicesAsync();
+
+		// Assert
+		Assert.Single(devices);
+		Assert.Contains(devices, d => d.Platforms.Contains("ios"));
+		Assert.Equal(DeviceType.Simulator, devices[0].Type);
+	}
+
+	[Fact]
+	public async Task GetAllDevicesAsync_ReturnsBothAndroidAndApple()
+	{
+		// Arrange
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device { Id = "emulator-5554", Name = "Pixel 6", Platforms = new[] { "android" }, Type = DeviceType.Emulator, State = DeviceState.Booted, IsEmulator = true, IsRunning = true }
+			}
+		};
+		var fakeApple = new FakeAppleProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device { Id = "sim-udid", Name = "iPhone 15", Platforms = new[] { "ios" }, Type = DeviceType.Simulator, State = DeviceState.Booted, IsEmulator = true, IsRunning = true }
+			}
+		};
+
+		var manager = new DeviceManager(fakeAndroid, fakeApple);
+
+		// Act
+		var devices = await manager.GetAllDevicesAsync();
+
+		// Assert
+		Assert.Equal(2, devices.Count);
+		Assert.Contains(devices, d => d.Platforms.Contains("android"));
+		Assert.Contains(devices, d => d.Platforms.Contains("ios"));
+	}
+
+	[Fact]
 	public async Task GetDevicesByPlatformAsync_FiltersCorrectly()
 	{
 		// Arrange
@@ -53,6 +117,35 @@ public class DeviceManagerTests
 		// Assert
 		Assert.Single(androidOnly);
 		Assert.All(androidOnly, d => Assert.Contains("android", d.Platforms));
+	}
+
+	[Fact]
+	public async Task GetDevicesByPlatformAsync_FiltersIosDevices()
+	{
+		// Arrange
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device { Id = "emulator-5554", Name = "Pixel 6", Platforms = new[] { "android" }, Type = DeviceType.Emulator, State = DeviceState.Booted, IsEmulator = true, IsRunning = true }
+			}
+		};
+		var fakeApple = new FakeAppleProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device { Id = "sim-udid", Name = "iPhone 15", Platforms = new[] { "ios" }, Type = DeviceType.Simulator, State = DeviceState.Booted, IsEmulator = true, IsRunning = true }
+			}
+		};
+
+		var manager = new DeviceManager(fakeAndroid, fakeApple);
+
+		// Act
+		var iosOnly = await manager.GetDevicesByPlatformAsync("ios");
+
+		// Assert
+		Assert.Single(iosOnly);
+		Assert.All(iosOnly, d => Assert.Contains("ios", d.Platforms));
 	}
 
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DoctorServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DoctorServiceTests.cs
@@ -60,6 +60,41 @@ public class DoctorServiceTests
 	}
 
 	[Fact]
+	public async Task RunAllChecksAsync_IncludesAppleChecks_WhenProviderReturnsChecks()
+	{
+		// Arrange
+		var fakeApple = new FakeAppleProvider
+		{
+			HealthChecks = new List<HealthCheck>
+			{
+				new HealthCheck
+				{
+					Category = "apple",
+					Name = "Xcode",
+					Status = CheckStatus.Ok,
+					Message = "Xcode 16.0"
+				},
+				new HealthCheck
+				{
+					Category = "apple",
+					Name = "Command Line Tools",
+					Status = CheckStatus.Ok,
+					Message = "CLT installed"
+				}
+			}
+		};
+
+		var service = new DoctorService(appleProvider: fakeApple);
+
+		// Act
+		var report = await service.RunAllChecksAsync();
+
+		// Assert
+		Assert.Contains(report.Checks, c => c.Category == "apple" && c.Name == "Xcode");
+		Assert.Contains(report.Checks, c => c.Category == "apple" && c.Name == "Command Line Tools");
+	}
+
+	[Fact]
 	public async Task RunAllChecksAsync_CalculatesCorrectSummary()
 	{
 		// Arrange
@@ -106,6 +141,27 @@ public class DoctorServiceTests
 	}
 
 	[Fact]
+	public async Task RunCategoryChecksAsync_AppleCategory_ReturnsAppleChecks()
+	{
+		// Arrange
+		var fakeApple = new FakeAppleProvider
+		{
+			HealthChecks = new List<HealthCheck>
+			{
+				new HealthCheck { Category = "apple", Name = "Xcode", Status = CheckStatus.Ok, Message = "Xcode 16.0" }
+			}
+		};
+
+		var service = new DoctorService(appleProvider: fakeApple);
+
+		// Act
+		var report = await service.RunCategoryChecksAsync("apple");
+
+		// Assert
+		Assert.Contains(report.Checks, c => c.Category == "apple" && c.Name == "Xcode");
+	}
+
+	[Fact]
 	public async Task RunAllChecksAsync_IncludesAndroidChecks_WhenProviderReturnsAndroidOnly()
 	{
 		// Arrange
@@ -124,5 +180,34 @@ public class DoctorServiceTests
 
 		// Assert - android checks should be present
 		Assert.Contains(report.Checks, c => c.Category == "android" && c.Name == "JDK");
+	}
+
+	[Fact]
+	public async Task RunAllChecksAsync_BothProviders_IncludesBothChecks()
+	{
+		// Arrange
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			HealthChecks = new List<HealthCheck>
+			{
+				new HealthCheck { Category = "android", Name = "JDK", Status = CheckStatus.Ok }
+			}
+		};
+		var fakeApple = new FakeAppleProvider
+		{
+			HealthChecks = new List<HealthCheck>
+			{
+				new HealthCheck { Category = "apple", Name = "Xcode", Status = CheckStatus.Ok }
+			}
+		};
+
+		var service = new DoctorService(fakeAndroid, fakeApple);
+
+		// Act
+		var report = await service.RunAllChecksAsync();
+
+		// Assert
+		Assert.Contains(report.Checks, c => c.Category == "android");
+		Assert.Contains(report.Checks, c => c.Category == "apple");
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.Providers.Apple;
+
+namespace Microsoft.Maui.Cli.UnitTests.Fakes;
+
+/// <summary>
+/// Hand-written fake for <see cref="IAppleProvider"/> used in unit tests.
+/// Set the public properties to control return values; inspect the tracking
+/// lists to verify which methods were called and with what arguments.
+/// </summary>
+public class FakeAppleProvider : IAppleProvider
+{
+	// --- Configurable return values ---
+
+	public List<XcodeInstallation> XcodeInstallations { get; set; } = new();
+	public XcodeInstallation? SelectedXcode { get; set; }
+	public CommandLineToolsStatus CltStatus { get; set; } = new();
+	public List<RuntimeInfo> Runtimes { get; set; } = new();
+	public List<SimulatorInfo> Simulators { get; set; } = new();
+	public List<HealthCheck> HealthChecks { get; set; } = new();
+	public List<Device> Devices { get; set; } = new();
+
+	public bool SelectXcodeResult { get; set; } = true;
+	public bool BootSimulatorResult { get; set; } = true;
+	public bool ShutdownSimulatorResult { get; set; } = true;
+	public bool DeleteSimulatorResult { get; set; } = true;
+	public string? CreateSimulatorResult { get; set; } = "new-udid";
+
+	// --- Call tracking ---
+
+	public List<string> SelectedXcodePaths { get; } = new();
+	public List<string> BootedSimulators { get; } = new();
+	public List<string> ShutdownSimulators { get; } = new();
+	public List<string> DeletedSimulators { get; } = new();
+	public List<(string Name, string DeviceType, string? Runtime)> CreatedSimulators { get; } = new();
+
+	// --- IAppleProvider implementation ---
+
+	public List<XcodeInstallation> GetXcodeInstallations() => XcodeInstallations;
+
+	public XcodeInstallation? GetSelectedXcode() => SelectedXcode;
+
+	public bool SelectXcode(string path)
+	{
+		SelectedXcodePaths.Add(path);
+		return SelectXcodeResult;
+	}
+
+	public CommandLineToolsStatus GetCommandLineToolsStatus() => CltStatus;
+
+	public List<RuntimeInfo> GetRuntimes(string? platform = null, bool availableOnly = false)
+	{
+		var result = Runtimes;
+		if (platform is not null)
+			result = result.Where(r => string.Equals(r.Platform, platform, StringComparison.OrdinalIgnoreCase)).ToList();
+		if (availableOnly)
+			result = result.Where(r => r.IsAvailable).ToList();
+		return result;
+	}
+
+	public List<SimulatorInfo> GetSimulators(bool availableOnly = false)
+	{
+		return availableOnly ? Simulators.Where(s => s.IsAvailable).ToList() : Simulators;
+	}
+
+	public bool BootSimulator(string udidOrName)
+	{
+		BootedSimulators.Add(udidOrName);
+		return BootSimulatorResult;
+	}
+
+	public bool ShutdownSimulator(string udidOrName)
+	{
+		ShutdownSimulators.Add(udidOrName);
+		return ShutdownSimulatorResult;
+	}
+
+	public bool DeleteSimulator(string udidOrName)
+	{
+		DeletedSimulators.Add(udidOrName);
+		return DeleteSimulatorResult;
+	}
+
+	public string? CreateSimulator(string name, string deviceTypeIdentifier, string? runtimeIdentifier = null)
+	{
+		CreatedSimulators.Add((name, deviceTypeIdentifier, runtimeIdentifier));
+		return CreateSimulatorResult;
+	}
+
+	public List<HealthCheck> CheckHealth() => HealthChecks;
+
+	public List<Device> GetDevices() => Devices;
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Cli.DevFlow;
 using Microsoft.Maui.Cli.Providers.Android;
+using Microsoft.Maui.Cli.Providers.Apple;
 using Microsoft.Maui.Cli.Services;
 using Microsoft.Maui.Cli.UnitTests.Fakes;
 using Xunit;
@@ -21,6 +22,7 @@ public class ServiceConfigurationTests
 		// Assert
 		Assert.NotNull(provider.GetService<IJdkManager>());
 		Assert.NotNull(provider.GetService<IAndroidProvider>());
+		Assert.NotNull(provider.GetService<IAppleProvider>());
 		Assert.NotNull(provider.GetService<IDoctorService>());
 		Assert.NotNull(provider.GetService<IDeviceManager>());
 		Assert.NotNull(provider.GetService<IDevFlowOutputWriter>());
@@ -33,9 +35,12 @@ public class ServiceConfigurationTests
 		var provider = ServiceConfiguration.CreateServiceProvider();
 		var android1 = provider.GetService<IAndroidProvider>();
 		var android2 = provider.GetService<IAndroidProvider>();
+		var apple1 = provider.GetService<IAppleProvider>();
+		var apple2 = provider.GetService<IAppleProvider>();
 
 		// Assert
 		Assert.Same(android1, android2);
+		Assert.Same(apple1, apple2);
 	}
 
 	[Fact]
@@ -43,13 +48,16 @@ public class ServiceConfigurationTests
 	{
 		// Arrange
 		var fakeAndroid = new FakeAndroidProvider();
+		var fakeApple = new FakeAppleProvider();
 
 		// Act
 		var provider = ServiceConfiguration.CreateTestServiceProvider(
-			androidProvider: fakeAndroid);
+			androidProvider: fakeAndroid,
+			appleProvider: fakeApple);
 
 		// Assert
 		Assert.Same(fakeAndroid, provider.GetService<IAndroidProvider>());
+		Assert.Same(fakeApple, provider.GetService<IAppleProvider>());
 	}
 
 	[Fact]
@@ -64,6 +72,7 @@ public class ServiceConfigurationTests
 
 		// Assert - should create real services for everything else
 		Assert.Same(fakeAndroid, provider.GetService<IAndroidProvider>());
+		Assert.NotNull(provider.GetService<IAppleProvider>());
 		Assert.NotNull(provider.GetService<IDoctorService>());
 	}
 
@@ -74,14 +83,17 @@ public class ServiceConfigurationTests
 		{
 			// Arrange
 			var fakeAndroid = new FakeAndroidProvider();
+			var fakeApple = new FakeAppleProvider();
 			var testProvider = ServiceConfiguration.CreateTestServiceProvider(
-				androidProvider: fakeAndroid);
+				androidProvider: fakeAndroid,
+				appleProvider: fakeApple);
 
 			// Act
 			Program.Services = testProvider;
 
 			// Assert
 			Assert.Same(fakeAndroid, Program.AndroidProvider);
+			Assert.Same(fakeApple, Program.AppleProvider);
 		}
 		finally
 		{

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -32,17 +32,18 @@ public static class AppleCommands
 
 		// maui apple xcode list
 		var listCommand = new Command("list", "List installed Xcode versions");
-		listCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		listCommand.SetAction((ParseResult parseResult) =>
 		{
-			var appleProvider = Program.AppleProvider;
 			var formatter = Program.GetFormatter(parseResult);
-			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 
 			if (!PlatformDetector.IsMacOS)
 			{
 				formatter.WriteWarning("Xcode is only available on macOS.");
 				return 1;
 			}
+
+			var appleProvider = Program.AppleProvider;
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 
 			var installations = appleProvider.GetXcodeInstallations();
 			if (useJson)
@@ -84,18 +85,19 @@ public static class AppleCommands
 			platformOption
 		};
 
-		listCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		listCommand.SetAction((ParseResult parseResult) =>
 		{
-			var appleProvider = Program.AppleProvider;
 			var formatter = Program.GetFormatter(parseResult);
-			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
-			var platform = parseResult.GetValue(platformOption);
 
 			if (!PlatformDetector.IsMacOS)
 			{
 				formatter.WriteWarning("Runtimes are only available on macOS.");
 				return 1;
 			}
+
+			var appleProvider = Program.AppleProvider;
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			var platform = parseResult.GetValue(platformOption);
 
 			var runtimes = appleProvider.GetRuntimes(platform, availableOnly: false);
 			if (useJson)
@@ -133,17 +135,18 @@ public static class AppleCommands
 
 		// maui apple simulator list
 		var listCommand = new Command("list", "List simulator devices");
-		listCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		listCommand.SetAction((ParseResult parseResult) =>
 		{
-			var appleProvider = Program.AppleProvider;
 			var formatter = Program.GetFormatter(parseResult);
-			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 
 			if (!PlatformDetector.IsMacOS)
 			{
 				formatter.WriteWarning("Simulators are only available on macOS.");
 				return 1;
 			}
+
+			var appleProvider = Program.AppleProvider;
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 
 			var simulators = appleProvider.GetSimulators(availableOnly: false);
 			if (useJson)
@@ -174,17 +177,18 @@ public static class AppleCommands
 		// maui apple simulator start <name-or-udid>
 		var startNameArg = new Argument<string>("name-or-udid") { Description = "Simulator name or UDID to boot" };
 		var startCommand = new Command("start", "Boot a simulator") { startNameArg };
-		startCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		startCommand.SetAction((ParseResult parseResult) =>
 		{
-			var appleProvider = Program.AppleProvider;
 			var formatter = Program.GetFormatter(parseResult);
-			var target = parseResult.GetValue(startNameArg);
 
 			if (!PlatformDetector.IsMacOS)
 			{
 				formatter.WriteWarning("Simulators are only available on macOS.");
 				return 1;
 			}
+
+			var appleProvider = Program.AppleProvider;
+			var target = parseResult.GetValue(startNameArg);
 
 			var success = appleProvider.BootSimulator(target!);
 			if (success)
@@ -198,17 +202,18 @@ public static class AppleCommands
 		// maui apple simulator stop <name-or-udid>
 		var stopNameArg = new Argument<string>("name-or-udid") { Description = "Simulator name or UDID to shut down (or 'all')" };
 		var stopCommand = new Command("stop", "Shut down a simulator") { stopNameArg };
-		stopCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		stopCommand.SetAction((ParseResult parseResult) =>
 		{
-			var appleProvider = Program.AppleProvider;
 			var formatter = Program.GetFormatter(parseResult);
-			var target = parseResult.GetValue(stopNameArg);
 
 			if (!PlatformDetector.IsMacOS)
 			{
 				formatter.WriteWarning("Simulators are only available on macOS.");
 				return 1;
 			}
+
+			var appleProvider = Program.AppleProvider;
+			var target = parseResult.GetValue(stopNameArg);
 
 			var success = appleProvider.ShutdownSimulator(target!);
 			if (success)
@@ -222,17 +227,18 @@ public static class AppleCommands
 		// maui apple simulator delete <name-or-udid>
 		var deleteNameArg = new Argument<string>("name-or-udid") { Description = "Simulator name or UDID to delete" };
 		var deleteCommand = new Command("delete", "Delete a simulator") { deleteNameArg };
-		deleteCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		deleteCommand.SetAction((ParseResult parseResult) =>
 		{
-			var appleProvider = Program.AppleProvider;
 			var formatter = Program.GetFormatter(parseResult);
-			var target = parseResult.GetValue(deleteNameArg);
 
 			if (!PlatformDetector.IsMacOS)
 			{
 				formatter.WriteWarning("Simulators are only available on macOS.");
 				return 1;
 			}
+
+			var appleProvider = Program.AppleProvider;
+			var target = parseResult.GetValue(deleteNameArg);
 
 			var success = appleProvider.DeleteSimulator(target!);
 			if (success)

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -1,0 +1,252 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Microsoft.Maui.Cli.Output;
+using Microsoft.Maui.Cli.Providers.Apple;
+using Microsoft.Maui.Cli.Utils;
+
+namespace Microsoft.Maui.Cli.Commands;
+
+/// <summary>
+/// Implementation of 'maui apple' command group.
+/// Sub-commands: xcode, runtime, simulator.
+/// </summary>
+public static class AppleCommands
+{
+	public static Command Create()
+	{
+		var command = new Command("apple", "Apple platform management (Xcode, simulators, runtimes)");
+
+		command.Add(CreateXcodeCommand());
+		command.Add(CreateRuntimeCommand());
+		command.Add(CreateSimulatorCommand());
+
+		return command;
+	}
+
+	static Command CreateXcodeCommand()
+	{
+		var xcodeCommand = new Command("xcode", "Manage Xcode installations");
+
+		// maui apple xcode list
+		var listCommand = new Command("list", "List installed Xcode versions");
+		listCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var appleProvider = Program.AppleProvider;
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteWarning("Xcode is only available on macOS.");
+				return 1;
+			}
+
+			var installations = appleProvider.GetXcodeInstallations();
+			if (useJson)
+			{
+				formatter.Write(installations);
+			}
+			else
+			{
+				if (!installations.Any())
+				{
+					formatter.WriteWarning("No Xcode installations found.");
+					return 0;
+				}
+
+				if (formatter is SpectreOutputFormatter spectre)
+				{
+					spectre.WriteTable(installations,
+						("Version", x => x.Version ?? "?"),
+						("Build", x => x.Build ?? "?"),
+						("Path", x => x.Path),
+						("Selected", x => x.IsSelected ? "✓" : ""));
+				}
+			}
+			return 0;
+		});
+
+		xcodeCommand.Add(listCommand);
+		return xcodeCommand;
+	}
+
+	static Command CreateRuntimeCommand()
+	{
+		var runtimeCommand = new Command("runtime", "Manage simulator runtimes");
+
+		// maui apple runtime list [--platform ios]
+		var platformOption = new Option<string?>("--platform") { Description = "Filter by platform (iOS, tvOS, watchOS, visionOS)" };
+		var listCommand = new Command("list", "List installed simulator runtimes")
+		{
+			platformOption
+		};
+
+		listCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var appleProvider = Program.AppleProvider;
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			var platform = parseResult.GetValue(platformOption);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteWarning("Runtimes are only available on macOS.");
+				return 1;
+			}
+
+			var runtimes = appleProvider.GetRuntimes(platform, availableOnly: false);
+			if (useJson)
+			{
+				formatter.Write(runtimes);
+			}
+			else
+			{
+				if (!runtimes.Any())
+				{
+					formatter.WriteWarning("No simulator runtimes found.");
+					return 0;
+				}
+
+				if (formatter is SpectreOutputFormatter spectre)
+				{
+					spectre.WriteTable(runtimes,
+						("Name", r => r.Name),
+						("Platform", r => r.Platform ?? "?"),
+						("Version", r => r.Version ?? "?"),
+						("Available", r => r.IsAvailable ? "✓" : "✗"),
+						("Bundled", r => r.IsBundled ? "Yes" : "No"));
+				}
+			}
+			return 0;
+		});
+
+		runtimeCommand.Add(listCommand);
+		return runtimeCommand;
+	}
+
+	static Command CreateSimulatorCommand()
+	{
+		var simCommand = new Command("simulator", "Manage iOS simulators");
+
+		// maui apple simulator list
+		var listCommand = new Command("list", "List simulator devices");
+		listCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var appleProvider = Program.AppleProvider;
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteWarning("Simulators are only available on macOS.");
+				return 1;
+			}
+
+			var simulators = appleProvider.GetSimulators(availableOnly: false);
+			if (useJson)
+			{
+				formatter.Write(simulators);
+			}
+			else
+			{
+				if (!simulators.Any())
+				{
+					formatter.WriteWarning("No simulators found.");
+					return 0;
+				}
+
+				if (formatter is SpectreOutputFormatter spectre)
+				{
+					spectre.WriteTable(simulators,
+						("Name", s => s.Name),
+						("UDID", s => s.Udid),
+						("OS", s => $"{s.Platform} {s.OSVersion}"),
+						("State", s => s.IsBooted ? "Booted" : s.State ?? "Shutdown"),
+						("Available", s => s.IsAvailable ? "✓" : "✗"));
+				}
+			}
+			return 0;
+		});
+
+		// maui apple simulator start <name-or-udid>
+		var startNameArg = new Argument<string>("name-or-udid") { Description = "Simulator name or UDID to boot" };
+		var startCommand = new Command("start", "Boot a simulator") { startNameArg };
+		startCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var appleProvider = Program.AppleProvider;
+			var formatter = Program.GetFormatter(parseResult);
+			var target = parseResult.GetValue(startNameArg);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteWarning("Simulators are only available on macOS.");
+				return 1;
+			}
+
+			var success = appleProvider.BootSimulator(target!);
+			if (success)
+				formatter.WriteSuccess($"Simulator '{target}' booted.");
+			else
+				formatter.WriteWarning($"Failed to boot simulator '{target}'.");
+
+			return success ? 0 : 1;
+		});
+
+		// maui apple simulator stop <name-or-udid>
+		var stopNameArg = new Argument<string>("name-or-udid") { Description = "Simulator name or UDID to shut down (or 'all')" };
+		var stopCommand = new Command("stop", "Shut down a simulator") { stopNameArg };
+		stopCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var appleProvider = Program.AppleProvider;
+			var formatter = Program.GetFormatter(parseResult);
+			var target = parseResult.GetValue(stopNameArg);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteWarning("Simulators are only available on macOS.");
+				return 1;
+			}
+
+			var success = appleProvider.ShutdownSimulator(target!);
+			if (success)
+				formatter.WriteSuccess($"Simulator '{target}' shut down.");
+			else
+				formatter.WriteWarning($"Failed to shut down simulator '{target}'.");
+
+			return success ? 0 : 1;
+		});
+
+		// maui apple simulator delete <name-or-udid>
+		var deleteNameArg = new Argument<string>("name-or-udid") { Description = "Simulator name or UDID to delete" };
+		var deleteCommand = new Command("delete", "Delete a simulator") { deleteNameArg };
+		deleteCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var appleProvider = Program.AppleProvider;
+			var formatter = Program.GetFormatter(parseResult);
+			var target = parseResult.GetValue(deleteNameArg);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteWarning("Simulators are only available on macOS.");
+				return 1;
+			}
+
+			var success = appleProvider.DeleteSimulator(target!);
+			if (success)
+				formatter.WriteSuccess($"Simulator '{target}' deleted.");
+			else
+				formatter.WriteWarning($"Failed to delete simulator '{target}'.");
+
+			return success ? 0 : 1;
+		});
+
+		simCommand.Add(listCommand);
+		simCommand.Add(startCommand);
+		simCommand.Add(stopCommand);
+		simCommand.Add(deleteCommand);
+		return simCommand;
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodes.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodes.cs
@@ -37,6 +37,12 @@ public static class ErrorCodes
 	public const string AndroidDeviceNotFound = "E2111";
 	public const string AndroidAvdDeleteFailed = "E2112";
 
+	// Platform/SDK errors - Apple (E22xx)
+	public const string AppleXcodeNotFound = "E2201";
+	public const string AppleCltNotFound = "E2202";
+	public const string AppleSimctlFailed = "E2203";
+	public const string AppleSimulatorNotFound = "E2204";
+
 	// Platform/SDK errors - Windows (E23xx)
 	public const string WindowsSdkNotFound = "E2301";
 

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Websocket.Client" />
     <PackageReference Include="Xamarin.Android.Tools.AndroidSdk" />
+    <PackageReference Include="Xamarin.Apple.Tools.MaciOS" />
     <PackageReference Include="XenoAtom.Terminal.UI" />
   </ItemGroup>
 

--- a/src/Cli/Microsoft.Maui.Cli/Program.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Cli.Commands;
 using Microsoft.Maui.Cli.Output;
 using Microsoft.Maui.Cli.Providers.Android;
+using Microsoft.Maui.Cli.Providers.Apple;
 using Microsoft.Maui.Cli.Services;
 using Microsoft.Maui.Cli.Utils;
 
@@ -37,6 +38,7 @@ public class Program
 
 	// Convenience accessors for services
 	internal static IAndroidProvider AndroidProvider => Services.GetRequiredService<IAndroidProvider>();
+	internal static IAppleProvider AppleProvider => Services.GetRequiredService<IAppleProvider>();
 	internal static IDoctorService DoctorService => Services.GetRequiredService<IDoctorService>();
 	internal static IDeviceManager DeviceManager => Services.GetRequiredService<IDeviceManager>();
 	internal static IJdkManager JdkManager => Services.GetRequiredService<IJdkManager>();
@@ -89,6 +91,7 @@ public class Program
 
 		// Platform-specific command groups
 		rootCommand.Add(AndroidCommands.Create());
+		rootCommand.Add(AppleCommands.Create());
 
 		// DevFlow automation commands (maui devflow ...)
 		rootCommand.Add(DevFlow.DevFlowCommands.CreateDevFlowCommand(GlobalOptions.JsonOption));

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
@@ -229,20 +229,46 @@ public class AppleProvider : IAppleProvider
 		}
 
 		// Simulator runtimes check
-		var runtimes = _runtimeService?.List(availableOnly: true);
-		if (runtimes is { Count: > 0 })
+		HealthCheck iosRuntimesCheck;
+		try
 		{
-			var iosRuntimes = runtimes.Where(r => r.Platform == "iOS").ToList();
-			checks.Add(new HealthCheck
+			var runtimes = _runtimeService?.List(availableOnly: true);
+			if (runtimes is { Count: > 0 })
+			{
+				var iosRuntimes = runtimes.Where(r => r.Platform == "iOS").ToList();
+				iosRuntimesCheck = new HealthCheck
+				{
+					Category = "apple",
+					Name = "iOS Runtimes",
+					Status = iosRuntimes.Count > 0 ? CheckStatus.Ok : CheckStatus.Warning,
+					Message = iosRuntimes.Count > 0
+						? $"{iosRuntimes.Count} iOS runtime(s) available (latest: {iosRuntimes.OrderByDescending(r => r.Version).First().Name})"
+						: "No iOS runtimes found. Install one via Xcode."
+				};
+			}
+			else
+			{
+				iosRuntimesCheck = new HealthCheck
+				{
+					Category = "apple",
+					Name = "iOS Runtimes",
+					Status = CheckStatus.Warning,
+					Message = "No simulator runtimes found. Install simulator runtimes via Xcode."
+				};
+			}
+		}
+		catch
+		{
+			iosRuntimesCheck = new HealthCheck
 			{
 				Category = "apple",
 				Name = "iOS Runtimes",
-				Status = iosRuntimes.Count > 0 ? CheckStatus.Ok : CheckStatus.Warning,
-				Message = iosRuntimes.Count > 0
-					? $"{iosRuntimes.Count} iOS runtime(s) available (latest: {iosRuntimes.OrderByDescending(r => r.Version).First().Name})"
-					: "No iOS runtimes found. Install one via Xcode."
-			});
+				Status = CheckStatus.Warning,
+				Message = "Unable to determine installed iOS simulator runtimes."
+			};
 		}
+
+		checks.Add(iosRuntimesCheck);
 
 		return checks;
 	}

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
@@ -1,0 +1,290 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Maui.Cli.Errors;
+using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.Utils;
+using Xamarin.MacDev;
+
+namespace Microsoft.Maui.Cli.Providers.Apple;
+
+/// <summary>
+/// Apple platform provider backed by Xamarin.Apple.Tools.MaciOS.
+/// Only functional on macOS; returns empty results on other platforms.
+/// </summary>
+public class AppleProvider : IAppleProvider
+{
+	readonly XcodeManager? _xcodeManager;
+	readonly SimulatorService? _simulatorService;
+	readonly RuntimeService? _runtimeService;
+	readonly CommandLineTools? _commandLineTools;
+
+	public AppleProvider()
+	{
+		if (!PlatformDetector.IsMacOS)
+			return;
+
+		var logger = ConsoleLogger.Instance;
+		_xcodeManager = new XcodeManager(logger);
+		_simulatorService = new SimulatorService(logger);
+		_runtimeService = new RuntimeService(logger);
+		_commandLineTools = new CommandLineTools(logger);
+	}
+
+	public List<XcodeInstallation> GetXcodeInstallations()
+	{
+		if (_xcodeManager is null)
+			return new List<XcodeInstallation>();
+
+		return _xcodeManager.List().Select(x => new XcodeInstallation
+		{
+			Path = x.Path,
+			Version = x.Version.ToString(),
+			Build = x.Build,
+			IsSelected = x.IsSelected
+		}).ToList();
+	}
+
+	public XcodeInstallation? GetSelectedXcode()
+	{
+		if (_xcodeManager is null)
+			return null;
+
+		var selected = _xcodeManager.GetSelected();
+		if (selected is null)
+			return null;
+
+		return new XcodeInstallation
+		{
+			Path = selected.Path,
+			Version = selected.Version.ToString(),
+			Build = selected.Build,
+			IsSelected = true
+		};
+	}
+
+	public bool SelectXcode(string path)
+	{
+		if (_xcodeManager is null)
+			return false;
+
+		return _xcodeManager.Select(path);
+	}
+
+	public CommandLineToolsStatus GetCommandLineToolsStatus()
+	{
+		if (_commandLineTools is null)
+			return new CommandLineToolsStatus();
+
+		var info = _commandLineTools.Check();
+		return new CommandLineToolsStatus
+		{
+			IsInstalled = info.IsInstalled,
+			Version = info.Version,
+			Path = info.Path
+		};
+	}
+
+	public List<RuntimeInfo> GetRuntimes(string? platform = null, bool availableOnly = false)
+	{
+		if (_runtimeService is null)
+			return new List<RuntimeInfo>();
+
+		var runtimes = string.IsNullOrEmpty(platform)
+			? _runtimeService.List(availableOnly)
+			: _runtimeService.ListByPlatform(platform!, availableOnly);
+
+		return runtimes.Select(r => new RuntimeInfo
+		{
+			Name = r.Name,
+			Identifier = r.Identifier,
+			Platform = r.Platform,
+			Version = r.Version,
+			BuildVersion = r.BuildVersion,
+			IsAvailable = r.IsAvailable,
+			IsBundled = r.IsBundled
+		}).ToList();
+	}
+
+	public List<SimulatorInfo> GetSimulators(bool availableOnly = false)
+	{
+		if (_simulatorService is null)
+			return new List<SimulatorInfo>();
+
+		return _simulatorService.List(availableOnly).Select(s => new SimulatorInfo
+		{
+			Name = s.Name,
+			Udid = s.Udid,
+			State = s.State,
+			Platform = s.Platform,
+			OSVersion = s.OSVersion,
+			RuntimeIdentifier = s.RuntimeIdentifier,
+			DeviceTypeIdentifier = s.DeviceTypeIdentifier,
+			IsAvailable = s.IsAvailable,
+			IsBooted = s.IsBooted
+		}).ToList();
+	}
+
+	public bool BootSimulator(string udidOrName)
+	{
+		return _simulatorService?.Boot(udidOrName) ?? false;
+	}
+
+	public bool ShutdownSimulator(string udidOrName)
+	{
+		return _simulatorService?.Shutdown(udidOrName) ?? false;
+	}
+
+	public bool DeleteSimulator(string udidOrName)
+	{
+		return _simulatorService?.Delete(udidOrName) ?? false;
+	}
+
+	public string? CreateSimulator(string name, string deviceTypeIdentifier, string? runtimeIdentifier = null)
+	{
+		return _simulatorService?.Create(name, deviceTypeIdentifier, runtimeIdentifier);
+	}
+
+	public List<HealthCheck> CheckHealth()
+	{
+		var checks = new List<HealthCheck>();
+
+		if (!PlatformDetector.IsMacOS)
+		{
+			checks.Add(new HealthCheck
+			{
+				Category = "apple",
+				Name = "Platform",
+				Status = CheckStatus.Skipped,
+				Message = "Apple checks only available on macOS"
+			});
+			return checks;
+		}
+
+		// Xcode check
+		var xcode = _xcodeManager?.GetBest();
+		if (xcode is not null)
+		{
+			checks.Add(new HealthCheck
+			{
+				Category = "apple",
+				Name = "Xcode",
+				Status = CheckStatus.Ok,
+				Message = $"Xcode {xcode.Version} ({xcode.Build}) at {xcode.Path}",
+				Details = new Dictionary<string, object>
+				{
+					["version"] = xcode.Version.ToString(),
+					["build"] = xcode.Build,
+					["path"] = xcode.Path,
+					["selected"] = xcode.IsSelected
+				}
+			});
+		}
+		else
+		{
+			checks.Add(new HealthCheck
+			{
+				Category = "apple",
+				Name = "Xcode",
+				Status = CheckStatus.Error,
+				Message = "Xcode not found. Install Xcode from the App Store.",
+				Fix = new FixInfo
+				{
+					IssueId = ErrorCodes.AppleXcodeNotFound,
+					Description = "Install Xcode from the Mac App Store",
+					AutoFixable = false,
+					ManualSteps = new[] { "Open the Mac App Store and install Xcode" }
+				}
+			});
+		}
+
+		// Command Line Tools check
+		var clt = _commandLineTools?.Check();
+		if (clt is not null && clt.IsInstalled)
+		{
+			checks.Add(new HealthCheck
+			{
+				Category = "apple",
+				Name = "Command Line Tools",
+				Status = CheckStatus.Ok,
+				Message = $"CLT {clt.Version ?? "installed"} at {clt.Path}"
+			});
+		}
+		else
+		{
+			checks.Add(new HealthCheck
+			{
+				Category = "apple",
+				Name = "Command Line Tools",
+				Status = CheckStatus.Warning,
+				Message = "Xcode Command Line Tools not found",
+				Fix = new FixInfo
+				{
+					IssueId = ErrorCodes.AppleCltNotFound,
+					Description = "Install Command Line Tools",
+					AutoFixable = true,
+					Command = "xcode-select --install"
+				}
+			});
+		}
+
+		// Simulator runtimes check
+		var runtimes = _runtimeService?.List(availableOnly: true);
+		if (runtimes is { Count: > 0 })
+		{
+			var iosRuntimes = runtimes.Where(r => r.Platform == "iOS").ToList();
+			checks.Add(new HealthCheck
+			{
+				Category = "apple",
+				Name = "iOS Runtimes",
+				Status = iosRuntimes.Count > 0 ? CheckStatus.Ok : CheckStatus.Warning,
+				Message = iosRuntimes.Count > 0
+					? $"{iosRuntimes.Count} iOS runtime(s) available (latest: {iosRuntimes.OrderByDescending(r => r.Version).First().Name})"
+					: "No iOS runtimes found. Install one via Xcode."
+			});
+		}
+
+		return checks;
+	}
+
+	public List<Device> GetDevices()
+	{
+		if (_simulatorService is null)
+			return new List<Device>();
+
+		var sims = _simulatorService.List(availableOnly: true);
+		return sims.Select(s =>
+		{
+			var platform = s.Platform?.ToLowerInvariant() switch
+			{
+				"ios" => Platforms.iOS,
+				"tvos" or "watchos" or "visionos" => s.Platform!.ToLowerInvariant(),
+				_ => Platforms.iOS
+			};
+
+			return new Device
+			{
+				Id = s.Udid,
+				Name = s.Name,
+				Platforms = new[] { platform },
+				Type = DeviceType.Simulator,
+				State = s.IsBooted ? DeviceState.Booted : DeviceState.Shutdown,
+				IsEmulator = true,
+				IsRunning = s.IsBooted,
+				ConnectionType = Models.ConnectionType.Local,
+				EmulatorId = s.Udid,
+				Model = s.DeviceTypeIdentifier,
+				Manufacturer = "Apple",
+				Version = s.OSVersion,
+				VersionName = s.Platform != null ? $"{s.Platform} {s.OSVersion}" : s.OSVersion,
+				Idiom = s.DeviceTypeIdentifier.Contains("iPad") ? DeviceIdiom.Tablet : DeviceIdiom.Phone,
+				Details = new Dictionary<string, object>
+				{
+					["runtime"] = s.RuntimeIdentifier,
+					["device_type"] = s.DeviceTypeIdentifier,
+					["platform"] = s.Platform ?? ""
+				}
+			};
+		}).ToList();
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
@@ -235,14 +235,14 @@ public class AppleProvider : IAppleProvider
 			var runtimes = _runtimeService?.List(availableOnly: true);
 			if (runtimes is { Count: > 0 })
 			{
-				var iosRuntimes = runtimes.Where(r => r.Platform == "iOS").ToList();
+				var iosRuntimes = runtimes.Where(r => string.Equals(r.Platform, "iOS", StringComparison.OrdinalIgnoreCase)).ToList();
 				iosRuntimesCheck = new HealthCheck
 				{
 					Category = "apple",
 					Name = "iOS Runtimes",
 					Status = iosRuntimes.Count > 0 ? CheckStatus.Ok : CheckStatus.Warning,
 					Message = iosRuntimes.Count > 0
-						? $"{iosRuntimes.Count} iOS runtime(s) available (latest: {iosRuntimes.OrderByDescending(r => r.Version).First().Name})"
+						? $"{iosRuntimes.Count} iOS runtime(s) available (latest: {iosRuntimes.OrderByDescending(r => Version.TryParse(r.Version, out var v) ? v : new Version(0, 0)).First().Name})"
 						: "No iOS runtimes found. Install one via Xcode."
 				};
 			}
@@ -257,14 +257,14 @@ public class AppleProvider : IAppleProvider
 				};
 			}
 		}
-		catch
+		catch (Exception ex)
 		{
 			iosRuntimesCheck = new HealthCheck
 			{
 				Category = "apple",
 				Name = "iOS Runtimes",
 				Status = CheckStatus.Warning,
-				Message = "Unable to determine installed iOS simulator runtimes."
+				Message = $"Unable to determine installed iOS simulator runtimes: {ex.Message}"
 			};
 		}
 
@@ -281,12 +281,9 @@ public class AppleProvider : IAppleProvider
 		var sims = _simulatorService.List(availableOnly: true);
 		return sims.Select(s =>
 		{
-			var platform = s.Platform?.ToLowerInvariant() switch
-			{
-				"ios" => Platforms.iOS,
-				"tvos" or "watchos" or "visionos" => s.Platform!.ToLowerInvariant(),
-				_ => Platforms.iOS
-			};
+			// Scope to iOS simulators only for now; tvOS/watchOS/visionOS
+			// are not yet recognized in the shared Platforms model.
+			var platform = Platforms.iOS;
 
 			return new Device
 			{
@@ -303,11 +300,11 @@ public class AppleProvider : IAppleProvider
 				Manufacturer = "Apple",
 				Version = s.OSVersion,
 				VersionName = s.Platform != null ? $"{s.Platform} {s.OSVersion}" : s.OSVersion,
-				Idiom = s.DeviceTypeIdentifier.Contains("iPad") ? DeviceIdiom.Tablet : DeviceIdiom.Phone,
+				Idiom = s.DeviceTypeIdentifier?.Contains("iPad") == true ? DeviceIdiom.Tablet : DeviceIdiom.Phone,
 				Details = new Dictionary<string, object>
 				{
-					["runtime"] = s.RuntimeIdentifier,
-					["device_type"] = s.DeviceTypeIdentifier,
+					["runtime"] = s.RuntimeIdentifier ?? "",
+					["device_type"] = s.DeviceTypeIdentifier ?? "",
 					["platform"] = s.Platform ?? ""
 				}
 			};

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Maui.Cli.Models;
+
+namespace Microsoft.Maui.Cli.Providers.Apple;
+
+/// <summary>
+/// Interface for Apple platform operations (Xcode, simulators, runtimes).
+/// Wraps the Xamarin.Apple.Tools.MaciOS package APIs.
+/// </summary>
+public interface IAppleProvider
+{
+	/// <summary>
+	/// Lists installed Xcode installations.
+	/// </summary>
+	List<XcodeInstallation> GetXcodeInstallations();
+
+	/// <summary>
+	/// Gets the currently selected Xcode installation.
+	/// </summary>
+	XcodeInstallation? GetSelectedXcode();
+
+	/// <summary>
+	/// Selects an Xcode installation by path.
+	/// </summary>
+	bool SelectXcode(string path);
+
+	/// <summary>
+	/// Gets the Command Line Tools installation info.
+	/// </summary>
+	CommandLineToolsStatus GetCommandLineToolsStatus();
+
+	/// <summary>
+	/// Lists simulator runtimes. Optionally filter by platform (e.g., "iOS").
+	/// </summary>
+	List<RuntimeInfo> GetRuntimes(string? platform = null, bool availableOnly = false);
+
+	/// <summary>
+	/// Lists simulator devices. Optionally filters by availability.
+	/// </summary>
+	List<SimulatorInfo> GetSimulators(bool availableOnly = false);
+
+	/// <summary>
+	/// Boots a simulator device.
+	/// </summary>
+	bool BootSimulator(string udidOrName);
+
+	/// <summary>
+	/// Shuts down a simulator device. Pass "all" to shut down all.
+	/// </summary>
+	bool ShutdownSimulator(string udidOrName);
+
+	/// <summary>
+	/// Deletes a simulator device.
+	/// </summary>
+	bool DeleteSimulator(string udidOrName);
+
+	/// <summary>
+	/// Creates a new simulator device.
+	/// </summary>
+	string? CreateSimulator(string name, string deviceTypeIdentifier, string? runtimeIdentifier = null);
+
+	/// <summary>
+	/// Gets the health status of Apple tooling (Xcode, CLT, simulators).
+	/// </summary>
+	List<HealthCheck> CheckHealth();
+
+	/// <summary>
+	/// Lists simulator devices as <see cref="Device"/> models for device manager integration.
+	/// </summary>
+	List<Device> GetDevices();
+}
+
+/// <summary>
+/// Information about an Xcode installation.
+/// </summary>
+public record XcodeInstallation
+{
+	public required string Path { get; init; }
+	public string? Version { get; init; }
+	public string? Build { get; init; }
+	public bool IsSelected { get; init; }
+}
+
+/// <summary>
+/// Status of the Xcode Command Line Tools installation.
+/// </summary>
+public record CommandLineToolsStatus
+{
+	public bool IsInstalled { get; init; }
+	public string? Version { get; init; }
+	public string? Path { get; init; }
+}
+
+/// <summary>
+/// Information about a simulator runtime.
+/// </summary>
+public record RuntimeInfo
+{
+	public required string Name { get; init; }
+	public required string Identifier { get; init; }
+	public string? Platform { get; init; }
+	public string? Version { get; init; }
+	public string? BuildVersion { get; init; }
+	public bool IsAvailable { get; init; }
+	public bool IsBundled { get; init; }
+}
+
+/// <summary>
+/// Information about a simulator device.
+/// </summary>
+public record SimulatorInfo
+{
+	public required string Name { get; init; }
+	public required string Udid { get; init; }
+	public string? State { get; init; }
+	public string? Platform { get; init; }
+	public string? OSVersion { get; init; }
+	public string? RuntimeIdentifier { get; init; }
+	public string? DeviceTypeIdentifier { get; init; }
+	public bool IsAvailable { get; init; }
+	public bool IsBooted { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/ServiceConfiguration.cs
+++ b/src/Cli/Microsoft.Maui.Cli/ServiceConfiguration.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Cli.DevFlow;
 using Microsoft.Maui.Cli.Output;
 using Microsoft.Maui.Cli.Providers.Android;
+using Microsoft.Maui.Cli.Providers.Apple;
 using Microsoft.Maui.Cli.Services;
 using Microsoft.Maui.Cli.Utils;
 
@@ -34,6 +35,9 @@ public static class ServiceConfiguration
 		services.AddSingleton<IJdkManager, JdkManager>();
 		services.AddSingleton<IAndroidProvider, AndroidProvider>();
 
+		// Apple providers
+		services.AddSingleton<IAppleProvider, AppleProvider>();
+
 		// Core services
 		services.AddSingleton<IDoctorService, DoctorService>();
 		services.AddSingleton<IDeviceManager, DeviceManager>();
@@ -51,6 +55,7 @@ public static class ServiceConfiguration
 	/// </summary>
 	public static IServiceProvider CreateTestServiceProvider(
 		IAndroidProvider? androidProvider = null,
+		IAppleProvider? appleProvider = null,
 		IJdkManager? jdkManager = null,
 		IDoctorService? doctorService = null,
 		IDeviceManager? deviceManager = null,
@@ -68,6 +73,11 @@ public static class ServiceConfiguration
 			services.AddSingleton(androidProvider);
 		else
 			services.AddSingleton<IAndroidProvider, AndroidProvider>();
+
+		if (appleProvider != null)
+			services.AddSingleton(appleProvider);
+		else
+			services.AddSingleton<IAppleProvider, AppleProvider>();
 
 		if (doctorService != null)
 			services.AddSingleton(doctorService);

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -4,6 +4,7 @@
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
+using Microsoft.Maui.Cli.Providers.Apple;
 using Microsoft.Maui.Cli.Utils;
 
 namespace Microsoft.Maui.Cli.Services;
@@ -14,10 +15,12 @@ namespace Microsoft.Maui.Cli.Services;
 public class DeviceManager : IDeviceManager
 {
 	readonly IAndroidProvider? _androidProvider;
+	readonly IAppleProvider? _appleProvider;
 
-	public DeviceManager(IAndroidProvider? androidProvider = null)
+	public DeviceManager(IAndroidProvider? androidProvider = null, IAppleProvider? appleProvider = null)
 	{
 		_androidProvider = androidProvider;
+		_appleProvider = appleProvider;
 	}
 
 	public async Task<IReadOnlyList<Device>> GetAllDevicesAsync(CancellationToken cancellationToken = default)
@@ -108,8 +111,12 @@ public class DeviceManager : IDeviceManager
 			}
 		}
 
-		// TODO: Get Apple devices when AppleProvider is implemented
-		// TODO: Get Windows devices when WindowsProvider is implemented
+		// Get Apple devices (simulators) when on macOS
+		if (_appleProvider != null)
+		{
+			var appleDevices = _appleProvider.GetDevices();
+			devices.AddRange(appleDevices);
+		}
 
 		return devices;
 	}

--- a/src/Cli/Microsoft.Maui.Cli/Services/DoctorService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DoctorService.cs
@@ -4,6 +4,7 @@
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
+using Microsoft.Maui.Cli.Providers.Apple;
 using Microsoft.Maui.Cli.Utils;
 
 namespace Microsoft.Maui.Cli.Services;
@@ -14,10 +15,12 @@ namespace Microsoft.Maui.Cli.Services;
 public class DoctorService : IDoctorService
 {
 	readonly IAndroidProvider? _androidProvider;
+	readonly IAppleProvider? _appleProvider;
 
-	public DoctorService(IAndroidProvider? androidProvider = null)
+	public DoctorService(IAndroidProvider? androidProvider = null, IAppleProvider? appleProvider = null)
 	{
 		_androidProvider = androidProvider;
+		_appleProvider = appleProvider;
 	}
 
 	public async Task<DoctorReport> RunAllChecksAsync(CancellationToken cancellationToken = default)
@@ -35,6 +38,13 @@ public class DoctorService : IDoctorService
 		{
 			var androidChecks = await _androidProvider.CheckHealthAsync(cancellationToken);
 			checks.AddRange(androidChecks);
+		}
+
+		// Apple checks (macOS only)
+		if (_appleProvider != null)
+		{
+			var appleChecks = _appleProvider.CheckHealth();
+			checks.AddRange(appleChecks);
 		}
 
 		// Windows checks (Windows only)
@@ -65,6 +75,23 @@ public class DoctorService : IDoctorService
 				}
 				break;
 
+			case "apple":
+				if (_appleProvider != null)
+				{
+					checks.AddRange(_appleProvider.CheckHealth());
+				}
+				else if (!PlatformDetector.IsMacOS)
+				{
+					checks.Add(new HealthCheck
+					{
+						Category = "apple",
+						Name = "Platform",
+						Status = CheckStatus.Skipped,
+						Message = "Apple checks only available on macOS"
+					});
+				}
+				break;
+
 			case "windows":
 				if (PlatformDetector.IsWindows)
 				{
@@ -85,7 +112,7 @@ public class DoctorService : IDoctorService
 			default:
 				throw new MauiToolException(
 					ErrorCodes.InvalidArgument,
-					$"Unknown category: {category}. Valid categories: dotnet, android, windows");
+					$"Unknown category: {category}. Valid categories: dotnet, android, apple, windows");
 		}
 
 		return CreateReport(checks);

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -46,6 +46,23 @@ maui android emulator create --name MyEmulator
 maui android emulator start --name MyEmulator
 ```
 
+### 4. Set up Apple development (macOS only)
+
+```bash
+# List installed Xcode versions
+maui apple xcode list
+
+# List simulator runtimes
+maui apple runtime list
+maui apple runtime list --platform iOS
+
+# Manage simulators
+maui apple simulator list
+maui apple simulator start "iPhone 16 Pro"
+maui apple simulator stop "iPhone 16 Pro"
+maui apple simulator delete "iPhone 16 Pro"
+```
+
 ## Commands
 
 | Command | Description |
@@ -61,6 +78,12 @@ maui android emulator start --name MyEmulator
 | `maui android emulator start` | Start an Android emulator |
 | `maui android emulator stop` | Stop a running emulator |
 | `maui android emulator delete` | Delete an emulator |
+| `maui apple xcode list` | List installed Xcode versions (macOS only) |
+| `maui apple runtime list` | List installed simulator runtimes (macOS only) |
+| `maui apple simulator list` | List simulator devices (macOS only) |
+| `maui apple simulator start` | Boot a simulator (macOS only) |
+| `maui apple simulator stop` | Shut down a simulator (macOS only) |
+| `maui apple simulator delete` | Delete a simulator (macOS only) |
 | `maui devflow` | MAUI app automation via Agent API and Blazor WebViews via CDP |
 | `maui devflow MAUI tree` | Dump the visual tree of a running MAUI app |
 | `maui devflow MAUI screenshot` | Take a screenshot of a running MAUI app |
@@ -94,11 +117,11 @@ maui doctor --json | jq '.checks[] | select(.status == "failed")'
 
 ## Platform Support
 
-| Platform | Status |
-|----------|--------|
-| macOS | ✅ |
-| Windows | ✅ |
-| Linux | ✅ |
+| Platform | Status | Notes |
+|----------|--------|-------|
+| macOS | ✅ | Full support including Apple commands (Xcode, simulators, runtimes) |
+| Windows | ✅ | Android and Windows SDK commands |
+| Linux | ✅ | Android commands |
 
 ## Development
 


### PR DESCRIPTION
## Summary

Add Apple CLI commands backed by the `Xamarin.Apple.Tools.MaciOS` NuGet package from [dotnet/macios-devtools](https://github.com/dotnet/macios-devtools).

## New Commands

| Command | Description |
|---------|-------------|
| `maui apple xcode list` | List installed Xcode installations |
| `maui apple runtime list [--platform]` | List simulator runtimes |
| `maui apple simulator list` | List simulator devices |
| `maui apple simulator start <name-or-udid>` | Boot a simulator |
| `maui apple simulator stop <name-or-udid>` | Shut down a simulator |
| `maui apple simulator delete <name-or-udid>` | Delete a simulator |

## Implementation

- **IAppleProvider / AppleProvider** — Interface and implementation using `Xamarin.MacDev` APIs (`XcodeManager`, `SimulatorService`, `RuntimeService`, `CommandLineTools`)
- **AppleCommands** — CLI command group with JSON output support and Spectre.Console table formatting
- **DoctorService** — Added Apple health checks (Xcode, CLT, iOS runtimes) and `apple` category
- **DeviceManager** — Apple simulator devices included in `maui device list`
- **ErrorCodes** — Added E22xx Apple error codes
- **FakeAppleProvider** — Test fake with configurable return values and call tracking

## Dependency

Added `Xamarin.Apple.Tools.MaciOS 1.0.0-preview.1.26201.1` as a maestro dependency from the `dotnet10` feed.

## Tests

- 9 new tests added (Apple provider, doctor, device manager)
- All 127 tests pass