### PR TITLE
Fix Android install bootstrap when sdkmanager is missing

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -27,10 +27,28 @@ public class AndroidProviderIsSdkInstalledTests : IDisposable
 	/// <summary>
 	/// Mirrors the <c>AndroidProvider.IsSdkInstalled</c> check so tests stay in sync with the implementation.
 	/// </summary>
-	static bool IsSdkInstalledCheck(string? sdkPath) =>
-		!string.IsNullOrEmpty(sdkPath)
-		&& Directory.Exists(sdkPath)
-		&& Directory.Exists(Path.Combine(sdkPath, "cmdline-tools"));
+	static bool IsSdkInstalledCheck(string? sdkPath)
+	{
+		if (string.IsNullOrEmpty(sdkPath) || !Directory.Exists(sdkPath))
+			return false;
+
+		var ext = OperatingSystem.IsWindows() ? ".bat" : "";
+		var candidates = new[]
+		{
+			Path.Combine(sdkPath, "cmdline-tools", "latest", "bin", "sdkmanager" + ext),
+			Path.Combine(sdkPath, "cmdline-tools", "bin", "sdkmanager" + ext),
+			Path.Combine(sdkPath, "tools", "bin", "sdkmanager" + ext)
+		};
+
+		if (candidates.Any(File.Exists))
+			return true;
+
+		var cmdlineToolsDir = Path.Combine(sdkPath, "cmdline-tools");
+		return Directory.Exists(cmdlineToolsDir)
+			&& Directory.GetDirectories(cmdlineToolsDir)
+				.Select(dir => Path.Combine(dir, "bin", "sdkmanager" + ext))
+				.Any(File.Exists);
+	}
 
 	[Fact]
 	public void IsSdkInstalled_ReturnsFalse_WhenSdkDirectoryExistsButCmdlineToolsMissing()
@@ -44,9 +62,20 @@ public class AndroidProviderIsSdkInstalledTests : IDisposable
 	}
 
 	[Fact]
-	public void IsSdkInstalled_ReturnsTrue_WhenSdkDirectoryAndCmdlineToolsBothExist()
+	public void IsSdkInstalled_ReturnsFalse_WhenCmdlineToolsExistsButSdkManagerIsMissing()
 	{
 		Directory.CreateDirectory(Path.Combine(_tempDir, "cmdline-tools"));
+
+		Assert.False(IsSdkInstalledCheck(_tempDir));
+	}
+
+	[Fact]
+	public void IsSdkInstalled_ReturnsTrue_WhenSdkManagerExistsUnderCmdlineTools()
+	{
+		var sdkManagerPath = Path.Combine(_tempDir, "cmdline-tools", "latest", "bin",
+			OperatingSystem.IsWindows() ? "sdkmanager.bat" : "sdkmanager");
+		Directory.CreateDirectory(Path.GetDirectoryName(sdkManagerPath)!);
+		File.WriteAllText(sdkManagerPath, string.Empty);
 
 		Assert.True(IsSdkInstalledCheck(_tempDir));
 	}
@@ -63,6 +92,36 @@ public class AndroidProviderIsSdkInstalledTests : IDisposable
 	public void IsSdkInstalled_ReturnsFalse_WhenSdkPathIsNull()
 	{
 		Assert.False(IsSdkInstalledCheck(null));
+	}
+}
+
+public class SdkManagerTests : IDisposable
+{
+	readonly string _tempDir;
+
+	public SdkManagerTests()
+	{
+		_tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+		Directory.CreateDirectory(_tempDir);
+	}
+
+	public void Dispose()
+	{
+		if (Directory.Exists(_tempDir))
+			Directory.Delete(_tempDir, recursive: true);
+	}
+
+	[Fact]
+	public void SdkManagerPath_FindsVersionedCmdlineToolsLayout()
+	{
+		var sdkManagerPath = Path.Combine(_tempDir, "cmdline-tools", "16.0", "bin",
+			OperatingSystem.IsWindows() ? "sdkmanager.bat" : "sdkmanager");
+		Directory.CreateDirectory(Path.GetDirectoryName(sdkManagerPath)!);
+		File.WriteAllText(sdkManagerPath, string.Empty);
+
+		using var sdkManager = new SdkManager(() => _tempDir, () => null);
+
+		Assert.Equal(sdkManagerPath, sdkManager.SdkManagerPath);
 	}
 }
 

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.UnitTests.Fakes;
@@ -27,55 +28,26 @@ public class AndroidProviderIsSdkInstalledTests : IDisposable
 	/// <summary>
 	/// Mirrors the <c>AndroidProvider.IsSdkInstalled</c> check so tests stay in sync with the implementation.
 	/// </summary>
