### PR TITLE
feat: Add CI/CD pipeline for Linux GTK4 backend

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -23,12 +23,22 @@ on:
         type: boolean
         default: true
         description: 'Install MAUI workloads and Android SDK (not needed for net10.0-only projects)'
+      os:
+        required: false
+        type: string
+        default: '["macos-latest", "windows-latest"]'
+        description: 'JSON array of runner OS labels'
+      native-deps:
+        required: false
+        type: string
+        default: ''
+        description: 'Shell command to install native dependencies (e.g. apt-get for GTK4)'
 
 jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: ${{ fromJson(inputs.os) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -37,6 +47,10 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
+
+      - name: Install native dependencies
+        if: inputs.native-deps != ''
+        run: ${{ inputs.native-deps }}
 
       - name: Install workloads
         if: inputs.install-workloads
@@ -62,6 +76,14 @@ jobs:
 
       - name: Build and Test (macOS)
         if: matrix.os == 'macos-latest'
+        run: >
+          ./eng/common/cibuild.sh
+          --configuration Release
+          --prepareMachine
+          --projects $(pwd)/${{ inputs.project-path }}
+
+      - name: Build and Test (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
         run: >
           ./eng/common/cibuild.sh
           --configuration Release
@@ -129,7 +151,7 @@ jobs:
           path: artifacts/TestResults/**/*.xml
 
       - name: Upload packages
-        if: inputs.pack && matrix.os == 'windows-latest'
+        if: inputs.pack && (matrix.os == 'windows-latest' || !contains(fromJson(inputs.os), 'windows-latest'))
         uses: actions/upload-artifact@v7
         with:
           name: packages-${{ inputs.project-name }}

--- a/.github/workflows/ci-linux-gtk4.yml
+++ b/.github/workflows/ci-linux-gtk4.yml
@@ -1,0 +1,43 @@
+name: CI - Linux GTK4
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platforms/Linux.Gtk4/**'
+      - 'eng/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'NuGet.config'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'platforms/Linux.Gtk4/**'
+      - 'eng/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'NuGet.config'
+
+jobs:
+  build:
+    uses: ./.github/workflows/_build.yml
+    with:
+      project-path: platforms/Linux.Gtk4/Linux.Gtk4.slnx
+      project-name: linux-gtk4
+      os: '["ubuntu-24.04"]'
+      install-workloads: false
+      native-deps: >-
+        sudo apt-get update && sudo apt-get install -y
+        libgtk-4-dev
+        libwebkitgtk-6.0-dev
+        gobject-introspection
+        libgirepository1.0-dev
+        gir1.2-gtk-4.0
+        gir1.2-webkit-6.0
+        pkg-config
+      run-tests: false
+      pack: true

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -1,6 +1,6 @@
-# Azure DevOps official build pipeline for DevFlow and Cli
+# Azure DevOps official build pipeline for DevFlow, Cli, and Linux GTK4.
 # Uses Arcade build system with 1ES Pipeline Templates for security compliance.
-# Both products build in parallel; each can be published to NuGet.org independently.
+# All products build in parallel; each can be published to NuGet.org independently.
 
 trigger:
   batch: true
@@ -18,6 +18,10 @@ parameters:
   default: false
 - name: publishCliNuget
   displayName: 'Publish Cli packages to NuGet.org'
+  type: boolean
+  default: false
+- name: publishLinuxGtk4Nuget
+  displayName: 'Publish Linux GTK4 packages to NuGet.org'
   type: boolean
   default: false
 
@@ -113,6 +117,42 @@ extends:
                 -projects $(Build.SourcesDirectory)\src\Cli\Cli.slnf
                 $(_OfficialBuildArgs)
               displayName: Build and Test Cli
+
+          - job: LinuxGtk4
+            displayName: Linux GTK4 - Ubuntu
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals ubuntu.2404.amd64
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+                  _OfficialBuildArgs: /p:DotNetSignType=$(_SignType)
+                    /p:TeamName=$(_TeamName)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            steps:
+            - task: UseDotNet@2
+              displayName: Install .NET SDK
+              inputs:
+                useGlobalJson: true
+            - script: |
+                sudo apt-get update
+                sudo apt-get install -y \
+                  libgtk-4-dev \
+                  libwebkitgtk-6.0-dev \
+                  gobject-introspection \
+                  libgirepository1.0-dev \
+                  gir1.2-gtk-4.0 \
+                  gir1.2-webkit-6.0 \
+                  pkg-config
+              displayName: Install GTK4 dependencies
+            - script: |
+                ./eng/common/cibuild.sh \
+                  --configuration $(_BuildConfig) \
+                  --prepareMachine \
+                  --projects $(Build.SourcesDirectory)/platforms/Linux.Gtk4/Linux.Gtk4.slnx \
+                  $(_OfficialBuildArgs)
+              displayName: Build and Pack Linux GTK4
        
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
@@ -227,5 +267,60 @@ extends:
               useDotNetTask: false
               packagesToPush: '$(Pipeline.Workspace)/CliPackages/*.nupkg'
               packageParentPath: '$(Pipeline.Workspace)/CliPackages'
+              nuGetFeedType: external
+              publishFeedCredentials: 'nuget.org (dotnetframework)'
+
+    # Publish Linux GTK4 packages to NuGet.org
+    - ${{ if eq(parameters.publishLinuxGtk4Nuget, true) }}:
+      - stage: publish_linux_gtk4_nuget
+        displayName: 'Publish Linux GTK4 to NuGet.org'
+        dependsOn:
+        - Validate
+        - publish_using_darc
+        jobs:
+        - job: PrepareArtifacts
+          displayName: 'Prepare Linux GTK4 Artifacts'
+          timeoutInMinutes: 15
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026preview.scout.amd64
+            os: windows
+          templateContext:
+            outputs:
+            - output: pipelineArtifact
+              displayName: Publish Linux GTK4 Packages
+              targetPath: '$(Pipeline.Workspace)/LinuxGtk4Packages'
+              artifactName: LinuxGtk4PackagesForNuGet
+          steps:
+          - download: current
+            artifact: PackageArtifacts
+            displayName: Download PackageArtifacts
+          - powershell: |
+              New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/LinuxGtk4Packages'
+              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Platforms.Linux.Gtk4.*.nupkg' '$(Pipeline.Workspace)/LinuxGtk4Packages/' -Verbose
+            displayName: Filter Linux GTK4 packages
+
+        - job: PublishNuGet
+          displayName: 'Push Linux GTK4 to NuGet.org'
+          dependsOn: PrepareArtifacts
+          timeoutInMinutes: 30
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026preview.scout.amd64
+            os: windows
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              artifactName: LinuxGtk4PackagesForNuGet
+              targetPath: '$(Pipeline.Workspace)/LinuxGtk4Packages'
+          steps:
+          - task: 1ES.PublishNuget@1
+            displayName: 'Push Linux GTK4 to NuGet.org'
+            inputs:
+              useDotNetTask: false
+              packagesToPush: '$(Pipeline.Workspace)/LinuxGtk4Packages/*.nupkg'
+              packageParentPath: '$(Pipeline.Workspace)/LinuxGtk4Packages'
               nuGetFeedType: external
               publishFeedCredentials: 'nuget.org (dotnetframework)'

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -6,8 +6,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <MauiVersion>10.0.41</MauiVersion>
-    <!-- Suppress platform compatibility warnings — this is a Linux-only backend
-         targeting net10.0 that intentionally uses Linux/GTK4-specific APIs. -->
+    <!-- This is an experimental Linux-only backend. Disable warnings-as-errors
+         to match the repo default (TreatWarningsAsErrors=false in root props).
+         Arcade's cibuild.sh forces /warnaserror which catches CS0109, CS0612, CA1416 etc.
+         These should be cleaned up incrementally, not block CI. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
     <!-- Set to false when the maui-labs DevFlow projects should not be referenced by the sample -->
     <EnableMauiDevFlow Condition="'$(EnableMauiDevFlow)' == ''">false</EnableMauiDevFlow>

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -14,7 +14,7 @@
          CS0414: Assigned but unused fields
          CS0612: Obsolete API usage (IFontNamedSizeService, NamedSize)
          CS8600/CS8602/CS8604/CS8613/CS8766: Nullable reference analysis -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1416;CS0108;CS0109;CS0414;CS0612;CS8600;CS8602;CS8604;CS8613;CS8766</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1416;CS0108;CS0109;CS0414;CS0612;CS0618;CS8600;CS8602;CS8604;CS8613;CS8766</WarningsNotAsErrors>
     <!-- Set to false when the maui-labs DevFlow projects should not be referenced by the sample -->
     <EnableMauiDevFlow Condition="'$(EnableMauiDevFlow)' == ''">false</EnableMauiDevFlow>
   </PropertyGroup>

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <MauiVersion>10.0.41</MauiVersion>
+    <!-- Suppress platform compatibility warnings — this is a Linux-only backend
+         targeting net10.0 that intentionally uses Linux/GTK4-specific APIs. -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
     <!-- Set to false when the maui-labs DevFlow projects should not be referenced by the sample -->
     <EnableMauiDevFlow Condition="'$(EnableMauiDevFlow)' == ''">false</EnableMauiDevFlow>
   </PropertyGroup>

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -14,9 +14,7 @@
     <DefineConstants>$(DefineConstants);MAUIDEVFLOW</DefineConstants>
   </PropertyGroup>
 
-  <!-- Common NuGet package properties for all src/ projects.
-       Versions come from eng/Versions.props (PlatformMauiLinuxGtk4Version)
-       and Arcade computes the full package version including build suffix. -->
+  <!-- Common NuGet package properties for all src/ projects -->
   <PropertyGroup>
     <Authors>Microsoft</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -6,12 +6,15 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <MauiVersion>10.0.41</MauiVersion>
-    <!-- This is an experimental Linux-only backend. Disable warnings-as-errors
-         to match the repo default (TreatWarningsAsErrors=false in root props).
-         Arcade's cibuild.sh forces /warnaserror which catches CS0109, CS0612, CA1416 etc.
-         These should be cleaned up incrementally, not block CI. -->
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <!-- This is an experimental Linux-only backend. Arcade's cibuild.sh forces
+         /warnaserror on the command line (overrides TreatWarningsAsErrors in props).
+         Use WarningsNotAsErrors to exempt specific codes that need incremental cleanup.
+         CA1416: Platform compatibility (Linux-only backend targeting net10.0)
+         CS0108/CS0109: Member hiding (GTK handler mapper patterns)
+         CS0414: Assigned but unused fields
+         CS0612: Obsolete API usage (IFontNamedSizeService, NamedSize)
+         CS8602/CS8604/CS8766: Nullable reference analysis -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1416;CS0108;CS0109;CS0414;CS0612;CS8602;CS8604;CS8766</WarningsNotAsErrors>
     <!-- Set to false when the maui-labs DevFlow projects should not be referenced by the sample -->
     <EnableMauiDevFlow Condition="'$(EnableMauiDevFlow)' == ''">false</EnableMauiDevFlow>
   </PropertyGroup>

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -6,15 +6,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <MauiVersion>10.0.41</MauiVersion>
-    <!-- This is an experimental Linux-only backend. Arcade's cibuild.sh forces
-         /warnaserror on the command line (overrides TreatWarningsAsErrors in props).
-         Use WarningsNotAsErrors to exempt specific codes that need incremental cleanup.
-         CA1416: Platform compatibility (Linux-only backend targeting net10.0)
-         CS0108/CS0109: Member hiding (GTK handler mapper patterns)
-         CS0414: Assigned but unused fields
-         CS0612: Obsolete API usage (IFontNamedSizeService, NamedSize)
-         CS8600/CS8602/CS8604/CS8613/CS8766: Nullable reference analysis -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1416;CS0108;CS0109;CS0414;CS0612;CS0618;CS8600;CS8602;CS8604;CS8613;CS8766</WarningsNotAsErrors>
     <!-- Set to false when the maui-labs DevFlow projects should not be referenced by the sample -->
     <EnableMauiDevFlow Condition="'$(EnableMauiDevFlow)' == ''">false</EnableMauiDevFlow>
   </PropertyGroup>

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -14,10 +14,10 @@
     <DefineConstants>$(DefineConstants);MAUIDEVFLOW</DefineConstants>
   </PropertyGroup>
 
-  <!-- Common NuGet package properties for all src/ projects -->
+  <!-- Common NuGet package properties for all src/ projects.
+       Versions come from eng/Versions.props (PlatformMauiLinuxGtk4Version)
+       and Arcade computes the full package version including build suffix. -->
   <PropertyGroup>
-    <VersionPrefix>0.6.0</VersionPrefix>
-    <Version>$(VersionPrefix)</Version>
     <Authors>Microsoft</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dotnet/maui-labs/tree/main/platforms/Linux.Gtk4</PackageProjectUrl>

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -13,8 +13,8 @@
          CS0108/CS0109: Member hiding (GTK handler mapper patterns)
          CS0414: Assigned but unused fields
          CS0612: Obsolete API usage (IFontNamedSizeService, NamedSize)
-         CS8602/CS8604/CS8766: Nullable reference analysis -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1416;CS0108;CS0109;CS0414;CS0612;CS8602;CS8604;CS8766</WarningsNotAsErrors>
+         CS8600/CS8602/CS8604/CS8613/CS8766: Nullable reference analysis -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1416;CS0108;CS0109;CS0414;CS0612;CS8600;CS8602;CS8604;CS8613;CS8766</WarningsNotAsErrors>
     <!-- Set to false when the maui-labs DevFlow projects should not be referenced by the sample -->
     <EnableMauiDevFlow Condition="'$(EnableMauiDevFlow)' == ''">false</EnableMauiDevFlow>
   </PropertyGroup>

--- a/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/AssemblyInfo.cs
+++ b/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("linux")]

--- a/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/AlertsPage.cs
+++ b/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/AlertsPage.cs
@@ -26,7 +26,7 @@ public class AlertsPage : ContentPage
 		simpleAlertBtn.Clicked += async (s, e) =>
 		{
 			resultLabel.Text = "Result: Alert requested...";
-			await ConnectedPage.DisplayAlert("Hello!", "This is a simple alert with one button.", "OK");
+			await ConnectedPage.DisplayAlertAsync("Hello!", "This is a simple alert with one button.", "OK");
 			resultLabel.Text = "Result: Simple alert dismissed";
 		};
 
@@ -34,7 +34,7 @@ public class AlertsPage : ContentPage
 		var confirmAlertBtn = new Button { Text = "Confirm Alert (Yes / No)" };
 		confirmAlertBtn.Clicked += async (s, e) =>
 		{
-			bool answer = await ConnectedPage.DisplayAlert("Confirm", "Do you want to proceed?", "Yes", "No");
+			bool answer = await ConnectedPage.DisplayAlertAsync("Confirm", "Do you want to proceed?", "Yes", "No");
 			resultLabel.Text = $"Result: Confirmed = {answer}";
 		};
 
@@ -42,7 +42,7 @@ public class AlertsPage : ContentPage
 		var actionSheetBtn = new Button { Text = "Action Sheet" };
 		actionSheetBtn.Clicked += async (s, e) =>
 		{
-			string action = await ConnectedPage.DisplayActionSheet(
+			string action = await ConnectedPage.DisplayActionSheetAsync(
 				"Choose an action",
 				"Cancel",
 				"Delete",
@@ -54,7 +54,7 @@ public class AlertsPage : ContentPage
 		var actionSheet2Btn = new Button { Text = "Action Sheet (no destructive)" };
 		actionSheet2Btn.Clicked += async (s, e) =>
 		{
-			string action = await ConnectedPage.DisplayActionSheet(
+			string action = await ConnectedPage.DisplayActionSheetAsync(
 				"Pick a color",
 				"Cancel",
 				null,

--- a/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/CarouselIndicatorPage.cs
+++ b/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/CarouselIndicatorPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
 using System.Collections.ObjectModel;
 
@@ -28,14 +29,15 @@ public class CarouselIndicatorPage : ContentPage
 			Loop = false,
 			ItemTemplate = new DataTemplate(() =>
 			{
-				var frame = new Frame
+				var border = new Border
 				{
-					CornerRadius = 12,
+					StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(12) },
+					Stroke = Colors.Transparent,
+					StrokeThickness = 0,
 					Padding = new Thickness(24),
 					Margin = new Thickness(8),
-					HasShadow = true,
 				};
-				frame.SetBinding(VisualElement.BackgroundColorProperty, "Color");
+				border.SetBinding(VisualElement.BackgroundColorProperty, "Color");
 
 				var stack = new StackLayout
 				{
@@ -62,8 +64,8 @@ public class CarouselIndicatorPage : ContentPage
 
 				stack.Children.Add(title);
 				stack.Children.Add(desc);
-				frame.Content = stack;
-				return frame;
+				border.Content = stack;
+				return border;
 			}),
 		};
 

--- a/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/ShellDemoPage.cs
+++ b/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/ShellDemoPage.cs
@@ -197,7 +197,7 @@ class ShellBrowsePage : ContentPage
 			{
 				new Label { Text = "📂 Browse", FontSize = 22, FontAttributes = FontAttributes.Bold },
 				new Label { Text = "This is the Browse tab under the Explore section.", TextColor = Colors.DimGray },
-				new CollectionView
+				new ListView
 				{
 					ItemsSource = new[] { "Documents", "Pictures", "Music", "Videos", "Downloads" },
 					HeightRequest = 200,

--- a/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/ShellDemoPage.cs
+++ b/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/ShellDemoPage.cs
@@ -197,7 +197,7 @@ class ShellBrowsePage : ContentPage
 			{
 				new Label { Text = "📂 Browse", FontSize = 22, FontAttributes = FontAttributes.Bold },
 				new Label { Text = "This is the Browse tab under the Explore section.", TextColor = Colors.DimGray },
-				new ListView
+				new CollectionView
 				{
 					ItemsSource = new[] { "Documents", "Pictures", "Music", "Videos", "Downloads" },
 					HeightRequest = 200,

--- a/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/ShellDemoPage.cs
+++ b/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/ShellDemoPage.cs
@@ -39,8 +39,8 @@ public class ShellDemoPage : ContentPage
 					Command = new Command(() =>
 					{
 						// Replace the main page with a Shell instance
-						if (Application.Current != null)
-							Application.Current.MainPage = new DemoShell();
+						if (Application.Current?.Windows.Count > 0)
+							Application.Current.Windows[0].Page = new DemoShell();
 					}),
 				},
 			}
@@ -156,8 +156,8 @@ class ShellHomePage : ContentPage
 					Text = "← Back to Main App",
 					Command = new Command(() =>
 					{
-						if (Application.Current is Sample.App)
-							Application.Current.MainPage = new Sample.MainShell();
+						if (Application.Current is Sample.App && Application.Current.Windows.Count > 0)
+							Application.Current.Windows[0].Page = new Sample.MainShell();
 					}),
 				},
 				new Label { Text = "GoToAsync Navigation:", FontAttributes = FontAttributes.Bold, Margin = new Thickness(0, 12, 0, 0) },
@@ -197,7 +197,7 @@ class ShellBrowsePage : ContentPage
 			{
 				new Label { Text = "📂 Browse", FontSize = 22, FontAttributes = FontAttributes.Bold },
 				new Label { Text = "This is the Browse tab under the Explore section.", TextColor = Colors.DimGray },
-				new ListView
+				new CollectionView
 				{
 					ItemsSource = new[] { "Documents", "Pictures", "Music", "Videos", "Downloads" },
 					HeightRequest = 200,

--- a/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/TransformsPage.cs
+++ b/platforms/Linux.Gtk4/samples/Linux.Gtk4.Sample/Pages/TransformsPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Platforms.Linux.Gtk4.Sample.Pages;
@@ -210,10 +211,11 @@ class TransformsPage : ContentPage
 						Spacing = 16,
 						Children =
 						{
-							new Frame
+							new Border
 							{
 								WidthRequest = 120, HeightRequest = 80, Padding = 0,
-								CornerRadius = 8, BorderColor = Colors.Transparent, HasShadow = false,
+								StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(8) },
+								Stroke = Colors.Transparent,
 								Background = new LinearGradientBrush
 								{
 									StartPoint = new Point(0, 0), EndPoint = new Point(1, 1),
@@ -221,10 +223,11 @@ class TransformsPage : ContentPage
 								},
 								Content = new Label { Text = "Linear ↘", TextColor = Colors.White, FontAttributes = FontAttributes.Bold, HorizontalTextAlignment = TextAlignment.Center, VerticalTextAlignment = TextAlignment.Center },
 							},
-							new Frame
+							new Border
 							{
 								WidthRequest = 120, HeightRequest = 80, Padding = 0,
-								CornerRadius = 8, BorderColor = Colors.Transparent, HasShadow = false,
+								StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(8) },
+								Stroke = Colors.Transparent,
 								Background = new LinearGradientBrush
 								{
 									StartPoint = new Point(0, 0.5), EndPoint = new Point(1, 0.5),
@@ -232,10 +235,11 @@ class TransformsPage : ContentPage
 								},
 								Content = new Label { Text = "3-Stop →", TextColor = Colors.White, FontAttributes = FontAttributes.Bold, HorizontalTextAlignment = TextAlignment.Center, VerticalTextAlignment = TextAlignment.Center },
 							},
-							new Frame
+							new Border
 							{
 								WidthRequest = 120, HeightRequest = 80, Padding = 0,
-								CornerRadius = 8, BorderColor = Colors.Transparent, HasShadow = false,
+								StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(8) },
+								Stroke = Colors.Transparent,
 								Background = new RadialGradientBrush
 								{
 									Center = new Point(0.5, 0.5), Radius = 0.6,
@@ -243,10 +247,11 @@ class TransformsPage : ContentPage
 								},
 								Content = new Label { Text = "Radial", TextColor = Colors.White, FontAttributes = FontAttributes.Bold, HorizontalTextAlignment = TextAlignment.Center, VerticalTextAlignment = TextAlignment.Center },
 							},
-							new Frame
+							new Border
 							{
 								WidthRequest = 120, HeightRequest = 80, Padding = 0,
-								CornerRadius = 40, BorderColor = Colors.Transparent, HasShadow = false,
+								StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(40) },
+								Stroke = Colors.Transparent,
 								Background = new LinearGradientBrush
 								{
 									StartPoint = new Point(0, 0), EndPoint = new Point(0, 1),
@@ -373,38 +378,38 @@ class TransformsPage : ContentPage
 		var translateBtn = new Button { Text = "TranslateTo", BackgroundColor = Colors.CornflowerBlue, TextColor = Colors.White };
 		translateBtn.Clicked += async (s, e) =>
 		{
-			statusLabel.Text = "TranslateTo(100, 0) ...";
-			await animBox.TranslateTo(100, 0, 500, Easing.CubicInOut);
-			await animBox.TranslateTo(0, 0, 500, Easing.CubicInOut);
-			statusLabel.Text = "TranslateTo done ✅";
+			statusLabel.Text = "TranslateToAsync(100, 0) ...";
+			await animBox.TranslateToAsync(100, 0, 500, Easing.CubicInOut);
+			await animBox.TranslateToAsync(0, 0, 500, Easing.CubicInOut);
+			statusLabel.Text = "TranslateToAsync done ✅";
 		};
 
 		var fadeBtn = new Button { Text = "FadeTo", BackgroundColor = Colors.Coral, TextColor = Colors.White };
 		fadeBtn.Clicked += async (s, e) =>
 		{
-			statusLabel.Text = "FadeTo(0.2) ...";
-			await animBox.FadeTo(0.2, 500);
-			await animBox.FadeTo(1.0, 500);
-			statusLabel.Text = "FadeTo done ✅";
+			statusLabel.Text = "FadeToAsync(0.2) ...";
+			await animBox.FadeToAsync(0.2, 500);
+			await animBox.FadeToAsync(1.0, 500);
+			statusLabel.Text = "FadeToAsync done ✅";
 		};
 
 		var scaleBtn = new Button { Text = "ScaleTo", BackgroundColor = Colors.MediumSeaGreen, TextColor = Colors.White };
 		scaleBtn.Clicked += async (s, e) =>
 		{
-			statusLabel.Text = "ScaleTo(1.5) ...";
-			await animBox.ScaleTo(1.5, 400, Easing.SpringOut);
-			await animBox.ScaleTo(1.0, 400, Easing.SpringIn);
-			statusLabel.Text = "ScaleTo done ✅";
+			statusLabel.Text = "ScaleToAsync(1.5) ...";
+			await animBox.ScaleToAsync(1.5, 400, Easing.SpringOut);
+			await animBox.ScaleToAsync(1.0, 400, Easing.SpringIn);
+			statusLabel.Text = "ScaleToAsync done ✅";
 		};
 
 		var rotateBtn = new Button { Text = "RotateTo", BackgroundColor = Colors.Orchid, TextColor = Colors.White };
 		rotateBtn.Clicked += async (s, e) =>
 		{
-			statusLabel.Text = "RotateTo(360) ...";
+			statusLabel.Text = "RotateToAsync(360) ...";
 			animBox.Rotation = 0;
-			await animBox.RotateTo(360, 800, Easing.CubicInOut);
+			await animBox.RotateToAsync(360, 800, Easing.CubicInOut);
 			animBox.Rotation = 0;
-			statusLabel.Text = "RotateTo done ✅";
+			statusLabel.Text = "RotateToAsync done ✅";
 		};
 
 		var allBtn = new Button { Text = "All Combined", BackgroundColor = Colors.DeepPink, TextColor = Colors.White };
@@ -412,16 +417,16 @@ class TransformsPage : ContentPage
 		{
 			statusLabel.Text = "All animations ...";
 			await Task.WhenAll(
-				animBox.TranslateTo(60, -20, 600, Easing.CubicInOut),
-				animBox.ScaleTo(1.3, 600, Easing.CubicInOut),
-				animBox.RotateTo(180, 600, Easing.CubicInOut),
-				animBox.FadeTo(0.5, 600)
+				animBox.TranslateToAsync(60, -20, 600, Easing.CubicInOut),
+				animBox.ScaleToAsync(1.3, 600, Easing.CubicInOut),
+				animBox.RotateToAsync(180, 600, Easing.CubicInOut),
+				animBox.FadeToAsync(0.5, 600)
 			);
 			await Task.WhenAll(
-				animBox.TranslateTo(0, 0, 600, Easing.CubicInOut),
-				animBox.ScaleTo(1.0, 600, Easing.CubicInOut),
-				animBox.RotateTo(360, 600, Easing.CubicInOut),
-				animBox.FadeTo(1.0, 600)
+				animBox.TranslateToAsync(0, 0, 600, Easing.CubicInOut),
+				animBox.ScaleToAsync(1.0, 600, Easing.CubicInOut),
+				animBox.RotateToAsync(360, 600, Easing.CubicInOut),
+				animBox.FadeToAsync(1.0, 600)
 			);
 			animBox.Rotation = 0;
 			statusLabel.Text = "All animations done ✅";

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/AssemblyInfo.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("linux")]

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/GtkBlazorWebView.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/GtkBlazorWebView.cs
@@ -143,7 +143,7 @@ public sealed class GtkBlazorWebView : IDisposable
 				blockList: null));
 
 		// Register app:// scheme for Blazor static content
-		webView.WebContext.RegisterUriScheme(Scheme, HandleUriScheme);
+		webView.WebContext?.RegisterUriScheme(Scheme, HandleUriScheme);
 
 		return webView;
 	}

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/Linux.Gtk4.BlazorWebView.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/Linux.Gtk4.BlazorWebView.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView</RootNamespace>
     <AssemblyName>Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView</AssemblyName>
     <PackageId>Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView</PackageId>
+    <Version>$(PlatformMauiLinuxGtk4BlazorWebViewVersion)</Version>
     <Description>Blazor Hybrid support for Microsoft.Maui.Platforms.Linux.Gtk4 — host Blazor components in a native GTK4 window using WebKitGTK.</Description>
     <PackageTags>maui;linux;blazor;webview;gtk;gtk4;webkit;webkitgtk;hybrid</PackageTags>
     <IsPackable>true</IsPackable>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/AssemblyInfo.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("linux")]

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Authentication/LinuxWebAuthenticator.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Authentication/LinuxWebAuthenticator.cs
@@ -52,7 +52,7 @@ public class LinuxWebAuthenticator : IWebAuthenticator
 
 			var responseQuery = System.Web.HttpUtility.ParseQueryString(responseUrl.Query);
 			var properties = new Dictionary<string, string>();
-			foreach (string key in responseQuery.AllKeys)
+			foreach (string? key in responseQuery.AllKeys)
 			{
 				if (key is not null)
 					properties[key] = responseQuery[key] ?? string.Empty;

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Linux.Gtk4.Essentials.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Linux.Gtk4.Essentials.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Microsoft.Maui.Platforms.Linux.Gtk4.Essentials</RootNamespace>
     <AssemblyName>Microsoft.Maui.Platforms.Linux.Gtk4.Essentials</AssemblyName>
     <PackageId>Microsoft.Maui.Platforms.Linux.Gtk4.Essentials</PackageId>
+    <Version>$(PlatformMauiLinuxGtk4EssentialsVersion)</Version>
     <Description>MAUI Essentials implementations for Linux — clipboard, preferences, device info, connectivity, and more using GTK4, DBus, and freedesktop.org APIs.</Description>
     <PackageTags>maui;linux;essentials;gtk;gtk4;dbus;freedesktop;clipboard;preferences</PackageTags>
     <IsPackable>true</IsPackable>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Media/LinuxMediaPicker.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Media/LinuxMediaPicker.cs
@@ -65,6 +65,7 @@ public class LinuxMediaPicker : IMediaPicker
 			if (window is null) return new List<FileResult>();
 
 			var files = await dialog.OpenMultipleAsync(window);
+			if (files is null) return new List<FileResult>();
 			var results = new List<FileResult>();
 			for (uint i = 0; i < files.GetNItems(); i++)
 			{

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Media/LinuxScreenshot.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Media/LinuxScreenshot.cs
@@ -6,17 +6,17 @@ public class LinuxScreenshot : IScreenshot
 {
 	public bool IsCaptureSupported => true;
 
-	public Task<IScreenshotResult?> CaptureAsync()
+	public Task<IScreenshotResult> CaptureAsync()
 	{
 		try
 		{
 			var window = (Gtk.Application.GetDefault() as Gtk.Application)?.GetActiveWindow();
 			if (window is null)
-				return Task.FromResult<IScreenshotResult?>(null);
+				return Task.FromResult<IScreenshotResult>(null!);
 
 			var renderer = window.GetRenderer();
 			if (renderer is null)
-				return Task.FromResult<IScreenshotResult?>(null);
+				return Task.FromResult<IScreenshotResult>(null!);
 
 			// Use a GtkSnapshot to capture the window content
 			var snapshot = Gtk.Snapshot.New();
@@ -24,7 +24,7 @@ public class LinuxScreenshot : IScreenshot
 			var height = window.GetHeight();
 
 			if (width <= 0 || height <= 0)
-				return Task.FromResult<IScreenshotResult?>(null);
+				return Task.FromResult<IScreenshotResult>(null!);
 
 			// Snapshot the window's child (the content)
 			var child = window.GetChild();
@@ -33,17 +33,17 @@ public class LinuxScreenshot : IScreenshot
 
 			var node = snapshot.FreeToNode();
 			if (node is null)
-				return Task.FromResult<IScreenshotResult?>(null);
+				return Task.FromResult<IScreenshotResult>(null!);
 
 			var texture = renderer.RenderTexture(node, null);
 			var tempPath = Path.Combine(Path.GetTempPath(), $"screenshot_{Guid.NewGuid()}.png");
 			texture.SaveToPng(tempPath);
 
-			return Task.FromResult<IScreenshotResult?>(new LinuxScreenshotResult(tempPath, width, height));
+			return Task.FromResult<IScreenshotResult>(new LinuxScreenshotResult(tempPath, width, height));
 		}
 		catch
 		{
-			return Task.FromResult<IScreenshotResult?>(null);
+			return Task.FromResult<IScreenshotResult>(null!);
 		}
 	}
 }

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Storage/LinuxFilePicker.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Storage/LinuxFilePicker.cs
@@ -10,9 +10,9 @@ public class LinuxFilePicker : IFilePicker
 		return results?.FirstOrDefault();
 	}
 
-	public async Task<IEnumerable<FileResult>?> PickMultipleAsync(PickOptions? options)
+	public async Task<IEnumerable<FileResult?>> PickMultipleAsync(PickOptions? options)
 	{
-		return await PickInternalAsync(true, options);
+		return await PickInternalAsync(true, options) ?? Enumerable.Empty<FileResult?>();
 	}
 
 	private async Task<List<FileResult>?> PickInternalAsync(bool multiple, PickOptions? options)
@@ -53,6 +53,7 @@ public class LinuxFilePicker : IFilePicker
 			}
 
 			var files = await dialog.OpenMultipleAsync(window);
+			if (files is null) return new List<FileResult>();
 			var results = new List<FileResult>();
 			for (uint i = 0; i < files.GetNItems(); i++)
 			{

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/AssemblyInfo.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("linux")]

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ActivityIndicatorHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ActivityIndicatorHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class ActivityIndicatorHandler : GtkViewHandler<IActivityIndicator, Gtk.Spinner>
 {
-	public static new IPropertyMapper<IActivityIndicator, ActivityIndicatorHandler> Mapper =
+	public static IPropertyMapper<IActivityIndicator, ActivityIndicatorHandler> Mapper =
 		new PropertyMapper<IActivityIndicator, ActivityIndicatorHandler>(ViewMapper)
 		{
 			[nameof(IActivityIndicator.IsRunning)] = MapIsRunning,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/BorderHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/BorderHandler.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class BorderHandler : GtkViewHandler<IBorderView, Platform.GtkLayoutPanel>
 {
-	public static new IPropertyMapper<IBorderView, BorderHandler> Mapper =
+	public static IPropertyMapper<IBorderView, BorderHandler> Mapper =
 		new PropertyMapper<IBorderView, BorderHandler>(ViewMapper)
 		{
 			[nameof(IBorderView.Content)] = MapContent,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/BoxViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/BoxViewHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 /// </summary>
 public class BoxViewHandler : GtkViewHandler<IView, Gtk.DrawingArea>
 {
-	public static new IPropertyMapper<IView, BoxViewHandler> Mapper =
+	public static IPropertyMapper<IView, BoxViewHandler> Mapper =
 		new PropertyMapper<IView, BoxViewHandler>(ViewMapper);
 
 	public BoxViewHandler() : base(Mapper) { }

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ButtonHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ButtonHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class ButtonHandler : GtkViewHandler<IButton, Gtk.Button>
 {
-	public static new IPropertyMapper<IButton, ButtonHandler> Mapper =
+	public static IPropertyMapper<IButton, ButtonHandler> Mapper =
 		new PropertyMapper<IButton, ButtonHandler>(ViewMapper)
 		{
 			[nameof(ITextButton.Text)] = MapText,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/CarouselViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/CarouselViewHandler.cs
@@ -18,7 +18,7 @@ public class CarouselViewHandler : GtkViewHandler<IView, Gtk.Box>
 	int _currentPosition;
 	bool _isVertical;
 
-	public static new IPropertyMapper<IView, CarouselViewHandler> Mapper =
+	public static IPropertyMapper<IView, CarouselViewHandler> Mapper =
 		new PropertyMapper<IView, CarouselViewHandler>(ViewMapper)
 		{
 			["ItemsSource"] = MapItemsSource,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/CheckBoxHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/CheckBoxHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class CheckBoxHandler : GtkViewHandler<ICheckBox, Gtk.CheckButton>
 {
-	public static new IPropertyMapper<ICheckBox, CheckBoxHandler> Mapper =
+	public static IPropertyMapper<ICheckBox, CheckBoxHandler> Mapper =
 		new PropertyMapper<ICheckBox, CheckBoxHandler>(ViewMapper)
 		{
 			[nameof(ICheckBox.IsChecked)] = MapIsChecked,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/CollectionViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/CollectionViewHandler.cs
@@ -25,7 +25,7 @@ public class CollectionViewHandler : GtkViewHandler<IView, Gtk.ScrolledWindow>
 	bool _updatingSelection;
 	INotifyCollectionChanged? _observedCollection;
 
-	public static new IPropertyMapper<IView, CollectionViewHandler> Mapper =
+	public static IPropertyMapper<IView, CollectionViewHandler> Mapper =
 		new PropertyMapper<IView, CollectionViewHandler>(ViewMapper)
 		{
 			["ItemsSource"] = MapItemsSource,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ContentViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ContentViewHandler.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class ContentViewHandler : GtkViewHandler<IContentView, Gtk.Box>
 {
-	public static new IPropertyMapper<IContentView, ContentViewHandler> Mapper =
+	public static IPropertyMapper<IContentView, ContentViewHandler> Mapper =
 		new PropertyMapper<IContentView, ContentViewHandler>(ViewMapper)
 		{
 			[nameof(IContentView.Content)] = MapContent,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/DatePickerHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/DatePickerHandler.cs
@@ -6,7 +6,7 @@ public class DatePickerHandler : GtkViewHandler<IDatePicker, Gtk.Box>
 {
 	Gtk.Window? _dialog;
 
-	public static new IPropertyMapper<IDatePicker, DatePickerHandler> Mapper =
+	public static IPropertyMapper<IDatePicker, DatePickerHandler> Mapper =
 		new PropertyMapper<IDatePicker, DatePickerHandler>(ViewMapper)
 		{
 			[nameof(IDatePicker.Date)] = MapDate,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/EditorHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/EditorHandler.cs
@@ -6,7 +6,7 @@ public class EditorHandler : GtkViewHandler<IEditor, Gtk.TextView>
 {
 	int? _maxLength;
 
-	public static new IPropertyMapper<IEditor, EditorHandler> Mapper =
+	public static IPropertyMapper<IEditor, EditorHandler> Mapper =
 		new PropertyMapper<IEditor, EditorHandler>(ViewMapper)
 		{
 			[nameof(IEditor.Text)] = MapText,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/EntryHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/EntryHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class EntryHandler : GtkViewHandler<IEntry, Gtk.Entry>
 {
-	public static new IPropertyMapper<IEntry, EntryHandler> Mapper =
+	public static IPropertyMapper<IEntry, EntryHandler> Mapper =
 		new PropertyMapper<IEntry, EntryHandler>(ViewMapper)
 		{
 			[nameof(IEntry.Text)] = MapText,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/FlyoutPageHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/FlyoutPageHandler.cs
@@ -7,7 +7,7 @@ public class FlyoutPageHandler : GtkViewHandler<IFlyoutView, Gtk.Paned>
 {
 	int _lastPosition = 250;
 
-	public static new IPropertyMapper<IFlyoutView, FlyoutPageHandler> Mapper =
+	public static IPropertyMapper<IFlyoutView, FlyoutPageHandler> Mapper =
 		new PropertyMapper<IFlyoutView, FlyoutPageHandler>(ViewMapper)
 		{
 			[nameof(IFlyoutView.Flyout)] = MapFlyout,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/FrameHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/FrameHandler.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class FrameHandler : GtkViewHandler<IContentView, Gtk.Frame>
 {
-	public static new IPropertyMapper<IContentView, FrameHandler> Mapper =
+	public static IPropertyMapper<IContentView, FrameHandler> Mapper =
 		new PropertyMapper<IContentView, FrameHandler>(ViewMapper)
 		{
 			[nameof(IContentView.Content)] = MapContent,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/GraphicsViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/GraphicsViewHandler.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 /// </summary>
 public class GraphicsViewHandler : GtkViewHandler<IGraphicsView, Gtk.DrawingArea>
 {
-	public static new IPropertyMapper<IGraphicsView, GraphicsViewHandler> Mapper =
+	public static IPropertyMapper<IGraphicsView, GraphicsViewHandler> Mapper =
 		new PropertyMapper<IGraphicsView, GraphicsViewHandler>(ViewMapper)
 		{
 			[nameof(IGraphicsView.Drawable)] = MapDrawable,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/GtkViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/GtkViewHandler.cs
@@ -15,7 +15,7 @@ public abstract class GtkViewHandler<TVirtualView, TPlatformView> : ViewHandler<
 {
 	private Gtk.CssProvider? _currentCssProvider;
 
-	public static IPropertyMapper<IView, GtkViewHandler<TVirtualView, TPlatformView>> ViewMapper =
+	public static new IPropertyMapper<IView, GtkViewHandler<TVirtualView, TPlatformView>> ViewMapper =
 		new PropertyMapper<IView, GtkViewHandler<TVirtualView, TPlatformView>>(ViewHandler.ViewMapper)
 		{
 			[nameof(IView.Background)] = MapBackground,
@@ -46,7 +46,7 @@ public abstract class GtkViewHandler<TVirtualView, TPlatformView> : ViewHandler<
 			["ContextFlyout"] = MapContextFlyout,
 		};
 
-	public static CommandMapper<TVirtualView, GtkViewHandler<TVirtualView, TPlatformView>> ViewCommandMapper =
+	public static new CommandMapper<TVirtualView, GtkViewHandler<TVirtualView, TPlatformView>> ViewCommandMapper =
 		new(ViewHandler.ViewCommandMapper)
 		{
 			["Focus"] = MapFocus,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/GtkViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/GtkViewHandler.cs
@@ -280,18 +280,18 @@ public abstract class GtkViewHandler<TVirtualView, TPlatformView> : ViewHandler<
 
 		var anchorPt = Graphene.Point.Alloc();
 		anchorPt.Init(anchorX, anchorY);
-		transform = transform.Translate(anchorPt);
+		transform = transform!.Translate(anchorPt)!;
 		anchorPt.Free();
 
 		if (hasRotation)
-			transform = transform.Rotate((float)view.Rotation);
+			transform = transform.Rotate((float)view.Rotation)!;
 
 		if (hasScale)
-			transform = transform.Scale((float)sx, (float)sy);
+			transform = transform.Scale((float)sx, (float)sy)!;
 
 		var negPt = Graphene.Point.Alloc();
 		negPt.Init(-anchorX, -anchorY);
-		transform = transform.Translate(negPt);
+		transform = transform.Translate(negPt)!;
 		negPt.Free();
 
 		layoutPanel.SetChildTransform(widget, transform);

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ImageButtonHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ImageButtonHandler.cs
@@ -7,7 +7,7 @@ public class ImageButtonHandler : GtkViewHandler<IImageButton, Gtk.Button>
 {
 	CancellationTokenSource? _imageSourceCts;
 
-	public static new IPropertyMapper<IImageButton, ImageButtonHandler> Mapper =
+	public static IPropertyMapper<IImageButton, ImageButtonHandler> Mapper =
 		new PropertyMapper<IImageButton, ImageButtonHandler>(ViewMapper)
 		{
 			[nameof(IImageButton.Padding)] = MapPadding,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ImageHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ImageHandler.cs
@@ -8,7 +8,7 @@ public class ImageHandler : GtkViewHandler<IImage, Gtk.Picture>
 {
 	CancellationTokenSource? _imageSourceCts;
 
-	public static new IPropertyMapper<IImage, ImageHandler> Mapper =
+	public static IPropertyMapper<IImage, ImageHandler> Mapper =
 		new PropertyMapper<IImage, ImageHandler>(ViewMapper)
 		{
 			[nameof(IImage.Aspect)] = MapAspect,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/IndicatorViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/IndicatorViewHandler.cs
@@ -14,7 +14,7 @@ public class IndicatorViewHandler : GtkViewHandler<IView, Gtk.Box>
 {
 	readonly List<Gtk.DrawingArea> _dots = new();
 
-	public static new IPropertyMapper<IView, IndicatorViewHandler> Mapper =
+	public static IPropertyMapper<IView, IndicatorViewHandler> Mapper =
 		new PropertyMapper<IView, IndicatorViewHandler>(ViewMapper)
 		{
 			["Count"] = MapIndicators,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/LabelHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/LabelHandler.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class LabelHandler : GtkViewHandler<ILabel, Gtk.Label>
 {
-	public static new IPropertyMapper<ILabel, LabelHandler> Mapper =
+	public static IPropertyMapper<ILabel, LabelHandler> Mapper =
 		new PropertyMapper<ILabel, LabelHandler>(ViewMapper)
 		{
 			[nameof(ILabel.Text)] = MapText,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/LayoutHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/LayoutHandler.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class LayoutHandler : GtkViewHandler<ILayout, GtkLayoutPanel>, ILayoutHandler
 {
-	public static new IPropertyMapper<ILayout, LayoutHandler> Mapper =
+	public static IPropertyMapper<ILayout, LayoutHandler> Mapper =
 		new PropertyMapper<ILayout, LayoutHandler>(ViewMapper)
 		{
 			[nameof(ILayout.Background)] = MapBackground,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/LayoutHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/LayoutHandler.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class LayoutHandler : GtkViewHandler<ILayout, GtkLayoutPanel>, ILayoutHandler
 {
+	object ILayoutHandler.PlatformView => base.PlatformView!;
+
 	public static IPropertyMapper<ILayout, LayoutHandler> Mapper =
 		new PropertyMapper<ILayout, LayoutHandler>(ViewMapper)
 		{

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ListViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ListViewHandler.cs
@@ -27,7 +27,7 @@ public class ListViewHandler : GtkViewHandler<ListView, Gtk.ScrolledWindow>
 	bool _updatingSelection;
 	INotifyCollectionChanged? _observableSource;
 
-	public static new IPropertyMapper<ListView, ListViewHandler> Mapper =
+	public static IPropertyMapper<ListView, ListViewHandler> Mapper =
 		new PropertyMapper<ListView, ListViewHandler>(ViewMapper)
 		{
 			[nameof(ListView.ItemsSource)] = MapItemsSource,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/NavigationPageHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/NavigationPageHandler.cs
@@ -15,7 +15,7 @@ public class NavigationPageHandler : GtkViewHandler<IStackNavigationView, Gtk.Bo
 	Gtk.Stack? _stack;
 	IReadOnlyList<IView>? _currentStack;
 
-	public static new IPropertyMapper<IStackNavigationView, NavigationPageHandler> Mapper =
+	public static IPropertyMapper<IStackNavigationView, NavigationPageHandler> Mapper =
 		new PropertyMapper<IStackNavigationView, NavigationPageHandler>(ViewMapper)
 		{
 		};

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/PageHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/PageHandler.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class PageHandler : GtkViewHandler<IContentView, Gtk.Box>
 {
-	public static new IPropertyMapper<IContentView, PageHandler> Mapper =
+	public static IPropertyMapper<IContentView, PageHandler> Mapper =
 		new PropertyMapper<IContentView, PageHandler>(ViewMapper)
 		{
 			[nameof(IContentView.Content)] = MapContent,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/PickerHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/PickerHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class PickerHandler : GtkViewHandler<IPicker, Gtk.DropDown>
 {
-	public static new IPropertyMapper<IPicker, PickerHandler> Mapper =
+	public static IPropertyMapper<IPicker, PickerHandler> Mapper =
 		new PropertyMapper<IPicker, PickerHandler>(ViewMapper)
 		{
 			[nameof(IPicker.Title)] = MapTitle,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ProgressBarHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ProgressBarHandler.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class ProgressBarHandler : GtkViewHandler<IProgress, Gtk.ProgressBar>
 {
-	public static new IPropertyMapper<IProgress, ProgressBarHandler> Mapper =
+	public static IPropertyMapper<IProgress, ProgressBarHandler> Mapper =
 		new PropertyMapper<IProgress, ProgressBarHandler>(ViewMapper)
 		{
 			[nameof(IProgress.Progress)] = MapProgress,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/RadioButtonHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/RadioButtonHandler.cs
@@ -6,7 +6,7 @@ public class RadioButtonHandler : GtkViewHandler<IRadioButton, Gtk.CheckButton>
 {
 	static readonly Dictionary<string, WeakReference<Gtk.CheckButton>> _groupLeaders = new();
 
-	public static new IPropertyMapper<IRadioButton, RadioButtonHandler> Mapper =
+	public static IPropertyMapper<IRadioButton, RadioButtonHandler> Mapper =
 		new PropertyMapper<IRadioButton, RadioButtonHandler>(ViewMapper)
 		{
 			[nameof(IRadioButton.IsChecked)] = MapIsChecked,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/RefreshViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/RefreshViewHandler.cs
@@ -16,7 +16,7 @@ public class RefreshViewHandler : GtkViewHandler<IView, Gtk.Box>
 	Gtk.Button? _refreshButton;
 	Gtk.Widget? _contentWidget;
 
-	public static new IPropertyMapper<IView, RefreshViewHandler> Mapper =
+	public static IPropertyMapper<IView, RefreshViewHandler> Mapper =
 		new PropertyMapper<IView, RefreshViewHandler>(ViewMapper)
 		{
 			["Content"] = MapContent,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ScrollViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ScrollViewHandler.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class ScrollViewHandler : GtkViewHandler<IScrollView, Gtk.ScrolledWindow>
 {
-	public static new IPropertyMapper<IScrollView, ScrollViewHandler> Mapper =
+	public static IPropertyMapper<IScrollView, ScrollViewHandler> Mapper =
 		new PropertyMapper<IScrollView, ScrollViewHandler>(ViewMapper)
 		{
 			[nameof(IScrollView.Content)] = MapContent,
@@ -15,7 +15,7 @@ public class ScrollViewHandler : GtkViewHandler<IScrollView, Gtk.ScrolledWindow>
 			[nameof(IScrollView.VerticalScrollBarVisibility)] = MapVerticalScrollBarVisibility,
 		};
 
-	public static new CommandMapper<IScrollView, ScrollViewHandler> CommandMapper =
+	public static CommandMapper<IScrollView, ScrollViewHandler> CommandMapper =
 		new(ViewCommandMapper)
 		{
 			[nameof(IScrollView.RequestScrollTo)] = MapRequestScrollTo,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SearchBarHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SearchBarHandler.cs
@@ -6,7 +6,7 @@ public class SearchBarHandler : GtkViewHandler<ISearchBar, Gtk.SearchEntry>
 {
 	int _maxLength = int.MaxValue;
 
-	public static new IPropertyMapper<ISearchBar, SearchBarHandler> Mapper =
+	public static IPropertyMapper<ISearchBar, SearchBarHandler> Mapper =
 		new PropertyMapper<ISearchBar, SearchBarHandler>(ViewMapper)
 		{
 			[nameof(ISearchBar.Text)] = MapText,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ShapeHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ShapeHandler.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 /// </summary>
 public class ShapeHandler : GtkViewHandler<IView, Gtk.DrawingArea>
 {
-	public static new IPropertyMapper<IView, ShapeHandler> Mapper =
+	public static IPropertyMapper<IView, ShapeHandler> Mapper =
 		new PropertyMapper<IView, ShapeHandler>(ViewMapper);
 
 	public ShapeHandler() : base(Mapper) { }

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ShapeViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ShapeViewHandler.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 /// </summary>
 public class ShapeViewHandler : GtkViewHandler<IShapeView, Gtk.DrawingArea>
 {
-	public static new IPropertyMapper<IShapeView, ShapeViewHandler> Mapper =
+	public static IPropertyMapper<IShapeView, ShapeViewHandler> Mapper =
 		new PropertyMapper<IShapeView, ShapeViewHandler>(ViewMapper)
 		{
 			[nameof(IShapeView.Shape)] = MapShape,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ShellHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ShellHandler.cs
@@ -27,7 +27,7 @@ public partial class ShellHandler : GtkViewHandler<Shell, Gtk.Box>
 	int _flyoutWidth = 250;
 	bool _updatingSelection;
 
-	public static new IPropertyMapper<Shell, ShellHandler> Mapper =
+	public static IPropertyMapper<Shell, ShellHandler> Mapper =
 		new PropertyMapper<Shell, ShellHandler>(ViewMapper)
 		{
 			[nameof(Shell.CurrentItem)] = MapCurrentItem,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SliderHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SliderHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class SliderHandler : GtkViewHandler<ISlider, Gtk.Scale>
 {
-	public static new IPropertyMapper<ISlider, SliderHandler> Mapper =
+	public static IPropertyMapper<ISlider, SliderHandler> Mapper =
 		new PropertyMapper<ISlider, SliderHandler>(ViewMapper)
 		{
 			[nameof(ISlider.Minimum)] = MapMinimum,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/StepperHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/StepperHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class StepperHandler : GtkViewHandler<IStepper, Gtk.SpinButton>
 {
-	public static new IPropertyMapper<IStepper, StepperHandler> Mapper =
+	public static IPropertyMapper<IStepper, StepperHandler> Mapper =
 		new PropertyMapper<IStepper, StepperHandler>(ViewMapper)
 		{
 			[nameof(IStepper.Minimum)] = MapMinimum,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SwipeViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SwipeViewHandler.cs
@@ -21,7 +21,9 @@ public class SwipeViewHandler : GtkViewHandler<IView, Gtk.Box>
 	double _dragOffset;
 	double _committedOffset;
 	int _contentWidth;
+#pragma warning disable CS0414 // Field is assigned but never read — reserved for future swipe state tracking
 	bool _isOpen;
+#pragma warning restore CS0414
 
 	public static IPropertyMapper<IView, SwipeViewHandler> Mapper =
 		new PropertyMapper<IView, SwipeViewHandler>(ViewMapper)

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SwipeViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SwipeViewHandler.cs
@@ -23,7 +23,7 @@ public class SwipeViewHandler : GtkViewHandler<IView, Gtk.Box>
 	int _contentWidth;
 	bool _isOpen;
 
-	public static new IPropertyMapper<IView, SwipeViewHandler> Mapper =
+	public static IPropertyMapper<IView, SwipeViewHandler> Mapper =
 		new PropertyMapper<IView, SwipeViewHandler>(ViewMapper)
 		{
 			["Content"] = MapContent,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SwitchHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SwitchHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class SwitchHandler : GtkViewHandler<ISwitch, Gtk.Switch>
 {
-	public static new IPropertyMapper<ISwitch, SwitchHandler> Mapper =
+	public static IPropertyMapper<ISwitch, SwitchHandler> Mapper =
 		new PropertyMapper<ISwitch, SwitchHandler>(ViewMapper)
 		{
 			[nameof(ISwitch.IsOn)] = MapIsOn,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/TabbedPageHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/TabbedPageHandler.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platforms.Linux.Gtk4.Handlers;
 
 public class TabbedPageHandler : GtkViewHandler<ITabbedView, Gtk.Notebook>
 {
-	public static new IPropertyMapper<ITabbedView, TabbedPageHandler> Mapper =
+	public static IPropertyMapper<ITabbedView, TabbedPageHandler> Mapper =
 		new PropertyMapper<ITabbedView, TabbedPageHandler>(ViewMapper)
 		{
 		};

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/TableViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/TableViewHandler.cs
@@ -17,7 +17,7 @@ public class TableViewHandler : GtkViewHandler<TableView, Gtk.ScrolledWindow>
 	Gtk.Box? _contentBox;
 	readonly List<Gtk.Widget> _sectionWidgets = [];
 
-	public static new IPropertyMapper<TableView, TableViewHandler> Mapper =
+	public static IPropertyMapper<TableView, TableViewHandler> Mapper =
 		new PropertyMapper<TableView, TableViewHandler>(ViewMapper)
 		{
 			[nameof(TableView.Root)] = MapRoot,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/TimePickerHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/TimePickerHandler.cs
@@ -6,7 +6,7 @@ public class TimePickerHandler : GtkViewHandler<ITimePicker, Gtk.Box>
 {
 	Gtk.Window? _dialog;
 
-	public static new IPropertyMapper<ITimePicker, TimePickerHandler> Mapper =
+	public static IPropertyMapper<ITimePicker, TimePickerHandler> Mapper =
 		new PropertyMapper<ITimePicker, TimePickerHandler>(ViewMapper)
 		{
 			[nameof(ITimePicker.Time)] = MapTime,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/WebViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/WebViewHandler.cs
@@ -9,7 +9,7 @@ public class WebViewHandler : GtkViewHandler<IWebView, WebKit.WebView>, IWebView
 	WebNavigationEvent _currentNavigationEvent = WebNavigationEvent.NewPage;
 	string _lastUrl = "about:blank";
 
-	public static new IPropertyMapper<IWebView, WebViewHandler> Mapper =
+	public static IPropertyMapper<IWebView, WebViewHandler> Mapper =
 		new PropertyMapper<IWebView, WebViewHandler>(ViewMapper)
 		{
 			[nameof(IWebView.Source)] = MapSource,

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Hosting/AppHostBuilderExtensions.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Hosting/AppHostBuilderExtensions.cs
@@ -127,7 +127,9 @@ public static partial class AppHostBuilderExtensions
 		builder.Services.AddSingleton<ITicker>(svc => new GtkPlatformTicker());
 
 		// Named font sizes (FontSize="Title", etc.)
+#pragma warning disable CS0612 // IFontNamedSizeService is obsolete but still needed for compatibility
 		Microsoft.Maui.Controls.DependencyService.Register<Microsoft.Maui.Controls.Internals.IFontNamedSizeService, GtkFontNamedSizeService>();
+#pragma warning restore CS0612
 
 		// Graphics platform services
 		builder.Services.AddSingleton<IStringSizeService, CairoStringSizeService>();

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Microsoft.Maui.Platforms.Linux.Gtk4</RootNamespace>
     <AssemblyName>Microsoft.Maui.Platforms.Linux.Gtk4</AssemblyName>
     <PackageId>Microsoft.Maui.Platforms.Linux.Gtk4</PackageId>
+    <Version>$(PlatformMauiLinuxGtk4Version)</Version>
     <Description>A .NET MAUI backend for Linux using GTK4. Run your MAUI apps natively on Linux desktops with real GTK4 widgets via GirCore bindings.</Description>
     <PackageTags>maui;linux;gtk;gtk4;desktop;dotnet;cross-platform;gircore</PackageTags>
     <IsPackable>true</IsPackable>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkFontNamedSizeService.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkFontNamedSizeService.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0612 // Type or member is obsolete (IFontNamedSizeService, NamedSize)
+
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Internals;
 

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkMauiApplication.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkMauiApplication.cs
@@ -166,7 +166,10 @@ public abstract class GtkMauiApplication : IPlatformApplication
 	/// </summary>
 	internal void CreateAndShowNewWindow(IApplication app, Microsoft.Maui.Handlers.OpenWindowRequest? request)
 	{
-		var activationState = new ActivationState(_applicationContext, request?.State);
+		var state = request?.State;
+		var activationState = state is not null
+			? new ActivationState(_applicationContext, state)
+			: new ActivationState(_applicationContext);
 		var virtualWindow = app.CreateWindow(activationState);
 		CreateAndShowWindow(virtualWindow);
 	}

--- a/platforms/Linux.Gtk4/templates/Linux.Gtk4.Templates.csproj
+++ b/platforms/Linux.Gtk4/templates/Linux.Gtk4.Templates.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageId>Microsoft.Maui.Platforms.Linux.Gtk4.Templates</PackageId>
-    <Version>0.1.0-preview.1</Version>
+    <Version>$(PlatformMauiLinuxGtk4Version)</Version>
     <Authors>Microsoft</Authors>
     <Description>Project templates for .NET MAUI apps running on Linux with GTK4.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Adds full CI and release pipeline support for the Linux GTK4 backend (merged in #29).

### GitHub Actions

- **Extends `_build.yml`** with two new inputs:
  - ` JSON array of runner labels (default: `["macos-latest", "windows-latest"]`)os` 
  - `native- Optional shell command to install native dependencies before builddeps` 
  - Added Linux build step (`startsWith(matrix.os, 'ubuntu')`)
  - Fixed package upload to work when Windows isn't in the matrix
- **New `ci-linux-gtk4. Calls `_build.yml` with:yml`** 
  - Ubuntu 24.04 runner
  - GTK4/WebKitGTK native deps via `apt-get`
  - `install-workloads: false` (net10.0-only project)
  - Triggers on `platforms/Linux.Gtk4/**` changes

### Azure DevOps

- **New `LinuxGtk4` build job** in `devflow-official.yml`:
  - Ubuntu 24.04 pool (`ubuntu.2404.amd64`)
  - GTK4 dependency installation
  - `cibuild.sh` with `Linux.Gtk4.slnx`
- **New `publishLinuxGtk4Nuget` parameter + publish stage**:
  - Filters `Microsoft.Maui.Platforms.Linux.Gtk4.*.nupkg`
  - Pushes via `1ES.PublishNuget@1` to nuget.org

### Arcade Versioning Integration

Removed hardcoded `VersionPrefix=0.6.0` from `platforms/Linux.Gtk4/Directory.Build.props`. Each csproj now references centralized version properties from `eng/Versions.props`:

| Package | Version Property |
|---------|-----------------|
| `Microsoft.Maui.Platforms.Linux.Gtk4` | `PlatformMauiLinuxGtk4Version` |
| `Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView` | `PlatformMauiLinuxGtk4BlazorWebViewVersion` |
| `Microsoft.Maui.Platforms.Linux.Gtk4.Essentials` | `PlatformMauiLinuxGtk4EssentialsVersion` |
| `Microsoft.Maui.Platforms.Linux.Gtk4.Templates` | `PlatformMauiLinuxGtk4Version` |

Official AzDO builds will produce versioned packages like `0.6.0-preview.1.26413.1`.

### Packages published (4 total)

- `Microsoft.Maui.Platforms.Linux.Gtk4`
- `Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView`
- `Microsoft.Maui.Platforms.Linux.Gtk4.Essentials`
- `Microsoft.Maui.Platforms.Linux.Gtk4.Templates`

Follows up on #29.