### PR TITLE
fix: Use Arcade-provisioned SDK for workload install in AzDO pipeline

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -74,16 +74,15 @@ extends:
                     /p:TeamName=$(_TeamName)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
-            - script: eng\common\dotnet.cmd --info
-              displayName: Provision .NET SDK via Arcade
+            - task: UseDotNet@2
+              displayName: Install .NET SDK
+              inputs:
+                packageType: sdk
+                version: 10.0.x
             - script: dotnet workload install maui maui-android macos maui-tizen
               displayName: Install MAUI workloads
-              env:
-                DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)\.dotnet
             - script: dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
               displayName: Install Android SDK dependencies
-              env:
-                DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)\.dotnet
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -74,14 +74,11 @@ extends:
                     /p:TeamName=$(_TeamName)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
-            - task: UseDotNet@2
-              displayName: Install .NET SDK
-              inputs:
-                packageType: sdk
-                version: 10.0.x
-            - script: dotnet workload install maui maui-android macos maui-tizen
+            - script: eng\common\dotnet.cmd --info
+              displayName: Provision .NET SDK via Arcade
+            - script: .dotnet\dotnet workload install maui maui-android macos maui-tizen
               displayName: Install MAUI workloads
-            - script: dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
+            - script: .dotnet\dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
               displayName: Install Android SDK dependencies
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -74,11 +74,11 @@ extends:
                     /p:TeamName=$(_TeamName)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
-            - script: eng\common\build.cmd -restore -ci
+            - script: eng\common\dotnet.cmd --info
               displayName: Provision .NET SDK via Arcade
-            - script: .dotnet\dotnet workload install maui macos maui-tizen
+            - script: eng\common\dotnet.cmd workload install maui maui-android macos maui-tizen
               displayName: Install MAUI workloads
-            - script: .dotnet\dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
+            - script: eng\common\dotnet.cmd build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
               displayName: Install Android SDK dependencies
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -76,10 +76,14 @@ extends:
             steps:
             - script: eng\common\dotnet.cmd --info
               displayName: Provision .NET SDK via Arcade
-            - script: eng\common\dotnet.cmd workload install maui maui-android macos maui-tizen
+            - script: dotnet workload install maui maui-android macos maui-tizen
               displayName: Install MAUI workloads
-            - script: eng\common\dotnet.cmd build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
+              env:
+                DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)\.dotnet
+            - script: dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
               displayName: Install Android SDK dependencies
+              env:
+                DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)\.dotnet
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -74,13 +74,11 @@ extends:
                     /p:TeamName=$(_TeamName)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
-            - task: UseDotNet@2
-              displayName: Install .NET SDK
-              inputs:
-                useGlobalJson: true
-            - script: dotnet workload install maui macos maui-tizen
+            - script: eng\common\build.cmd -restore -ci
+              displayName: Provision .NET SDK via Arcade
+            - script: .dotnet\dotnet workload install maui macos maui-tizen
               displayName: Install MAUI workloads
-            - script: dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
+            - script: .dotnet\dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
               displayName: Install Android SDK dependencies
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,10 @@
 {
   "sdk": {
     "version": "10.0.105",
+    "paths": [
+      ".dotnet",
+      "$host$"
+    ],
     "rollForward": "latestMinor",
     "allowPrerelease": false
   },


### PR DESCRIPTION
## Problem

The DevFlow - Windows Release job in the AzDO official pipeline fails with:

```
NETSDK1147: To build this project, the following workloads must be installed: maui-android
```

## Root Cause

SDK version mismatch between workload install and build:

1. `UseDotNet@2` installs SDK **10.0.201** (latest in 10.x channel)
2. `dotnet workload install maui` installs workloads to **10.0.201**
3. Arcade's `cibuild.cmd` provisions SDK **10.0.105** (from global.json) to `.dotnet/`
 NETSDK1147

## Fix

- Remove `UseDotNet@2` task (Arcade handles SDK provisioning)
- Provision the SDK first via `eng\common\build.cmd -restore -ci`
- Install workloads using `.dotnet\dotnet` so they target the correct SDK (10.0.105)