-	static bool IsSdkInstalledCheck(string? sdkPath)
-	{
-		if (string.IsNullOrEmpty(sdkPath) || !Directory.Exists(sdkPath))
-			return false;
-
-		var ext = OperatingSystem.IsWindows() ? ".bat" : "";
-		var candidates = new[]
-		{
-			Path.Combine(sdkPath, "cmdline-tools", "latest", "bin", "sdkmanager" + ext),
-			Path.Combine(sdkPath, "cmdline-tools", "bin", "sdkmanager" + ext),
-			Path.Combine(sdkPath, "tools", "bin", "sdkmanager" + ext)
-		};
-
-		if (candidates.Any(File.Exists))
-			return true;
-
-		var cmdlineToolsDir = Path.Combine(sdkPath, "cmdline-tools");
-		return Directory.Exists(cmdlineToolsDir)
-			&& Directory.GetDirectories(cmdlineToolsDir)
-				.Select(dir => Path.Combine(dir, "bin", "sdkmanager" + ext))
-				.Any(File.Exists);
-	}
+	static bool IsSdkInstalledCheck(string? sdkPath) =>
+		!string.IsNullOrEmpty(sdkPath)
+		&& Directory.Exists(sdkPath);
 
 	[Fact]
-	public void IsSdkInstalled_ReturnsFalse_WhenSdkDirectoryExistsButCmdlineToolsMissing()
+	public void IsSdkInstalled_ReturnsTrue_WhenSdkDirectoryExistsButCmdlineToolsAreMissing()
 	{
 		// The SDK directory exists but cmdline-tools subdirectory does NOT exist —
-		// this is the exact scenario described in issue E2102.
+		// this should still count as "SDK directory present" so the health check can
+		// surface the more specific sdkmanager-missing error.
 		Assert.True(Directory.Exists(_tempDir));
 		Assert.False(Directory.Exists(Path.Combine(_tempDir, "cmdline-tools")));
 
-		Assert.False(IsSdkInstalledCheck(_tempDir));
+		Assert.True(IsSdkInstalledCheck(_tempDir));
 	}
 
 	[Fact]
-	public void IsSdkInstalled_ReturnsFalse_WhenCmdlineToolsExistsButSdkManagerIsMissing()
+	public void IsSdkInstalled_ReturnsTrue_WhenSdkDirectoryAndCmdlineToolsBothExist()
 	{
 		Directory.CreateDirectory(Path.Combine(_tempDir, "cmdline-tools"));
-
-		Assert.False(IsSdkInstalledCheck(_tempDir));
-	}
-
-	[Fact]
-	public void IsSdkInstalled_ReturnsTrue_WhenSdkManagerExistsUnderCmdlineTools()
-	{
-		var sdkManagerPath = Path.Combine(_tempDir, "cmdline-tools", "latest", "bin",
-			OperatingSystem.IsWindows() ? "sdkmanager.bat" : "sdkmanager");
-		Directory.CreateDirectory(Path.GetDirectoryName(sdkManagerPath)!);
-		File.WriteAllText(sdkManagerPath, string.Empty);
 
 		Assert.True(IsSdkInstalledCheck(_tempDir));
 	}
@@ -123,11 +95,75 @@ public class SdkManagerTests : IDisposable
 
 		Assert.Equal(sdkManagerPath, sdkManager.SdkManagerPath);
 	}
-}
 
+	[Fact]
+	public void ResolveSdkManagerPath_ReturnsNull_WhenSdkManagerIsMissing()
+	{
+		Directory.CreateDirectory(Path.Combine(_tempDir, "cmdline-tools", "latest", "bin"));
+
+		Assert.Null(SdkManager.ResolveSdkManagerPath(_tempDir));
+	}
+}
 
 public class AndroidProviderTests
 {
+	sealed class StubJdkManager : IJdkManager
+	{
+		public string? DetectedJdkPath { get; init; } = Path.GetTempPath();
+		public int? DetectedJdkVersion { get; init; } = 17;
+		public bool IsInstalled => true;
+
+		public Task<HealthCheck> CheckHealthAsync(CancellationToken cancellationToken = default) =>
+			Task.FromResult(new HealthCheck
+			{
+				Category = "android",
+				Name = "JDK",
+				Status = CheckStatus.Ok,
+				Message = "JDK 17"
+			});
+
+		public Task InstallAsync(int version = 17, string? installPath = null, CancellationToken cancellationToken = default) =>
+			Task.CompletedTask;
+
+		public Task InstallAsync(int version, string? installPath, Action<double, string>? onProgress, CancellationToken cancellationToken = default) =>
+			Task.CompletedTask;
+
+		public IEnumerable<int> GetAvailableVersions() => [17, 21];
+	}
+
+	[Fact]
+	public async Task CheckHealthAsync_ReturnsSdkManagerError_WhenSdkDirectoryExistsButManagerIsMissing()
+	{
+		var tempSdk = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+		Directory.CreateDirectory(tempSdk);
+
+		var originalAndroidHome = Environment.GetEnvironmentVariable("ANDROID_HOME");
+		var originalAndroidSdkRoot = Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT");
+
+		try
+		{
+			Environment.SetEnvironmentVariable("ANDROID_HOME", tempSdk);
+			Environment.SetEnvironmentVariable("ANDROID_SDK_ROOT", null);
+
+			using var provider = new AndroidProvider(new StubJdkManager());
+			var checks = await provider.CheckHealthAsync();
+
+			Assert.Contains(checks, c => c.Name == "Android SDK" && c.Status == CheckStatus.Ok);
+			Assert.Contains(checks, c =>
+				c.Name == "SDK Manager"
+				&& c.Status == CheckStatus.Error
+				&& c.Fix?.IssueId == ErrorCodes.AndroidSdkManagerNotFound);
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("ANDROID_HOME", originalAndroidHome);
+			Environment.SetEnvironmentVariable("ANDROID_SDK_ROOT", originalAndroidSdkRoot);
+
+			if (Directory.Exists(tempSdk))
+				Directory.Delete(tempSdk, recursive: true);
+		}
+	}
+
 	[Fact]
 	public async Task GetMostRecentSystemImageAsync_ReturnsHighestApiLevel()
 	{

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -94,7 +94,7 @@ public static partial class AndroidCommands
 
 						// Step 2: SDK command-line tools
 						var sdkTask = ctx.AddTask("Installing SDK Tools");
-						if (!androidProvider.IsSdkInstalled)
+						if (!HasSdkManager(androidProvider))
 						{
 							var targetSdkPath = sdkPath ?? PlatformDetector.Paths.DefaultAndroidSdkPath;
 							await androidProvider.InstallSdkToolsAsync(targetSdkPath,

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.cs
@@ -47,6 +47,11 @@ public static partial class AndroidCommands
 		if (isCi)
 			return GetDefaultPackages();
 
+		// On a first-time or partial install, the command-line tools are not ready yet.
+		// Fall back to the default MAUI package set instead of querying sdkmanager early.
+		if (!androidProvider.IsSdkInstalled)
+			return GetDefaultPackages();
+
 		// Try to fetch available packages for interactive selection
 		List<SdkPackage> installed;
 		List<SdkPackage> available;

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.cs
@@ -49,7 +49,7 @@ public static partial class AndroidCommands
 
 		// On a first-time or partial install, the command-line tools are not ready yet.
 		// Fall back to the default MAUI package set instead of querying sdkmanager early.
-		if (!androidProvider.IsSdkInstalled)
+		if (!HasSdkManager(androidProvider))
 			return GetDefaultPackages();
 
 		// Try to fetch available packages for interactive selection
@@ -175,6 +175,9 @@ public static partial class AndroidCommands
 
 	record PlatformChoice(string PackagePath, string DisplayName, string Description, bool IsInstalled);
 	record InstallScope(string Name, string Description, List<string> Packages);
+
+	static bool HasSdkManager(IAndroidProvider androidProvider) =>
+		androidProvider.GetLicenseAcceptanceCommand() is not null;
 
 	/// <summary>
 	/// Checks if the SDK is in a protected location and attempts elevation if needed.

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -32,11 +32,10 @@ public class AndroidProvider : IAndroidProvider
 	public string? SdkPath => _sdkPath ??= PlatformDetector.Paths.GetAndroidSdkPath();
 	public string? JdkPath => _jdkPath ??= _jdkManager.DetectedJdkPath ?? PlatformDetector.Paths.GetJdkPath();
 
-	public bool IsSdkInstalled => !string.IsNullOrEmpty(SdkPath)
-		&& Directory.Exists(SdkPath)
-		&& SdkManager.ResolveSdkManagerPath(SdkPath) is not null;
+	public bool IsSdkInstalled => !string.IsNullOrEmpty(SdkPath) && Directory.Exists(SdkPath);
 	public bool IsJdkInstalled => !string.IsNullOrEmpty(JdkPath) && Directory.Exists(JdkPath);
 	public bool SdkPathRequiresElevation => _sdkManager.SdkPathRequiresElevation();
+	bool IsSdkManagerInstalled => _sdkManager.IsAvailable;
 
 	public AndroidProvider(IJdkManager jdkManager, SdkManager? sdkManager = null, Adb? adb = null, AvdManager? avdManager = null)
 	{
@@ -352,7 +351,7 @@ public class AndroidProvider : IAndroidProvider
 		}
 
 		// Step 2: Install Android SDK if not present
-		if (!IsSdkInstalled)
+		if (!IsSdkManagerInstalled)
 		{
 			progress?.Report("Step 2/4: Installing Android SDK command-line tools...");
 			var targetSdkPath = sdkPath ?? PlatformDetector.Paths.DefaultAndroidSdkPath;
@@ -363,7 +362,7 @@ public class AndroidProvider : IAndroidProvider
 		}
 		else
 		{
-			progress?.Report("Step 2/4: Android SDK already installed ✓");
+			progress?.Report("Step 2/4: Android SDK command-line tools already installed ✓");
 		}
 
 		// Step 3: Accept licenses (only if --accept-licenses was passed)

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -32,8 +32,9 @@ public class AndroidProvider : IAndroidProvider
 	public string? SdkPath => _sdkPath ??= PlatformDetector.Paths.GetAndroidSdkPath();
 	public string? JdkPath => _jdkPath ??= _jdkManager.DetectedJdkPath ?? PlatformDetector.Paths.GetJdkPath();
 
-	public bool IsSdkInstalled => !string.IsNullOrEmpty(SdkPath) && Directory.Exists(SdkPath)
-		&& Directory.Exists(Path.Combine(SdkPath, "cmdline-tools"));
+	public bool IsSdkInstalled => !string.IsNullOrEmpty(SdkPath)
+		&& Directory.Exists(SdkPath)
+		&& SdkManager.ResolveSdkManagerPath(SdkPath) is not null;
 	public bool IsJdkInstalled => !string.IsNullOrEmpty(JdkPath) && Directory.Exists(JdkPath);
 	public bool SdkPathRequiresElevation => _sdkManager.SdkPathRequiresElevation();
 

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
@@ -50,11 +50,67 @@ public class SdkManager : IDisposable
 		_sdkManager.JavaSdkPath = _getJdkPath();
 	}
 
-	public string? SdkManagerPath { get { SyncPaths(); return _sdkManager.FindSdkManagerPath(); } }
+	public string? SdkManagerPath
+	{
+		get
+		{
+			SyncPaths();
+			return ResolveSdkManagerPath(_getSdkPath()) ?? _sdkManager.FindSdkManagerPath();
+		}
+	}
 
 	public bool IsAvailable => !string.IsNullOrEmpty(SdkManagerPath);
 
 	public void Dispose() => _sdkManager.Dispose();
+
+	internal static string? ResolveSdkManagerPath(string? sdkPath)
+	{
+		if (string.IsNullOrEmpty(sdkPath))
+			return null;
+
+		var ext = OperatingSystem.IsWindows() ? ".bat" : "";
+
+		static string? FindToolInDirectory(string directoryPath, string extension)
+		{
+			var toolPath = Path.Combine(directoryPath, "bin", "sdkmanager" + extension);
+			return File.Exists(toolPath) ? toolPath : null;
+		}
+
+		var cmdlineToolsDir = Path.Combine(sdkPath, "cmdline-tools");
+		if (Directory.Exists(cmdlineToolsDir))
+		{
+			var subdirs = new List<(string path, Version version)>();
+			foreach (var dir in Directory.GetDirectories(cmdlineToolsDir))
+			{
+				var name = Path.GetFileName(dir);
+				if (string.IsNullOrEmpty(name) || name.Equals("latest", StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				Version.TryParse(name, out var version);
+				subdirs.Add((dir, version ?? new Version(0, 0)));
+			}
+
+			subdirs.Sort((a, b) => b.version.CompareTo(a.version));
+
+			foreach (var (dir, _) in subdirs)
+			{
+				var toolPath = FindToolInDirectory(dir, ext);
+				if (toolPath != null)
+					return toolPath;
+			}
+
+			var latestPath = FindToolInDirectory(Path.Combine(cmdlineToolsDir, "latest"), ext);
+			if (latestPath != null)
+				return latestPath;
+
+			var directPath = FindToolInDirectory(cmdlineToolsDir, ext);
+			if (directPath != null)
+				return directPath;
+		}
+
+		var legacyPath = Path.Combine(sdkPath, "tools", "bin", "sdkmanager" + ext);
+		return File.Exists(legacyPath) ? legacyPath : null;
+	}
 
 	public async Task<List<SdkPackage>> GetInstalledPackagesAsync(CancellationToken cancellationToken = default)
 	{

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
@@ -44,18 +44,21 @@ public class SdkManager : IDisposable
 		_sdkManager = new XatSdkManager(logger: CreateLogger(verbose));
 	}
 
-	void SyncPaths()
+	(string? SdkPath, string? JdkPath) SyncPaths()
 	{
-		_sdkManager.AndroidSdkPath = _getSdkPath();
-		_sdkManager.JavaSdkPath = _getJdkPath();
+		var sdkPath = _getSdkPath();
+		var jdkPath = _getJdkPath();
+		_sdkManager.AndroidSdkPath = sdkPath;
+		_sdkManager.JavaSdkPath = jdkPath;
+		return (sdkPath, jdkPath);
 	}
 
 	public string? SdkManagerPath
 	{
 		get
 		{
-			SyncPaths();
-			return ResolveSdkManagerPath(_getSdkPath()) ?? _sdkManager.FindSdkManagerPath();
+			var (sdkPath, _) = SyncPaths();
+			return ResolveSdkManagerPath(sdkPath) ?? _sdkManager.FindSdkManagerPath();
 		}
 	}
 


### PR DESCRIPTION
## Summary
Fixes the circular `E2102` failure from `maui android install` when the Android SDK directory exists but the command-line tools were not actually bootstrapped.

## Changes
- resolve `sdkmanager` from real `cmdline-tools` layouts
- treat partial SDK folders as incomplete
- skip early interactive package discovery until the SDK tools are available
- add regression coverage for the incomplete SDK case

Fixes #72