### PR TITLE
Align DevFlow with the v1 spec and integration harness

### DIFF
--- a/.claude/skills/maui-ai-debugging/SKILL.md
+++ b/.claude/skills/maui-ai-debugging/SKILL.md
@@ -7,7 +7,7 @@ description: >
   filling text, screenshots, property queries), (3) Debugging Blazor WebView content via CDP, (4) Managing
   simulators or emulators, (5) Setting up MauiDevFlow in a MAUI project, (6) Completing a build-deploy-inspect-fix
   feedback loop, (7) Handling permission dialogs and system alerts, (8) Managing multiple simultaneous apps via
-  the broker daemon. Covers: maui-devflow CLI, androidsdk.tool, appledev.tools, adb, xcrun simctl, xdotool,
+  the broker daemon. Covers: the unified `maui devflow` CLI, androidsdk.tool, appledev.tools, adb, xcrun simctl, xdotool,
   and dotnet build/run for all MAUI target platforms including macOS (AppKit) and Linux/GTK.
 ---
 
@@ -19,13 +19,13 @@ feedback loop: **build → deploy → inspect → fix → rebuild**.
 ## Prerequisites
 
 ```bash
-dotnet tool install --global Microsoft.Maui.DevFlow.CLI || dotnet tool update --global Microsoft.Maui.DevFlow.CLI
+dotnet tool install --global Microsoft.Maui.Cli --prerelease || dotnet tool update --global Microsoft.Maui.Cli --prerelease
 dotnet tool install --global androidsdk.tool    # Android only
 dotnet tool install --global appledev.tools     # iOS/Mac only
 ```
 
-Keep the skill up to date: `maui-devflow update-skill`. Check installed version vs remote
-with `maui-devflow skill-version`. For full update procedures, see
+Keep the skill up to date: `maui devflow update-skill`. Check installed version vs remote
+with `maui devflow skill-version`. For full update procedures, see
 [references/setup.md](references/setup.md#checking-for-updates).
 
 ## Integrating MauiDevFlow into a MAUI App
@@ -55,13 +55,13 @@ Before building or launching anything, determine if DevFlow is available for the
 grep -rl "MauiDevFlow\|Maui\.DevFlow" --include="*.csproj" .
 ```
 
-If grep returns results, DevFlow IS integrated — even if `maui-devflow list` shows nothing.
+If grep returns results, DevFlow IS integrated — even if `maui devflow list` shows nothing.
 
 **Check runtime connection:**
 ```bash
-maui-devflow list                          # shows connected agents
-maui-devflow broker status                 # shows broker health
-maui-devflow diagnose                      # full end-to-end health check (recommended)
+maui devflow list                          # shows connected agents
+maui devflow broker status                 # shows broker health
+maui devflow diagnose                      # full end-to-end health check (recommended)
 ```
 
 **Decision tree — what to do based on results:**
@@ -69,16 +69,16 @@ maui-devflow diagnose                      # full end-to-end health check (recom
 | Project has DevFlow packages? | Agent in `list`? | Action |
 |-------------------------------|------------------|--------|
 | ✅ Yes | ✅ Yes | Ready — proceed to inspection/interaction |
-| ✅ Yes | ❌ No | App not running in Debug, or broker issue. Launch app, then `maui-devflow wait` |
+| ✅ Yes | ❌ No | App not running in Debug, or broker issue. Launch app, then `maui devflow wait` |
 | ❌ No | — | Need to integrate DevFlow (see "Integrating MauiDevFlow into a MAUI App") |
 
-**⚠️ CRITICAL:** `maui-devflow list` shows RUNTIME state (connected agents), NOT project integration.
+**⚠️ CRITICAL:** `maui devflow list` shows RUNTIME state (connected agents), NOT project integration.
 An empty list does NOT mean "DevFlow is not installed." Always check project files first.
 
 **After launching the app (via `dotnet build -t:Run` or through Aspire):**
 ```bash
-maui-devflow wait                          # blocks until agent connects (default 120s)
-maui-devflow wait --project path/to/App.csproj  # filter to specific project
+maui devflow wait                          # blocks until agent connects (default 120s)
+maui devflow wait --project path/to/App.csproj  # filter to specific project
 ```
 ALWAYS run `wait` after launching. Never assume the agent is connected — verify it.
 
@@ -89,7 +89,7 @@ ALWAYS run `wait` after launching. Never assume the agent is connected — verif
 prevent apps from replacing each other. Check what's already in use first:
 
 ```bash
-maui-devflow list     # check if any agents are already connected (runtime state only — see Step 0 for integration check)
+maui devflow list     # check if any agents are already connected (runtime state only — see Step 0 for integration check)
 ```
 
 If another iOS or Android agent is already registered, **create a new simulator/emulator**
@@ -133,12 +133,12 @@ Use the detected version (e.g. `net9.0`) in all build commands. The examples use
 Follow these steps for every launch and rebuild.
 
 **Step 1: Kill any previous instance** (skip on first launch).
-A stale app's agent stays registered with the broker, causing `maui-devflow wait` to return
+A stale app's agent stays registered with the broker, causing `maui devflow wait` to return
 the old port instantly instead of waiting for the new build.
 
 ```bash
 # Stop the async shell from the previous launch, then confirm:
-maui-devflow list                 # should show no agents (or only unrelated ones)
+maui devflow list                 # should show no agents (or only unrelated ones)
 ```
 
 **Step 2: Launch in an async shell.**
@@ -171,12 +171,12 @@ dotnet run --project <path-to-gtk-project>
 **Step 3: Wait for the agent** — never use `sleep`.
 
 ```bash
-maui-devflow wait                                # blocks until agent registers (default 120s)
-maui-devflow wait --project path/to/App.csproj   # filter to specific project
+maui devflow wait                                # blocks until agent registers (default 120s)
+maui devflow wait --project path/to/App.csproj   # filter to specific project
 ```
 
-`maui-devflow wait` prints the assigned port as soon as the agent connects. Exit code 1
-means timeout. If `wait` times out, run `maui-devflow diagnose` to identify the issue.
+`maui devflow wait` prints the assigned port as soon as the agent connects. Exit code 1
+means timeout. If `wait` times out, run `maui devflow diagnose` to identify the issue.
 Check async shell output for build errors.
 
 **Android only** — set up port forwarding after the agent connects:
@@ -191,59 +191,59 @@ if the build fails.
 ### 4. Inspect and Interact
 
 **Typical inspection flow:**
-1. `maui-devflow MAUI tree --depth 15 --fields "id,type,text,automationId"` — tree with key fields only (depth 15 reaches most controls)
-2. `maui-devflow MAUI tree --window 1` — filter to a specific window (0-based index)
-3. `maui-devflow MAUI query --automationId "MyButton"` — find specific elements
-4. `maui-devflow MAUI query --type Entry --fields "id,text,automationId"` — all Entry fields with specific fields
-5. `maui-devflow MAUI element <id>` — get full details (type, bounds, visibility, children)
-6. `maui-devflow MAUI property <id> Text` — read any property by name
-7. `maui-devflow MAUI screenshot --output screen.png` — visual verification (auto-scaled to 1x on HiDPI)
-8. `maui-devflow MAUI screenshot --id <elementId> --output el.png` — element-only screenshot
-9. `maui-devflow MAUI screenshot --selector "Button" --output btn.png` — screenshot by CSS selector
+1. `maui devflow ui tree --depth 15 --fields "id,type,text,automationId"` — tree with key fields only (depth 15 reaches most controls)
+2. `maui devflow ui tree --window 1` — filter to a specific window (0-based index)
+3. `maui devflow ui query --automationId "MyButton"` — find specific elements
+4. `maui devflow ui query --type Entry --fields "id,text,automationId"` — all Entry fields with specific fields
+5. `maui devflow ui element <id>` — get full details (type, bounds, visibility, children)
+6. `maui devflow ui property <id> Text` — read any property by name
+7. `maui devflow ui screenshot --output screen.png` — visual verification (auto-scaled to 1x on HiDPI)
+8. `maui devflow ui screenshot --id <elementId> --output el.png` — element-only screenshot
+9. `maui devflow ui screenshot --selector "Button" --output btn.png` — screenshot by CSS selector
 
 **Property inspection** is more reliable than screenshots for verifying exact runtime values:
 ```bash
-maui-devflow MAUI property <id> BackgroundColor    # verify dark mode colors
-maui-devflow MAUI property <id> IsVisible          # check element visibility
+maui devflow ui property <id> BackgroundColor    # verify dark mode colors
+maui devflow ui property <id> IsVisible          # check element visibility
 ```
 
 **Live editing (no rebuild needed):**
 ```bash
-maui-devflow MAUI set-property <id> TextColor "Tomato"
-maui-devflow MAUI set-property <id> FontSize "24"
+maui devflow ui set-property <id> TextColor "Tomato"
+maui devflow ui set-property <id> FontSize "24"
 ```
 Supports: string, bool, int, double, Color (named/hex), Thickness, enums. Changes persist
 until the app restarts — safe for experimentation.
 
 **Typical interaction flow:**
-1. `maui-devflow MAUI fill --automationId "MyEntry" "text"` — type into Entry/Editor fields (no query needed)
-2. `maui-devflow MAUI tap --automationId "MyButton"` — tap buttons, checkboxes, list items
-3. `maui-devflow MAUI clear --automationId "MyEntry"` — clear text fields
-4. Or use element IDs from tree/query: `maui-devflow MAUI tap <elementId>`
+1. `maui devflow ui fill --automationId "MyEntry" "text"` — type into Entry/Editor fields (no query needed)
+2. `maui devflow ui tap --automationId "MyButton"` — tap buttons, checkboxes, list items
+3. `maui devflow ui clear --automationId "MyEntry"` — clear text fields
+4. Or use element IDs from tree/query: `maui devflow ui tap <elementId>`
 5. Take screenshot to verify result, or use `--and-screenshot` on the action
 
 **Blazor WebView (if applicable):**
-1. `maui-devflow cdp snapshot` — DOM tree as accessible text (best for AI)
-2. `maui-devflow cdp Input fill "css-selector" "text"` — fill inputs
-3. `maui-devflow cdp Input dispatchClickEvent "css-selector"` — click elements
-4. `maui-devflow cdp Runtime evaluate "js-expression"` — run JS
+1. `maui devflow webview snapshot` — DOM tree as accessible text (best for AI)
+2. `maui devflow webview Input fill "css-selector" "text"` — fill inputs
+3. `maui devflow webview Input dispatchClickEvent "css-selector"` — click elements
+4. `maui devflow webview Runtime evaluate "js-expression"` — run JS
 
 **Multiple BlazorWebViews:** If the app has more than one `BlazorWebView`, each is
-registered independently with its `AutomationId`. Use `cdp webviews` to list them,
+registered independently with its `AutomationId`. Use `webview webviews` to list them,
 then target a specific one with `--webview` (or `-w`):
 
 ```bash
-maui-devflow cdp webviews                                  # list all WebViews
-maui-devflow cdp -w BlazorLeft snapshot                    # snapshot of a specific WebView
-maui-devflow cdp -w 1 Runtime evaluate "document.title"    # target by index
+maui devflow webview webviews                                  # list all WebViews
+maui devflow webview -w BlazorLeft snapshot                    # snapshot of a specific WebView
+maui devflow webview -w 1 Runtime evaluate "document.title"    # target by index
 ```
 
 Without `--webview`, commands target the first (index 0) WebView.
 
 **Live CSS/DOM editing in Blazor (no rebuild needed):**
 ```bash
-maui-devflow cdp Runtime evaluate "document.querySelector('h1').style.color = 'tomato'"
-maui-devflow cdp Runtime evaluate "document.documentElement.style.setProperty('--bg-color', '#1a1a2e')"
+maui devflow webview Runtime evaluate "document.querySelector('h1').style.color = 'tomato'"
+maui devflow webview Runtime evaluate "document.documentElement.style.setProperty('--bg-color', '#1a1a2e')"
 ```
 
 ### 5. Reading Application Logs
@@ -252,16 +252,16 @@ MauiDevFlow automatically captures all `ILogger` output and WebView `console.*` 
 to rotating log files, retrievable remotely:
 
 ```bash
-maui-devflow MAUI logs                   # fetch 100 most recent log entries
-maui-devflow MAUI logs --limit 50        # fetch 50 entries
-maui-devflow MAUI logs --source webview  # only WebView/Blazor console logs
-maui-devflow MAUI logs --source native   # only native ILogger logs
-maui-devflow MAUI logs --follow          # stream logs in real-time (Ctrl+C to stop)
-maui-devflow MAUI logs -f --source native  # stream only native logs
-maui-devflow MAUI logs -f --json         # stream as JSONL (machine-readable)
+maui devflow ui logs                   # fetch 100 most recent log entries
+maui devflow ui logs --limit 50        # fetch 50 entries
+maui devflow ui logs --source webview  # only WebView/Blazor console logs
+maui devflow ui logs --source native   # only native ILogger logs
+maui devflow ui logs --follow          # stream logs in real-time (Ctrl+C to stop)
+maui devflow ui logs -f --source native  # stream only native logs
+maui devflow ui logs -f --json         # stream as JSONL (machine-readable)
 ```
 
-**Debugging workflow:** Reproduce the issue → `maui-devflow MAUI logs --limit 20` → check for
+**Debugging workflow:** Reproduce the issue → `maui devflow ui logs --limit 20` → check for
 errors. Add temporary `ILogger` calls for more detail, rebuild, reproduce, and fetch logs again.
 
 ### 6. Screen Recording
@@ -271,15 +271,15 @@ using platform-native tools.
 
 ```bash
 # Start recording (default 30s timeout)
-maui-devflow MAUI recording start --output demo.mp4
+maui devflow recording start --output demo.mp4
 
 # Interact with the app
-maui-devflow MAUI tap <buttonId>
-maui-devflow MAUI navigate "//blazor"
-maui-devflow MAUI fill <entryId> "Hello World"
+maui devflow ui tap <buttonId>
+maui devflow ui navigate "//blazor"
+maui devflow ui fill <entryId> "Hello World"
 
 # Stop and save
-maui-devflow MAUI recording stop
+maui devflow recording stop
 ```
 
 **Platform tools used automatically:**
@@ -299,23 +299,23 @@ needed beyond the standard `AddMauiDevFlowAgent()` setup.
 
 ```bash
 # Live monitor — streams requests as they happen (Ctrl+C to stop)
-maui-devflow MAUI network
+maui devflow network
 
 # JSONL streaming — machine-readable, one JSON object per line
-maui-devflow MAUI network --json
+maui devflow network --json
 
 # One-shot: list recent captured requests
-maui-devflow MAUI network list
+maui devflow network list
 
 # Filter by method or host
-maui-devflow MAUI network list --method POST
-maui-devflow MAUI network list --host api.example.com
+maui devflow network list --method POST
+maui devflow network list --host api.example.com
 
 # Full request/response details (headers + body)
-maui-devflow MAUI network detail <requestId>
+maui devflow network detail <requestId>
 
 # Clear captured requests
-maui-devflow MAUI network clear
+maui devflow network clear
 ```
 
 **How it works:**
@@ -328,7 +328,7 @@ maui-devflow MAUI network clear
 
 **JSONL output** is ideal for AI parsing — pipe to `jq` or process programmatically:
 ```bash
-maui-devflow MAUI network --json | jq 'select(.statusCode >= 400)'
+maui devflow network --json | jq 'select(.statusCode >= 400)'
 ```
 
 **WebSocket streaming:** The live monitor uses WebSocket (`/ws/network`) for real-time push.
@@ -341,23 +341,23 @@ debugging state, resetting app configuration, or injecting test values.
 
 ```bash
 # Preferences (typed key-value store)
-maui-devflow MAUI preferences list                       # list all known keys
-maui-devflow MAUI preferences get theme_mode             # get a string value
-maui-devflow MAUI preferences get counter --type int     # get a typed value
-maui-devflow MAUI preferences set api_url "https://dev.example.com"
-maui-devflow MAUI preferences set dark_mode true --type bool
-maui-devflow MAUI preferences delete temp_key
-maui-devflow MAUI preferences clear                      # clear all
+maui devflow preferences list                       # list all known keys
+maui devflow preferences get theme_mode             # get a string value
+maui devflow preferences get counter --type int     # get a typed value
+maui devflow preferences set api_url "https://dev.example.com"
+maui devflow preferences set dark_mode true --type bool
+maui devflow preferences delete temp_key
+maui devflow preferences clear                      # clear all
 
 # Shared preferences containers
-maui-devflow MAUI preferences list --sharedName settings
-maui-devflow MAUI preferences set key val --sharedName settings
+maui devflow preferences list --sharedName settings
+maui devflow preferences set key val --sharedName settings
 
 # Secure Storage (encrypted, string values only)
-maui-devflow MAUI secure-storage get auth_token
-maui-devflow MAUI secure-storage set auth_token "eyJhbGc..."
-maui-devflow MAUI secure-storage delete auth_token
-maui-devflow MAUI secure-storage clear
+maui devflow secure-storage get auth_token
+maui devflow secure-storage set auth_token "eyJhbGc..."
+maui devflow secure-storage delete auth_token
+maui devflow secure-storage clear
 ```
 
 **Note:** Preference key listing uses an internal registry (keys set via the agent are tracked).
@@ -368,16 +368,16 @@ Keys set directly in app code won't appear in `list` unless also set via the age
 Query read-only device and app state. These are one-shot snapshot reads.
 
 ```bash
-maui-devflow MAUI platform app-info         # app name, version, build, theme
-maui-devflow MAUI platform device-info      # manufacturer, model, OS, idiom
-maui-devflow MAUI platform display          # screen density, size, orientation
-maui-devflow MAUI platform battery          # charge level, state, power source
-maui-devflow MAUI platform connectivity     # WiFi/Cellular/Ethernet, network access
-maui-devflow MAUI platform version-tracking # version history, first launch detection
-maui-devflow MAUI platform permissions      # check all common permission statuses
-maui-devflow MAUI platform permissions camera  # check a specific permission
-maui-devflow MAUI platform geolocation      # current GPS coordinates
-maui-devflow MAUI platform geolocation --accuracy High --timeout 15
+maui devflow platform app-info         # app name, version, build, theme
+maui devflow platform device-info      # manufacturer, model, OS, idiom
+maui devflow platform display          # screen density, size, orientation
+maui devflow platform battery          # charge level, state, power source
+maui devflow platform connectivity     # WiFi/Cellular/Ethernet, network access
+maui devflow platform version-tracking # version history, first launch detection
+maui devflow platform permissions      # check all common permission statuses
+maui devflow platform permissions camera  # check a specific permission
+maui devflow platform geolocation      # current GPS coordinates
+maui devflow platform geolocation --accuracy High --timeout 15
 ```
 
 ### 10. Device Sensors
@@ -385,14 +385,14 @@ maui-devflow MAUI platform geolocation --accuracy High --timeout 15
 Start, stop, and stream real-time sensor data. Sensors auto-start when streaming.
 
 ```bash
-maui-devflow MAUI sensors list                    # list sensors + status
-maui-devflow MAUI sensors start accelerometer     # start a sensor
-maui-devflow MAUI sensors stop accelerometer
+maui devflow sensors list                    # list sensors + status
+maui devflow sensors start accelerometer     # start a sensor
+maui devflow sensors stop accelerometer
 
 # Stream readings to stdout (JSONL)
-maui-devflow MAUI sensors stream accelerometer          # Ctrl+C to stop
-maui-devflow MAUI sensors stream gyroscope --speed Game  # higher frequency
-maui-devflow MAUI sensors stream compass --duration 10  # stop after 10 seconds
+maui devflow sensors stream accelerometer          # Ctrl+C to stop
+maui devflow sensors stream gyroscope --speed Game  # higher frequency
+maui devflow sensors stream compass --duration 10  # stop after 10 seconds
 ```
 
 Available sensors: `accelerometer`, `barometer`, `compass`, `gyroscope`, `magnetometer`, `orientation`.
@@ -403,7 +403,7 @@ real-time push. Each reading is a JSON object with `sensor`, `timestamp`, and `d
 
 ## Command Reference
 
-### maui-devflow MAUI (Native Agent)
+### maui devflow ui (Native Agent)
 
 Global options (work on any subcommand):
 - `--agent-host` (default localhost), `--agent-port` (auto-discovered via broker), `--platform`
@@ -421,13 +421,13 @@ resolution options are provided.
 
 | Command | Description |
 |---------|-------------|
-| `MAUI status [--window W]` | Agent connection status, platform, app name, window count |
-| `MAUI tree [--depth N] [--window W] [--fields F] [--format compact]` | Visual tree. `--fields "id,type,text"` projects specific fields. `--format compact` returns only id, type, text, automationId, bounds |
-| `MAUI query [--type T] [--automationId A] [--text T] [--selector S] [--fields F] [--format compact] [--wait-until exists\|gone] [--timeout N]` | Find elements. `--wait-until` polls until condition met (default 30s timeout). `--fields` and `--format` same as tree |
-| `MAUI hittest <x> <y> [--window W]` | Find elements at a point (deepest first). Returns IDs, types, bounds |
-| `MAUI tap [elementId] [--automationId A] [--type T] [--text T] [--index N] [--and-screenshot [path]] [--and-tree] [--and-tree-depth N]` | Tap element by ID or implicit resolution |
-| `MAUI fill [elementId] <text> [--automationId A] [--type T] [--text T] [--index N] [--and-screenshot [path]] [--and-tree]` | Fill text into Entry/Editor. elementId optional when using resolution options |
-| `MAUI clear [elementId] [--automationId A] [--type T] [--text T] [--index N] [--and-screenshot [path]] [--and-tree]` | Clear text. elementId optional when using resolution options |
+| `ui status [--window W]` | Agent connection status, platform, app name, window count |
+| `ui tree [--depth N] [--window W] [--fields F] [--format compact]` | Visual tree. `--fields "id,type,text"` projects specific fields. `--format compact` returns only id, type, text, automationId, bounds |
+| `ui query [--type T] [--automationId A] [--text T] [--selector S] [--fields F] [--format compact] [--wait-until exists\|gone] [--timeout N]` | Find elements. `--wait-until` polls until condition met (default 30s timeout). `--fields` and `--format` same as tree |
+| `ui hittest <x> <y> [--window W]` | Find elements at a point (deepest first). Returns IDs, types, bounds |
+| `ui tap [elementId] [--automationId A] [--type T] [--text T] [--index N] [--and-screenshot [path]] [--and-tree] [--and-tree-depth N]` | Tap element by ID or implicit resolution |
+| `ui fill [elementId] <text> [--automationId A] [--type T] [--text T] [--index N] [--and-screenshot [path]] [--and-tree]` | Fill text into Entry/Editor. elementId optional when using resolution options |
+| `ui clear [elementId] [--automationId A] [--type T] [--text T] [--index N] [--and-screenshot [path]] [--and-tree]` | Clear text. elementId optional when using resolution options |
 | `MAUI focus [elementId] [--automationId A] [--type T] [--text T] [--index N]` | Set focus. elementId optional when using resolution options |
 | `MAUI assert [--id ID] [--automationId A] <property> <expected>` | Assert element property value. Exit 0 if match, 1 if mismatch. Ideal for verification without screenshots |
 | `MAUI screenshot [--output path.png] [--window W] [--id ID] [--selector SEL] [--overwrite] [--max-width N] [--scale native]` | PNG screenshot. Auto-scales to 1x logical resolution on HiDPI displays (2x, 3x). Use `--scale native` for full resolution. `--max-width N` overrides auto-scaling with explicit width. `--overwrite` replaces existing file |
@@ -476,7 +476,7 @@ AutomationId, suffixes are appended: `TodoCheckBox`, `TodoCheckBox_1`, `TodoChec
 navigation, page changes, or significant UI updates, re-query to get fresh IDs. AutomationIds
 are stable across rebuilds (they come from XAML), so prefer `--automationId` for scripted flows.
 
-### maui-devflow cdp (Blazor WebView CDP)
+### maui devflow webview (Blazor WebView CDP)
 
 Global options: `--agent-host` (default localhost), `--agent-port` (auto-discovered via broker).
 CDP commands use the same agent port — all communication goes through a single port.
@@ -504,9 +504,9 @@ by index, AutomationId, or element ID. Default: first WebView.
 
 **Multi-WebView targeting:** If the app has multiple BlazorWebViews, use `cdp webviews`
 to list them, then `--webview <index-or-automationId>` on any command to target a specific one.
-Example: `maui-devflow cdp --webview 1 snapshot` or `maui-devflow cdp -w MyWebView Runtime evaluate "1+1"`.
+Example: `maui devflow webview --webview 1 snapshot` or `maui devflow webview -w MyWebView Runtime evaluate "1+1"`.
 
-### maui-devflow Broker & Discovery
+### maui devflow broker & discovery
 
 The broker is a background daemon that manages port assignments for all running agents.
 The CLI auto-starts the broker on first use — no manual setup needed.
@@ -520,13 +520,13 @@ The CLI auto-starts the broker on first use — no manual setup needed.
 | `broker stop` | Stop broker daemon |
 | `broker log` | Show broker log file |
 
-### maui-devflow batch (Multi-Command Execution)
+### maui devflow batch (Multi-Command Execution)
 
 Execute multiple commands in one invocation via stdin. Returns JSONL responses. Use for
 multi-step interactions to avoid repeated port resolution.
 
 ```bash
-echo "MAUI fill textUsername user; MAUI fill textPassword pwd123; MAUI tap buttonLogin" | maui-devflow batch
+echo "ui fill textUsername user; ui fill textPassword pwd123; ui tap buttonLogin" | maui devflow batch
 ```
 
 For full options, JSONL format, and streaming details, see [references/batch.md](references/batch.md).
@@ -554,7 +554,7 @@ or otherwise disrupt the user's desktop. The user is likely working on the same 
 - Any command that moves the mouse cursor or simulates input at the OS level
 - `open -a` to bring apps to the foreground (use `open` only to launch, not to focus)
 
-**Instead:** All inspection and interaction goes through `maui-devflow` CLI commands, which
+**Instead:** All inspection and interaction goes through `maui devflow` CLI commands, which
 communicate with the in-app agent over HTTP — no foreground focus required. If you need
 something that would require OS-level control (e.g., dismissing a system dialog outside the
 app), **ask the user** to do it manually rather than attempting automation that would hijack
@@ -562,13 +562,13 @@ their input.
 
 ## Tips
 
-- **`maui-devflow list` shows runtime state, not project integration.** Empty list ≠ "not installed."
+- **`maui devflow list` shows runtime state, not project integration.** Empty list ≠ "not installed."
   Always check project files (`grep -rl "MauiDevFlow" --include="*.csproj" .`) before concluding DevFlow is unavailable.
-- **`maui-devflow diagnose`** is the fastest way to check the entire chain: CLI → broker → agents → projects.
-- After launching through Aspire, always run `maui-devflow wait` before attempting any interaction.
-- **Use `maui-devflow batch`** for multi-step interactions — resolves port once, adds delays,
+- **`maui devflow diagnose`** is the fastest way to check the entire chain: CLI → broker → agents → projects.
+- After launching through Aspire, always run `maui devflow wait` before attempting any interaction.
+- **Use `maui devflow batch`** for multi-step interactions — resolves port once, adds delays,
   returns structured JSONL. See [references/batch.md](references/batch.md).
-- **Always use `maui-devflow MAUI screenshot`** — captures in-process, app does NOT need
+- **Always use `maui devflow ui screenshot`** — captures in-process, app does NOT need
   foreground focus.
 - Use `AutomationId` on important MAUI controls for stable element references.
 - For Blazor Hybrid, `cdp snapshot` is the most AI-friendly way to read page state.
@@ -611,46 +611,46 @@ Screenshots are **automatically scaled to 1x logical resolution** by default. Th
 the device's display density (2x on Retina, 3x on iPhone Pro Max, 1x on desktop) and divides
 the screenshot dimensions accordingly. This happens server-side before transfer.
 
-- **No action needed** — just use `maui-devflow MAUI screenshot --output screen.png` and the
+- **No action needed** — just use `maui devflow ui screenshot --output screen.png` and the
   image will be appropriately sized for AI understanding.
 - **Full resolution:** Use `--scale native` when you need pixel-perfect images (e.g., verifying
   exact colors, alignment, or anti-aliasing).
   ```bash
-  maui-devflow MAUI screenshot --output full-res.png --scale native
+  maui devflow ui screenshot --output full-res.png --scale native
   ```
 - **Explicit max width:** Use `--max-width N` to override auto-scaling with a specific pixel width.
   ```bash
-  maui-devflow MAUI screenshot --output screen.png --max-width 600
+  maui devflow ui screenshot --output screen.png --max-width 600
   ```
 
 ### Eliminating Round-Trips
 - **Use implicit resolution** instead of query-then-act:
   ```bash
   # Instead of: query → get ID → tap
-  maui-devflow MAUI tap --automationId "LoginButton"
-  maui-devflow MAUI fill --automationId "Username" "admin"
-  maui-devflow MAUI tap --type Button --index 0  # first Button
+  maui devflow ui tap --automationId "LoginButton"
+  maui devflow ui fill --automationId "Username" "admin"
+  maui devflow ui tap --type Button --index 0  # first Button
   ```
 - **Use `--wait-until`** instead of polling loops:
   ```bash
-  maui-devflow MAUI query --automationId "ResultsList" --wait-until exists --timeout 10
-  maui-devflow MAUI query --automationId "Spinner" --wait-until gone --timeout 30
+  maui devflow ui query --automationId "ResultsList" --wait-until exists --timeout 10
+  maui devflow ui query --automationId "Spinner" --wait-until gone --timeout 30
   ```
 - **Use post-action flags** to verify in one call:
   ```bash
-  maui-devflow MAUI tap abc123 --and-screenshot --and-tree --and-tree-depth 5
+  maui devflow ui tap abc123 --and-screenshot --and-tree --and-tree-depth 5
   ```
 - **Use `MAUI assert`** for quick state checks:
   ```bash
-  maui-devflow MAUI assert --id abc123 Text "Welcome!"
-  maui-devflow MAUI assert --automationId "Counter" Text "5"
+  maui devflow ui assert --id abc123 Text "Welcome!"
+  maui devflow ui assert --automationId "Counter" Text "5"
   ```
 
 ### Element IDs
 - Element IDs are **ephemeral** — re-query after navigation or state changes.
 - Don't cache element IDs across multiple actions — refresh with `tree` or `query`.
 - Prefer `--automationId` for stable references (set in XAML).
-- Use `maui-devflow commands --json` to discover available commands at runtime.
+- Use `maui devflow commands --json` to discover available commands at runtime.
 
 ### Shell Navigation
 - **Routes are case-sensitive** and come from `ShellContent Route=""` in XAML, not from
@@ -662,7 +662,7 @@ the screenshot dimensions accordingly. This happens server-side before transfer.
   at the top level of the tree output. Don't try to tap Labels inside flyout items.
 - **Flyout dismissal:** After tapping a flyout item, the flyout may stay open. Dismiss with:
   ```bash
-  maui-devflow MAUI set-property <shellId> FlyoutIsPresented "false"
+  maui devflow ui set-property <shellId> FlyoutIsPresented "false"
   ```
 
 ### CollectionView / ListView
@@ -673,19 +673,19 @@ the screenshot dimensions accordingly. This happens server-side before transfer.
   The tree shows `itemCount` in the CollectionView's properties so you know total items.
 - **Scrolling by item index** (best for reaching off-screen items):
   ```bash
-  maui-devflow MAUI scroll --element <cvId> --item-index 20 --position Center
+  maui devflow ui scroll --element <cvId> --item-index 20 --position Center
   ```
   This works even for items not in the tree yet — the platform scrolls to materialize them.
 - **Scrolling by pixel delta** (for fine-grained scrolling):
   ```bash
-  maui-devflow MAUI scroll --element <cvId> --dy -500
+  maui devflow ui scroll --element <cvId> --dy -500
   ```
   Uses native platform scroll (UIScrollView/RecyclerView) — works on CollectionView.
 - **Workflow:** Get tree → note `itemCount` → scroll by index → re-query tree → interact:
   ```bash
-  maui-devflow MAUI tree --depth 15   # CollectionView shows itemCount: 25
-  maui-devflow MAUI scroll --item-index 20
-  maui-devflow MAUI tree --depth 15   # items around index 20 now visible
+  maui devflow ui tree --depth 15   # CollectionView shows itemCount: 25
+  maui devflow ui scroll --item-index 20
+  maui devflow ui tree --depth 15   # items around index 20 now visible
   ```
 
 ### Implicit Resolution Gotchas
@@ -700,33 +700,33 @@ the screenshot dimensions accordingly. This happens server-side before transfer.
 
 **Login flow:**
 ```bash
-maui-devflow MAUI query --automationId "LoginPage" --wait-until exists --timeout 15
-maui-devflow MAUI fill --automationId "UsernameField" "admin"
-maui-devflow MAUI fill --automationId "PasswordField" "password"
-maui-devflow MAUI tap --automationId "LoginButton" --and-screenshot
-maui-devflow MAUI query --automationId "HomePage" --wait-until exists --timeout 10
+maui devflow ui query --automationId "LoginPage" --wait-until exists --timeout 15
+maui devflow ui fill --automationId "UsernameField" "admin"
+maui devflow ui fill --automationId "PasswordField" "password"
+maui devflow ui tap --automationId "LoginButton" --and-screenshot
+maui devflow ui query --automationId "HomePage" --wait-until exists --timeout 10
 ```
 
 **Shell navigation:**
 ```bash
 # Discover routes from XAML
 grep -i 'Route=' AppShell.xaml                              # find route names
-maui-devflow MAUI navigate "//home"                         # navigate to a route
-maui-devflow MAUI tap FlyoutButton                          # open flyout
-maui-devflow MAUI tree --depth 3 --fields "id,type,text"    # find flyout items
-maui-devflow MAUI tap <flyoutItemId>                        # tap item
-maui-devflow MAUI set-property <shellId> FlyoutIsPresented "false"  # dismiss flyout
+maui devflow ui navigate "//home"                         # navigate to a route
+maui devflow ui tap FlyoutButton                          # open flyout
+maui devflow ui tree --depth 3 --fields "id,type,text"    # find flyout items
+maui devflow ui tap <flyoutItemId>                        # tap item
+maui devflow ui set-property <shellId> FlyoutIsPresented "false"  # dismiss flyout
 ```
 
 **Element inspection:**
 ```bash
-maui-devflow MAUI query --automationId "MyControl" --json --fields "id,type,text,bounds"
-maui-devflow MAUI element <id> --json
-maui-devflow MAUI property <id> Text
+maui devflow ui query --automationId "MyControl" --json --fields "id,type,text,bounds"
+maui devflow ui element <id> --json
+maui devflow ui property <id> Text
 ```
 
 **State verification:**
 ```bash
-maui-devflow MAUI tap --automationId "IncrementButton"
-maui-devflow MAUI assert --automationId "CounterLabel" Text "1"
+maui devflow ui tap --automationId "IncrementButton"
+maui devflow ui assert --automationId "CounterLabel" Text "1"
 ```

--- a/.claude/skills/maui-ai-debugging/references/android.md
+++ b/.claude/skills/maui-ai-debugging/references/android.md
@@ -19,7 +19,7 @@ and can cause confusion when multiple emulators are running.
 
 **Before creating or starting an emulator, check what's already in use:**
 ```bash
-maui-devflow list                             # shows agents with platform + port
+maui devflow list                             # shows agents with platform + port
 adb devices                                   # shows connected emulators
 ```
 
@@ -85,7 +85,7 @@ adb forward tcp:<port> tcp:<port>            # Agent (lets CLI reach agent)
 ```
 
 The broker reverse is needed so the agent inside the emulator can connect to the host's
-broker daemon. The agent forward uses the port shown in `maui-devflow list` after the agent
+broker daemon. The agent forward uses the port shown in `maui devflow list` after the agent
 registers (range 10223–10899).
 
 If the broker isn't available (fallback mode), forward the port from `.mauidevflow` instead:
@@ -93,7 +93,7 @@ If the broker isn't available (fallback mode), forward the port from `.mauidevfl
 adb reverse tcp:9223 tcp:9223                # Fallback: direct agent port
 ```
 
-Then verify: `maui-devflow MAUI status` and `maui-devflow cdp status`.
+Then verify: `maui devflow ui status` and `maui devflow webview status`.
 
 ### Install APK manually
 ```bash
@@ -157,7 +157,7 @@ adb shell am force-stop <pkg>                 # kill app
 ### Port forwarding (critical for MauiDevFlow)
 ```bash
 adb reverse tcp:19223 tcp:19223              # Broker (agent → host)
-adb forward tcp:<port> tcp:<port>            # Agent (CLI → emulator, get port from `maui-devflow list`)
+adb forward tcp:<port> tcp:<port>            # Agent (CLI → emulator, get port from `maui devflow list`)
 adb reverse --list                            # verify forwarding
 adb forward --list                            # verify forwarding
 adb reverse --remove-all                      # clean up reverse
@@ -206,7 +206,7 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator
 ## Troubleshooting
 
 - **`adb devices` shows "unauthorized"**: Accept the USB debugging prompt on the device/emulator.
-- **Agent not connecting on emulator**: Forgot `adb reverse tcp:19223 tcp:19223` for the broker. Run port forwarding, then check `maui-devflow list`.
+- **Agent not connecting on emulator**: Forgot `adb reverse tcp:19223 tcp:19223` for the broker. Run port forwarding, then check `maui devflow list`.
 - **Emulator won't start**: Check available system images with `android avd targets`. May need
   to install with `android sdk install --package "system-images;..."`.
 - **Build error "No Android devices found"**: Ensure emulator is booted (`adb devices`).

--- a/.claude/skills/maui-ai-debugging/references/batch.md
+++ b/.claude/skills/maui-ai-debugging/references/batch.md
@@ -7,16 +7,16 @@ responses (one JSON object per line) to stdout — ideal for AI agents and scrip
 
 ```bash
 # Pipe multiple commands (semicolons or newlines as separators)
-echo "MAUI fill textUsername user; MAUI fill textPassword pwd123; MAUI tap buttonLogin" | maui-devflow batch
+echo "MAUI fill textUsername user; MAUI fill textPassword pwd123; MAUI tap buttonLogin" | maui devflow batch
 
 # Multi-line input
-printf "MAUI status\nMAUI tree\nMAUI screenshot --output screen.png" | maui-devflow batch
+printf "MAUI status\nMAUI tree\nMAUI screenshot --output screen.png" | maui devflow batch
 
 # With options
-echo "MAUI status; MAUI tree" | maui-devflow batch --delay 500 --continue-on-error --agent-port 10224
+echo "MAUI status; MAUI tree" | maui devflow batch --delay 500 --continue-on-error --agent-port 10224
 
 # Human-readable output instead of JSONL
-echo "MAUI status; MAUI tree" | maui-devflow batch --human
+echo "MAUI status; MAUI tree" | maui devflow batch --human
 ```
 
 ## Options

--- a/.claude/skills/maui-ai-debugging/references/ios-and-mac.md
+++ b/.claude/skills/maui-ai-debugging/references/ios-and-mac.md
@@ -17,7 +17,7 @@ will replace each other — only the last-deployed app survives.
 
 **Before creating or booting a simulator, check what's already in use:**
 ```bash
-maui-devflow list                             # shows agents with platform + port
+maui devflow list                             # shows agents with platform + port
 xcrun simctl list devices booted              # shows all booted simulators
 ```
 
@@ -71,12 +71,12 @@ apple simulator screenshot <UDID> --output output.png
 
 ### Screenshots (Mac Catalyst)
 
-**Use `maui-devflow MAUI screenshot`** for Mac Catalyst apps — it captures the UI in-process
+**Use `maui devflow ui screenshot`** for Mac Catalyst apps — it captures the UI in-process
 and does NOT require the app to be in the foreground. Never use `osascript` to bring the window
 to the front or `screencapture` for Mac Catalyst screenshots; they are unnecessary and unreliable.
 
 ```bash
-maui-devflow MAUI screenshot --output screen.png
+maui devflow ui screenshot --output screen.png
 ```
 
 ### Delete / erase
@@ -142,7 +142,7 @@ dotnet build -f net10.0-ios -t:Run -p:_DeviceName=:v2:udid=$UDID
 ```
 
 The `-t:Run` target keeps the process alive while the app runs — it **blocks until the app exits**.
-Always run in an async/background shell, then poll `maui-devflow MAUI status` to detect when the
+Always run in an async/background shell, then poll `maui devflow ui status` to detect when the
 app is ready. Do NOT wait for the process to finish.
 
 ### Determining the correct TFM
@@ -214,7 +214,7 @@ Key subcommands beyond the basics:
 - **Build error NETSDK1005 "Assets file doesn't have a target"**: Wrong TFM. Check
   `<TargetFrameworks>` in .csproj and use matching version (e.g. `net10.0-ios` not `net9.0-ios`).
 - **Agent not connecting after deploy**: The app may still be launching. Poll
-  `maui-devflow MAUI status` every few seconds. If it hasn't connected after ~60-90s, read the
+  `maui devflow ui status` every few seconds. If it hasn't connected after ~60-90s, read the
   async shell output from `dotnet build -t:Run` for build/launch errors.
 - **Mac Catalyst app name vs binary name**: The `.app` bundle name may differ from the project
   name (e.g. `MauiTodo.app` vs `SampleMauiApp`). Check the `ApplicationTitle` in .csproj.
@@ -316,8 +316,8 @@ xcrun simctl ui <UDID> appearance light
 ```
 
 ### Verify dark mode via inspection
-Use `maui-devflow` to verify colors without relying on screenshots:
+Use `maui devflow` to verify colors without relying on screenshots:
 ```bash
-maui-devflow MAUI property <elementId> BackgroundColor   # check MAUI element colors
-maui-devflow cdp Runtime evaluate "window.matchMedia('(prefers-color-scheme: dark)').matches"  # Blazor
+maui devflow ui property <elementId> BackgroundColor   # check MAUI element colors
+maui devflow webview Runtime evaluate "window.matchMedia('(prefers-color-scheme: dark)').matches"  # Blazor
 ```

--- a/.claude/skills/maui-ai-debugging/references/macos.md
+++ b/.claude/skills/maui-ai-debugging/references/macos.md
@@ -201,5 +201,5 @@ MacOSShell.SetUseNativeSidebar(this, true);
 
 ### Agent Not Connecting
 1. Ensure the app launched successfully (window appeared)
-2. Check `maui-devflow list` — agent should register within a few seconds
+2. Check `maui devflow list` — agent should register within a few seconds
 3. If using an older build, clean and rebuild to pick up latest agent code

--- a/.claude/skills/maui-ai-debugging/references/setup.md
+++ b/.claude/skills/maui-ai-debugging/references/setup.md
@@ -16,12 +16,12 @@ Complete guide for integrating MauiDevFlow into a .NET MAUI app.
 ## 1. Install CLI Tools
 
 ```bash
-dotnet tool install --global Microsoft.Maui.DevFlow.CLI    # maui-devflow
+dotnet tool install --global Microsoft.Maui.Cli --prerelease
 dotnet tool install --global androidsdk.tool               # android (Android only)
 dotnet tool install --global appledev.tools                # apple (iOS/Mac only)
 ```
 
-Verify: `maui-devflow --version`
+Verify: `maui devflow version`
 
 ## 2. Add NuGet Packages
 
@@ -138,7 +138,7 @@ file in the project directory to set an explicit port:
 
 Both the MSBuild targets and the CLI read this file automatically:
 - **Build**: `dotnet build -t:Run` — agent starts on the configured port
-- **CLI**: `maui-devflow MAUI status` — connects to the configured port (when run from project dir)
+- **CLI**: `maui devflow ui status` — connects to the configured port (when run from project dir)
 
 **Port priority:** Explicit `--agent-port` > Broker discovery > `.mauidevflow` > default 9223.
 
@@ -150,9 +150,9 @@ Both the MSBuild targets and the CLI read this file automatically:
 5. Falls back to `.mauidevflow` config file → default 9223
 
 **Multiple apps simultaneously:** The broker assigns unique ports from range 10223–10899.
-Use `maui-devflow list` to see all agents, then target a specific one:
+Use `maui devflow list` to see all agents, then target a specific one:
 ```bash
-maui-devflow MAUI status --agent-port 10224    # target specific agent
+maui devflow ui status --agent-port 10224    # target specific agent
 ```
 
 **Blazor options:**
@@ -253,13 +253,13 @@ After deploying to an Android emulator, set up port forwarding for the broker an
 
 ```bash
 adb reverse tcp:19223 tcp:19223  # Broker (lets agent register with host broker)
-adb forward tcp:<port> tcp:<port> # Agent (lets CLI reach agent — get port from `maui-devflow list`)
+adb forward tcp:<port> tcp:<port> # Agent (lets CLI reach agent — get port from `maui devflow list`)
 ```
 
 The broker reverse (`tcp:19223`) is needed so the agent inside the emulator can connect to
 the host's broker daemon. Set this up once per emulator session.
 
-The agent forward uses the port shown in `maui-devflow list` after the agent registers
+The agent forward uses the port shown in `maui devflow list` after the agent registers
 (range 10223–10899).
 
 **Fallback (no broker):** If using direct mode with a `.mauidevflow` config file:
@@ -272,14 +272,14 @@ adb reverse tcp:9223 tcp:9223    # Direct agent port (single port for Agent + CD
 After building and running the app:
 
 ```bash
-maui-devflow list                 # Should show registered agents (via broker)
-maui-devflow MAUI status          # Should show agent info, platform, app name
-maui-devflow cdp status           # Should show "Connected" (Blazor Hybrid only)
+maui devflow list                 # Should show registered agents (via broker)
+maui devflow ui status            # Should show agent info, platform, app name
+maui devflow webview status       # Should show "Connected" (Blazor Hybrid only)
 ```
 
 If status commands fail:
-- **Broker not running?** `maui-devflow broker status` — CLI auto-starts the broker, but check if it's healthy
-- **Agent not registered?** `maui-devflow list` — wait a few seconds for the agent to register
+- **Broker not running?** `maui devflow broker status` — CLI auto-starts the broker, but check if it's healthy
+- **Agent not registered?** `maui devflow list` — wait a few seconds for the agent to register
 - **Mac Catalyst:** Check entitlements (Step 5)
 - **macOS (AppKit):** Ensure `AddMacOSEssentials()` is called — see [references/macos.md](macos.md)
 - **Android:** Check port forwarding (Step 6) — need both `adb reverse tcp:19223` and `adb forward tcp:<port>`
@@ -287,7 +287,7 @@ If status commands fail:
 - **Linux/GTK:** Should work without extra config — runs directly on localhost
 - **All platforms:** Ensure the app is running and the `#if DEBUG` block is active
 - **Port conflict:** Check if another process holds the port: `lsof -i :9223` (or your configured port)
-- **Wrong port:** Use `maui-devflow list` to find the assigned port, or ensure CLI is run from the project directory
+- **Wrong port:** Use `maui devflow list` to find the assigned port, or ensure CLI is run from the project directory
 
 ## Quick Checklist
 
@@ -302,7 +302,7 @@ For an AI agent setting up MauiDevFlow in a new project:
 7. [ ] `adb reverse tcp:19223` for broker + `adb forward tcp:<port>` for agent (Android only)
 8. [ ] Linux/GTK: `app.StartDevFlowAgent()` called after app activation
 9. [ ] macOS (AppKit): `UseMauiAppMacOS()`, `AddMacOSEssentials()`, `MacOSBlazorWebView` — see [macos.md](macos.md)
-10. [ ] Verify with `maui-devflow list` and `maui-devflow MAUI status`
+10. [ ] Verify with `maui devflow list` and `maui devflow ui status`
 
 ## Checking for Updates
 
@@ -311,7 +311,7 @@ packages are up to date. Outdated components can cause confusing failures or mis
 
 ### Check CLI version
 ```bash
-maui-devflow --version
+maui devflow version
 dotnet tool search Microsoft.Maui.DevFlow.CLI | head -5
 ```
 
@@ -323,17 +323,17 @@ dotnet tool update --global Microsoft.Maui.DevFlow.CLI
 ### Update the skill
 ```bash
 # Check if the skill is up to date (compares local commit SHA against remote)
-maui-devflow skill-version
+maui devflow skill-version
 
 # Download the latest skill files from GitHub
-maui-devflow update-skill
+maui devflow update-skill
 ```
 
 The `update-skill` command writes a `.skill-version` file tracking the installed commit SHA.
 The `skill-version` command reads this file and compares against the latest remote commit.
 
 **AI agents should check at session start:** If `.claude/skills/maui-ai-debugging/.skill-version`
-exists, run `maui-devflow skill-version` to see if an update is available. If the remote SHA
+exists, run `maui devflow skill-version` to see if an update is available. If the remote SHA
 differs from the installed SHA, ask the user if they'd like to update before proceeding.
 
 ### Check NuGet packages in the project

--- a/.claude/skills/maui-ai-debugging/references/troubleshooting.md
+++ b/.claude/skills/maui-ai-debugging/references/troubleshooting.md
@@ -8,10 +8,10 @@
 
 ## Connection Refused / Cannot Connect
 
-If `maui-devflow MAUI status` fails with connection refused:
+If `maui devflow ui status` fails with connection refused:
 
 1. **App not running?** Verify the app launched: check the build output for errors.
-2. **Check the broker:** Run `maui-devflow list` to see if the agent registered. If the list
+2. **Check the broker:** Run `maui devflow list` to see if the agent registered. If the list
    is empty, the app may not have connected to the broker yet (wait a few seconds and retry).
 3. **Wrong port?** If using `.mauidevflow`, ensure the port matches between build and CLI.
    Run CLI from the project directory so it auto-detects the config file.
@@ -26,7 +26,7 @@ If `maui-devflow MAUI status` fails with connection refused:
 7. **macOS (AppKit)?** Ensure `AddMacOSEssentials()` is called and the app window appeared.
    See [references/macos.md](macos.md) for troubleshooting.
 8. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
-9. **Broker issues?** `maui-devflow broker status` to check. `maui-devflow broker stop` then
+9. **Broker issues?** `maui devflow broker status` to check. `maui devflow broker stop` then
    retry (CLI will auto-restart it).
 
 ## Build Failures
@@ -60,11 +60,11 @@ profiles via `apple appstoreconnect profiles list`.
 
 ## CDP Not Connecting (Blazor Hybrid)
 
-If `maui-devflow cdp status` fails but `MAUI status` works:
+If `maui devflow webview status` fails but `ui status` works:
 
 1. **Chobitsu not loading?** Check logs for `[BlazorDevFlow]` messages. If auto-injection failed, add `<script src="chobitsu.js"></script>` manually to `wwwroot/index.html`
 2. **Blazor not initialized?** Navigate to a Blazor page first, then retry
-3. Check app logs: `maui-devflow MAUI logs --limit 20` — look for `[BlazorDevFlow]` errors
+3. Check app logs: `maui devflow logs --limit 20` — look for `[BlazorDevFlow]` errors
 
 ## Mac Catalyst: Repeated Permission Dialogs on Rebuild
 

--- a/.github/instructions/devflow-architecture.instructions.md
+++ b/.github/instructions/devflow-architecture.instructions.md
@@ -11,7 +11,7 @@ DevFlow uses a three-tier architecture:
 ```
 ┌──────────────┐                ┌──────────────┐                ┌──────────────────────────┐
 │  CLI / MCP   │  HTTP (direct) │    Broker     │  WebSocket     │  Agent (in-app)          │
-│  (maui-devflow)│ ◄──────────► │  (port 19223) │ ◄───────────── │  (dynamic port)          │
+│  (maui devflow)│ ◄──────────► │  (port 19223) │ ◄───────────── │  (dynamic port)          │
 └──────────────┘  (after port   └──────────────┘  (registration) └──────────────────────────┘
       │            discovery)          │                                │
       │ HTTP (direct, after discovery) │                                │ Platform APIs
@@ -29,7 +29,7 @@ DevFlow uses a three-tier architecture:
 
 1. **Agent** runs inside the MAUI app process (added via NuGet package). Exposes HTTP API on a dynamic port. Registers with the Broker over WebSocket. Has direct access to the visual tree, pages, platform views.
 2. **Broker** runs on the developer machine (port 19223). Agents register with it via WebSocket. CLI discovers agent ports through the broker's HTTP API.
-3. **CLI** (`maui-devflow`) discovers agents via the broker, then communicates **directly** with agents over HTTP. Also hosts the MCP server for AI agent integration.
+3. **CLI** (`maui devflow`) discovers agents via the broker, then communicates **directly** with agents over HTTP. Also hosts the MCP server for AI agent integration.
 
 ## Package Dependency Graph
 

--- a/.github/workflows/devflow-integration.yml
+++ b/.github/workflows/devflow-integration.yml
@@ -1,0 +1,96 @@
+name: DevFlow Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Target platform for the real app integration suite
+        required: true
+        default: maccatalyst
+        type: choice
+        options:
+          - maccatalyst
+          - ios
+          - android
+          - windows
+      ios-version:
+        description: Optional iOS version filter used by the simulator fixture (for example 18.x)
+        required: false
+        default: ""
+        type: string
+      android-api:
+        description: Android API level used by the emulator fixture
+        required: false
+        default: "35"
+        type: string
+
+jobs:
+  integration-apple-android:
+    if: ${{ inputs.platform != 'windows' }}
+    runs-on: [self-hosted, macOS]
+    timeout-minutes: 60
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DEVFLOW_TEST_PLATFORM: ${{ inputs.platform }}
+      DEVFLOW_TEST_IOS_VERSION: ${{ inputs.ios-version }}
+      DEVFLOW_TEST_ANDROID_API: ${{ inputs.android-api }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install MAUI workloads
+        run: dotnet workload install maui ios android maccatalyst
+
+      - name: Run DevFlow integration tests
+        run: >
+          dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Microsoft.Maui.DevFlow.Agent.IntegrationTests.csproj
+          --logger "trx;LogFileName=devflow-integration-${{ inputs.platform }}.trx"
+          --logger "console;verbosity=normal"
+          --results-directory ./artifacts/TestResults/devflow-integration/${{ inputs.platform }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: devflow-integration-${{ inputs.platform }}-results
+          path: ./artifacts/TestResults/devflow-integration/${{ inputs.platform }}/
+          retention-days: 30
+
+  integration-windows:
+    if: ${{ inputs.platform == 'windows' }}
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DEVFLOW_TEST_PLATFORM: windows
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install MAUI workloads
+        run: dotnet workload install maui
+
+      - name: Run DevFlow integration tests
+        run: >
+          dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Microsoft.Maui.DevFlow.Agent.IntegrationTests.csproj
+          --logger "trx;LogFileName=devflow-integration-windows.trx"
+          --logger "console;verbosity=normal"
+          --results-directory .\artifacts\TestResults\devflow-integration\windows
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: devflow-integration-windows-results
+          path: .\artifacts\TestResults\devflow-integration\windows\
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This repository hosts experimental .NET MAUI packages. It is a **multi-product m
 
 | Product | Package / Tool | Description |
 |---------|---------------|-------------|
-| **DevFlow** | `Microsoft.Maui.DevFlow.*` (8 packages), `maui-devflow` CLI | Runtime MAUI automation toolkit. In-app agent with HTTP API, visual tree inspection, CDP bridge for Blazor WebViews, MCP server for AI agents, cross-platform driver library. |
+| **DevFlow** | `Microsoft.Maui.DevFlow.*` packages plus the unified `maui devflow` CLI surface | Runtime MAUI automation toolkit. In-app agent with HTTP API, visual tree inspection, CDP bridge for Blazor WebViews, MCP server for AI agents, cross-platform driver library. |
 
 ### Technology Stack
 
@@ -85,7 +85,7 @@ maui-labs/
 │       ├── Microsoft.Maui.DevFlow.Agent.Gtk/     # GTK/Linux agent
 │       ├── Microsoft.Maui.DevFlow.Blazor/        # Blazor WebView CDP bridge
 │       ├── Microsoft.Maui.DevFlow.Blazor.Gtk/    # WebKitGTK CDP bridge
-│       ├── Microsoft.Maui.DevFlow.CLI/           # CLI global tool (maui-devflow)
+│       ├── Microsoft.Maui.DevFlow.CLI/           # DevFlow command implementation behind `maui devflow`
 │       │   ├── Broker/                           # Connection management
 │       │   └── Mcp/Tools/                        # MCP tool implementations
 │       ├── Microsoft.Maui.DevFlow.Driver/        # Cross-platform driver (AgentClient)
@@ -123,7 +123,7 @@ maui-labs/
 ## Packaging and Signing
 
 - Packages are built by the Arcade SDK's `Pack` target
-- **PackAsTool**: Both CLIs (`maui-devflow`, `maui`) set `PackAsTool=true`
+- **PackAsTool**: The user-facing global tool is `maui`; DevFlow functionality is exposed via `maui devflow`
 - **IsShipping/IsPackable**: Default `false` in `Directory.Build.props`; shipped projects override to `true`
 - **Signing**: `eng/Signing.props` configures Microsoft .NET certificate for first-party DLLs, `3PartySHA2` for third-party dependencies, `NuGet` certificate for `.nupkg` files
 - **Version flow**: `eng/Versions.props` defines `VersionPrefix`/`VersionSuffix`, Arcade SDK applies them

--- a/MauiLabs.slnx
+++ b/MauiLabs.slnx
@@ -21,6 +21,7 @@
     <Project Path="src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/Microsoft.Maui.DevFlow.Agent.Core.csproj" />
     <Project Path="src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/Microsoft.Maui.DevFlow.Agent.Gtk.csproj" />
     <Project Path="src/DevFlow/Microsoft.Maui.DevFlow.Agent/Microsoft.Maui.DevFlow.Agent.csproj" />
+    <Project Path="src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Microsoft.Maui.DevFlow.Agent.IntegrationTests.csproj" />
     <Project Path="src/DevFlow/Microsoft.Maui.DevFlow.Blazor.Gtk/Microsoft.Maui.DevFlow.Blazor.Gtk.csproj" />
     <Project Path="src/DevFlow/Microsoft.Maui.DevFlow.Blazor/Microsoft.Maui.DevFlow.Blazor.csproj" />
     <Project Path="src/DevFlow/Microsoft.Maui.DevFlow.Driver/Microsoft.Maui.DevFlow.Driver.csproj" />

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A comprehensive MAUI testing, automation, and debugging toolkit. The DevFlow CLI
 
 - **In-app HTTP agent** for visual tree inspection, element interaction, and screenshots
 - **Blazor CDP bridge** for Chrome DevTools Protocol on Blazor WebViews
-- **MCP server** for AI agent integration (via `maui devflow mcp`)
+- **MCP server** for AI agent integration (via `maui devflow mcp-serve`)
 - **Platform drivers** for iOS, Android, Mac Catalyst, Windows, and Linux/GTK
 - **Network monitoring** and **performance profiling**
 
@@ -51,6 +51,8 @@ A comprehensive MAUI testing, automation, and debugging toolkit. The DevFlow CLI
 ## Getting Started
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development setup.
+
+For the formal DevFlow HTTP and WebSocket contract, see [`docs/DevFlow/spec`](docs/DevFlow/spec/README.md).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A comprehensive MAUI testing, automation, and debugging toolkit. The DevFlow CLI
 
 - **In-app HTTP agent** for visual tree inspection, element interaction, and screenshots
 - **Blazor CDP bridge** for Chrome DevTools Protocol on Blazor WebViews
-- **MCP server** for AI agent integration (via `maui devflow mcp-serve`)
+- **MCP server** for AI agent integration (via `maui devflow mcp`)
 - **Platform drivers** for iOS, Android, Mac Catalyst, Windows, and Linux/GTK
 - **Network monitoring** and **performance profiling**
 

--- a/docs/DevFlow/broker.md
+++ b/docs/DevFlow/broker.md
@@ -85,7 +85,7 @@ When a MAUI app starts with `AddMicrosoft.Maui.DevFlowAgent()`:
 
 ### CLI Discovery
 
-When you run a CLI command like `maui-devflow MAUI status`:
+When you run a CLI command like `maui devflow ui status`:
 
 1. The CLI calls `EnsureBrokerRunningAsync()` to make sure the broker is alive
    (starting it if necessary).
@@ -169,17 +169,17 @@ the last app exits in case you're about to rebuild and relaunch.
 For troubleshooting, you can manage the broker directly:
 
 ```bash
-maui-devflow broker start              # Start detached (same as auto-start)
-maui-devflow broker start --foreground # Start in current terminal (debug mode)
-maui-devflow broker stop               # Graceful shutdown
-maui-devflow broker status             # Show PID, port, uptime, connected agents
-maui-devflow broker log                # Show last 50 lines of broker.log
+maui devflow broker start              # Start detached (same as auto-start)
+maui devflow broker start --foreground # Start in current terminal (debug mode)
+maui devflow broker stop               # Graceful shutdown
+maui devflow broker status             # Show PID, port, uptime, connected agents
+maui devflow broker log                # Show last 50 lines of broker.log
 ```
 
 ### Listing Connected Agents
 
 ```bash
-maui-devflow list
+maui devflow list
 ```
 
 Shows all agents currently registered with the broker:
@@ -205,7 +205,7 @@ ID             App                  Platform       TFM                      Port
 7ff0e6fd13d9   MauiTodo             MacCatalyst    net10.0-maccatalyst      10223
 a3c9e1f20b44   MauiTodo             Android        net10.0-android          10224
 
-Example: maui-devflow MAUI status --agent-port <port>
+Example: maui devflow ui status --agent-port <port>
 ```
 
 This output is **non-interactive** by design. AI agents can parse it and re-run
@@ -322,13 +322,13 @@ The broker exposes a simple HTTP API on port 19223 for CLI and diagnostic use:
 
 - **Port 19223 in use?** Check with `lsof -i :19223` (macOS/Linux) or
   `netstat -ano | findstr 19223` (Windows). Kill the conflicting process or
-  stop the existing broker with `maui-devflow broker stop`.
+  stop the existing broker with `maui devflow broker stop`.
 - **Stale state file?** Delete `~/.mauidevflow/broker.json` and try again.
 - **Permissions?** The broker binds to `localhost` only — no admin/root required.
 
-### Agent not appearing in `maui-devflow list`
+### Agent not appearing in `maui devflow list`
 
-- **Broker running?** Run `maui-devflow broker status` to check.
+- **Broker running?** Run `maui devflow broker status` to check.
 - **App actually started?** The agent registers during app startup. Verify the
   app launched successfully.
 - **Firewall?** On Android, ensure `adb reverse tcp:19223 tcp:19223` is set up.
@@ -338,7 +338,7 @@ The broker exposes a simple HTTP API on port 19223 for CLI and diagnostic use:
 ### CLI can't connect to agent
 
 - **Port mismatch?** The broker may have assigned a different port than expected.
-  Run `maui-devflow list` to see actual port assignments.
+  Run `maui devflow list` to see actual port assignments.
 - **Agent crashed after registration?** The broker may show the agent briefly
   before detecting the disconnect. Wait a moment and check again.
 - **Android?** You need `adb reverse` for **both** port 19223 (broker) and the

--- a/docs/DevFlow/spec/README.md
+++ b/docs/DevFlow/spec/README.md
@@ -1,0 +1,10 @@
+# DevFlow protocol spec
+
+This directory contains the canonical DevFlow protocol contract used by the MAUI implementation in this repository.
+
+- `openapi.yaml` defines the versioned HTTP surface under `/api/v1/*`
+- `asyncapi.yaml` defines the streaming channels under `/ws/v1/*`
+- `schemas/` contains the shared payload models
+- `examples/` contains representative request and response payloads
+
+These spec files are intended to stay framework-agnostic so the same DevFlow contract can be implemented across MAUI and other UI stacks.

--- a/docs/DevFlow/spec/asyncapi.yaml
+++ b/docs/DevFlow/spec/asyncapi.yaml
@@ -1,0 +1,908 @@
+asyncapi: 3.0.0
+
+info:
+  title: DevFlow Agent Protocol — WebSocket Channels
+  version: 1.0.0
+  description: |
+    Real-time streaming channels for the DevFlow Agent Protocol.
+    These complement the HTTP API defined in openapi.yaml.
+
+    All messages (both directions) use a standard envelope:
+    ```json
+    {
+      "type": "string (event/command type)",
+      "timestamp": "ISO 8601 datetime",
+      "data": { ... }
+    }
+    ```
+
+servers:
+  agent:
+    host: localhost:{port}
+    protocol: ws
+    description: Agent WebSocket server
+    variables:
+      port:
+        description: Port number the agent is listening on.
+
+defaultContentType: application/json
+
+# ---------------------------------------------------------------------------
+# Channels
+# ---------------------------------------------------------------------------
+channels:
+
+  # ── Network Request Stream ───────────────────────────────────────────────
+  network:
+    address: /ws/v1/network
+    description: |
+      Real-time stream of captured HTTP requests. On connect the server replays
+      recent requests, then streams new requests as they are captured. Clients
+      may request full details for a specific request or clear the buffer.
+    servers:
+      - $ref: '#/servers/agent'
+    messages:
+      # ── server → client ──
+      networkReplay:
+        name: networkReplay
+        title: Network Replay
+        summary: Initial replay of recent requests on connect.
+        contentType: application/json
+        payload:
+          type: object
+          description: Replay of recent network request entries.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: replay
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [entries]
+              properties:
+                entries:
+                  type: array
+                  items:
+                    $ref: './schemas/network.json#/$defs/NetworkRequestSummary'
+                  description: Array of recent network request summaries.
+
+      networkRequest:
+        name: networkRequest
+        title: Network Request Captured
+        summary: New HTTP request captured.
+        contentType: application/json
+        payload:
+          type: object
+          description: Live network request event.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: request
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [entry]
+              properties:
+                entry:
+                  $ref: './schemas/network.json#/$defs/NetworkRequestSummary'
+                  description: The captured network request summary.
+
+      networkDetails:
+        name: networkDetails
+        title: Request Details Response
+        summary: Full details for a previously captured network request.
+        contentType: application/json
+        payload:
+          type: object
+          description: Response containing full request/response details.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: details
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [entry]
+              properties:
+                entry:
+                  $ref: './schemas/network.json#/$defs/NetworkRequestDetail'
+                  description: Full details of the network request.
+
+      networkCleared:
+        name: networkCleared
+        title: Buffer Cleared
+        summary: Server confirms the request buffer has been cleared.
+        contentType: application/json
+        payload:
+          type: object
+          description: Confirmation that the request buffer was cleared.
+          required: [type, timestamp]
+          properties:
+            type:
+              type: string
+              const: cleared
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+
+      # ── client → server ──
+      networkGetDetails:
+        name: networkGetDetails
+        title: Get Request Details
+        summary: Request full details for a specific captured network request.
+        contentType: application/json
+        payload:
+          type: object
+          description: Command to retrieve full details for a network request.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: get_details
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+                  description: Unique identifier of the network request to retrieve.
+
+      networkClear:
+        name: networkClear
+        title: Clear Request Buffer
+        summary: Clear the server's captured request buffer.
+        contentType: application/json
+        payload:
+          type: object
+          description: Command to clear the request buffer.
+          required: [type, timestamp]
+          properties:
+            type:
+              type: string
+              const: clear
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+
+  # ── Log Stream ───────────────────────────────────────────────────────────
+  logs:
+    address: /ws/v1/logs
+    description: |
+      Real-time application log streaming. Supports filtering by source and
+      minimum severity level via query-string parameters. Replays recent
+      entries on connect.
+    servers:
+      - $ref: '#/servers/agent'
+    bindings:
+      ws:
+        query:
+          type: object
+          description: Connection query-string parameters for log filtering.
+          properties:
+            source:
+              type: string
+              enum: [native, webview, framework, all]
+              default: all
+              description: Filter logs by source.
+            level:
+              type: string
+              enum: [trace, debug, info, warning, error, critical]
+              default: info
+              description: Minimum log severity level to stream.
+            replay:
+              type: integer
+              default: 100
+              minimum: 0
+              description: Number of recent entries to replay on connect.
+    messages:
+      logReplay:
+        name: logReplay
+        title: Log Replay
+        summary: Initial replay of recent log entries on connect.
+        contentType: application/json
+        payload:
+          type: object
+          description: Replay of recent log entries.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: replay
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [entries]
+              properties:
+                entries:
+                  type: array
+                  items:
+                    $ref: './schemas/logs.json#/$defs/LogEntry'
+                  description: Array of recent log entries.
+
+      logEntry:
+        name: logEntry
+        title: Log Entry
+        summary: New log entry from the application.
+        contentType: application/json
+        payload:
+          type: object
+          description: Live log entry event.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: log
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [entry]
+              properties:
+                entry:
+                  $ref: './schemas/logs.json#/$defs/LogEntry'
+                  description: The log entry.
+
+  # ── Sensor Readings Stream ──────────────────────────────────────────────
+  sensors:
+    address: /ws/v1/device/sensors
+    description: |
+      Live sensor data streaming. Connect with query parameters to specify the
+      sensor, reading speed, and throttle interval. Supports subscribing to
+      different sensors or changing settings over the same connection.
+    servers:
+      - $ref: '#/servers/agent'
+    bindings:
+      ws:
+        query:
+          type: object
+          description: Connection query-string parameters.
+          required: [sensor]
+          properties:
+            sensor:
+              type: string
+              enum: [accelerometer, barometer, compass, gyroscope, magnetometer, orientation]
+              description: Sensor to subscribe to (required).
+            speed:
+              type: string
+              enum: [UI, Game, Fastest, Default]
+              default: UI
+              description: Reading speed preset.
+            throttleMs:
+              type: integer
+              default: 100
+              minimum: 0
+              description: Minimum milliseconds between readings.
+    messages:
+      # ── server → client ──
+      sensorSubscribed:
+        name: sensorSubscribed
+        title: Sensor Subscribed
+        summary: Confirmation that the sensor subscription is active.
+        contentType: application/json
+        payload:
+          type: object
+          description: Sensor subscription confirmation.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: subscribed
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [sensor, speed, throttleMs]
+              properties:
+                sensor:
+                  type: string
+                  description: Name of the subscribed sensor.
+                speed:
+                  type: string
+                  description: Active reading speed.
+                throttleMs:
+                  type: number
+                  description: Active throttle interval in milliseconds.
+
+      sensorReading:
+        name: sensorReading
+        title: Sensor Reading
+        summary: New sensor reading.
+        contentType: application/json
+        payload:
+          type: object
+          description: Live sensor reading event.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: reading
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              $ref: './schemas/device.json#/$defs/SensorReading'
+              description: Sensor reading data (shape varies by sensor type).
+
+      sensorError:
+        name: sensorError
+        title: Sensor Error
+        summary: Error occurred while reading sensor data.
+        contentType: application/json
+        payload:
+          type: object
+          description: Sensor error notification.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: error
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [sensor, message]
+              properties:
+                sensor:
+                  type: string
+                  description: Name of the sensor that encountered an error.
+                message:
+                  type: string
+                  description: Human-readable error message.
+
+      sensorStopped:
+        name: sensorStopped
+        title: Sensor Stopped
+        summary: Sensor data streaming has stopped.
+        contentType: application/json
+        payload:
+          type: object
+          description: Sensor stopped notification.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: stopped
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [sensor]
+              properties:
+                sensor:
+                  type: string
+                  description: Name of the sensor that was stopped.
+
+      # ── client → server ──
+      sensorSubscribe:
+        name: sensorSubscribe
+        title: Subscribe to Sensor
+        summary: Subscribe to a different sensor or change settings.
+        contentType: application/json
+        payload:
+          type: object
+          description: Command to subscribe to a sensor or update settings.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: subscribe
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [sensor]
+              properties:
+                sensor:
+                  type: string
+                  description: Name of the sensor to subscribe to.
+                speed:
+                  type: string
+                  enum: [UI, Game, Fastest, Default]
+                  description: Reading speed preset.
+                throttleMs:
+                  type: integer
+                  minimum: 0
+                  description: Minimum milliseconds between readings.
+
+      sensorUnsubscribe:
+        name: sensorUnsubscribe
+        title: Unsubscribe from Sensor
+        summary: Stop receiving readings for a sensor.
+        contentType: application/json
+        payload:
+          type: object
+          description: Command to unsubscribe from a sensor.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: unsubscribe
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [sensor]
+              properties:
+                sensor:
+                  type: string
+                  description: Name of the sensor to unsubscribe from.
+
+  # ── Profiler Data Stream ────────────────────────────────────────────────
+  profiler:
+    address: /ws/v1/profiler
+    description: |
+      Real-time profiler data stream. Streams periodic batches of samples,
+      markers, and spans from an active profiling session. Use cursor
+      parameters to resume from a specific position.
+    servers:
+      - $ref: '#/servers/agent'
+    bindings:
+      ws:
+        query:
+          type: object
+          description: Connection query-string parameters.
+          required: [sessionId]
+          properties:
+            sessionId:
+              type: string
+              description: Profiler session ID (required).
+            sampleCursor:
+              type: integer
+              default: 0
+              minimum: 0
+              description: Starting sample cursor position.
+            markerCursor:
+              type: integer
+              default: 0
+              minimum: 0
+              description: Starting marker cursor position.
+            spanCursor:
+              type: integer
+              default: 0
+              minimum: 0
+              description: Starting span cursor position.
+    messages:
+      profilerBatch:
+        name: profilerBatch
+        title: Profiler Batch
+        summary: Periodic batch of profiler samples, markers, and spans.
+        contentType: application/json
+        payload:
+          type: object
+          description: Batch of profiler data with updated cursors.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: batch
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              $ref: './schemas/profiler.json#/$defs/ProfilerBatch'
+              description: >
+                Profiler batch containing samples, markers, spans, and
+                updated cursor positions for pagination.
+
+      profilerStopped:
+        name: profilerStopped
+        title: Profiler Stopped
+        summary: Profiling session has ended.
+        contentType: application/json
+        payload:
+          type: object
+          description: Notification that a profiling session ended.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: stopped
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [sessionId]
+              properties:
+                sessionId:
+                  type: string
+                  description: Identifier of the stopped profiler session.
+
+  # ── UI Lifecycle Events Stream ──────────────────────────────────────────
+  uiEvents:
+    address: /ws/v1/ui/events
+    description: |
+      Real-time UI state change notifications including navigation, lifecycle
+      changes, visual tree mutations, system alerts, and unhandled exceptions.
+      Clients subscribe to the event types they are interested in.
+    servers:
+      - $ref: '#/servers/agent'
+    messages:
+      # ── server → client ──
+      uiNavigation:
+        name: uiNavigation
+        title: Navigation Event
+        summary: Page or screen navigation occurred.
+        contentType: application/json
+        payload:
+          type: object
+          description: Navigation event indicating a page or route change.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: navigation
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [to, timestamp]
+              properties:
+                from:
+                  type:
+                    - string
+                    - 'null'
+                  description: Route or page navigated away from.
+                to:
+                  type: string
+                  description: Route or page navigated to.
+                route:
+                  type:
+                    - string
+                    - 'null'
+                  description: Route pattern, if applicable.
+                timestamp:
+                  $ref: './schemas/common.json#/$defs/Timestamp'
+                  description: Timestamp when the navigation occurred.
+
+      uiLifecycle:
+        name: uiLifecycle
+        title: Lifecycle Event
+        summary: Application lifecycle state change.
+        contentType: application/json
+        payload:
+          type: object
+          description: Application lifecycle event.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: lifecycle
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [state, timestamp]
+              properties:
+                state:
+                  type: string
+                  enum: [started, resumed, paused, stopped, backgrounded, foregrounded]
+                  description: New lifecycle state.
+                timestamp:
+                  $ref: './schemas/common.json#/$defs/Timestamp'
+                  description: Timestamp when the lifecycle change occurred.
+
+      uiTreeChange:
+        name: uiTreeChange
+        title: Tree Change Event
+        summary: Visual tree structure changed (element added, removed, or modified).
+        contentType: application/json
+        payload:
+          type: object
+          description: Visual tree mutation event.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: treeChange
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [changeType, elementId, elementType, timestamp]
+              properties:
+                changeType:
+                  type: string
+                  enum: [added, removed, modified]
+                  description: Type of tree change.
+                elementId:
+                  type: string
+                  description: Identifier of the changed element.
+                elementType:
+                  type: string
+                  description: Type name of the changed element.
+                parentId:
+                  type:
+                    - string
+                    - 'null'
+                  description: Identifier of the parent element, or null for root elements.
+                timestamp:
+                  $ref: './schemas/common.json#/$defs/Timestamp'
+                  description: Timestamp when the tree change occurred.
+
+      uiAlert:
+        name: uiAlert
+        title: Alert Event
+        summary: System alert or dialog appeared.
+        contentType: application/json
+        payload:
+          type: object
+          description: System alert / dialog event.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: alert
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [buttons, timestamp]
+              properties:
+                title:
+                  type:
+                    - string
+                    - 'null'
+                  description: Alert title.
+                message:
+                  type:
+                    - string
+                    - 'null'
+                  description: Alert message body.
+                buttons:
+                  type: array
+                  items:
+                    type: string
+                  description: Labels of the alert buttons.
+                timestamp:
+                  $ref: './schemas/common.json#/$defs/Timestamp'
+                  description: Timestamp when the alert appeared.
+
+      uiError:
+        name: uiError
+        title: Unhandled Error Event
+        summary: Unhandled exception occurred in the application.
+        contentType: application/json
+        payload:
+          type: object
+          description: Unhandled exception event.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: error
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [message, timestamp]
+              properties:
+                message:
+                  type: string
+                  description: Error message.
+                stackTrace:
+                  type:
+                    - string
+                    - 'null'
+                  description: Stack trace, if available.
+                timestamp:
+                  $ref: './schemas/common.json#/$defs/Timestamp'
+                  description: Timestamp when the error occurred.
+
+      # ── client → server ──
+      uiSubscribe:
+        name: uiSubscribe
+        title: Subscribe to Events
+        summary: Subscribe to specific UI event types.
+        contentType: application/json
+        payload:
+          type: object
+          description: Command to subscribe to UI event types.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: subscribe
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [events]
+              properties:
+                events:
+                  type: array
+                  items:
+                    type: string
+                    enum: [navigation, lifecycle, treeChange, alert, error, all]
+                  description: >
+                    Event types to subscribe to. Use "all" to receive every
+                    event type.
+
+      uiUnsubscribe:
+        name: uiUnsubscribe
+        title: Unsubscribe from Events
+        summary: Unsubscribe from specific UI event types.
+        contentType: application/json
+        payload:
+          type: object
+          description: Command to unsubscribe from UI event types.
+          required: [type, timestamp, data]
+          properties:
+            type:
+              type: string
+              const: unsubscribe
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            data:
+              type: object
+              required: [events]
+              properties:
+                events:
+                  type: array
+                  items:
+                    type: string
+                    enum: [navigation, lifecycle, treeChange, alert, error, all]
+                  description: Event types to unsubscribe from.
+
+# ---------------------------------------------------------------------------
+# Operations
+# ---------------------------------------------------------------------------
+operations:
+
+  # ── Network ──────────────────────────────────────────────────────────────
+  sendNetworkEvents:
+    action: send
+    channel:
+      $ref: '#/channels/network'
+    summary: Server streams network request events to the client.
+    description: |
+      Sends a replay of recent requests on connect, followed by individual
+      request events as new HTTP traffic is captured. Also sends detail
+      responses and buffer-cleared confirmations in reply to client commands.
+    messages:
+      - $ref: '#/channels/network/messages/networkReplay'
+      - $ref: '#/channels/network/messages/networkRequest'
+      - $ref: '#/channels/network/messages/networkDetails'
+      - $ref: '#/channels/network/messages/networkCleared'
+
+  receiveNetworkCommands:
+    action: receive
+    channel:
+      $ref: '#/channels/network'
+    summary: Client sends commands to the network channel.
+    description: |
+      Clients can request full details for a captured request or clear the
+      request buffer.
+    messages:
+      - $ref: '#/channels/network/messages/networkGetDetails'
+      - $ref: '#/channels/network/messages/networkClear'
+
+  # ── Logs ─────────────────────────────────────────────────────────────────
+  sendLogEvents:
+    action: send
+    channel:
+      $ref: '#/channels/logs'
+    summary: Server streams log entries to the client.
+    description: |
+      Sends a replay of recent log entries on connect (filtered by query-string
+      parameters), then streams new entries in real time.
+    messages:
+      - $ref: '#/channels/logs/messages/logReplay'
+      - $ref: '#/channels/logs/messages/logEntry'
+
+  # ── Sensors ──────────────────────────────────────────────────────────────
+  sendSensorEvents:
+    action: send
+    channel:
+      $ref: '#/channels/sensors'
+    summary: Server streams sensor data to the client.
+    description: |
+      Sends subscription confirmation, live sensor readings, error
+      notifications, and stop events for device sensors.
+    messages:
+      - $ref: '#/channels/sensors/messages/sensorSubscribed'
+      - $ref: '#/channels/sensors/messages/sensorReading'
+      - $ref: '#/channels/sensors/messages/sensorError'
+      - $ref: '#/channels/sensors/messages/sensorStopped'
+
+  receiveSensorCommands:
+    action: receive
+    channel:
+      $ref: '#/channels/sensors'
+    summary: Client sends sensor subscription commands.
+    description: |
+      Clients can subscribe to a different sensor or change settings,
+      or unsubscribe to stop receiving readings.
+    messages:
+      - $ref: '#/channels/sensors/messages/sensorSubscribe'
+      - $ref: '#/channels/sensors/messages/sensorUnsubscribe'
+
+  # ── Profiler ─────────────────────────────────────────────────────────────
+  sendProfilerEvents:
+    action: send
+    channel:
+      $ref: '#/channels/profiler'
+    summary: Server streams profiler data to the client.
+    description: |
+      Sends periodic batches of profiler samples, markers, and spans.
+      Sends a stopped event when the profiling session ends.
+    messages:
+      - $ref: '#/channels/profiler/messages/profilerBatch'
+      - $ref: '#/channels/profiler/messages/profilerStopped'
+
+  # ── UI Events ────────────────────────────────────────────────────────────
+  sendUIEvents:
+    action: send
+    channel:
+      $ref: '#/channels/uiEvents'
+    summary: Server streams UI lifecycle events to the client.
+    description: |
+      Sends real-time notifications for navigation, lifecycle changes,
+      visual tree mutations, system alerts, and unhandled exceptions.
+    messages:
+      - $ref: '#/channels/uiEvents/messages/uiNavigation'
+      - $ref: '#/channels/uiEvents/messages/uiLifecycle'
+      - $ref: '#/channels/uiEvents/messages/uiTreeChange'
+      - $ref: '#/channels/uiEvents/messages/uiAlert'
+      - $ref: '#/channels/uiEvents/messages/uiError'
+
+  receiveUICommands:
+    action: receive
+    channel:
+      $ref: '#/channels/uiEvents'
+    summary: Client sends subscription commands for UI events.
+    description: |
+      Clients can subscribe or unsubscribe to specific UI event types.
+    messages:
+      - $ref: '#/channels/uiEvents/messages/uiSubscribe'
+      - $ref: '#/channels/uiEvents/messages/uiUnsubscribe'

--- a/docs/DevFlow/spec/examples/agent-status-response.json
+++ b/docs/DevFlow/spec/examples/agent-status-response.json
@@ -1,0 +1,22 @@
+{
+  "agent": {
+    "name": "devflow-maui",
+    "version": "1.0.0",
+    "framework": "maui",
+    "frameworkVersion": "10.0"
+  },
+  "platform": "maccatalyst",
+  "device": {
+    "model": "MacBook Pro",
+    "manufacturer": "Apple",
+    "osVersion": "15.2",
+    "idiom": "desktop"
+  },
+  "app": {
+    "name": "MyApp",
+    "version": "2.1.0",
+    "packageId": "com.example.myapp"
+  },
+  "running": true,
+  "uptime": "PT5M30S"
+}

--- a/docs/DevFlow/spec/examples/batch-request.json
+++ b/docs/DevFlow/spec/examples/batch-request.json
@@ -1,0 +1,11 @@
+{
+  "actions": [
+    { "action": "tap", "elementId": "txt_email" },
+    { "action": "fill", "elementId": "txt_email", "text": "user@example.com" },
+    { "action": "tap", "elementId": "txt_password" },
+    { "action": "fill", "elementId": "txt_password", "text": "MyP@ssw0rd" },
+    { "action": "tap", "elementId": "btn_signin" }
+  ],
+  "include": ["screenshot"],
+  "continueOnError": false
+}

--- a/docs/DevFlow/spec/examples/capabilities-maui-response.json
+++ b/docs/DevFlow/spec/examples/capabilities-maui-response.json
@@ -1,0 +1,56 @@
+{
+  "agent": {
+    "name": "devflow-maui",
+    "version": "1.0.0",
+    "framework": "maui",
+    "frameworkVersion": "10.0"
+  },
+  "capabilities": {
+    "ui.tree": {
+      "version": 1,
+      "features": ["css-selectors", "hit-test", "native-layer", "render-layer"]
+    },
+    "ui.actions": {
+      "version": 1,
+      "features": [
+        "tap",
+        "fill",
+        "clear",
+        "scroll",
+        "focus",
+        "navigate",
+        "back",
+        "gesture",
+        "batch"
+      ]
+    },
+    "ui.screenshot": {
+      "version": 1,
+      "features": ["fullPage", "element"]
+    },
+    "profiler": {
+      "version": 1,
+      "features": ["samples", "spans", "markers", "hotspots"]
+    },
+    "logs": {
+      "version": 1,
+      "features": ["stream", "query"]
+    },
+    "device.info": {
+      "version": 1,
+      "features": ["display", "battery", "connectivity", "geolocation"]
+    },
+    "device.sensors": {
+      "version": 1,
+      "features": ["accelerometer", "gyroscope", "magnetometer"]
+    },
+    "storage.preferences": {
+      "version": 1,
+      "features": ["get", "set", "delete", "clear"]
+    },
+    "storage.secure": {
+      "version": 1,
+      "features": ["get", "set", "delete", "clear"]
+    }
+  }
+}

--- a/docs/DevFlow/spec/examples/element-query-response.json
+++ b/docs/DevFlow/spec/examples/element-query-response.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "txt_email",
+    "parentId": "layout_root",
+    "type": "Entry",
+    "fullType": "Microsoft.Maui.Controls.Entry",
+    "framework": "maui",
+    "automationId": "txt_email",
+    "text": "Email",
+    "value": "",
+    "role": "textbox",
+    "traits": ["interactive", "focusable"],
+    "state": {
+      "displayed": true,
+      "enabled": true,
+      "selected": false,
+      "focused": false,
+      "opacity": 1.0
+    },
+    "bounds": { "x": 40, "y": 172, "width": 400, "height": 44 }
+  },
+  {
+    "id": "txt_password",
+    "parentId": "layout_root",
+    "type": "Entry",
+    "fullType": "Microsoft.Maui.Controls.Entry",
+    "framework": "maui",
+    "automationId": "txt_password",
+    "text": "Password",
+    "value": "",
+    "role": "textbox",
+    "traits": ["interactive", "focusable"],
+    "state": {
+      "displayed": true,
+      "enabled": true,
+      "selected": false,
+      "focused": false,
+      "opacity": 1.0
+    },
+    "bounds": { "x": 40, "y": 232, "width": 400, "height": 44 }
+  }
+]

--- a/docs/DevFlow/spec/examples/error-element-not-found.json
+++ b/docs/DevFlow/spec/examples/error-element-not-found.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://devflow.dev/errors/element-not-found",
+  "title": "Element Not Found",
+  "status": 404,
+  "detail": "No element found with ID 'btn_nonexistent'. The element may have been removed from the visual tree.",
+  "instance": "/api/v1/ui/elements/btn_nonexistent",
+  "errorCode": "element-not-found"
+}

--- a/docs/DevFlow/spec/examples/error-element-not-interactable.json
+++ b/docs/DevFlow/spec/examples/error-element-not-interactable.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://devflow.dev/errors/element-not-interactable",
+  "title": "Element Not Interactable",
+  "status": 400,
+  "detail": "Element 'btn_submit' exists but is not interactable: IsEnabled=false, IsVisible=true.",
+  "instance": "/api/v1/ui/actions/tap",
+  "errorCode": "element-not-interactable"
+}

--- a/docs/DevFlow/spec/examples/gesture-request.json
+++ b/docs/DevFlow/spec/examples/gesture-request.json
@@ -1,0 +1,8 @@
+{
+  "actions": [
+    { "type": "pointerMove", "x": 200, "y": 600, "duration": 0 },
+    { "type": "pointerDown" },
+    { "type": "pointerMove", "x": 200, "y": 200, "duration": 300 },
+    { "type": "pointerUp" }
+  ]
+}

--- a/docs/DevFlow/spec/examples/tap-request.json
+++ b/docs/DevFlow/spec/examples/tap-request.json
@@ -1,0 +1,4 @@
+{
+  "elementId": "btn_signin",
+  "include": ["screenshot", "tree"]
+}

--- a/docs/DevFlow/spec/examples/tap-response.json
+++ b/docs/DevFlow/spec/examples/tap-response.json
@@ -1,0 +1,81 @@
+{
+  "success": true,
+  "screenshot": "iVBORw0KGgo...truncated...",
+  "tree": [
+    {
+      "id": "win_main",
+      "parentId": null,
+      "type": "Window",
+      "fullType": "Microsoft.Maui.Controls.Window",
+      "framework": "maui",
+      "text": "MyApp",
+      "role": "window",
+      "traits": ["focusable"],
+      "state": {
+        "displayed": true,
+        "enabled": true,
+        "selected": false,
+        "focused": true,
+        "opacity": 1.0
+      },
+      "bounds": { "x": 0, "y": 0, "width": 1280, "height": 800, "coordinate": "screen" },
+      "children": [
+        {
+          "id": "nav_page_0",
+          "parentId": "win_main",
+          "type": "NavigationPage",
+          "fullType": "Microsoft.Maui.Controls.NavigationPage",
+          "framework": "maui",
+          "text": "Dashboard",
+          "state": {
+            "displayed": true,
+            "enabled": true,
+            "selected": false,
+            "focused": false,
+            "opacity": 1.0
+          },
+          "bounds": { "x": 0, "y": 0, "width": 1280, "height": 800 },
+          "children": [
+            {
+              "id": "page_dashboard",
+              "parentId": "nav_page_0",
+              "type": "ContentPage",
+              "fullType": "Microsoft.Maui.Controls.ContentPage",
+              "framework": "maui",
+              "text": "Dashboard",
+              "role": "heading",
+              "state": {
+                "displayed": true,
+                "enabled": true,
+                "selected": false,
+                "focused": false,
+                "opacity": 1.0
+              },
+              "bounds": { "x": 0, "y": 48, "width": 1280, "height": 752 },
+              "children": [
+                {
+                  "id": "lbl_dashboard_title",
+                  "parentId": "page_dashboard",
+                  "type": "Label",
+                  "fullType": "Microsoft.Maui.Controls.Label",
+                  "framework": "maui",
+                  "text": "Good morning, John!",
+                  "role": "heading",
+                  "traits": ["header"],
+                  "state": {
+                    "displayed": true,
+                    "enabled": true,
+                    "selected": false,
+                    "focused": false,
+                    "opacity": 1.0
+                  },
+                  "bounds": { "x": 40, "y": 80, "width": 600, "height": 36 }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/DevFlow/spec/examples/tree-response.json
+++ b/docs/DevFlow/spec/examples/tree-response.json
@@ -1,0 +1,269 @@
+[
+  {
+    "id": "win_main",
+    "parentId": null,
+    "type": "Window",
+    "fullType": "Microsoft.Maui.Controls.Window",
+    "framework": "maui",
+    "text": "MyApp",
+    "role": "window",
+    "traits": ["focusable"],
+    "state": {
+      "displayed": true,
+      "enabled": true,
+      "selected": false,
+      "focused": true,
+      "opacity": 1.0
+    },
+    "bounds": { "x": 0, "y": 0, "width": 1280, "height": 800, "coordinate": "screen" },
+    "children": [
+      {
+        "id": "nav_page_0",
+        "parentId": "win_main",
+        "type": "NavigationPage",
+        "fullType": "Microsoft.Maui.Controls.NavigationPage",
+        "framework": "maui",
+        "text": "Sign In",
+        "state": {
+          "displayed": true,
+          "enabled": true,
+          "selected": false,
+          "focused": false,
+          "opacity": 1.0
+        },
+        "bounds": { "x": 0, "y": 0, "width": 1280, "height": 800 },
+        "children": [
+          {
+            "id": "page_login",
+            "parentId": "nav_page_0",
+            "type": "ContentPage",
+            "fullType": "Microsoft.Maui.Controls.ContentPage",
+            "framework": "maui",
+            "text": "Sign In",
+            "role": "heading",
+            "state": {
+              "displayed": true,
+              "enabled": true,
+              "selected": false,
+              "focused": false,
+              "opacity": 1.0
+            },
+            "bounds": { "x": 0, "y": 48, "width": 1280, "height": 752 },
+            "children": [
+              {
+                "id": "layout_root",
+                "parentId": "page_login",
+                "type": "VerticalStackLayout",
+                "fullType": "Microsoft.Maui.Controls.VerticalStackLayout",
+                "framework": "maui",
+                "state": {
+                  "displayed": true,
+                  "enabled": true,
+                  "selected": false,
+                  "focused": false,
+                  "opacity": 1.0
+                },
+                "bounds": { "x": 40, "y": 120, "width": 400, "height": 340 },
+                "children": [
+                  {
+                    "id": "lbl_welcome",
+                    "parentId": "layout_root",
+                    "type": "Label",
+                    "fullType": "Microsoft.Maui.Controls.Label",
+                    "framework": "maui",
+                    "text": "Welcome back, John",
+                    "role": "heading",
+                    "traits": ["header"],
+                    "state": {
+                      "displayed": true,
+                      "enabled": true,
+                      "selected": false,
+                      "focused": false,
+                      "opacity": 1.0
+                    },
+                    "bounds": { "x": 40, "y": 120, "width": 400, "height": 32 },
+                    "style": { "classes": ["title-label"] }
+                  },
+                  {
+                    "id": "txt_email",
+                    "parentId": "layout_root",
+                    "type": "Entry",
+                    "fullType": "Microsoft.Maui.Controls.Entry",
+                    "framework": "maui",
+                    "automationId": "txt_email",
+                    "text": "Email",
+                    "value": "",
+                    "role": "textbox",
+                    "traits": ["interactive", "focusable"],
+                    "state": {
+                      "displayed": true,
+                      "enabled": true,
+                      "selected": false,
+                      "focused": false,
+                      "opacity": 1.0
+                    },
+                    "bounds": { "x": 40, "y": 172, "width": 400, "height": 44 },
+                    "nativeView": {
+                      "type": "AppKit.NSTextField",
+                      "properties": {
+                        "placeholderString": "Email",
+                        "isEditable": true
+                      }
+                    },
+                    "frameworkProperties": {
+                      "maui:bindingContext": "MyApp.ViewModels.LoginViewModel",
+                      "maui:keyboard": "Email"
+                    }
+                  },
+                  {
+                    "id": "txt_password",
+                    "parentId": "layout_root",
+                    "type": "Entry",
+                    "fullType": "Microsoft.Maui.Controls.Entry",
+                    "framework": "maui",
+                    "automationId": "txt_password",
+                    "text": "Password",
+                    "value": "",
+                    "role": "textbox",
+                    "traits": ["interactive", "focusable"],
+                    "state": {
+                      "displayed": true,
+                      "enabled": true,
+                      "selected": false,
+                      "focused": false,
+                      "opacity": 1.0
+                    },
+                    "bounds": { "x": 40, "y": 232, "width": 400, "height": 44 },
+                    "nativeView": {
+                      "type": "AppKit.NSSecureTextField",
+                      "properties": {
+                        "placeholderString": "Password",
+                        "isEditable": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "btn_signin",
+                    "parentId": "layout_root",
+                    "type": "Button",
+                    "fullType": "Microsoft.Maui.Controls.Button",
+                    "framework": "maui",
+                    "automationId": "btn_signin",
+                    "text": "Sign In",
+                    "role": "button",
+                    "traits": ["interactive", "focusable"],
+                    "gestures": ["tap"],
+                    "state": {
+                      "displayed": true,
+                      "enabled": true,
+                      "selected": false,
+                      "focused": false,
+                      "opacity": 1.0
+                    },
+                    "bounds": { "x": 40, "y": 296, "width": 400, "height": 48 },
+                    "style": { "classes": ["primary-button"] }
+                  },
+                  {
+                    "id": "lbl_forgot",
+                    "parentId": "layout_root",
+                    "type": "Label",
+                    "fullType": "Microsoft.Maui.Controls.Label",
+                    "framework": "maui",
+                    "text": "Forgot password?",
+                    "role": "link",
+                    "traits": ["interactive"],
+                    "gestures": ["tap"],
+                    "state": {
+                      "displayed": true,
+                      "enabled": true,
+                      "selected": false,
+                      "focused": false,
+                      "opacity": 1.0
+                    },
+                    "bounds": { "x": 40, "y": 360, "width": 140, "height": 20 },
+                    "style": { "classes": ["link-label"] }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "win_secondary",
+    "parentId": null,
+    "type": "Window",
+    "fullType": "Microsoft.Maui.Controls.Window",
+    "framework": "maui",
+    "text": "Settings",
+    "role": "window",
+    "traits": ["focusable"],
+    "state": {
+      "displayed": true,
+      "enabled": true,
+      "selected": false,
+      "focused": false,
+      "opacity": 1.0
+    },
+    "bounds": { "x": 300, "y": 100, "width": 640, "height": 480, "coordinate": "screen" },
+    "children": [
+      {
+        "id": "page_settings",
+        "parentId": "win_secondary",
+        "type": "ContentPage",
+        "fullType": "Microsoft.Maui.Controls.ContentPage",
+        "framework": "maui",
+        "text": "Settings",
+        "role": "heading",
+        "state": {
+          "displayed": true,
+          "enabled": true,
+          "selected": false,
+          "focused": false,
+          "opacity": 1.0
+        },
+        "bounds": { "x": 0, "y": 48, "width": 640, "height": 432 },
+        "children": [
+          {
+            "id": "lbl_settings_title",
+            "parentId": "page_settings",
+            "type": "Label",
+            "fullType": "Microsoft.Maui.Controls.Label",
+            "framework": "maui",
+            "text": "App Settings",
+            "role": "heading",
+            "traits": ["header"],
+            "state": {
+              "displayed": true,
+              "enabled": true,
+              "selected": false,
+              "focused": false,
+              "opacity": 1.0
+            },
+            "bounds": { "x": 20, "y": 68, "width": 600, "height": 28 }
+          },
+          {
+            "id": "switch_darkmode",
+            "parentId": "page_settings",
+            "type": "Switch",
+            "fullType": "Microsoft.Maui.Controls.Switch",
+            "framework": "maui",
+            "automationId": "switch_darkmode",
+            "role": "checkbox",
+            "traits": ["interactive", "focusable", "adjustable"],
+            "state": {
+              "displayed": true,
+              "enabled": true,
+              "selected": true,
+              "focused": false,
+              "opacity": 1.0
+            },
+            "bounds": { "x": 540, "y": 116, "width": 51, "height": 31 }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/DevFlow/spec/examples/websocket-network-messages.json
+++ b/docs/DevFlow/spec/examples/websocket-network-messages.json
@@ -1,0 +1,105 @@
+[
+  {
+    "_comment": "Server sends replay of recent requests on connect to /ws/v1/network",
+    "direction": "server → client",
+    "message": {
+      "type": "replay",
+      "timestamp": "2025-01-15T10:30:00.000Z",
+      "entries": [
+        {
+          "id": "req_a1b2c3",
+          "timestamp": "2025-01-15T10:29:45.120Z",
+          "method": "GET",
+          "url": "https://api.example.com/api/v2/user/profile",
+          "host": "api.example.com",
+          "path": "/api/v2/user/profile",
+          "statusCode": 200,
+          "statusText": "OK",
+          "durationMs": 142,
+          "requestContentType": null,
+          "responseContentType": "application/json",
+          "requestSize": 0,
+          "responseSize": 1024
+        },
+        {
+          "id": "req_d4e5f6",
+          "timestamp": "2025-01-15T10:29:50.340Z",
+          "method": "GET",
+          "url": "https://api.example.com/api/v2/user/settings",
+          "host": "api.example.com",
+          "path": "/api/v2/user/settings",
+          "statusCode": 200,
+          "statusText": "OK",
+          "durationMs": 89,
+          "requestContentType": null,
+          "responseContentType": "application/json",
+          "requestSize": 0,
+          "responseSize": 512
+        }
+      ]
+    }
+  },
+  {
+    "_comment": "Server sends a new live request event (POST to /api/login)",
+    "direction": "server → client",
+    "message": {
+      "type": "request",
+      "timestamp": "2025-01-15T10:30:12.550Z",
+      "entry": {
+        "id": "req_g7h8i9",
+        "timestamp": "2025-01-15T10:30:12.200Z",
+        "method": "POST",
+        "url": "https://api.example.com/api/v2/auth/login",
+        "host": "api.example.com",
+        "path": "/api/v2/auth/login",
+        "statusCode": 200,
+        "statusText": "OK",
+        "durationMs": 350,
+        "requestContentType": "application/json",
+        "responseContentType": "application/json",
+        "requestSize": 86,
+        "responseSize": 2048
+      }
+    }
+  },
+  {
+    "_comment": "Client requests full details for a specific request via GET /api/v1/network/requests/{id}",
+    "direction": "client → server (HTTP)",
+    "request": "GET /api/v1/network/requests/req_g7h8i9"
+  },
+  {
+    "_comment": "Server responds with full request details including headers and body",
+    "direction": "server → client (HTTP)",
+    "response": {
+      "id": "req_g7h8i9",
+      "timestamp": "2025-01-15T10:30:12.200Z",
+      "method": "POST",
+      "url": "https://api.example.com/api/v2/auth/login",
+      "host": "api.example.com",
+      "path": "/api/v2/auth/login",
+      "statusCode": 200,
+      "statusText": "OK",
+      "durationMs": 350,
+      "requestContentType": "application/json",
+      "responseContentType": "application/json",
+      "requestSize": 86,
+      "responseSize": 2048,
+      "requestHeaders": {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "MyApp/2.1.0 (maccatalyst)"
+      },
+      "responseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Request-Id": "abc123-def456",
+        "Cache-Control": "no-store"
+      },
+      "requestBody": "{\"email\":\"user@example.com\",\"password\":\"***\"}",
+      "responseBody": "{\"token\":\"eyJhbGciOiJSUzI1NiIs...truncated...\",\"expiresIn\":3600,\"user\":{\"id\":\"u_42\",\"name\":\"John Doe\"}}",
+      "requestBodyEncoding": "utf-8",
+      "responseBodyEncoding": "utf-8",
+      "requestBodyTruncated": false,
+      "responseBodyTruncated": false
+    }
+  }
+]

--- a/docs/DevFlow/spec/examples/websocket-sensor-messages.json
+++ b/docs/DevFlow/spec/examples/websocket-sensor-messages.json
@@ -1,0 +1,76 @@
+[
+  {
+    "_comment": "Client subscribes to accelerometer sensor on /ws/v1/sensors",
+    "direction": "client → server",
+    "message": {
+      "type": "subscribe",
+      "filter": {
+        "sensor": "accelerometer"
+      }
+    }
+  },
+  {
+    "_comment": "Server confirms sensor subscription",
+    "direction": "server → client",
+    "message": {
+      "type": "subscribed",
+      "timestamp": "2025-01-15T10:31:00.000Z",
+      "sensor": {
+        "name": "accelerometer",
+        "available": true,
+        "active": true
+      }
+    }
+  },
+  {
+    "_comment": "Server sends first accelerometer reading",
+    "direction": "server → client",
+    "message": {
+      "type": "reading",
+      "timestamp": "2025-01-15T10:31:00.050Z",
+      "reading": {
+        "sensor": "accelerometer",
+        "timestamp": "2025-01-15T10:31:00.048Z",
+        "values": {
+          "x": 0.0123,
+          "y": -0.0045,
+          "z": -9.7891
+        }
+      }
+    }
+  },
+  {
+    "_comment": "Server sends second accelerometer reading",
+    "direction": "server → client",
+    "message": {
+      "type": "reading",
+      "timestamp": "2025-01-15T10:31:00.100Z",
+      "reading": {
+        "sensor": "accelerometer",
+        "timestamp": "2025-01-15T10:31:00.098Z",
+        "values": {
+          "x": 0.0156,
+          "y": -0.0031,
+          "z": -9.7924
+        }
+      }
+    }
+  },
+  {
+    "_comment": "Server sends third accelerometer reading",
+    "direction": "server → client",
+    "message": {
+      "type": "reading",
+      "timestamp": "2025-01-15T10:31:00.150Z",
+      "reading": {
+        "sensor": "accelerometer",
+        "timestamp": "2025-01-15T10:31:00.149Z",
+        "values": {
+          "x": 0.0189,
+          "y": -0.0058,
+          "z": -9.7856
+        }
+      }
+    }
+  }
+]

--- a/docs/DevFlow/spec/examples/webview-contexts-response.json
+++ b/docs/DevFlow/spec/examples/webview-contexts-response.json
@@ -1,0 +1,18 @@
+{
+  "contexts": [
+    {
+      "id": "webview_0",
+      "elementId": "blazor_main",
+      "url": "https://app/_content/index.html",
+      "title": "Dashboard",
+      "ready": true
+    },
+    {
+      "id": "webview_1",
+      "elementId": "help_webview",
+      "url": "https://docs.example.com/help",
+      "title": "Help Center",
+      "ready": true
+    }
+  ]
+}

--- a/docs/DevFlow/spec/openapi.json
+++ b/docs/DevFlow/spec/openapi.json
@@ -1,0 +1,5116 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "DevFlow Agent Protocol",
+    "version": "1.0.0",
+    "description": "Protocol for runtime app inspection, interaction, and debugging in DevFlow-enabled applications.\n",
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:{port}",
+      "description": "Agent HTTP server running inside the target application",
+      "variables": {
+        "port": {
+          "default": "9223",
+          "description": "Port the agent is listening on"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "agent",
+      "description": "Agent discovery and status"
+    },
+    {
+      "name": "ui",
+      "description": "UI tree inspection, element queries, screenshots"
+    },
+    {
+      "name": "ui-actions",
+      "description": "UI interaction (tap, fill, scroll, gestures, etc.)"
+    },
+    {
+      "name": "webview",
+      "description": "WebView inspection and interaction"
+    },
+    {
+      "name": "profiler",
+      "description": "Performance profiling"
+    },
+    {
+      "name": "network",
+      "description": "Network request monitoring"
+    },
+    {
+      "name": "logs",
+      "description": "Application logs"
+    },
+    {
+      "name": "device",
+      "description": "Device info, sensors, permissions, geolocation"
+    },
+    {
+      "name": "storage",
+      "description": "Preferences and secure storage"
+    },
+    {
+      "name": "extensions",
+      "description": "Third-party extension routes"
+    }
+  ],
+  "paths": {
+    "/api/v1/agent/status": {
+      "get": {
+        "operationId": "getAgentStatus",
+        "tags": [
+          "agent"
+        ],
+        "summary": "Get agent status",
+        "description": "Returns the agent's identity, platform, version, and running state.\n",
+        "responses": {
+          "200": {
+            "description": "Agent status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/agent-status"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/agent/capabilities": {
+      "get": {
+        "operationId": "getAgentCapabilities",
+        "tags": [
+          "agent"
+        ],
+        "summary": "Get agent capabilities",
+        "description": "Returns the capabilities and extensions supported by this agent.\n",
+        "responses": {
+          "200": {
+            "description": "Agent capabilities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/agent-capabilities"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/tree": {
+      "get": {
+        "operationId": "getUiTree",
+        "tags": [
+          "ui"
+        ],
+        "summary": "Get visual tree",
+        "description": "Returns the full visual tree of the application. Windows are root nodes. Use query parameters to limit depth, select a tree layer, or scope to a subtree.\n",
+        "parameters": [
+          {
+            "name": "depth",
+            "in": "query",
+            "description": "Maximum depth of the tree to return. Unlimited if omitted.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "layer",
+            "in": "query",
+            "description": "Which tree layer to return.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "framework",
+                "native",
+                "render"
+              ],
+              "default": "framework"
+            }
+          },
+          {
+            "name": "rootId",
+            "in": "query",
+            "description": "Element ID to scope the tree to a subtree.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Additional data to include with each element.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "properties"
+                ]
+              }
+            },
+            "style": "form",
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of root elements (windows) with their children.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/element-info"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/elements/{id}": {
+      "get": {
+        "operationId": "getElement",
+        "tags": [
+          "ui"
+        ],
+        "summary": "Get element by ID",
+        "description": "Returns a single element by its globally unique identifier.\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ElementIdPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested element.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/element-info"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/elements": {
+      "get": {
+        "operationId": "queryElements",
+        "tags": [
+          "ui"
+        ],
+        "summary": "Query elements with locator strategies",
+        "description": "Searches the visual tree for elements matching the given locator strategy and value.\n",
+        "parameters": [
+          {
+            "name": "strategy",
+            "in": "query",
+            "required": true,
+            "description": "Locator strategy to use.",
+            "schema": {
+              "$ref": "#/components/schemas/LocatorStrategy"
+            }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "required": true,
+            "description": "Locator value.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Additional data to include with each element.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "properties",
+                  "bounds"
+                ]
+              }
+            },
+            "style": "form",
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching elements.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/element-info"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidSelector"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/hit-test": {
+      "get": {
+        "operationId": "hitTest",
+        "tags": [
+          "ui"
+        ],
+        "summary": "Find element at coordinates",
+        "description": "Returns the elements at the given screen coordinates, ordered deepest first (innermost element first).\n",
+        "parameters": [
+          {
+            "name": "x",
+            "in": "query",
+            "required": true,
+            "description": "X coordinate.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "y",
+            "in": "query",
+            "required": true,
+            "description": "Y coordinate.",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Elements at the given coordinates (deepest first).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/element-info"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/screenshot": {
+      "get": {
+        "operationId": "captureScreenshot",
+        "tags": [
+          "ui"
+        ],
+        "summary": "Capture screenshot",
+        "description": "Captures a screenshot of the entire screen or a specific element.\n",
+        "parameters": [
+          {
+            "name": "elementId",
+            "in": "query",
+            "description": "Element to screenshot. If omitted, captures the full screen.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "maxWidth",
+            "in": "query",
+            "description": "Maximum width in pixels. The image is scaled down if wider.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "scale",
+            "in": "query",
+            "description": "Scale mode. `native` returns at device pixel density; `auto` returns a reasonable size for agent consumption.\n",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "native",
+                "auto"
+              ],
+              "default": "auto"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Image format.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "png",
+                "jpeg"
+              ],
+              "default": "png"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Screenshot image.",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/tap": {
+      "post": {
+        "operationId": "tapElement",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Tap element or coordinates",
+        "description": "Taps on an element (by ID) or at absolute coordinates.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TapRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/ElementNotInteractable"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/fill": {
+      "post": {
+        "operationId": "fillElement",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Fill text into element",
+        "description": "Clears any existing text and fills the element with the given text.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FillRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/ElementNotInteractable"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/clear": {
+      "post": {
+        "operationId": "clearElement",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Clear text from element",
+        "description": "Clears any text content from the specified element.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClearRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/ElementNotInteractable"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/focus": {
+      "post": {
+        "operationId": "focusElement",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Focus element",
+        "description": "Gives keyboard focus to the specified element.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FocusRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/ElementNotInteractable"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/scroll": {
+      "post": {
+        "operationId": "scrollElement",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Scroll element",
+        "description": "Scrolls an element by delta, to an item index, or to a named position.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScrollRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/ElementNotInteractable"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/navigate": {
+      "post": {
+        "operationId": "navigateRoute",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Navigate to route",
+        "description": "Navigates the application to the specified route or page.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NavigateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/resize": {
+      "post": {
+        "operationId": "resizeWindow",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Resize window",
+        "description": "Resizes a window or element to the given dimensions.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResizeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/back": {
+      "post": {
+        "operationId": "goBack",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Go back",
+        "description": "Performs a back navigation gesture in the application.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BackRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/key": {
+      "post": {
+        "operationId": "pressKey",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Press key",
+        "description": "Sends a key press event to the focused element or the application.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KeyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/gesture": {
+      "post": {
+        "operationId": "performGesture",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Perform complex gesture",
+        "description": "Executes a sequence of pointer actions (move, down, up, pause) to perform complex gestures like swipe, pinch, or drag.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GestureRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/actions/batch": {
+      "post": {
+        "operationId": "batchActions",
+        "tags": [
+          "ui-actions"
+        ],
+        "summary": "Execute batch actions",
+        "description": "Executes multiple actions in sequence. Optionally continues on error.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ActionSuccess"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/ui/elements/{id}/properties/{name}": {
+      "get": {
+        "operationId": "getElementProperty",
+        "tags": [
+          "ui"
+        ],
+        "summary": "Get element property value",
+        "description": "Returns the current value of a named property on an element.\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ElementIdPath"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "Property name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Property value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "value"
+                  ],
+                  "properties": {
+                    "value": {}
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "put": {
+        "operationId": "setElementProperty",
+        "tags": [
+          "ui"
+        ],
+        "summary": "Set element property value",
+        "description": "Sets the value of a named property on an element and returns the new value.\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ElementIdPath"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "Property name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "description": "The value to set."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The new property value after setting.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "value"
+                  ],
+                  "properties": {
+                    "value": {}
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/contexts": {
+      "get": {
+        "operationId": "getWebViewContexts",
+        "tags": [
+          "webview"
+        ],
+        "summary": "List WebView instances",
+        "description": "Returns all active WebView contexts in the application.\n",
+        "responses": {
+          "200": {
+            "description": "Array of WebView contexts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WebViewContext"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/evaluate": {
+      "post": {
+        "operationId": "evaluateJavaScript",
+        "tags": [
+          "webview"
+        ],
+        "summary": "Execute JavaScript in WebView",
+        "description": "Evaluates a JavaScript expression inside a WebView context and returns the result.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Evaluation result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/dom": {
+      "get": {
+        "operationId": "getWebViewDom",
+        "tags": [
+          "webview"
+        ],
+        "summary": "Get DOM snapshot",
+        "description": "Returns a simplified snapshot of the DOM tree in the WebView.\n",
+        "parameters": [
+          {
+            "name": "contextId",
+            "in": "query",
+            "description": "WebView context ID. Uses the default context if omitted.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simplified DOM tree.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Simplified DOM tree representation."
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/dom/query": {
+      "post": {
+        "operationId": "queryWebViewDom",
+        "tags": [
+          "webview"
+        ],
+        "summary": "CSS query in DOM",
+        "description": "Executes a CSS selector query against the WebView DOM and returns matching nodes.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DomQueryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Matching DOM nodes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "description": "Simplified DOM node."
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidSelector"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/source": {
+      "get": {
+        "operationId": "getWebViewSource",
+        "tags": [
+          "webview"
+        ],
+        "summary": "Get page source",
+        "description": "Returns the HTML source of the WebView page.\n",
+        "parameters": [
+          {
+            "name": "contextId",
+            "in": "query",
+            "description": "WebView context ID. Uses the default context if omitted.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page HTML source.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/navigate": {
+      "post": {
+        "operationId": "navigateWebView",
+        "tags": [
+          "webview"
+        ],
+        "summary": "Navigate WebView",
+        "description": "Navigates the WebView to the specified URL.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebViewNavigateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Navigation initiated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/input/click": {
+      "post": {
+        "operationId": "clickInWebView",
+        "tags": [
+          "webview"
+        ],
+        "summary": "Click element in WebView",
+        "description": "Clicks a DOM element matching the given CSS selector inside the WebView.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebViewInputClickRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Click performed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidSelector"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/input/fill": {
+      "post": {
+        "operationId": "fillInWebView",
+        "tags": [
+          "webview"
+        ],
+        "summary": "Fill field in WebView",
+        "description": "Clears and fills a DOM input element matching the given CSS selector.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebViewInputFillRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Fill performed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidSelector"
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/input/text": {
+      "post": {
+        "operationId": "insertTextInWebView",
+        "tags": [
+          "webview"
+        ],
+        "summary": "Insert text in WebView",
+        "description": "Inserts text into the currently focused element in the WebView without clearing existing content.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebViewInputTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Text inserted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/webview/screenshot": {
+      "get": {
+        "operationId": "captureWebViewScreenshot",
+        "tags": [
+          "webview"
+        ],
+        "summary": "Capture WebView screenshot",
+        "description": "Captures a screenshot of the WebView content.\n",
+        "parameters": [
+          {
+            "name": "contextId",
+            "in": "query",
+            "description": "WebView context ID. Uses the default context if omitted.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Screenshot image.",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ElementNotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/profiler/capabilities": {
+      "get": {
+        "operationId": "getProfilerCapabilities",
+        "tags": [
+          "profiler"
+        ],
+        "summary": "Get profiling capabilities",
+        "description": "Returns which profiling features are supported on the current platform.\n",
+        "responses": {
+          "200": {
+            "description": "Profiler capabilities.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfilerCapabilities"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/profiler/sessions": {
+      "post": {
+        "operationId": "startProfilerSession",
+        "tags": [
+          "profiler"
+        ],
+        "summary": "Start profiler session",
+        "description": "Starts a new profiling session with the given sample interval.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sampleIntervalMs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Sampling interval in milliseconds."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session started.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfilerSessionInfo"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/profiler/sessions/{id}": {
+      "delete": {
+        "operationId": "stopProfilerSession",
+        "tags": [
+          "profiler"
+        ],
+        "summary": "Stop profiler session",
+        "description": "Stops an active profiling session.\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Profiler session ID.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session stopped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfilerSessionInfo"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/profiler/sessions/{id}/samples": {
+      "get": {
+        "operationId": "getProfilerSamples",
+        "tags": [
+          "profiler"
+        ],
+        "summary": "Get profiler samples",
+        "description": "Returns profiling samples, markers, and spans collected since the given cursors. Use cursor values from the previous response to poll for new data.\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Profiler session ID.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleCursor",
+            "in": "query",
+            "description": "Cursor for samples. Start at 0.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "markerCursor",
+            "in": "query",
+            "description": "Cursor for markers. Start at 0.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "spanCursor",
+            "in": "query",
+            "description": "Cursor for spans. Start at 0.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of items to return per category.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Profiler batch of samples, markers, and spans.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfilerBatch"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/profiler/markers": {
+      "post": {
+        "operationId": "publishProfilerMarker",
+        "tags": [
+          "profiler"
+        ],
+        "summary": "Publish profiler marker",
+        "description": "Publishes a timestamped marker event into the active profiling session.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfilerMarker"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Marker published.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/profiler/spans": {
+      "post": {
+        "operationId": "publishProfilerSpan",
+        "tags": [
+          "profiler"
+        ],
+        "summary": "Publish profiler span",
+        "description": "Publishes a completed span into the active profiling session.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfilerSpan"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Span published.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/profiler/hotspots": {
+      "get": {
+        "operationId": "getProfilerHotspots",
+        "tags": [
+          "profiler"
+        ],
+        "summary": "Get performance hotspots",
+        "description": "Returns aggregated performance hotspots from the profiling session.\n",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of hotspots to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "minDurationMs",
+            "in": "query",
+            "description": "Minimum average duration in milliseconds.",
+            "schema": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "description": "Filter by hotspot kind.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of hotspots.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProfilerHotspot"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/network/requests": {
+      "get": {
+        "operationId": "getNetworkRequests",
+        "tags": [
+          "network"
+        ],
+        "summary": "List captured network requests",
+        "description": "Returns captured HTTP requests, optionally filtered by host, method, or status code.\n",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of requests to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "host",
+            "in": "query",
+            "description": "Filter by host name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "method",
+            "in": "query",
+            "description": "Filter by HTTP method.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "statusCode",
+            "in": "query",
+            "description": "Filter by status code.",
+            "schema": {
+              "type": "integer",
+              "minimum": 100,
+              "maximum": 599
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of network request summaries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NetworkRequestSummary"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "clearNetworkRequests",
+        "tags": [
+          "network"
+        ],
+        "summary": "Clear captured requests",
+        "description": "Clears all captured network requests from the buffer.\n",
+        "responses": {
+          "204": {
+            "description": "Requests cleared."
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/network/requests/{id}": {
+      "get": {
+        "operationId": "getNetworkRequestDetail",
+        "tags": [
+          "network"
+        ],
+        "summary": "Get network request detail",
+        "description": "Returns full details for a captured network request, including headers and body content.\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Network request ID.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Full network request detail.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetworkRequestDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/logs": {
+      "get": {
+        "operationId": "getLogs",
+        "tags": [
+          "logs"
+        ],
+        "summary": "Query application logs",
+        "description": "Returns application log entries, optionally filtered by source and level.\n",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of log entries.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "Number of entries to skip (for pagination).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "description": "Filter by log source.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "native",
+                "webview",
+                "framework"
+              ]
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "description": "Minimum log level.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "trace",
+                "debug",
+                "info",
+                "warning",
+                "error",
+                "critical"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of log entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogEntry"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/info": {
+      "get": {
+        "operationId": "getDeviceInfo",
+        "tags": [
+          "device"
+        ],
+        "summary": "Get device info",
+        "description": "Returns hardware and OS information about the device.\n",
+        "responses": {
+          "200": {
+            "description": "Device information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceInfo"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/display": {
+      "get": {
+        "operationId": "getDisplayInfo",
+        "tags": [
+          "device"
+        ],
+        "summary": "Get display info",
+        "description": "Returns display dimensions, density, and orientation.\n",
+        "responses": {
+          "200": {
+            "description": "Display information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisplayInfo"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/battery": {
+      "get": {
+        "operationId": "getBatteryInfo",
+        "tags": [
+          "device"
+        ],
+        "summary": "Get battery info",
+        "description": "Returns battery level, state, and power source.\n",
+        "responses": {
+          "200": {
+            "description": "Battery information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatteryInfo"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/connectivity": {
+      "get": {
+        "operationId": "getConnectivityInfo",
+        "tags": [
+          "device"
+        ],
+        "summary": "Get connectivity info",
+        "description": "Returns network connectivity status and connection profiles.\n",
+        "responses": {
+          "200": {
+            "description": "Connectivity information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectivityInfo"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/app": {
+      "get": {
+        "operationId": "getAppInfo",
+        "tags": [
+          "device"
+        ],
+        "summary": "Get app info",
+        "description": "Returns application name, version, build number, and package ID.\n",
+        "responses": {
+          "200": {
+            "description": "Application information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/sensors": {
+      "get": {
+        "operationId": "listSensors",
+        "tags": [
+          "device"
+        ],
+        "summary": "List available sensors",
+        "description": "Returns the list of sensors and their availability/active status.\n",
+        "responses": {
+          "200": {
+            "description": "Array of sensor info.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SensorInfo"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/sensors/{name}/start": {
+      "post": {
+        "operationId": "startSensor",
+        "tags": [
+          "device"
+        ],
+        "summary": "Start sensor",
+        "description": "Starts collecting data from the named sensor. Readings are delivered via the WebSocket sensor channel.\n",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "Sensor name (e.g. accelerometer, gyroscope, compass).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "speed",
+            "in": "query",
+            "description": "Sensor update speed. Framework-dependent (e.g. \"fastest\", \"game\", \"ui\", \"default\").\n",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sensor started.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SensorInfo"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "501": {
+            "$ref": "#/components/responses/UnsupportedCapability"
+          }
+        }
+      }
+    },
+    "/api/v1/device/sensors/{name}/stop": {
+      "post": {
+        "operationId": "stopSensor",
+        "tags": [
+          "device"
+        ],
+        "summary": "Stop sensor",
+        "description": "Stops collecting data from the named sensor.\n",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "Sensor name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sensor stopped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SensorInfo"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/permissions": {
+      "get": {
+        "operationId": "listPermissions",
+        "tags": [
+          "device"
+        ],
+        "summary": "List permissions",
+        "description": "Returns the status of all known permissions.\n",
+        "responses": {
+          "200": {
+            "description": "Array of permission info.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PermissionInfo"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/permissions/{name}": {
+      "get": {
+        "operationId": "checkPermission",
+        "tags": [
+          "device"
+        ],
+        "summary": "Check permission status",
+        "description": "Returns the current status of a specific permission.\n",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "Permission name (e.g. camera, location, microphone).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Permission status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionInfo"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/device/geolocation": {
+      "get": {
+        "operationId": "getGeolocation",
+        "tags": [
+          "device"
+        ],
+        "summary": "Get current location",
+        "description": "Returns the device's current geographic location.\n",
+        "parameters": [
+          {
+            "name": "accuracy",
+            "in": "query",
+            "description": "Desired accuracy level.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Timeout in milliseconds for the location request.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current location.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeolocationResult"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "501": {
+            "$ref": "#/components/responses/UnsupportedCapability"
+          }
+        }
+      }
+    },
+    "/api/v1/storage/preferences": {
+      "get": {
+        "operationId": "listPreferences",
+        "tags": [
+          "storage"
+        ],
+        "summary": "List preferences",
+        "description": "Returns all preference entries, optionally scoped to a shared container.\n",
+        "parameters": [
+          {
+            "name": "sharedName",
+            "in": "query",
+            "description": "Shared preference container name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of preference entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PreferenceEntry"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "clearPreferences",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Clear all preferences",
+        "description": "Deletes all preferences, optionally scoped to a shared container.\n",
+        "parameters": [
+          {
+            "name": "sharedName",
+            "in": "query",
+            "description": "Shared preference container name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Preferences cleared."
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/storage/preferences/{key}": {
+      "get": {
+        "operationId": "getPreference",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Get preference value",
+        "description": "Returns the value of a specific preference key.\n",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "description": "Preference key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Expected value type for deserialization.",
+            "schema": {
+              "$ref": "#/components/schemas/PreferenceValueType"
+            }
+          },
+          {
+            "name": "sharedName",
+            "in": "query",
+            "description": "Shared preference container name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Preference entry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreferenceEntry"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "put": {
+        "operationId": "setPreference",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Set preference value",
+        "description": "Creates or updates a preference entry.\n",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "description": "Preference key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreferenceSetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Preference set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreferenceEntry"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deletePreference",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Delete preference",
+        "description": "Deletes a specific preference by key.\n",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "description": "Preference key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sharedName",
+            "in": "query",
+            "description": "Shared preference container name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Preference deleted."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/storage/secure": {
+      "delete": {
+        "operationId": "clearSecureStorage",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Clear all secure storage",
+        "description": "Deletes all values from secure storage.\n",
+        "responses": {
+          "204": {
+            "description": "Secure storage cleared."
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/storage/secure/{key}": {
+      "get": {
+        "operationId": "getSecureValue",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Get secure storage value",
+        "description": "Returns the value stored under the given key in secure storage.\n",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "description": "Secure storage key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Secure value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "value"
+                  ],
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "put": {
+        "operationId": "setSecureValue",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Set secure storage value",
+        "description": "Stores a value in secure storage under the given key.\n",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "description": "Secure storage key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SecureStorageSetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Value stored.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteSecureValue",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Delete secure storage value",
+        "description": "Deletes a specific value from secure storage.\n",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "description": "Secure storage key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Value deleted."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "ElementIdPath": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Globally unique element identifier.",
+        "schema": {
+          "$ref": "#/components/schemas/ElementId"
+        }
+      }
+    },
+    "responses": {
+      "ActionSuccess": {
+        "description": "Action completed.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ActionResponse"
+            }
+          }
+        }
+      },
+      "ElementNotFound": {
+        "description": "Element not found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "example": {
+              "type": "urn:devflow:error:element-not-found",
+              "title": "Element not found",
+              "status": 404,
+              "errorCode": "element-not-found"
+            }
+          }
+        }
+      },
+      "ElementNotInteractable": {
+        "description": "Element is not interactable.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "example": {
+              "type": "urn:devflow:error:element-not-interactable",
+              "title": "Element not interactable",
+              "status": 400,
+              "errorCode": "element-not-interactable"
+            }
+          }
+        }
+      },
+      "InvalidSelector": {
+        "description": "Invalid selector or locator.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "example": {
+              "type": "urn:devflow:error:invalid-selector",
+              "title": "Invalid selector",
+              "status": 400,
+              "errorCode": "invalid-selector"
+            }
+          }
+        }
+      },
+      "Timeout": {
+        "description": "Operation timed out.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "example": {
+              "type": "urn:devflow:error:timeout",
+              "title": "Timeout",
+              "status": 408,
+              "errorCode": "timeout"
+            }
+          }
+        }
+      },
+      "UnsupportedCapability": {
+        "description": "Capability not supported on this platform.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "example": {
+              "type": "urn:devflow:error:unsupported-capability",
+              "title": "Unsupported capability",
+              "status": 501,
+              "errorCode": "unsupported-capability"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "example": {
+              "type": "urn:devflow:error:element-not-found",
+              "title": "Not found",
+              "status": 404
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "Internal server error.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "example": {
+              "type": "urn:devflow:error:internal-error",
+              "title": "Internal error",
+              "status": 500,
+              "errorCode": "internal-error"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "agent-status": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "agent-status.json",
+        "title": "AgentStatus",
+        "description": "Agent status response providing runtime information about the agent, device, and application.",
+        "type": "object",
+        "required": [
+          "agent",
+          "platform",
+          "device",
+          "app",
+          "running",
+          "uptime"
+        ],
+        "properties": {
+          "agent": {
+            "type": "object",
+            "description": "Information about the DevFlow agent itself.",
+            "required": [
+              "name",
+              "version",
+              "framework",
+              "frameworkVersion"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the DevFlow agent implementation."
+              },
+              "version": {
+                "type": "string",
+                "description": "Semantic version of the agent."
+              },
+              "framework": {
+                "type": "string",
+                "description": "The UI layer the agent is instrumented for (for example 'maui' or 'native')."
+              },
+              "frameworkVersion": {
+                "type": "string",
+                "description": "Version of the UI framework."
+              }
+            }
+          },
+          "platform": {
+            "type": "string",
+            "enum": [
+              "ios",
+              "android",
+              "maccatalyst",
+              "windows",
+              "linux",
+              "macos"
+            ],
+            "description": "The target platform the agent is running on."
+          },
+          "device": {
+            "type": "object",
+            "description": "Information about the device or emulator/simulator.",
+            "required": [
+              "model",
+              "manufacturer",
+              "osVersion",
+              "idiom"
+            ],
+            "properties": {
+              "model": {
+                "type": "string",
+                "description": "Device model name (e.g. 'iPhone 15 Pro', 'Pixel 8')."
+              },
+              "manufacturer": {
+                "type": "string",
+                "description": "Device manufacturer (e.g. 'Apple', 'Google')."
+              },
+              "osVersion": {
+                "type": "string",
+                "description": "Operating system version string."
+              },
+              "idiom": {
+                "type": "string",
+                "enum": [
+                  "phone",
+                  "tablet",
+                  "desktop",
+                  "tv",
+                  "watch"
+                ],
+                "description": "Device form factor idiom."
+              }
+            }
+          },
+          "app": {
+            "type": "object",
+            "description": "Information about the instrumented application.",
+            "required": [
+              "name",
+              "version",
+              "packageId"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Display name of the application."
+              },
+              "version": {
+                "type": "string",
+                "description": "Application version string."
+              },
+              "packageId": {
+                "type": "string",
+                "description": "Application package identifier (e.g. 'com.example.myapp')."
+              }
+            }
+          },
+          "running": {
+            "type": "boolean",
+            "description": "Whether the application is currently running and responsive."
+          },
+          "uptime": {
+            "type": "string",
+            "description": "Agent uptime as an ISO 8601 duration (e.g. 'PT1H30M15S').",
+            "pattern": "^P"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "description": "RFC 7807 Problem Details error response.",
+        "required": [
+          "type",
+          "title",
+          "status"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code for this occurrence of the problem.",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "instance": {
+            "type": "string",
+            "format": "uri",
+            "description": "A URI reference that identifies the specific occurrence of the problem."
+          },
+          "errorCode": {
+            "type": "string",
+            "enum": [
+              "element-not-found",
+              "stale-element-reference",
+              "element-not-interactable",
+              "invalid-selector",
+              "timeout",
+              "unknown-command",
+              "unsupported-capability",
+              "internal-error"
+            ],
+            "description": "Machine-readable error code identifying the category of failure."
+          }
+        }
+      },
+      "agent-capabilities": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "agent-capabilities.json",
+        "title": "AgentCapabilities",
+        "description": "Capability discovery response describing what the agent supports.",
+        "type": "object",
+        "required": [
+          "agent",
+          "capabilities"
+        ],
+        "properties": {
+          "agent": {
+            "type": "object",
+            "description": "Information about the DevFlow agent itself.",
+            "required": [
+              "name",
+              "version",
+              "framework",
+              "frameworkVersion"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the DevFlow agent implementation."
+              },
+              "version": {
+                "type": "string",
+                "description": "Semantic version of the agent."
+              },
+              "framework": {
+                "type": "string",
+                "description": "The UI framework the agent is instrumented for."
+              },
+              "frameworkVersion": {
+                "type": "string",
+                "description": "Version of the UI framework."
+              }
+            }
+          },
+          "capabilities": {
+            "type": "object",
+            "description": "Map of capability namespaces to their details. Keys are dot-separated namespaces.",
+            "additionalProperties": {
+              "type": "object",
+              "required": [
+                "version",
+                "features"
+              ],
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "description": "Capability version number.",
+                  "minimum": 1
+                },
+                "features": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of supported features within this capability namespace."
+                }
+              },
+              "additionalProperties": true,
+              "description": "Capability details including version, features, and optional extra fields."
+            },
+            "examples": [
+              {
+                "ui.tree": {
+                  "version": 1,
+                  "features": [
+                    "find",
+                    "query",
+                    "snapshot"
+                  ]
+                },
+                "ui.actions": {
+                  "version": 1,
+                  "features": [
+                    "tap",
+                    "fill",
+                    "scroll",
+                    "gesture"
+                  ]
+                },
+                "ui.screenshot": {
+                  "version": 1,
+                  "features": [
+                    "fullPage",
+                    "element"
+                  ]
+                },
+                "webview": {
+                  "version": 1,
+                  "features": [
+                    "evaluate",
+                    "dom",
+                    "navigate"
+                  ]
+                },
+                "profiler": {
+                  "version": 1,
+                  "features": [
+                    "samples",
+                    "spans",
+                    "markers"
+                  ]
+                },
+                "network": {
+                  "version": 1,
+                  "features": [
+                    "capture",
+                    "detail"
+                  ]
+                },
+                "logs": {
+                  "version": 1,
+                  "features": [
+                    "stream",
+                    "query"
+                  ]
+                },
+                "device.info": {
+                  "version": 1,
+                  "features": [
+                    "display",
+                    "battery",
+                    "connectivity"
+                  ]
+                },
+                "device.sensors": {
+                  "version": 1,
+                  "features": [
+                    "accelerometer",
+                    "gyroscope",
+                    "compass"
+                  ]
+                },
+                "storage.preferences": {
+                  "version": 1,
+                  "features": [
+                    "get",
+                    "set",
+                    "delete"
+                  ]
+                },
+                "storage.secure": {
+                  "version": 1,
+                  "features": [
+                    "get",
+                    "set",
+                    "delete"
+                  ]
+                }
+              }
+            ]
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Map of extension namespaces (reverse-domain notation) to their route registrations.",
+            "additionalProperties": {
+              "type": "object",
+              "required": [
+                "routes"
+              ],
+              "properties": {
+                "routes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "method",
+                      "path"
+                    ],
+                    "properties": {
+                      "method": {
+                        "type": "string",
+                        "description": "HTTP method for this route (e.g. 'GET', 'POST')."
+                      },
+                      "path": {
+                        "type": "string",
+                        "description": "URL path for this route."
+                      }
+                    }
+                  },
+                  "description": "Routes registered by this extension."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Human-readable description of this extension."
+                }
+              },
+              "description": "Extension details including registered routes."
+            }
+          }
+        }
+      },
+      "ElementId": {
+        "type": "string",
+        "description": "Globally unique element identifier within the visual tree."
+      },
+      "CoordinateSystem": {
+        "type": "string",
+        "enum": [
+          "window",
+          "screen"
+        ],
+        "description": "Coordinate system for bounding rectangles and points."
+      },
+      "bounds-info": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "bounds-info.json",
+        "title": "BoundsInfo",
+        "description": "Bounding rectangle for a visual element.",
+        "type": "object",
+        "required": [
+          "x",
+          "y",
+          "width",
+          "height"
+        ],
+        "properties": {
+          "x": {
+            "type": "number",
+            "description": "The x-coordinate of the top-left corner."
+          },
+          "y": {
+            "type": "number",
+            "description": "The y-coordinate of the top-left corner."
+          },
+          "width": {
+            "type": "number",
+            "description": "The width of the bounding rectangle.",
+            "minimum": 0
+          },
+          "height": {
+            "type": "number",
+            "description": "The height of the bounding rectangle.",
+            "minimum": 0
+          },
+          "coordinate": {
+            "$ref": "#/components/schemas/CoordinateSystem",
+            "description": "The coordinate system for this bounding rectangle.",
+            "default": "window"
+          }
+        }
+      },
+      "element-info": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "element-info.json",
+        "title": "ElementInfo",
+        "description": "Core visual tree element model representing a single node in the UI hierarchy.",
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "fullType",
+          "framework",
+          "state",
+          "bounds"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ElementId",
+            "description": "Globally unique identifier for this element."
+          },
+          "parentId": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ElementId"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Identifier of the parent element, or null for root elements."
+          },
+          "type": {
+            "type": "string",
+            "description": "Short type name of the element (e.g. 'Button')."
+          },
+          "fullType": {
+            "type": "string",
+            "description": "Fully qualified type name (e.g. 'Microsoft.Maui.Controls.Button')."
+          },
+          "framework": {
+            "type": "string",
+            "description": "The UI framework that owns this element.",
+            "examples": [
+              "maui",
+              "native",
+              "android",
+              "ios",
+              "windows"
+            ]
+          },
+          "automationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Automation identifier set by the developer for testing purposes."
+          },
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Visible text content of the element."
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Current value for input elements (e.g. text field content, slider value)."
+          },
+          "role": {
+            "type": "string",
+            "description": "Semantic role of the element for accessibility and interaction purposes.",
+            "examples": [
+              "button",
+              "textbox",
+              "checkbox",
+              "image",
+              "list",
+              "listitem",
+              "link",
+              "heading",
+              "window"
+            ]
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Semantic traits describing the element's capabilities and behavior.",
+            "examples": [
+              [
+                "interactive",
+                "focusable",
+                "scrollable",
+                "adjustable",
+                "header",
+                "summary"
+              ]
+            ]
+          },
+          "state": {
+            "type": "object",
+            "description": "Current interactive and visual state of the element.",
+            "required": [
+              "displayed",
+              "enabled",
+              "selected",
+              "focused",
+              "opacity"
+            ],
+            "properties": {
+              "displayed": {
+                "type": "boolean",
+                "description": "Whether the element is currently visible on screen."
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether the element is enabled for user interaction."
+              },
+              "selected": {
+                "type": "boolean",
+                "description": "Whether the element is currently selected."
+              },
+              "focused": {
+                "type": "boolean",
+                "description": "Whether the element currently has input focus."
+              },
+              "opacity": {
+                "type": "number",
+                "description": "Opacity of the element from fully transparent (0) to fully opaque (1).",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          },
+          "bounds": {
+            "$ref": "#/components/schemas/bounds-info",
+            "description": "Bounding rectangle of the element."
+          },
+          "gestures": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gesture types recognized by this element.",
+            "examples": [
+              [
+                "tap",
+                "doubleTap",
+                "longPress",
+                "swipe",
+                "pinch"
+              ]
+            ]
+          },
+          "style": {
+            "type": "object",
+            "description": "Style information for the element.",
+            "properties": {
+              "classes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "CSS or style classes applied to this element."
+              }
+            }
+          },
+          "nativeView": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Information about the underlying native platform view.",
+            "properties": {
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Native platform type name (e.g. 'UIButton', 'android.widget.Button')."
+              },
+              "properties": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": true,
+                "description": "Key-value pairs of native view properties."
+              }
+            }
+          },
+          "frameworkProperties": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true,
+            "description": "Framework-specific key-value pairs not captured by standard fields."
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/element-info",
+              "description": "Child element in the visual tree."
+            },
+            "description": "Child elements forming the subtree under this element."
+          }
+        }
+      },
+      "LocatorStrategy": {
+        "type": "string",
+        "enum": [
+          "accessibility-id",
+          "css-selector",
+          "type",
+          "text",
+          "xpath"
+        ],
+        "description": "Strategy used to locate an element in the visual tree."
+      },
+      "IncludeOption": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "screenshot",
+            "tree"
+          ]
+        },
+        "description": "Optional data to include in the action response."
+      },
+      "TapRequest": {
+        "type": "object",
+        "description": "Request to perform a tap/click action on an element or at coordinates.",
+        "properties": {
+          "elementId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target element identifier. Either elementId or coordinates must be provided."
+          },
+          "x": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "X coordinate for the tap. Used when tapping by position rather than element."
+          },
+          "y": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Y coordinate for the tap. Used when tapping by position rather than element."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "ActionResponse": {
+        "type": "object",
+        "description": "Response returned after executing an action, optionally including a screenshot and/or visual tree.",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the action completed successfully."
+          },
+          "error": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ProblemDetails"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details if the action failed."
+          },
+          "screenshot": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "contentEncoding": "base64",
+            "description": "Base64-encoded screenshot taken after the action, if requested via include."
+          },
+          "tree": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/element-info"
+            },
+            "description": "Visual tree snapshot taken after the action, if requested via include."
+          }
+        }
+      },
+      "FillRequest": {
+        "type": "object",
+        "description": "Request to fill text into an input element.",
+        "required": [
+          "elementId",
+          "text"
+        ],
+        "properties": {
+          "elementId": {
+            "type": "string",
+            "description": "Target input element identifier."
+          },
+          "text": {
+            "type": "string",
+            "description": "Text content to fill into the element."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "ClearRequest": {
+        "type": "object",
+        "description": "Request to clear the content of an input element.",
+        "required": [
+          "elementId"
+        ],
+        "properties": {
+          "elementId": {
+            "type": "string",
+            "description": "Target input element identifier."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "FocusRequest": {
+        "type": "object",
+        "description": "Request to move input focus to an element.",
+        "required": [
+          "elementId"
+        ],
+        "properties": {
+          "elementId": {
+            "type": "string",
+            "description": "Target element identifier to receive focus."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "ScrollRequest": {
+        "type": "object",
+        "description": "Request to perform a scroll action on a scrollable element.",
+        "properties": {
+          "elementId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target scrollable element identifier. If null, scrolls the primary scrollable view."
+          },
+          "deltaX": {
+            "type": "number",
+            "description": "Horizontal scroll delta in device-independent pixels."
+          },
+          "deltaY": {
+            "type": "number",
+            "description": "Vertical scroll delta in device-independent pixels."
+          },
+          "animated": {
+            "type": "boolean",
+            "description": "Whether the scroll should be animated.",
+            "default": true
+          },
+          "itemIndex": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Index of the item to scroll to in a list or collection view.",
+            "minimum": 0
+          },
+          "groupIndex": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Index of the group containing the target item.",
+            "minimum": 0
+          },
+          "scrollToPosition": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "makeVisible",
+              "start",
+              "center",
+              "end",
+              null
+            ],
+            "description": "Alignment of the target item within the viewport after scrolling."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "NavigateRequest": {
+        "type": "object",
+        "description": "Request to navigate to a named route or URI within the application.",
+        "required": [
+          "route"
+        ],
+        "properties": {
+          "route": {
+            "type": "string",
+            "description": "Route or URI to navigate to."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "ResizeRequest": {
+        "type": "object",
+        "description": "Request to resize a window or element.",
+        "required": [
+          "width",
+          "height"
+        ],
+        "properties": {
+          "elementId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target window element identifier. If null, resizes the main application window."
+          },
+          "width": {
+            "type": "integer",
+            "description": "Target width in device-independent pixels.",
+            "minimum": 1
+          },
+          "height": {
+            "type": "integer",
+            "description": "Target height in device-independent pixels.",
+            "minimum": 1
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "BackRequest": {
+        "type": "object",
+        "description": "Request to perform a back navigation action.",
+        "properties": {
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "KeyRequest": {
+        "type": "object",
+        "description": "Request to send a key press event.",
+        "required": [
+          "key"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Key identifier to press (e.g. 'Enter', 'Escape', 'Tab', 'a', 'F1')."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "GestureAction": {
+        "type": "object",
+        "description": "A single action within a gesture sequence.",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "pointerMove",
+              "pointerDown",
+              "pointerUp",
+              "pause"
+            ],
+            "description": "The type of gesture action to perform."
+          },
+          "x": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "X coordinate for the action."
+          },
+          "y": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Y coordinate for the action."
+          },
+          "duration": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Duration of this action in milliseconds.",
+            "minimum": 0
+          },
+          "button": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Pointer button index (0 = primary, 1 = middle, 2 = secondary).",
+            "default": 0,
+            "minimum": 0
+          }
+        }
+      },
+      "GestureRequest": {
+        "type": "object",
+        "description": "Request to perform a complex gesture as a sequence of pointer actions.",
+        "required": [
+          "actions"
+        ],
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GestureAction"
+            },
+            "description": "Ordered sequence of gesture actions to perform."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          }
+        }
+      },
+      "BatchAction": {
+        "type": "object",
+        "description": "A single action within a batch, combining the action type with its parameters.",
+        "required": [
+          "action"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "tap",
+              "fill",
+              "clear",
+              "focus",
+              "scroll",
+              "navigate",
+              "resize",
+              "back",
+              "key",
+              "gesture"
+            ],
+            "description": "The type of action to perform."
+          },
+          "elementId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target element identifier."
+          },
+          "x": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "X coordinate (for tap and gesture actions)."
+          },
+          "y": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Y coordinate (for tap and gesture actions)."
+          },
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Text content (for fill action)."
+          },
+          "deltaX": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Horizontal scroll delta (for scroll action)."
+          },
+          "deltaY": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Vertical scroll delta (for scroll action)."
+          },
+          "animated": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether scroll should be animated (for scroll action)."
+          },
+          "itemIndex": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Item index to scroll to (for scroll action).",
+            "minimum": 0
+          },
+          "groupIndex": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Group index for scroll target (for scroll action).",
+            "minimum": 0
+          },
+          "scrollToPosition": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "makeVisible",
+              "start",
+              "center",
+              "end",
+              null
+            ],
+            "description": "Scroll alignment (for scroll action)."
+          },
+          "route": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Route to navigate to (for navigate action)."
+          },
+          "width": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Target width (for resize action).",
+            "minimum": 1
+          },
+          "height": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Target height (for resize action).",
+            "minimum": 1
+          },
+          "key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Key to press (for key action)."
+          },
+          "actions": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/GestureAction"
+            },
+            "description": "Gesture action sequence (for gesture action)."
+          }
+        }
+      },
+      "BatchRequest": {
+        "type": "object",
+        "description": "Request to perform multiple actions in sequence as a single batch operation.",
+        "required": [
+          "actions"
+        ],
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BatchAction"
+            },
+            "description": "Ordered list of actions to perform."
+          },
+          "include": {
+            "$ref": "#/components/schemas/IncludeOption",
+            "description": "Optional data to include in the response."
+          },
+          "continueOnError": {
+            "type": "boolean",
+            "description": "Whether to continue executing remaining actions if one fails.",
+            "default": false
+          }
+        }
+      },
+      "WebViewContext": {
+        "type": "object",
+        "description": "Represents a discovered WebView context within the application.",
+        "required": [
+          "id",
+          "url",
+          "ready"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this WebView context."
+          },
+          "elementId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Identifier linking this WebView to its corresponding element in the native UI tree."
+          },
+          "url": {
+            "type": "string",
+            "description": "Current URL loaded in the WebView."
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Page title of the WebView content."
+          },
+          "ready": {
+            "type": "boolean",
+            "description": "Whether the WebView is ready for interaction (page loaded and DOM available)."
+          }
+        }
+      },
+      "EvaluateRequest": {
+        "type": "object",
+        "description": "Request to evaluate a JavaScript expression in a WebView context.",
+        "required": [
+          "expression"
+        ],
+        "properties": {
+          "expression": {
+            "type": "string",
+            "description": "JavaScript expression to evaluate."
+          },
+          "contextId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target WebView context identifier. If null, uses the default or only available context."
+          },
+          "returnByValue": {
+            "type": "boolean",
+            "description": "Whether to return the result by value (serialized) rather than by reference.",
+            "default": true
+          }
+        }
+      },
+      "EvaluateResponse": {
+        "type": "object",
+        "description": "Response from evaluating a JavaScript expression.",
+        "properties": {
+          "result": {
+            "description": "The result of the JavaScript evaluation as a JSON value."
+          },
+          "exceptionDetails": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Exception details if the evaluation threw an error.",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Exception message text."
+              },
+              "lineNumber": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Line number where the exception occurred.",
+                "minimum": 0
+              },
+              "columnNumber": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Column number where the exception occurred.",
+                "minimum": 0
+              }
+            }
+          }
+        }
+      },
+      "DomQueryRequest": {
+        "type": "object",
+        "description": "Request to query the DOM using a CSS selector.",
+        "required": [
+          "selector"
+        ],
+        "properties": {
+          "selector": {
+            "type": "string",
+            "description": "CSS selector to query the DOM."
+          },
+          "contextId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target WebView context identifier."
+          }
+        }
+      },
+      "WebViewNavigateRequest": {
+        "type": "object",
+        "description": "Request to navigate a WebView to a URL.",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "URL to navigate the WebView to."
+          },
+          "contextId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target WebView context identifier."
+          }
+        }
+      },
+      "WebViewInputClickRequest": {
+        "type": "object",
+        "description": "Request to click an element within a WebView using a CSS selector.",
+        "required": [
+          "selector"
+        ],
+        "properties": {
+          "selector": {
+            "type": "string",
+            "description": "CSS selector of the element to click."
+          },
+          "contextId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target WebView context identifier."
+          }
+        }
+      },
+      "WebViewInputFillRequest": {
+        "type": "object",
+        "description": "Request to fill text into a WebView input element identified by a CSS selector.",
+        "required": [
+          "selector",
+          "text"
+        ],
+        "properties": {
+          "selector": {
+            "type": "string",
+            "description": "CSS selector of the input element to fill."
+          },
+          "text": {
+            "type": "string",
+            "description": "Text content to fill into the input element."
+          },
+          "contextId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target WebView context identifier."
+          }
+        }
+      },
+      "WebViewInputTextRequest": {
+        "type": "object",
+        "description": "Request to type text into the currently focused element within a WebView.",
+        "required": [
+          "text"
+        ],
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Text to type into the focused element."
+          },
+          "contextId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Target WebView context identifier."
+          }
+        }
+      },
+      "ProfilerCapabilities": {
+        "type": "object",
+        "description": "Describes the profiler capabilities available on the current platform and agent.",
+        "required": [
+          "platform",
+          "managedMemorySupported",
+          "nativeMemorySupported",
+          "gcSupported",
+          "cpuPercentSupported",
+          "fpsSupported",
+          "frameTimingsEstimated",
+          "nativeFrameTimingsSupported",
+          "jankEventsSupported",
+          "uiThreadStallSupported",
+          "threadCountSupported"
+        ],
+        "properties": {
+          "platform": {
+            "type": "string",
+            "description": "Platform identifier (e.g. 'ios', 'android', 'maccatalyst')."
+          },
+          "managedMemorySupported": {
+            "type": "boolean",
+            "description": "Whether managed heap memory measurement is supported."
+          },
+          "nativeMemorySupported": {
+            "type": "boolean",
+            "description": "Whether native memory measurement is supported."
+          },
+          "gcSupported": {
+            "type": "boolean",
+            "description": "Whether garbage collection counter reporting is supported."
+          },
+          "cpuPercentSupported": {
+            "type": "boolean",
+            "description": "Whether CPU percentage measurement is supported."
+          },
+          "fpsSupported": {
+            "type": "boolean",
+            "description": "Whether frames-per-second measurement is supported."
+          },
+          "frameTimingsEstimated": {
+            "type": "boolean",
+            "description": "Whether frame timings are estimated rather than measured directly."
+          },
+          "nativeFrameTimingsSupported": {
+            "type": "boolean",
+            "description": "Whether native frame timing measurement is supported."
+          },
+          "jankEventsSupported": {
+            "type": "boolean",
+            "description": "Whether jank frame detection events are supported."
+          },
+          "uiThreadStallSupported": {
+            "type": "boolean",
+            "description": "Whether UI thread stall detection is supported."
+          },
+          "threadCountSupported": {
+            "type": "boolean",
+            "description": "Whether thread count reporting is supported."
+          }
+        }
+      },
+      "Timestamp": {
+        "type": "string",
+        "format": "date-time",
+        "description": "ISO 8601 date-time timestamp."
+      },
+      "ProfilerSessionInfo": {
+        "type": "object",
+        "description": "Information about an active or completed profiler session.",
+        "required": [
+          "sessionId",
+          "startedAtUtc",
+          "sampleIntervalMs",
+          "isActive"
+        ],
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Unique identifier for this profiler session."
+          },
+          "startedAtUtc": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "UTC timestamp when the profiler session started."
+          },
+          "sampleIntervalMs": {
+            "type": "integer",
+            "description": "Interval between profiler samples in milliseconds.",
+            "minimum": 1
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether the profiler session is currently active."
+          }
+        }
+      },
+      "ProfilerSample": {
+        "type": "object",
+        "description": "A single profiler sample capturing a point-in-time snapshot of performance metrics.",
+        "required": [
+          "tsUtc"
+        ],
+        "properties": {
+          "tsUtc": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "UTC timestamp when this sample was captured."
+          },
+          "fps": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Frames per second at the time of sampling.",
+            "minimum": 0
+          },
+          "frameTimeMsP50": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Median (P50) frame time in milliseconds.",
+            "minimum": 0
+          },
+          "frameTimeMsP95": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "95th percentile (P95) frame time in milliseconds.",
+            "minimum": 0
+          },
+          "worstFrameTimeMs": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Worst (maximum) frame time in milliseconds during the sample interval.",
+            "minimum": 0
+          },
+          "managedBytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Managed heap memory usage in bytes.",
+            "minimum": 0
+          },
+          "gc0": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of generation 0 garbage collections since last sample.",
+            "minimum": 0
+          },
+          "gc1": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of generation 1 garbage collections since last sample.",
+            "minimum": 0
+          },
+          "gc2": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of generation 2 garbage collections since last sample.",
+            "minimum": 0
+          },
+          "nativeMemoryBytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Native (unmanaged) memory usage in bytes.",
+            "minimum": 0
+          },
+          "nativeMemoryKind": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Kind of native memory measurement (e.g. 'resident', 'virtual', 'private')."
+          },
+          "cpuPercent": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "CPU usage percentage at the time of sampling.",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "threadCount": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Total number of threads in the process.",
+            "minimum": 0
+          },
+          "jankFrameCount": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of janky (dropped/slow) frames since last sample.",
+            "minimum": 0
+          },
+          "uiThreadStallCount": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of UI thread stalls since last sample.",
+            "minimum": 0
+          },
+          "frameSource": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Source of frame timing data (e.g. 'choreographer', 'displayLink', 'estimated')."
+          },
+          "frameQuality": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Qualitative assessment of frame quality (e.g. 'smooth', 'mild-jank', 'severe-jank')."
+          }
+        }
+      },
+      "ProfilerMarker": {
+        "type": "object",
+        "description": "A discrete profiler marker event representing a notable occurrence.",
+        "required": [
+          "tsUtc",
+          "type",
+          "name"
+        ],
+        "properties": {
+          "tsUtc": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "UTC timestamp when this marker was recorded."
+          },
+          "type": {
+            "type": "string",
+            "description": "Marker type category (e.g. 'gc', 'layout', 'navigation', 'user')."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the marker event."
+          },
+          "payloadJson": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional JSON-encoded payload with additional marker data."
+          }
+        }
+      },
+      "ProfilerSpan": {
+        "type": "object",
+        "description": "A profiler span representing a timed operation, compatible with OpenTelemetry span semantics.",
+        "required": [
+          "spanId",
+          "startTsUtc",
+          "durationMs",
+          "kind",
+          "name"
+        ],
+        "properties": {
+          "spanId": {
+            "type": "string",
+            "description": "Unique identifier for this span."
+          },
+          "parentSpanId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Identifier of the parent span, or null for root spans."
+          },
+          "traceId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Trace identifier grouping related spans."
+          },
+          "startTsUtc": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "UTC timestamp when this span started."
+          },
+          "endTsUtc": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "UTC timestamp when this span ended, or null if still in progress."
+          },
+          "durationMs": {
+            "type": "number",
+            "description": "Duration of the span in milliseconds.",
+            "minimum": 0
+          },
+          "kind": {
+            "type": "string",
+            "description": "Kind of span (e.g. 'layout', 'render', 'navigation', 'network', 'user')."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name describing the operation."
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Span status (e.g. 'ok', 'error', 'cancelled')."
+          },
+          "threadId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Identifier of the thread this span executed on."
+          },
+          "screen": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Screen or page name where this span occurred."
+          },
+          "elementPath": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Path to the element in the visual tree associated with this span."
+          },
+          "tagsJson": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional JSON-encoded tags with additional span metadata."
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Error message if the span ended with an error."
+          }
+        }
+      },
+      "ProfilerBatch": {
+        "type": "object",
+        "description": "A batch of profiler data including samples, markers, and spans with cursor positions for pagination.",
+        "required": [
+          "sessionId",
+          "samples",
+          "markers",
+          "spans",
+          "sampleCursor",
+          "markerCursor",
+          "spanCursor",
+          "isActive"
+        ],
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Identifier of the profiler session this batch belongs to."
+          },
+          "samples": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfilerSample"
+            },
+            "description": "Array of profiler samples in this batch."
+          },
+          "markers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfilerMarker"
+            },
+            "description": "Array of profiler markers in this batch."
+          },
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfilerSpan"
+            },
+            "description": "Array of profiler spans in this batch."
+          },
+          "sampleCursor": {
+            "type": "integer",
+            "description": "Cursor position for the next page of samples.",
+            "minimum": 0
+          },
+          "markerCursor": {
+            "type": "integer",
+            "description": "Cursor position for the next page of markers.",
+            "minimum": 0
+          },
+          "spanCursor": {
+            "type": "integer",
+            "description": "Cursor position for the next page of spans.",
+            "minimum": 0
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether the profiler session is still actively collecting data."
+          }
+        }
+      },
+      "ProfilerHotspot": {
+        "type": "object",
+        "description": "A profiler hotspot identifying a frequently occurring or slow operation.",
+        "required": [
+          "kind",
+          "name",
+          "count",
+          "avgDurationMs"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "Kind of hotspot (e.g. 'layout', 'render', 'navigation', 'network')."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the operation that is a hotspot."
+          },
+          "screen": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Screen or page where this hotspot occurs."
+          },
+          "count": {
+            "type": "integer",
+            "description": "Number of times this operation was observed.",
+            "minimum": 0
+          },
+          "errorCount": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Number of times this operation resulted in an error.",
+            "minimum": 0
+          },
+          "avgDurationMs": {
+            "type": "number",
+            "description": "Average duration of this operation in milliseconds.",
+            "minimum": 0
+          },
+          "p95DurationMs": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "95th percentile duration in milliseconds.",
+            "minimum": 0
+          },
+          "maxDurationMs": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Maximum observed duration in milliseconds.",
+            "minimum": 0
+          }
+        }
+      },
+      "NetworkRequestSummary": {
+        "type": "object",
+        "description": "Summary of a captured network request with key metadata and timing.",
+        "required": [
+          "id",
+          "timestamp",
+          "method",
+          "url"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this network request."
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "UTC timestamp when the request was initiated."
+          },
+          "method": {
+            "type": "string",
+            "description": "HTTP method (e.g. 'GET', 'POST', 'PUT', 'DELETE')."
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Full URL of the request."
+          },
+          "host": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Hostname portion of the URL."
+          },
+          "path": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Path portion of the URL."
+          },
+          "statusCode": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "HTTP status code of the response, or null if the request has not completed.",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "statusText": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "HTTP status text of the response (e.g. 'OK', 'Not Found')."
+          },
+          "durationMs": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Total request/response duration in milliseconds.",
+            "minimum": 0
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Error message if the request failed."
+          },
+          "requestContentType": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Content-Type header of the request."
+          },
+          "responseContentType": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Content-Type header of the response."
+          },
+          "requestSize": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Size of the request body in bytes.",
+            "minimum": 0
+          },
+          "responseSize": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Size of the response body in bytes.",
+            "minimum": 0
+          }
+        }
+      },
+      "NetworkRequestDetail": {
+        "description": "Detailed view of a captured network request including headers and body content.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NetworkRequestSummary"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "requestHeaders": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Request headers as key-value pairs."
+              },
+              "responseHeaders": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Response headers as key-value pairs."
+              },
+              "requestBody": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Request body content as a string."
+              },
+              "responseBody": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Response body content as a string."
+              },
+              "requestBodyEncoding": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Encoding of the request body (e.g. 'utf-8', 'base64')."
+              },
+              "responseBodyEncoding": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Encoding of the response body (e.g. 'utf-8', 'base64')."
+              },
+              "requestBodyTruncated": {
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Whether the request body was truncated due to size limits."
+              },
+              "responseBodyTruncated": {
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Whether the response body was truncated due to size limits."
+              }
+            }
+          }
+        ]
+      },
+      "LogEntry": {
+        "type": "object",
+        "description": "A single log entry from the application.",
+        "required": [
+          "timestamp",
+          "level",
+          "category",
+          "message",
+          "source"
+        ],
+        "properties": {
+          "timestamp": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "UTC timestamp when the log entry was recorded."
+          },
+          "level": {
+            "type": "string",
+            "enum": [
+              "trace",
+              "debug",
+              "info",
+              "warning",
+              "error",
+              "critical"
+            ],
+            "description": "Severity level of the log entry."
+          },
+          "category": {
+            "type": "string",
+            "description": "Log category or logger name (e.g. 'Microsoft.Maui.Controls', 'HttpClient', 'App')."
+          },
+          "message": {
+            "type": "string",
+            "description": "The log message text."
+          },
+          "exception": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Exception details if the log entry is associated with an error."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "native",
+              "webview",
+              "framework"
+            ],
+            "description": "Origin of the log entry."
+          }
+        }
+      },
+      "DeviceInfo": {
+        "type": "object",
+        "description": "Hardware and platform information about the device.",
+        "required": [
+          "model",
+          "manufacturer",
+          "osVersion",
+          "platform",
+          "idiom",
+          "architecture"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Device model name (e.g. 'iPhone 15 Pro', 'Pixel 8')."
+          },
+          "manufacturer": {
+            "type": "string",
+            "description": "Device manufacturer (e.g. 'Apple', 'Google', 'Samsung')."
+          },
+          "osVersion": {
+            "type": "string",
+            "description": "Operating system version string."
+          },
+          "platform": {
+            "type": "string",
+            "description": "Platform identifier (e.g. 'ios', 'android', 'maccatalyst', 'windows')."
+          },
+          "idiom": {
+            "type": "string",
+            "description": "Device form factor (e.g. 'phone', 'tablet', 'desktop', 'tv', 'watch')."
+          },
+          "architecture": {
+            "type": "string",
+            "description": "CPU architecture (e.g. 'arm64', 'x64', 'x86')."
+          }
+        }
+      },
+      "DisplayInfo": {
+        "type": "object",
+        "description": "Display characteristics of the device screen.",
+        "required": [
+          "width",
+          "height",
+          "density",
+          "orientation"
+        ],
+        "properties": {
+          "width": {
+            "type": "number",
+            "description": "Display width in device-independent pixels.",
+            "minimum": 0
+          },
+          "height": {
+            "type": "number",
+            "description": "Display height in device-independent pixels.",
+            "minimum": 0
+          },
+          "density": {
+            "type": "number",
+            "description": "Display pixel density (ratio of physical to logical pixels).",
+            "exclusiveMinimum": 0
+          },
+          "orientation": {
+            "type": "string",
+            "enum": [
+              "portrait",
+              "landscape"
+            ],
+            "description": "Current display orientation."
+          },
+          "refreshRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Display refresh rate in Hz, or null if unavailable.",
+            "exclusiveMinimum": 0
+          }
+        }
+      },
+      "BatteryInfo": {
+        "type": "object",
+        "description": "Battery status information.",
+        "required": [
+          "level",
+          "state",
+          "powerSource"
+        ],
+        "properties": {
+          "level": {
+            "type": "number",
+            "description": "Battery charge level from empty (0) to full (1).",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "unknown",
+              "charging",
+              "discharging",
+              "full",
+              "notCharging"
+            ],
+            "description": "Current battery charging state."
+          },
+          "powerSource": {
+            "type": "string",
+            "enum": [
+              "unknown",
+              "battery",
+              "ac",
+              "usb",
+              "wireless"
+            ],
+            "description": "Current power source."
+          }
+        }
+      },
+      "ConnectivityInfo": {
+        "type": "object",
+        "description": "Network connectivity status.",
+        "required": [
+          "networkAccess",
+          "connectionProfiles"
+        ],
+        "properties": {
+          "networkAccess": {
+            "type": "string",
+            "enum": [
+              "none",
+              "local",
+              "internet",
+              "constrainedInternet"
+            ],
+            "description": "Level of network access available."
+          },
+          "connectionProfiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Active connection profiles (e.g. 'wifi', 'cellular', 'ethernet', 'bluetooth')."
+          }
+        }
+      },
+      "AppInfo": {
+        "type": "object",
+        "description": "Application metadata.",
+        "required": [
+          "name",
+          "version",
+          "buildNumber",
+          "packageId"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name of the application."
+          },
+          "version": {
+            "type": "string",
+            "description": "Application version string."
+          },
+          "buildNumber": {
+            "type": "string",
+            "description": "Application build number."
+          },
+          "packageId": {
+            "type": "string",
+            "description": "Application package identifier (e.g. 'com.example.myapp')."
+          },
+          "theme": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Current application theme (e.g. 'light', 'dark', 'system')."
+          }
+        }
+      },
+      "SensorInfo": {
+        "type": "object",
+        "description": "Information about a device sensor.",
+        "required": [
+          "name",
+          "available",
+          "active"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the sensor (e.g. 'accelerometer', 'gyroscope', 'magnetometer', 'barometer', 'compass')."
+          },
+          "available": {
+            "type": "boolean",
+            "description": "Whether this sensor is available on the device."
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether this sensor is currently active and streaming data."
+          }
+        }
+      },
+      "PermissionInfo": {
+        "type": "object",
+        "description": "Status of a device permission.",
+        "required": [
+          "name",
+          "status"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the permission (e.g. 'camera', 'location', 'microphone', 'photos', 'contacts')."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "unknown",
+              "denied",
+              "granted",
+              "restricted",
+              "limited"
+            ],
+            "description": "Current status of this permission."
+          }
+        }
+      },
+      "GeolocationResult": {
+        "type": "object",
+        "description": "A geolocation reading.",
+        "required": [
+          "latitude",
+          "longitude",
+          "accuracy",
+          "timestamp"
+        ],
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "description": "Latitude in decimal degrees.",
+            "minimum": -90,
+            "maximum": 90
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Longitude in decimal degrees.",
+            "minimum": -180,
+            "maximum": 180
+          },
+          "altitude": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Altitude in meters above sea level, or null if unavailable."
+          },
+          "accuracy": {
+            "type": "number",
+            "description": "Horizontal accuracy in meters.",
+            "minimum": 0
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/Timestamp",
+            "description": "UTC timestamp when the location was determined."
+          }
+        }
+      },
+      "PreferenceValueType": {
+        "type": "string",
+        "enum": [
+          "string",
+          "int",
+          "bool",
+          "double",
+          "float",
+          "long",
+          "datetime"
+        ],
+        "description": "Data type of a preference value."
+      },
+      "PreferenceEntry": {
+        "type": "object",
+        "description": "A single preference key-value entry.",
+        "required": [
+          "key",
+          "value",
+          "type"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Preference key name."
+          },
+          "value": {
+            "description": "Preference value. The actual JSON type depends on the type field."
+          },
+          "type": {
+            "$ref": "#/components/schemas/PreferenceValueType",
+            "description": "Data type of the preference value."
+          }
+        }
+      },
+      "PreferenceSetRequest": {
+        "type": "object",
+        "description": "Request to set a preference value.",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "description": "The value to set for the preference."
+          },
+          "type": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PreferenceValueType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Data type of the value. If null, the type is auto-detected from the JSON value."
+          },
+          "sharedName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Shared preference container name. If null, uses the default container."
+          }
+        }
+      },
+      "SecureStorageSetRequest": {
+        "type": "object",
+        "description": "Request to set a value in secure (encrypted) storage.",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The string value to store securely."
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -1,0 +1,1806 @@
+openapi: 3.1.0
+info:
+  title: DevFlow Agent Protocol
+  version: 1.0.0
+  description: >
+    Protocol for runtime app inspection, interaction, and debugging in
+    DevFlow-enabled applications.
+  license:
+    name: MIT
+    identifier: MIT
+
+servers:
+  - url: http://localhost:{port}
+    description: Agent HTTP server running inside the target application
+    variables:
+      port:
+        default: "9223"
+        description: Port the agent is listening on
+
+tags:
+  - name: agent
+    description: Agent discovery and status
+  - name: ui
+    description: UI tree inspection, element queries, screenshots
+  - name: ui-actions
+    description: UI interaction (tap, fill, scroll, gestures, etc.)
+  - name: webview
+    description: WebView inspection and interaction
+  - name: profiler
+    description: Performance profiling
+  - name: network
+    description: Network request monitoring
+  - name: logs
+    description: Application logs
+  - name: device
+    description: Device info, sensors, permissions, geolocation
+  - name: storage
+    description: Preferences and secure storage
+  - name: extensions
+    description: Third-party extension routes
+
+paths:
+  # ─────────────────────────────── Agent ───────────────────────────────
+  /api/v1/agent/status:
+    get:
+      operationId: getAgentStatus
+      tags: [agent]
+      summary: Get agent status
+      description: >
+        Returns the agent's identity, platform, version, and running state.
+      responses:
+        "200":
+          description: Agent status
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/agent-status.json"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/agent/capabilities:
+    get:
+      operationId: getAgentCapabilities
+      tags: [agent]
+      summary: Get agent capabilities
+      description: >
+        Returns the capabilities and extensions supported by this agent.
+      responses:
+        "200":
+          description: Agent capabilities
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/agent-capabilities.json"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ─────────────────────────── UI Inspection ───────────────────────────
+  /api/v1/ui/tree:
+    get:
+      operationId: getUiTree
+      tags: [ui]
+      summary: Get visual tree
+      description: >
+        Returns the full visual tree of the application. Windows are root nodes.
+        Use query parameters to limit depth, select a tree layer, or scope to a
+        subtree.
+      parameters:
+        - name: depth
+          in: query
+          description: Maximum depth of the tree to return. Unlimited if omitted.
+          schema:
+            type: integer
+            minimum: 0
+        - name: layer
+          in: query
+          description: Which tree layer to return.
+          schema:
+            type: string
+            enum: [framework, native, render]
+            default: framework
+        - name: rootId
+          in: query
+          description: Element ID to scope the tree to a subtree.
+          schema:
+            type: string
+        - name: include
+          in: query
+          description: Additional data to include with each element.
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [properties]
+          style: form
+          explode: false
+      responses:
+        "200":
+          description: Array of root elements (windows) with their children.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/element-info.json"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/elements/{id}:
+    get:
+      operationId: getElement
+      tags: [ui]
+      summary: Get element by ID
+      description: >
+        Returns a single element by its globally unique identifier.
+      parameters:
+        - $ref: "#/components/parameters/ElementIdPath"
+      responses:
+        "200":
+          description: The requested element.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/element-info.json"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/elements:
+    get:
+      operationId: queryElements
+      tags: [ui]
+      summary: Query elements with locator strategies
+      description: >
+        Searches the visual tree for elements matching the given locator strategy
+        and value.
+      parameters:
+        - name: strategy
+          in: query
+          required: true
+          description: Locator strategy to use.
+          schema:
+            $ref: "./schemas/common.json#/$defs/LocatorStrategy"
+        - name: value
+          in: query
+          required: true
+          description: Locator value.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of results.
+          schema:
+            type: integer
+            minimum: 1
+            default: 10
+        - name: include
+          in: query
+          description: Additional data to include with each element.
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [properties, bounds]
+          style: form
+          explode: false
+      responses:
+        "200":
+          description: Matching elements.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/element-info.json"
+        "400":
+          $ref: "#/components/responses/InvalidSelector"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/hit-test:
+    get:
+      operationId: hitTest
+      tags: [ui]
+      summary: Find element at coordinates
+      description: >
+        Returns the elements at the given screen coordinates, ordered deepest
+        first (innermost element first).
+      parameters:
+        - name: x
+          in: query
+          required: true
+          description: X coordinate.
+          schema:
+            type: number
+        - name: y
+          in: query
+          required: true
+          description: Y coordinate.
+          schema:
+            type: number
+      responses:
+        "200":
+          description: Elements at the given coordinates (deepest first).
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/element-info.json"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/screenshot:
+    get:
+      operationId: captureScreenshot
+      tags: [ui]
+      summary: Capture screenshot
+      description: >
+        Captures a screenshot of the entire screen or a specific element.
+      parameters:
+        - name: elementId
+          in: query
+          description: Element to screenshot. If omitted, captures the full screen.
+          schema:
+            type: string
+        - name: maxWidth
+          in: query
+          description: Maximum width in pixels. The image is scaled down if wider.
+          schema:
+            type: integer
+            minimum: 1
+        - name: scale
+          in: query
+          description: >
+            Scale mode. `native` returns at device pixel density; `auto`
+            returns a reasonable size for agent consumption.
+          schema:
+            type: string
+            enum: [native, auto]
+            default: auto
+        - name: format
+          in: query
+          description: Image format.
+          schema:
+            type: string
+            enum: [png, jpeg]
+            default: png
+      responses:
+        "200":
+          description: Screenshot image.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ─────────────────────────── UI Actions ──────────────────────────────
+  /api/v1/ui/actions/tap:
+    post:
+      operationId: tapElement
+      tags: [ui-actions]
+      summary: Tap element or coordinates
+      description: >
+        Taps on an element (by ID) or at absolute coordinates.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/TapRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "400":
+          $ref: "#/components/responses/ElementNotInteractable"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/fill:
+    post:
+      operationId: fillElement
+      tags: [ui-actions]
+      summary: Fill text into element
+      description: >
+        Clears any existing text and fills the element with the given text.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/FillRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "400":
+          $ref: "#/components/responses/ElementNotInteractable"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/clear:
+    post:
+      operationId: clearElement
+      tags: [ui-actions]
+      summary: Clear text from element
+      description: >
+        Clears any text content from the specified element.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/ClearRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "400":
+          $ref: "#/components/responses/ElementNotInteractable"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/focus:
+    post:
+      operationId: focusElement
+      tags: [ui-actions]
+      summary: Focus element
+      description: >
+        Gives keyboard focus to the specified element.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/FocusRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "400":
+          $ref: "#/components/responses/ElementNotInteractable"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/scroll:
+    post:
+      operationId: scrollElement
+      tags: [ui-actions]
+      summary: Scroll element
+      description: >
+        Scrolls an element by delta, to an item index, or to a named position.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/ScrollRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "400":
+          $ref: "#/components/responses/ElementNotInteractable"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/navigate:
+    post:
+      operationId: navigateRoute
+      tags: [ui-actions]
+      summary: Navigate to route
+      description: >
+        Navigates the application to the specified route or page.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/NavigateRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/resize:
+    post:
+      operationId: resizeWindow
+      tags: [ui-actions]
+      summary: Resize window
+      description: >
+        Resizes a window or element to the given dimensions.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/ResizeRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/back:
+    post:
+      operationId: goBack
+      tags: [ui-actions]
+      summary: Go back
+      description: >
+        Performs a back navigation gesture in the application.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/BackRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/key:
+    post:
+      operationId: pressKey
+      tags: [ui-actions]
+      summary: Press key
+      description: >
+        Sends a key press event to the focused element or the application.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/KeyRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/gesture:
+    post:
+      operationId: performGesture
+      tags: [ui-actions]
+      summary: Perform complex gesture
+      description: >
+        Executes a sequence of pointer actions (move, down, up, pause) to
+        perform complex gestures like swipe, pinch, or drag.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/GestureRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/actions/batch:
+    post:
+      operationId: batchActions
+      tags: [ui-actions]
+      summary: Execute batch actions
+      description: >
+        Executes multiple actions in sequence. Optionally continues on error.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/actions.json#/$defs/BatchRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/ActionSuccess"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ──────────────────────── UI Element Properties ──────────────────────
+  /api/v1/ui/elements/{id}/properties/{name}:
+    get:
+      operationId: getElementProperty
+      tags: [ui]
+      summary: Get element property value
+      description: >
+        Returns the current value of a named property on an element.
+      parameters:
+        - $ref: "#/components/parameters/ElementIdPath"
+        - name: name
+          in: path
+          required: true
+          description: Property name.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Property value.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [value]
+                properties:
+                  value: {}
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    put:
+      operationId: setElementProperty
+      tags: [ui]
+      summary: Set element property value
+      description: >
+        Sets the value of a named property on an element and returns the new
+        value.
+      parameters:
+        - $ref: "#/components/parameters/ElementIdPath"
+        - name: name
+          in: path
+          required: true
+          description: Property name.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [value]
+              properties:
+                value:
+                  description: The value to set.
+      responses:
+        "200":
+          description: The new property value after setting.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [value]
+                properties:
+                  value: {}
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ──────────────────────────── WebView ────────────────────────────────
+  /api/v1/webview/contexts:
+    get:
+      operationId: getWebViewContexts
+      tags: [webview]
+      summary: List WebView instances
+      description: >
+        Returns all active WebView contexts in the application.
+      responses:
+        "200":
+          description: Array of WebView contexts.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/webview.json#/$defs/WebViewContext"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/evaluate:
+    post:
+      operationId: evaluateJavaScript
+      tags: [webview]
+      summary: Execute JavaScript in WebView
+      description: >
+        Evaluates a JavaScript expression inside a WebView context and returns
+        the result.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/webview.json#/$defs/EvaluateRequest"
+      responses:
+        "200":
+          description: Evaluation result.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/webview.json#/$defs/EvaluateResponse"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/dom:
+    get:
+      operationId: getWebViewDom
+      tags: [webview]
+      summary: Get DOM snapshot
+      description: >
+        Returns a simplified snapshot of the DOM tree in the WebView.
+      parameters:
+        - name: contextId
+          in: query
+          description: WebView context ID. Uses the default context if omitted.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Simplified DOM tree.
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Simplified DOM tree representation.
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/dom/query:
+    post:
+      operationId: queryWebViewDom
+      tags: [webview]
+      summary: CSS query in DOM
+      description: >
+        Executes a CSS selector query against the WebView DOM and returns
+        matching nodes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/webview.json#/$defs/DomQueryRequest"
+      responses:
+        "200":
+          description: Matching DOM nodes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: Simplified DOM node.
+        "400":
+          $ref: "#/components/responses/InvalidSelector"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/source:
+    get:
+      operationId: getWebViewSource
+      tags: [webview]
+      summary: Get page source
+      description: >
+        Returns the HTML source of the WebView page.
+      parameters:
+        - name: contextId
+          in: query
+          description: WebView context ID. Uses the default context if omitted.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Page HTML source.
+          content:
+            text/html:
+              schema:
+                type: string
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/navigate:
+    post:
+      operationId: navigateWebView
+      tags: [webview]
+      summary: Navigate WebView
+      description: >
+        Navigates the WebView to the specified URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/webview.json#/$defs/WebViewNavigateRequest"
+      responses:
+        "200":
+          description: Navigation initiated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/input/click:
+    post:
+      operationId: clickInWebView
+      tags: [webview]
+      summary: Click element in WebView
+      description: >
+        Clicks a DOM element matching the given CSS selector inside the WebView.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/webview.json#/$defs/WebViewInputClickRequest"
+      responses:
+        "200":
+          description: Click performed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        "400":
+          $ref: "#/components/responses/InvalidSelector"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/input/fill:
+    post:
+      operationId: fillInWebView
+      tags: [webview]
+      summary: Fill field in WebView
+      description: >
+        Clears and fills a DOM input element matching the given CSS selector.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/webview.json#/$defs/WebViewInputFillRequest"
+      responses:
+        "200":
+          description: Fill performed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        "400":
+          $ref: "#/components/responses/InvalidSelector"
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/input/text:
+    post:
+      operationId: insertTextInWebView
+      tags: [webview]
+      summary: Insert text in WebView
+      description: >
+        Inserts text into the currently focused element in the WebView without
+        clearing existing content.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/webview.json#/$defs/WebViewInputTextRequest"
+      responses:
+        "200":
+          description: Text inserted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/webview/screenshot:
+    get:
+      operationId: captureWebViewScreenshot
+      tags: [webview]
+      summary: Capture WebView screenshot
+      description: >
+        Captures a screenshot of the WebView content.
+      parameters:
+        - name: contextId
+          in: query
+          description: WebView context ID. Uses the default context if omitted.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Screenshot image.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ──────────────────────────── Profiler ───────────────────────────────
+  /api/v1/profiler/capabilities:
+    get:
+      operationId: getProfilerCapabilities
+      tags: [profiler]
+      summary: Get profiling capabilities
+      description: >
+        Returns which profiling features are supported on the current platform.
+      responses:
+        "200":
+          description: Profiler capabilities.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/profiler.json#/$defs/ProfilerCapabilities"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/profiler/sessions:
+    post:
+      operationId: startProfilerSession
+      tags: [profiler]
+      summary: Start profiler session
+      description: >
+        Starts a new profiling session with the given sample interval.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sampleIntervalMs:
+                  type: integer
+                  minimum: 1
+                  description: Sampling interval in milliseconds.
+      responses:
+        "200":
+          description: Session started.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/profiler.json#/$defs/ProfilerSessionInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/profiler/sessions/{id}:
+    delete:
+      operationId: stopProfilerSession
+      tags: [profiler]
+      summary: Stop profiler session
+      description: >
+        Stops an active profiling session.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Profiler session ID.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Session stopped.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/profiler.json#/$defs/ProfilerSessionInfo"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/profiler/sessions/{id}/samples:
+    get:
+      operationId: getProfilerSamples
+      tags: [profiler]
+      summary: Get profiler samples
+      description: >
+        Returns profiling samples, markers, and spans collected since the given
+        cursors. Use cursor values from the previous response to poll for new
+        data.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Profiler session ID.
+          schema:
+            type: string
+        - name: sampleCursor
+          in: query
+          description: Cursor for samples. Start at 0.
+          schema:
+            type: integer
+            minimum: 0
+        - name: markerCursor
+          in: query
+          description: Cursor for markers. Start at 0.
+          schema:
+            type: integer
+            minimum: 0
+        - name: spanCursor
+          in: query
+          description: Cursor for spans. Start at 0.
+          schema:
+            type: integer
+            minimum: 0
+        - name: limit
+          in: query
+          description: Maximum number of items to return per category.
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        "200":
+          description: Profiler batch of samples, markers, and spans.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/profiler.json#/$defs/ProfilerBatch"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/profiler/markers:
+    post:
+      operationId: publishProfilerMarker
+      tags: [profiler]
+      summary: Publish profiler marker
+      description: >
+        Publishes a timestamped marker event into the active profiling session.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/profiler.json#/$defs/ProfilerMarker"
+      responses:
+        "200":
+          description: Marker published.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/profiler/spans:
+    post:
+      operationId: publishProfilerSpan
+      tags: [profiler]
+      summary: Publish profiler span
+      description: >
+        Publishes a completed span into the active profiling session.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/profiler.json#/$defs/ProfilerSpan"
+      responses:
+        "200":
+          description: Span published.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/profiler/hotspots:
+    get:
+      operationId: getProfilerHotspots
+      tags: [profiler]
+      summary: Get performance hotspots
+      description: >
+        Returns aggregated performance hotspots from the profiling session.
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of hotspots to return.
+          schema:
+            type: integer
+            minimum: 1
+        - name: minDurationMs
+          in: query
+          description: Minimum average duration in milliseconds.
+          schema:
+            type: number
+            minimum: 0
+        - name: kind
+          in: query
+          description: Filter by hotspot kind.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Array of hotspots.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/profiler.json#/$defs/ProfilerHotspot"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ──────────────────────────── Network ────────────────────────────────
+  /api/v1/network/requests:
+    get:
+      operationId: getNetworkRequests
+      tags: [network]
+      summary: List captured network requests
+      description: >
+        Returns captured HTTP requests, optionally filtered by host, method, or
+        status code.
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of requests to return.
+          schema:
+            type: integer
+            minimum: 1
+        - name: host
+          in: query
+          description: Filter by host name.
+          schema:
+            type: string
+        - name: method
+          in: query
+          description: Filter by HTTP method.
+          schema:
+            type: string
+        - name: statusCode
+          in: query
+          description: Filter by status code.
+          schema:
+            type: integer
+            minimum: 100
+            maximum: 599
+      responses:
+        "200":
+          description: Array of network request summaries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/network.json#/$defs/NetworkRequestSummary"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: clearNetworkRequests
+      tags: [network]
+      summary: Clear captured requests
+      description: >
+        Clears all captured network requests from the buffer.
+      responses:
+        "204":
+          description: Requests cleared.
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/network/requests/{id}:
+    get:
+      operationId: getNetworkRequestDetail
+      tags: [network]
+      summary: Get network request detail
+      description: >
+        Returns full details for a captured network request, including headers
+        and body content.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Network request ID.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Full network request detail.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/network.json#/$defs/NetworkRequestDetail"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ────────────────────────────── Logs ─────────────────────────────────
+  /api/v1/logs:
+    get:
+      operationId: getLogs
+      tags: [logs]
+      summary: Query application logs
+      description: >
+        Returns application log entries, optionally filtered by source and level.
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of log entries.
+          schema:
+            type: integer
+            minimum: 1
+        - name: skip
+          in: query
+          description: Number of entries to skip (for pagination).
+          schema:
+            type: integer
+            minimum: 0
+        - name: source
+          in: query
+          description: Filter by log source.
+          schema:
+            type: string
+            enum: [native, webview, framework]
+        - name: level
+          in: query
+          description: Minimum log level.
+          schema:
+            type: string
+            enum: [trace, debug, info, warning, error, critical]
+      responses:
+        "200":
+          description: Array of log entries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/logs.json#/$defs/LogEntry"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ────────────────────────────── Device ───────────────────────────────
+  /api/v1/device/info:
+    get:
+      operationId: getDeviceInfo
+      tags: [device]
+      summary: Get device info
+      description: >
+        Returns hardware and OS information about the device.
+      responses:
+        "200":
+          description: Device information.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/DeviceInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/display:
+    get:
+      operationId: getDisplayInfo
+      tags: [device]
+      summary: Get display info
+      description: >
+        Returns display dimensions, density, and orientation.
+      responses:
+        "200":
+          description: Display information.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/DisplayInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/battery:
+    get:
+      operationId: getBatteryInfo
+      tags: [device]
+      summary: Get battery info
+      description: >
+        Returns battery level, state, and power source.
+      responses:
+        "200":
+          description: Battery information.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/BatteryInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/connectivity:
+    get:
+      operationId: getConnectivityInfo
+      tags: [device]
+      summary: Get connectivity info
+      description: >
+        Returns network connectivity status and connection profiles.
+      responses:
+        "200":
+          description: Connectivity information.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/ConnectivityInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/app:
+    get:
+      operationId: getAppInfo
+      tags: [device]
+      summary: Get app info
+      description: >
+        Returns application name, version, build number, and package ID.
+      responses:
+        "200":
+          description: Application information.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/AppInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/sensors:
+    get:
+      operationId: listSensors
+      tags: [device]
+      summary: List available sensors
+      description: >
+        Returns the list of sensors and their availability/active status.
+      responses:
+        "200":
+          description: Array of sensor info.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/device.json#/$defs/SensorInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/sensors/{name}/start:
+    post:
+      operationId: startSensor
+      tags: [device]
+      summary: Start sensor
+      description: >
+        Starts collecting data from the named sensor. Readings are delivered via
+        the WebSocket sensor channel.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Sensor name (e.g. accelerometer, gyroscope, compass).
+          schema:
+            type: string
+        - name: speed
+          in: query
+          description: >
+            Sensor update speed. Framework-dependent (e.g. "fastest",
+            "game", "ui", "default").
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Sensor started.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/SensorInfo"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "501":
+          $ref: "#/components/responses/UnsupportedCapability"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/sensors/{name}/stop:
+    post:
+      operationId: stopSensor
+      tags: [device]
+      summary: Stop sensor
+      description: >
+        Stops collecting data from the named sensor.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Sensor name.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Sensor stopped.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/SensorInfo"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/permissions:
+    get:
+      operationId: listPermissions
+      tags: [device]
+      summary: List permissions
+      description: >
+        Returns the status of all known permissions.
+      responses:
+        "200":
+          description: Array of permission info.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/device.json#/$defs/PermissionInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/permissions/{name}:
+    get:
+      operationId: checkPermission
+      tags: [device]
+      summary: Check permission status
+      description: >
+        Returns the current status of a specific permission.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Permission name (e.g. camera, location, microphone).
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Permission status.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/PermissionInfo"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/geolocation:
+    get:
+      operationId: getGeolocation
+      tags: [device]
+      summary: Get current location
+      description: >
+        Returns the device's current geographic location.
+      parameters:
+        - name: accuracy
+          in: query
+          description: Desired accuracy level.
+          schema:
+            type: string
+        - name: timeout
+          in: query
+          description: Timeout in milliseconds for the location request.
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        "200":
+          description: Current location.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/GeolocationResult"
+        "408":
+          $ref: "#/components/responses/Timeout"
+        "501":
+          $ref: "#/components/responses/UnsupportedCapability"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ─────────────────────────── Storage ─────────────────────────────────
+  /api/v1/storage/preferences:
+    get:
+      operationId: listPreferences
+      tags: [storage]
+      summary: List preferences
+      description: >
+        Returns all preference entries, optionally scoped to a shared container.
+      parameters:
+        - name: sharedName
+          in: query
+          description: Shared preference container name.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Array of preference entries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas/storage.json#/$defs/PreferenceEntry"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: clearPreferences
+      tags: [storage]
+      summary: Clear all preferences
+      description: >
+        Deletes all preferences, optionally scoped to a shared container.
+      parameters:
+        - name: sharedName
+          in: query
+          description: Shared preference container name.
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Preferences cleared.
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/storage/preferences/{key}:
+    get:
+      operationId: getPreference
+      tags: [storage]
+      summary: Get preference value
+      description: >
+        Returns the value of a specific preference key.
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Preference key.
+          schema:
+            type: string
+        - name: type
+          in: query
+          description: Expected value type for deserialization.
+          schema:
+            $ref: "./schemas/storage.json#/$defs/PreferenceValueType"
+        - name: sharedName
+          in: query
+          description: Shared preference container name.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Preference entry.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/storage.json#/$defs/PreferenceEntry"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    put:
+      operationId: setPreference
+      tags: [storage]
+      summary: Set preference value
+      description: >
+        Creates or updates a preference entry.
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Preference key.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/storage.json#/$defs/PreferenceSetRequest"
+      responses:
+        "200":
+          description: Preference set.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/storage.json#/$defs/PreferenceEntry"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: deletePreference
+      tags: [storage]
+      summary: Delete preference
+      description: >
+        Deletes a specific preference by key.
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Preference key.
+          schema:
+            type: string
+        - name: sharedName
+          in: query
+          description: Shared preference container name.
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Preference deleted.
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/storage/secure:
+    delete:
+      operationId: clearSecureStorage
+      tags: [storage]
+      summary: Clear all secure storage
+      description: >
+        Deletes all values from secure storage.
+      responses:
+        "204":
+          description: Secure storage cleared.
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/storage/secure/{key}:
+    get:
+      operationId: getSecureValue
+      tags: [storage]
+      summary: Get secure storage value
+      description: >
+        Returns the value stored under the given key in secure storage.
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Secure storage key.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Secure value.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [value]
+                properties:
+                  value:
+                    type: string
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    put:
+      operationId: setSecureValue
+      tags: [storage]
+      summary: Set secure storage value
+      description: >
+        Stores a value in secure storage under the given key.
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Secure storage key.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/storage.json#/$defs/SecureStorageSetRequest"
+      responses:
+        "200":
+          description: Value stored.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: deleteSecureValue
+      tags: [storage]
+      summary: Delete secure storage value
+      description: >
+        Deletes a specific value from secure storage.
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Secure storage key.
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Value deleted.
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+# ═══════════════════════════ Components ═══════════════════════════════
+components:
+  parameters:
+    ElementIdPath:
+      name: id
+      in: path
+      required: true
+      description: Globally unique element identifier.
+      schema:
+        $ref: "./schemas/common.json#/$defs/ElementId"
+
+  responses:
+    ActionSuccess:
+      description: Action completed.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/actions.json#/$defs/ActionResponse"
+
+    ElementNotFound:
+      description: Element not found.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:element-not-found"
+            title: Element not found
+            status: 404
+            errorCode: element-not-found
+
+    ElementNotInteractable:
+      description: Element is not interactable.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:element-not-interactable"
+            title: Element not interactable
+            status: 400
+            errorCode: element-not-interactable
+
+    InvalidSelector:
+      description: Invalid selector or locator.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:invalid-selector"
+            title: Invalid selector
+            status: 400
+            errorCode: invalid-selector
+
+    Timeout:
+      description: Operation timed out.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:timeout"
+            title: Timeout
+            status: 408
+            errorCode: timeout
+
+    UnsupportedCapability:
+      description: Capability not supported on this platform.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:unsupported-capability"
+            title: Unsupported capability
+            status: 501
+            errorCode: unsupported-capability
+
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:element-not-found"
+            title: Not found
+            status: 404
+
+    InternalError:
+      description: Internal server error.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:internal-error"
+            title: Internal error
+            status: 500
+            errorCode: internal-error

--- a/docs/DevFlow/spec/schemas/actions.json
+++ b/docs/DevFlow/spec/schemas/actions.json
@@ -1,0 +1,518 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "actions.json",
+  "title": "Action Models",
+  "description": "Action request and response models for UI interaction commands.",
+  "$defs": {
+    "IncludeOption": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "screenshot",
+          "tree"
+        ]
+      },
+      "description": "Optional data to include in the action response."
+    },
+    "TapRequest": {
+      "type": "object",
+      "description": "Request to perform a tap/click action on an element or at coordinates.",
+      "properties": {
+        "elementId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target element identifier. Either elementId or coordinates must be provided."
+        },
+        "x": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "X coordinate for the tap. Used when tapping by position rather than element."
+        },
+        "y": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Y coordinate for the tap. Used when tapping by position rather than element."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "FillRequest": {
+      "type": "object",
+      "description": "Request to fill text into an input element.",
+      "required": [
+        "elementId",
+        "text"
+      ],
+      "properties": {
+        "elementId": {
+          "type": "string",
+          "description": "Target input element identifier."
+        },
+        "text": {
+          "type": "string",
+          "description": "Text content to fill into the element."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "ClearRequest": {
+      "type": "object",
+      "description": "Request to clear the content of an input element.",
+      "required": [
+        "elementId"
+      ],
+      "properties": {
+        "elementId": {
+          "type": "string",
+          "description": "Target input element identifier."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "FocusRequest": {
+      "type": "object",
+      "description": "Request to move input focus to an element.",
+      "required": [
+        "elementId"
+      ],
+      "properties": {
+        "elementId": {
+          "type": "string",
+          "description": "Target element identifier to receive focus."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "ScrollRequest": {
+      "type": "object",
+      "description": "Request to perform a scroll action on a scrollable element.",
+      "properties": {
+        "elementId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target scrollable element identifier. If null, scrolls the primary scrollable view."
+        },
+        "deltaX": {
+          "type": "number",
+          "description": "Horizontal scroll delta in device-independent pixels."
+        },
+        "deltaY": {
+          "type": "number",
+          "description": "Vertical scroll delta in device-independent pixels."
+        },
+        "animated": {
+          "type": "boolean",
+          "description": "Whether the scroll should be animated.",
+          "default": true
+        },
+        "itemIndex": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Index of the item to scroll to in a list or collection view.",
+          "minimum": 0
+        },
+        "groupIndex": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Index of the group containing the target item.",
+          "minimum": 0
+        },
+        "scrollToPosition": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "makeVisible",
+            "start",
+            "center",
+            "end",
+            null
+          ],
+          "description": "Alignment of the target item within the viewport after scrolling."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "NavigateRequest": {
+      "type": "object",
+      "description": "Request to navigate to a named route or URI within the application.",
+      "required": [
+        "route"
+      ],
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Route or URI to navigate to."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "ResizeRequest": {
+      "type": "object",
+      "description": "Request to resize a window or element.",
+      "required": [
+        "width",
+        "height"
+      ],
+      "properties": {
+        "elementId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target window element identifier. If null, resizes the main application window."
+        },
+        "width": {
+          "type": "integer",
+          "description": "Target width in device-independent pixels.",
+          "minimum": 1
+        },
+        "height": {
+          "type": "integer",
+          "description": "Target height in device-independent pixels.",
+          "minimum": 1
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "BackRequest": {
+      "type": "object",
+      "description": "Request to perform a back navigation action.",
+      "properties": {
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "KeyRequest": {
+      "type": "object",
+      "description": "Request to send a key press event.",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Key identifier to press (e.g. 'Enter', 'Escape', 'Tab', 'a', 'F1')."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "GestureAction": {
+      "type": "object",
+      "description": "A single action within a gesture sequence.",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "pointerMove",
+            "pointerDown",
+            "pointerUp",
+            "pause"
+          ],
+          "description": "The type of gesture action to perform."
+        },
+        "x": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "X coordinate for the action."
+        },
+        "y": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Y coordinate for the action."
+        },
+        "duration": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Duration of this action in milliseconds.",
+          "minimum": 0
+        },
+        "button": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Pointer button index (0 = primary, 1 = middle, 2 = secondary).",
+          "default": 0,
+          "minimum": 0
+        }
+      }
+    },
+    "GestureRequest": {
+      "type": "object",
+      "description": "Request to perform a complex gesture as a sequence of pointer actions.",
+      "required": [
+        "actions"
+      ],
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GestureAction"
+          },
+          "description": "Ordered sequence of gesture actions to perform."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "BatchAction": {
+      "type": "object",
+      "description": "A single action within a batch, combining the action type with its parameters.",
+      "required": [
+        "action"
+      ],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "tap",
+            "fill",
+            "clear",
+            "focus",
+            "scroll",
+            "navigate",
+            "resize",
+            "back",
+            "key",
+            "gesture"
+          ],
+          "description": "The type of action to perform."
+        },
+        "elementId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target element identifier."
+        },
+        "x": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "X coordinate (for tap and gesture actions)."
+        },
+        "y": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Y coordinate (for tap and gesture actions)."
+        },
+        "text": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Text content (for fill action)."
+        },
+        "deltaX": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Horizontal scroll delta (for scroll action)."
+        },
+        "deltaY": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Vertical scroll delta (for scroll action)."
+        },
+        "animated": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether scroll should be animated (for scroll action)."
+        },
+        "itemIndex": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Item index to scroll to (for scroll action).",
+          "minimum": 0
+        },
+        "groupIndex": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Group index for scroll target (for scroll action).",
+          "minimum": 0
+        },
+        "scrollToPosition": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "makeVisible",
+            "start",
+            "center",
+            "end",
+            null
+          ],
+          "description": "Scroll alignment (for scroll action)."
+        },
+        "route": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Route to navigate to (for navigate action)."
+        },
+        "width": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Target width (for resize action).",
+          "minimum": 1
+        },
+        "height": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Target height (for resize action).",
+          "minimum": 1
+        },
+        "key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Key to press (for key action)."
+        },
+        "actions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/GestureAction"
+          },
+          "description": "Gesture action sequence (for gesture action)."
+        }
+      }
+    },
+    "BatchRequest": {
+      "type": "object",
+      "description": "Request to perform multiple actions in sequence as a single batch operation.",
+      "required": [
+        "actions"
+      ],
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/BatchAction"
+          },
+          "description": "Ordered list of actions to perform."
+        },
+        "include": {
+          "$ref": "#/$defs/IncludeOption",
+          "description": "Optional data to include in the response."
+        },
+        "continueOnError": {
+          "type": "boolean",
+          "description": "Whether to continue executing remaining actions if one fails.",
+          "default": false
+        }
+      }
+    },
+    "ActionResponse": {
+      "type": "object",
+      "description": "Response returned after executing an action, optionally including a screenshot and/or visual tree.",
+      "required": [
+        "success"
+      ],
+      "properties": {
+        "success": {
+          "type": "boolean",
+          "description": "Whether the action completed successfully."
+        },
+        "error": {
+          "oneOf": [
+            { "$ref": "common.json#/$defs/ProblemDetails" },
+            { "type": "null" }
+          ],
+          "description": "Error details if the action failed."
+        },
+        "screenshot": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "contentEncoding": "base64",
+          "description": "Base64-encoded screenshot taken after the action, if requested via include."
+        },
+        "tree": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "element-info.json"
+          },
+          "description": "Visual tree snapshot taken after the action, if requested via include."
+        }
+      }
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "agent-capabilities.json",
+  "title": "AgentCapabilities",
+  "description": "Capability discovery response describing what the agent supports.",
+  "type": "object",
+  "required": [
+    "agent",
+    "capabilities"
+  ],
+  "properties": {
+    "agent": {
+      "type": "object",
+      "description": "Information about the DevFlow agent itself.",
+      "required": [
+        "name",
+        "version",
+        "framework",
+        "frameworkVersion"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the DevFlow agent implementation."
+        },
+        "version": {
+          "type": "string",
+          "description": "Semantic version of the agent."
+        },
+        "framework": {
+          "type": "string",
+          "description": "The UI framework the agent is instrumented for."
+        },
+        "frameworkVersion": {
+          "type": "string",
+          "description": "Version of the UI framework."
+        }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "description": "Map of capability namespaces to their details. Keys are dot-separated namespaces.",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "version",
+          "features"
+        ],
+        "properties": {
+          "version": {
+            "type": "integer",
+            "description": "Capability version number.",
+            "minimum": 1
+          },
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of supported features within this capability namespace."
+          }
+        },
+        "additionalProperties": true,
+        "description": "Capability details including version, features, and optional extra fields."
+      },
+      "examples": [
+        {
+          "ui.tree": {
+            "version": 1,
+            "features": [
+              "find",
+              "query",
+              "snapshot"
+            ]
+          },
+          "ui.actions": {
+            "version": 1,
+            "features": [
+              "tap",
+              "fill",
+              "scroll",
+              "gesture"
+            ]
+          },
+          "ui.screenshot": {
+            "version": 1,
+            "features": [
+              "fullPage",
+              "element"
+            ]
+          },
+          "webview": {
+            "version": 1,
+            "features": [
+              "evaluate",
+              "dom",
+              "navigate"
+            ]
+          },
+          "profiler": {
+            "version": 1,
+            "features": [
+              "samples",
+              "spans",
+              "markers"
+            ]
+          },
+          "network": {
+            "version": 1,
+            "features": [
+              "capture",
+              "detail"
+            ]
+          },
+          "logs": {
+            "version": 1,
+            "features": [
+              "stream",
+              "query"
+            ]
+          },
+          "device.info": {
+            "version": 1,
+            "features": [
+              "display",
+              "battery",
+              "connectivity"
+            ]
+          },
+          "device.sensors": {
+            "version": 1,
+            "features": [
+              "accelerometer",
+              "gyroscope",
+              "compass"
+            ]
+          },
+          "storage.preferences": {
+            "version": 1,
+            "features": [
+              "get",
+              "set",
+              "delete"
+            ]
+          },
+          "storage.secure": {
+            "version": 1,
+            "features": [
+              "get",
+              "set",
+              "delete"
+            ]
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Map of extension namespaces (reverse-domain notation) to their route registrations.",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "routes"
+        ],
+        "properties": {
+          "routes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "method",
+                "path"
+              ],
+              "properties": {
+                "method": {
+                  "type": "string",
+                  "description": "HTTP method for this route (e.g. 'GET', 'POST')."
+                },
+                "path": {
+                  "type": "string",
+                  "description": "URL path for this route."
+                }
+              }
+            },
+            "description": "Routes registered by this extension."
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of this extension."
+          }
+        },
+        "description": "Extension details including registered routes."
+      }
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/agent-status.json
+++ b/docs/DevFlow/spec/schemas/agent-status.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "agent-status.json",
+  "title": "AgentStatus",
+  "description": "Agent status response providing runtime information about the agent, device, and application.",
+  "type": "object",
+  "required": [
+    "agent",
+    "platform",
+    "device",
+    "app",
+    "running",
+    "uptime"
+  ],
+  "properties": {
+    "agent": {
+      "type": "object",
+      "description": "Information about the DevFlow agent itself.",
+      "required": [
+        "name",
+        "version",
+        "framework",
+        "frameworkVersion"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the DevFlow agent implementation."
+        },
+        "version": {
+          "type": "string",
+          "description": "Semantic version of the agent."
+        },
+        "framework": {
+          "type": "string",
+          "description": "The UI layer the agent is instrumented for (for example 'maui' or 'native')."
+        },
+        "frameworkVersion": {
+          "type": "string",
+          "description": "Version of the UI framework."
+        }
+      }
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "ios",
+        "android",
+        "maccatalyst",
+        "windows",
+        "linux",
+        "macos"
+      ],
+      "description": "The target platform the agent is running on."
+    },
+    "device": {
+      "type": "object",
+      "description": "Information about the device or emulator/simulator.",
+      "required": [
+        "model",
+        "manufacturer",
+        "osVersion",
+        "idiom"
+      ],
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Device model name (e.g. 'iPhone 15 Pro', 'Pixel 8')."
+        },
+        "manufacturer": {
+          "type": "string",
+          "description": "Device manufacturer (e.g. 'Apple', 'Google')."
+        },
+        "osVersion": {
+          "type": "string",
+          "description": "Operating system version string."
+        },
+        "idiom": {
+          "type": "string",
+          "enum": [
+            "phone",
+            "tablet",
+            "desktop",
+            "tv",
+            "watch"
+          ],
+          "description": "Device form factor idiom."
+        }
+      }
+    },
+    "app": {
+      "type": "object",
+      "description": "Information about the instrumented application.",
+      "required": [
+        "name",
+        "version",
+        "packageId"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name of the application."
+        },
+        "version": {
+          "type": "string",
+          "description": "Application version string."
+        },
+        "packageId": {
+          "type": "string",
+          "description": "Application package identifier (e.g. 'com.example.myapp')."
+        }
+      }
+    },
+    "running": {
+      "type": "boolean",
+      "description": "Whether the application is currently running and responsive."
+    },
+    "uptime": {
+      "type": "string",
+      "description": "Agent uptime as an ISO 8601 duration (e.g. 'PT1H30M15S').",
+      "pattern": "^P"
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/bounds-info.json
+++ b/docs/DevFlow/spec/schemas/bounds-info.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "bounds-info.json",
+  "title": "BoundsInfo",
+  "description": "Bounding rectangle for a visual element.",
+  "type": "object",
+  "required": [
+    "x",
+    "y",
+    "width",
+    "height"
+  ],
+  "properties": {
+    "x": {
+      "type": "number",
+      "description": "The x-coordinate of the top-left corner."
+    },
+    "y": {
+      "type": "number",
+      "description": "The y-coordinate of the top-left corner."
+    },
+    "width": {
+      "type": "number",
+      "description": "The width of the bounding rectangle.",
+      "minimum": 0
+    },
+    "height": {
+      "type": "number",
+      "description": "The height of the bounding rectangle.",
+      "minimum": 0
+    },
+    "coordinate": {
+      "$ref": "common.json#/$defs/CoordinateSystem",
+      "description": "The coordinate system for this bounding rectangle.",
+      "default": "window"
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/common.json
+++ b/docs/DevFlow/spec/schemas/common.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "common.json",
+  "title": "Common Types",
+  "description": "Common types used across all DevFlow Agent Protocol schemas.",
+  "$defs": {
+    "Timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time timestamp."
+    },
+    "ElementId": {
+      "type": "string",
+      "description": "Globally unique element identifier within the visual tree."
+    },
+    "LocatorStrategy": {
+      "type": "string",
+      "enum": [
+        "accessibility-id",
+        "css-selector",
+        "type",
+        "text",
+        "xpath"
+      ],
+      "description": "Strategy used to locate an element in the visual tree."
+    },
+    "CoordinateSystem": {
+      "type": "string",
+      "enum": [
+        "window",
+        "screen"
+      ],
+      "description": "Coordinate system for bounding rectangles and points."
+    },
+    "ProblemDetails": {
+      "type": "object",
+      "description": "RFC 7807 Problem Details error response.",
+      "required": [
+        "type",
+        "title",
+        "status"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "A URI reference that identifies the problem type."
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, human-readable summary of the problem type."
+        },
+        "status": {
+          "type": "integer",
+          "description": "The HTTP status code for this occurrence of the problem.",
+          "minimum": 100,
+          "maximum": 599
+        },
+        "detail": {
+          "type": "string",
+          "description": "A human-readable explanation specific to this occurrence of the problem."
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "A URI reference that identifies the specific occurrence of the problem."
+        },
+        "errorCode": {
+          "type": "string",
+          "enum": [
+            "element-not-found",
+            "stale-element-reference",
+            "element-not-interactable",
+            "invalid-selector",
+            "timeout",
+            "unknown-command",
+            "unsupported-capability",
+            "internal-error"
+          ],
+          "description": "Machine-readable error code identifying the category of failure."
+        }
+      }
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/device.json
+++ b/docs/DevFlow/spec/schemas/device.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "device.json",
+  "title": "Device Models",
+  "description": "Device information models for hardware, display, battery, connectivity, sensors, and permissions.",
+  "$defs": {
+    "DeviceInfo": {
+      "type": "object",
+      "description": "Hardware and platform information about the device.",
+      "required": [
+        "model",
+        "manufacturer",
+        "osVersion",
+        "platform",
+        "idiom",
+        "architecture"
+      ],
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Device model name (e.g. 'iPhone 15 Pro', 'Pixel 8')."
+        },
+        "manufacturer": {
+          "type": "string",
+          "description": "Device manufacturer (e.g. 'Apple', 'Google', 'Samsung')."
+        },
+        "osVersion": {
+          "type": "string",
+          "description": "Operating system version string."
+        },
+        "platform": {
+          "type": "string",
+          "description": "Platform identifier (e.g. 'ios', 'android', 'maccatalyst', 'windows')."
+        },
+        "idiom": {
+          "type": "string",
+          "description": "Device form factor (e.g. 'phone', 'tablet', 'desktop', 'tv', 'watch')."
+        },
+        "architecture": {
+          "type": "string",
+          "description": "CPU architecture (e.g. 'arm64', 'x64', 'x86')."
+        }
+      }
+    },
+    "DisplayInfo": {
+      "type": "object",
+      "description": "Display characteristics of the device screen.",
+      "required": [
+        "width",
+        "height",
+        "density",
+        "orientation"
+      ],
+      "properties": {
+        "width": {
+          "type": "number",
+          "description": "Display width in device-independent pixels.",
+          "minimum": 0
+        },
+        "height": {
+          "type": "number",
+          "description": "Display height in device-independent pixels.",
+          "minimum": 0
+        },
+        "density": {
+          "type": "number",
+          "description": "Display pixel density (ratio of physical to logical pixels).",
+          "exclusiveMinimum": 0
+        },
+        "orientation": {
+          "type": "string",
+          "enum": [
+            "portrait",
+            "landscape"
+          ],
+          "description": "Current display orientation."
+        },
+        "refreshRate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Display refresh rate in Hz, or null if unavailable.",
+          "exclusiveMinimum": 0
+        }
+      }
+    },
+    "BatteryInfo": {
+      "type": "object",
+      "description": "Battery status information.",
+      "required": [
+        "level",
+        "state",
+        "powerSource"
+      ],
+      "properties": {
+        "level": {
+          "type": "number",
+          "description": "Battery charge level from empty (0) to full (1).",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "unknown",
+            "charging",
+            "discharging",
+            "full",
+            "notCharging"
+          ],
+          "description": "Current battery charging state."
+        },
+        "powerSource": {
+          "type": "string",
+          "enum": [
+            "unknown",
+            "battery",
+            "ac",
+            "usb",
+            "wireless"
+          ],
+          "description": "Current power source."
+        }
+      }
+    },
+    "ConnectivityInfo": {
+      "type": "object",
+      "description": "Network connectivity status.",
+      "required": [
+        "networkAccess",
+        "connectionProfiles"
+      ],
+      "properties": {
+        "networkAccess": {
+          "type": "string",
+          "enum": [
+            "none",
+            "local",
+            "internet",
+            "constrainedInternet"
+          ],
+          "description": "Level of network access available."
+        },
+        "connectionProfiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Active connection profiles (e.g. 'wifi', 'cellular', 'ethernet', 'bluetooth')."
+        }
+      }
+    },
+    "AppInfo": {
+      "type": "object",
+      "description": "Application metadata.",
+      "required": [
+        "name",
+        "version",
+        "buildNumber",
+        "packageId"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name of the application."
+        },
+        "version": {
+          "type": "string",
+          "description": "Application version string."
+        },
+        "buildNumber": {
+          "type": "string",
+          "description": "Application build number."
+        },
+        "packageId": {
+          "type": "string",
+          "description": "Application package identifier (e.g. 'com.example.myapp')."
+        },
+        "theme": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Current application theme (e.g. 'light', 'dark', 'system')."
+        }
+      }
+    },
+    "SensorInfo": {
+      "type": "object",
+      "description": "Information about a device sensor.",
+      "required": [
+        "name",
+        "available",
+        "active"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the sensor (e.g. 'accelerometer', 'gyroscope', 'magnetometer', 'barometer', 'compass')."
+        },
+        "available": {
+          "type": "boolean",
+          "description": "Whether this sensor is available on the device."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether this sensor is currently active and streaming data."
+        }
+      }
+    },
+    "SensorReading": {
+      "type": "object",
+      "description": "A reading from a device sensor. The values object varies by sensor type.",
+      "required": [
+        "sensor",
+        "timestamp",
+        "values"
+      ],
+      "properties": {
+        "sensor": {
+          "type": "string",
+          "description": "Name of the sensor that produced this reading."
+        },
+        "timestamp": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when the reading was taken."
+        },
+        "values": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Sensor-specific values. Common shapes: {x, y, z} for accelerometer/gyroscope/magnetometer, {heading, accuracy} for compass, {pressure} for barometer."
+        }
+      }
+    },
+    "PermissionInfo": {
+      "type": "object",
+      "description": "Status of a device permission.",
+      "required": [
+        "name",
+        "status"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the permission (e.g. 'camera', 'location', 'microphone', 'photos', 'contacts')."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "unknown",
+            "denied",
+            "granted",
+            "restricted",
+            "limited"
+          ],
+          "description": "Current status of this permission."
+        }
+      }
+    },
+    "GeolocationResult": {
+      "type": "object",
+      "description": "A geolocation reading.",
+      "required": [
+        "latitude",
+        "longitude",
+        "accuracy",
+        "timestamp"
+      ],
+      "properties": {
+        "latitude": {
+          "type": "number",
+          "description": "Latitude in decimal degrees.",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "type": "number",
+          "description": "Longitude in decimal degrees.",
+          "minimum": -180,
+          "maximum": 180
+        },
+        "altitude": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Altitude in meters above sea level, or null if unavailable."
+        },
+        "accuracy": {
+          "type": "number",
+          "description": "Horizontal accuracy in meters.",
+          "minimum": 0
+        },
+        "timestamp": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when the location was determined."
+        }
+      }
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/element-info.json
+++ b/docs/DevFlow/spec/schemas/element-info.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "element-info.json",
+  "title": "ElementInfo",
+  "description": "Core visual tree element model representing a single node in the UI hierarchy.",
+  "type": "object",
+  "required": [
+    "id",
+    "type",
+    "fullType",
+    "framework",
+    "state",
+    "bounds"
+  ],
+  "properties": {
+    "id": {
+      "$ref": "common.json#/$defs/ElementId",
+      "description": "Globally unique identifier for this element."
+    },
+    "parentId": {
+      "oneOf": [
+        { "$ref": "common.json#/$defs/ElementId" },
+        { "type": "null" }
+      ],
+      "description": "Identifier of the parent element, or null for root elements."
+    },
+    "type": {
+      "type": "string",
+      "description": "Short type name of the element (e.g. 'Button')."
+    },
+    "fullType": {
+      "type": "string",
+      "description": "Fully qualified type name (e.g. 'Microsoft.Maui.Controls.Button')."
+    },
+    "framework": {
+      "type": "string",
+      "description": "The UI framework that owns this element.",
+      "examples": [
+        "maui",
+        "native",
+        "android",
+        "ios",
+        "windows"
+      ]
+    },
+    "automationId": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Automation identifier set by the developer for testing purposes."
+    },
+    "text": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Visible text content of the element."
+    },
+    "value": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Current value for input elements (e.g. text field content, slider value)."
+    },
+    "role": {
+      "type": "string",
+      "description": "Semantic role of the element for accessibility and interaction purposes.",
+      "examples": [
+        "button",
+        "textbox",
+        "checkbox",
+        "image",
+        "list",
+        "listitem",
+        "link",
+        "heading",
+        "window"
+      ]
+    },
+    "traits": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Semantic traits describing the element's capabilities and behavior.",
+      "examples": [
+        [
+          "interactive",
+          "focusable",
+          "scrollable",
+          "adjustable",
+          "header",
+          "summary"
+        ]
+      ]
+    },
+    "state": {
+      "type": "object",
+      "description": "Current interactive and visual state of the element.",
+      "required": [
+        "displayed",
+        "enabled",
+        "selected",
+        "focused",
+        "opacity"
+      ],
+      "properties": {
+        "displayed": {
+          "type": "boolean",
+          "description": "Whether the element is currently visible on screen."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the element is enabled for user interaction."
+        },
+        "selected": {
+          "type": "boolean",
+          "description": "Whether the element is currently selected."
+        },
+        "focused": {
+          "type": "boolean",
+          "description": "Whether the element currently has input focus."
+        },
+        "opacity": {
+          "type": "number",
+          "description": "Opacity of the element from fully transparent (0) to fully opaque (1).",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "bounds": {
+      "$ref": "bounds-info.json",
+      "description": "Bounding rectangle of the element."
+    },
+    "gestures": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Gesture types recognized by this element.",
+      "examples": [
+        [
+          "tap",
+          "doubleTap",
+          "longPress",
+          "swipe",
+          "pinch"
+        ]
+      ]
+    },
+    "style": {
+      "type": "object",
+      "description": "Style information for the element.",
+      "properties": {
+        "classes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "CSS or style classes applied to this element."
+        }
+      }
+    },
+    "nativeView": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Information about the underlying native platform view.",
+      "properties": {
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Native platform type name (e.g. 'UIButton', 'android.widget.Button')."
+        },
+        "properties": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "description": "Key-value pairs of native view properties."
+        }
+      }
+    },
+    "frameworkProperties": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true,
+      "description": "Framework-specific key-value pairs not captured by standard fields."
+    },
+    "children": {
+      "type": "array",
+      "items": {
+        "$ref": "#",
+        "description": "Child element in the visual tree."
+      },
+      "description": "Child elements forming the subtree under this element."
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/logs.json
+++ b/docs/DevFlow/spec/schemas/logs.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "logs.json",
+  "title": "Log Models",
+  "description": "Log models for capturing and streaming application log entries.",
+  "$defs": {
+    "LogEntry": {
+      "type": "object",
+      "description": "A single log entry from the application.",
+      "required": [
+        "timestamp",
+        "level",
+        "category",
+        "message",
+        "source"
+      ],
+      "properties": {
+        "timestamp": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when the log entry was recorded."
+        },
+        "level": {
+          "type": "string",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warning",
+            "error",
+            "critical"
+          ],
+          "description": "Severity level of the log entry."
+        },
+        "category": {
+          "type": "string",
+          "description": "Log category or logger name (e.g. 'Microsoft.Maui.Controls', 'HttpClient', 'App')."
+        },
+        "message": {
+          "type": "string",
+          "description": "The log message text."
+        },
+        "exception": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Exception details if the log entry is associated with an error."
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "native",
+            "webview",
+            "framework"
+          ],
+          "description": "Origin of the log entry."
+        }
+      }
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/network.json
+++ b/docs/DevFlow/spec/schemas/network.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "network.json",
+  "title": "Network Models",
+  "description": "Network monitoring models for capturing and inspecting HTTP request/response traffic.",
+  "$defs": {
+    "NetworkRequestSummary": {
+      "type": "object",
+      "description": "Summary of a captured network request with key metadata and timing.",
+      "required": [
+        "id",
+        "timestamp",
+        "method",
+        "url"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this network request."
+        },
+        "timestamp": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when the request was initiated."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method (e.g. 'GET', 'POST', 'PUT', 'DELETE')."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Full URL of the request."
+        },
+        "host": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Hostname portion of the URL."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path portion of the URL."
+        },
+        "statusCode": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "HTTP status code of the response, or null if the request has not completed.",
+          "minimum": 100,
+          "maximum": 599
+        },
+        "statusText": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "HTTP status text of the response (e.g. 'OK', 'Not Found')."
+        },
+        "durationMs": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Total request/response duration in milliseconds.",
+          "minimum": 0
+        },
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Error message if the request failed."
+        },
+        "requestContentType": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Content-Type header of the request."
+        },
+        "responseContentType": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Content-Type header of the response."
+        },
+        "requestSize": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Size of the request body in bytes.",
+          "minimum": 0
+        },
+        "responseSize": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Size of the response body in bytes.",
+          "minimum": 0
+        }
+      }
+    },
+    "NetworkRequestDetail": {
+      "description": "Detailed view of a captured network request including headers and body content.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/NetworkRequestSummary"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "requestHeaders": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Request headers as key-value pairs."
+            },
+            "responseHeaders": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Response headers as key-value pairs."
+            },
+            "requestBody": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Request body content as a string."
+            },
+            "responseBody": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Response body content as a string."
+            },
+            "requestBodyEncoding": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Encoding of the request body (e.g. 'utf-8', 'base64')."
+            },
+            "responseBodyEncoding": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Encoding of the response body (e.g. 'utf-8', 'base64')."
+            },
+            "requestBodyTruncated": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether the request body was truncated due to size limits."
+            },
+            "responseBodyTruncated": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether the response body was truncated due to size limits."
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/profiler.json
+++ b/docs/DevFlow/spec/schemas/profiler.json
@@ -1,0 +1,487 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "profiler.json",
+  "title": "Profiler Models",
+  "description": "Profiler-related models for performance monitoring, frame timing, memory, and span tracing.",
+  "$defs": {
+    "ProfilerSample": {
+      "type": "object",
+      "description": "A single profiler sample capturing a point-in-time snapshot of performance metrics.",
+      "required": [
+        "tsUtc"
+      ],
+      "properties": {
+        "tsUtc": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when this sample was captured."
+        },
+        "fps": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Frames per second at the time of sampling.",
+          "minimum": 0
+        },
+        "frameTimeMsP50": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Median (P50) frame time in milliseconds.",
+          "minimum": 0
+        },
+        "frameTimeMsP95": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "95th percentile (P95) frame time in milliseconds.",
+          "minimum": 0
+        },
+        "worstFrameTimeMs": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Worst (maximum) frame time in milliseconds during the sample interval.",
+          "minimum": 0
+        },
+        "managedBytes": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Managed heap memory usage in bytes.",
+          "minimum": 0
+        },
+        "gc0": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of generation 0 garbage collections since last sample.",
+          "minimum": 0
+        },
+        "gc1": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of generation 1 garbage collections since last sample.",
+          "minimum": 0
+        },
+        "gc2": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of generation 2 garbage collections since last sample.",
+          "minimum": 0
+        },
+        "nativeMemoryBytes": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Native (unmanaged) memory usage in bytes.",
+          "minimum": 0
+        },
+        "nativeMemoryKind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Kind of native memory measurement (e.g. 'resident', 'virtual', 'private')."
+        },
+        "cpuPercent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CPU usage percentage at the time of sampling.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "threadCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Total number of threads in the process.",
+          "minimum": 0
+        },
+        "jankFrameCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of janky (dropped/slow) frames since last sample.",
+          "minimum": 0
+        },
+        "uiThreadStallCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of UI thread stalls since last sample.",
+          "minimum": 0
+        },
+        "frameSource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Source of frame timing data (e.g. 'choreographer', 'displayLink', 'estimated')."
+        },
+        "frameQuality": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Qualitative assessment of frame quality (e.g. 'smooth', 'mild-jank', 'severe-jank')."
+        }
+      }
+    },
+    "ProfilerMarker": {
+      "type": "object",
+      "description": "A discrete profiler marker event representing a notable occurrence.",
+      "required": [
+        "tsUtc",
+        "type",
+        "name"
+      ],
+      "properties": {
+        "tsUtc": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when this marker was recorded."
+        },
+        "type": {
+          "type": "string",
+          "description": "Marker type category (e.g. 'gc', 'layout', 'navigation', 'user')."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name of the marker event."
+        },
+        "payloadJson": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional JSON-encoded payload with additional marker data."
+        }
+      }
+    },
+    "ProfilerSpan": {
+      "type": "object",
+      "description": "A profiler span representing a timed operation, compatible with OpenTelemetry span semantics.",
+      "required": [
+        "spanId",
+        "startTsUtc",
+        "durationMs",
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "spanId": {
+          "type": "string",
+          "description": "Unique identifier for this span."
+        },
+        "parentSpanId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Identifier of the parent span, or null for root spans."
+        },
+        "traceId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Trace identifier grouping related spans."
+        },
+        "startTsUtc": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when this span started."
+        },
+        "endTsUtc": {
+          "oneOf": [
+            { "$ref": "common.json#/$defs/Timestamp" },
+            { "type": "null" }
+          ],
+          "description": "UTC timestamp when this span ended, or null if still in progress."
+        },
+        "durationMs": {
+          "type": "number",
+          "description": "Duration of the span in milliseconds.",
+          "minimum": 0
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of span (e.g. 'layout', 'render', 'navigation', 'network', 'user')."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name describing the operation."
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Span status (e.g. 'ok', 'error', 'cancelled')."
+        },
+        "threadId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Identifier of the thread this span executed on."
+        },
+        "screen": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Screen or page name where this span occurred."
+        },
+        "elementPath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the element in the visual tree associated with this span."
+        },
+        "tagsJson": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional JSON-encoded tags with additional span metadata."
+        },
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Error message if the span ended with an error."
+        }
+      }
+    },
+    "ProfilerBatch": {
+      "type": "object",
+      "description": "A batch of profiler data including samples, markers, and spans with cursor positions for pagination.",
+      "required": [
+        "sessionId",
+        "samples",
+        "markers",
+        "spans",
+        "sampleCursor",
+        "markerCursor",
+        "spanCursor",
+        "isActive"
+      ],
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "description": "Identifier of the profiler session this batch belongs to."
+        },
+        "samples": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ProfilerSample"
+          },
+          "description": "Array of profiler samples in this batch."
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ProfilerMarker"
+          },
+          "description": "Array of profiler markers in this batch."
+        },
+        "spans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ProfilerSpan"
+          },
+          "description": "Array of profiler spans in this batch."
+        },
+        "sampleCursor": {
+          "type": "integer",
+          "description": "Cursor position for the next page of samples.",
+          "minimum": 0
+        },
+        "markerCursor": {
+          "type": "integer",
+          "description": "Cursor position for the next page of markers.",
+          "minimum": 0
+        },
+        "spanCursor": {
+          "type": "integer",
+          "description": "Cursor position for the next page of spans.",
+          "minimum": 0
+        },
+        "isActive": {
+          "type": "boolean",
+          "description": "Whether the profiler session is still actively collecting data."
+        }
+      }
+    },
+    "ProfilerHotspot": {
+      "type": "object",
+      "description": "A profiler hotspot identifying a frequently occurring or slow operation.",
+      "required": [
+        "kind",
+        "name",
+        "count",
+        "avgDurationMs"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Kind of hotspot (e.g. 'layout', 'render', 'navigation', 'network')."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the operation that is a hotspot."
+        },
+        "screen": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Screen or page where this hotspot occurs."
+        },
+        "count": {
+          "type": "integer",
+          "description": "Number of times this operation was observed.",
+          "minimum": 0
+        },
+        "errorCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of times this operation resulted in an error.",
+          "minimum": 0
+        },
+        "avgDurationMs": {
+          "type": "number",
+          "description": "Average duration of this operation in milliseconds.",
+          "minimum": 0
+        },
+        "p95DurationMs": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "95th percentile duration in milliseconds.",
+          "minimum": 0
+        },
+        "maxDurationMs": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Maximum observed duration in milliseconds.",
+          "minimum": 0
+        }
+      }
+    },
+    "ProfilerSessionInfo": {
+      "type": "object",
+      "description": "Information about an active or completed profiler session.",
+      "required": [
+        "sessionId",
+        "startedAtUtc",
+        "sampleIntervalMs",
+        "isActive"
+      ],
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "description": "Unique identifier for this profiler session."
+        },
+        "startedAtUtc": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when the profiler session started."
+        },
+        "sampleIntervalMs": {
+          "type": "integer",
+          "description": "Interval between profiler samples in milliseconds.",
+          "minimum": 1
+        },
+        "isActive": {
+          "type": "boolean",
+          "description": "Whether the profiler session is currently active."
+        }
+      }
+    },
+    "ProfilerCapabilities": {
+      "type": "object",
+      "description": "Describes the profiler capabilities available on the current platform and agent.",
+      "required": [
+        "platform",
+        "managedMemorySupported",
+        "nativeMemorySupported",
+        "gcSupported",
+        "cpuPercentSupported",
+        "fpsSupported",
+        "frameTimingsEstimated",
+        "nativeFrameTimingsSupported",
+        "jankEventsSupported",
+        "uiThreadStallSupported",
+        "threadCountSupported"
+      ],
+      "properties": {
+        "platform": {
+          "type": "string",
+          "description": "Platform identifier (e.g. 'ios', 'android', 'maccatalyst')."
+        },
+        "managedMemorySupported": {
+          "type": "boolean",
+          "description": "Whether managed heap memory measurement is supported."
+        },
+        "nativeMemorySupported": {
+          "type": "boolean",
+          "description": "Whether native memory measurement is supported."
+        },
+        "gcSupported": {
+          "type": "boolean",
+          "description": "Whether garbage collection counter reporting is supported."
+        },
+        "cpuPercentSupported": {
+          "type": "boolean",
+          "description": "Whether CPU percentage measurement is supported."
+        },
+        "fpsSupported": {
+          "type": "boolean",
+          "description": "Whether frames-per-second measurement is supported."
+        },
+        "frameTimingsEstimated": {
+          "type": "boolean",
+          "description": "Whether frame timings are estimated rather than measured directly."
+        },
+        "nativeFrameTimingsSupported": {
+          "type": "boolean",
+          "description": "Whether native frame timing measurement is supported."
+        },
+        "jankEventsSupported": {
+          "type": "boolean",
+          "description": "Whether jank frame detection events are supported."
+        },
+        "uiThreadStallSupported": {
+          "type": "boolean",
+          "description": "Whether UI thread stall detection is supported."
+        },
+        "threadCountSupported": {
+          "type": "boolean",
+          "description": "Whether thread count reporting is supported."
+        }
+      }
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/storage.json
+++ b/docs/DevFlow/spec/schemas/storage.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "storage.json",
+  "title": "Storage Models",
+  "description": "Storage models for application preferences and secure storage operations.",
+  "$defs": {
+    "PreferenceValueType": {
+      "type": "string",
+      "enum": [
+        "string",
+        "int",
+        "bool",
+        "double",
+        "float",
+        "long",
+        "datetime"
+      ],
+      "description": "Data type of a preference value."
+    },
+    "PreferenceEntry": {
+      "type": "object",
+      "description": "A single preference key-value entry.",
+      "required": [
+        "key",
+        "value",
+        "type"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Preference key name."
+        },
+        "value": {
+          "description": "Preference value. The actual JSON type depends on the type field."
+        },
+        "type": {
+          "$ref": "#/$defs/PreferenceValueType",
+          "description": "Data type of the preference value."
+        }
+      }
+    },
+    "PreferenceSetRequest": {
+      "type": "object",
+      "description": "Request to set a preference value.",
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "description": "The value to set for the preference."
+        },
+        "type": {
+          "oneOf": [
+            { "$ref": "#/$defs/PreferenceValueType" },
+            { "type": "null" }
+          ],
+          "description": "Data type of the value. If null, the type is auto-detected from the JSON value."
+        },
+        "sharedName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Shared preference container name. If null, uses the default container."
+        }
+      }
+    },
+    "SecureStorageSetRequest": {
+      "type": "object",
+      "description": "Request to set a value in secure (encrypted) storage.",
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The string value to store securely."
+        }
+      }
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/websocket-messages.json
+++ b/docs/DevFlow/spec/schemas/websocket-messages.json
@@ -1,0 +1,427 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "websocket-messages.json",
+  "title": "WebSocket Messages",
+  "description": "WebSocket message envelope and event types for real-time streaming channels.",
+  "$defs": {
+    "WebSocketMessage": {
+      "type": "object",
+      "description": "Base envelope for all WebSocket messages.",
+      "required": [
+        "type",
+        "timestamp"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Message type identifier."
+        },
+        "timestamp": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when this message was produced."
+        },
+        "data": {
+          "description": "Message payload. Structure varies by message type."
+        }
+      }
+    },
+    "SubscribeMessage": {
+      "type": "object",
+      "description": "Client-sent message to subscribe to a streaming channel with an optional filter.",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "subscribe",
+          "description": "Message type, always 'subscribe'."
+        },
+        "filter": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "description": "Channel-specific filter criteria. Structure varies by channel type."
+        }
+      }
+    },
+    "NetworkEvent": {
+      "description": "Network monitoring event. Supports replay of historical entries and live streaming.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Replay of historical network request entries.",
+          "required": [
+            "type",
+            "timestamp",
+            "entries"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "replay",
+              "description": "Event type for historical replay."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the replay message."
+            },
+            "entries": {
+              "type": "array",
+              "items": {
+                "$ref": "network.json#/$defs/NetworkRequestSummary"
+              },
+              "description": "Array of historical network request summaries."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Live network request event.",
+          "required": [
+            "type",
+            "timestamp",
+            "entry"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "request",
+              "description": "Event type for a live network request."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "entry": {
+              "$ref": "network.json#/$defs/NetworkRequestSummary",
+              "description": "The network request summary."
+            }
+          }
+        }
+      ]
+    },
+    "LogEvent": {
+      "description": "Log streaming event. Supports replay of historical entries and live streaming.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Replay of historical log entries.",
+          "required": [
+            "type",
+            "timestamp",
+            "entries"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "replay",
+              "description": "Event type for historical replay."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the replay message."
+            },
+            "entries": {
+              "type": "array",
+              "items": {
+                "$ref": "logs.json#/$defs/LogEntry"
+              },
+              "description": "Array of historical log entries."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Live log entry event.",
+          "required": [
+            "type",
+            "timestamp",
+            "entry"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "log",
+              "description": "Event type for a live log entry."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "entry": {
+              "$ref": "logs.json#/$defs/LogEntry",
+              "description": "The log entry."
+            }
+          }
+        }
+      ]
+    },
+    "SensorEvent": {
+      "description": "Sensor streaming event. Includes subscription confirmation and live readings.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Sensor subscription confirmation.",
+          "required": [
+            "type",
+            "timestamp",
+            "sensor"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "subscribed",
+              "description": "Event type for subscription confirmation."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the confirmation."
+            },
+            "sensor": {
+              "$ref": "device.json#/$defs/SensorInfo",
+              "description": "Information about the subscribed sensor."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Live sensor reading event.",
+          "required": [
+            "type",
+            "timestamp",
+            "reading"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "reading",
+              "description": "Event type for a live sensor reading."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "reading": {
+              "$ref": "device.json#/$defs/SensorReading",
+              "description": "The sensor reading data."
+            }
+          }
+        }
+      ]
+    },
+    "ProfilerEvent": {
+      "description": "Profiler streaming event. Supports batch samples, individual markers, and spans.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Batch of profiler samples.",
+          "required": [
+            "type",
+            "timestamp",
+            "data"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "samples",
+              "description": "Event type for a batch of profiler samples."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "data": {
+              "$ref": "profiler.json#/$defs/ProfilerBatch",
+              "description": "Profiler batch containing samples, markers, and spans."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Individual profiler marker event.",
+          "required": [
+            "type",
+            "timestamp",
+            "data"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "marker",
+              "description": "Event type for a profiler marker."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "data": {
+              "$ref": "profiler.json#/$defs/ProfilerMarker",
+              "description": "The profiler marker data."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Individual profiler span event.",
+          "required": [
+            "type",
+            "timestamp",
+            "data"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "span",
+              "description": "Event type for a profiler span."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "data": {
+              "$ref": "profiler.json#/$defs/ProfilerSpan",
+              "description": "The profiler span data."
+            }
+          }
+        }
+      ]
+    },
+    "UIEvent": {
+      "description": "UI lifecycle and change events.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Navigation event indicating a page or route change.",
+          "required": [
+            "type",
+            "timestamp",
+            "data"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "navigation",
+              "description": "Event type for a navigation change."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "data": {
+              "type": "object",
+              "description": "Navigation event data.",
+              "properties": {
+                "from": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Route or page navigated away from."
+                },
+                "to": {
+                  "type": "string",
+                  "description": "Route or page navigated to."
+                },
+                "navigationType": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Type of navigation (e.g. 'push', 'pop', 'replace', 'modal')."
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Application lifecycle event.",
+          "required": [
+            "type",
+            "timestamp",
+            "data"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "lifecycle",
+              "description": "Event type for an application lifecycle change."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "data": {
+              "type": "object",
+              "description": "Lifecycle event data.",
+              "properties": {
+                "state": {
+                  "type": "string",
+                  "description": "Lifecycle state (e.g. 'created', 'started', 'resumed', 'paused', 'stopped', 'destroyed')."
+                },
+                "previousState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Previous lifecycle state."
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Visual tree change event.",
+          "required": [
+            "type",
+            "timestamp",
+            "data"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "treeChange",
+              "description": "Event type for a visual tree mutation."
+            },
+            "timestamp": {
+              "$ref": "common.json#/$defs/Timestamp",
+              "description": "UTC timestamp of the event."
+            },
+            "data": {
+              "type": "object",
+              "description": "Tree change event data.",
+              "properties": {
+                "changeType": {
+                  "type": "string",
+                  "description": "Type of tree change (e.g. 'added', 'removed', 'modified', 'reordered')."
+                },
+                "elementId": {
+                  "$ref": "common.json#/$defs/ElementId",
+                  "description": "Identifier of the element that changed."
+                },
+                "parentId": {
+                  "oneOf": [
+                    { "$ref": "common.json#/$defs/ElementId" },
+                    { "type": "null" }
+                  ],
+                  "description": "Identifier of the parent element."
+                },
+                "summary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Human-readable summary of the change."
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/DevFlow/spec/schemas/webview.json
+++ b/docs/DevFlow/spec/schemas/webview.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "webview.json",
+  "title": "WebView Models",
+  "description": "WebView interaction models for inspecting and controlling embedded web content.",
+  "$defs": {
+    "WebViewContext": {
+      "type": "object",
+      "description": "Represents a discovered WebView context within the application.",
+      "required": [
+        "id",
+        "url",
+        "ready"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this WebView context."
+        },
+        "elementId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Identifier linking this WebView to its corresponding element in the native UI tree."
+        },
+        "url": {
+          "type": "string",
+          "description": "Current URL loaded in the WebView."
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Page title of the WebView content."
+        },
+        "ready": {
+          "type": "boolean",
+          "description": "Whether the WebView is ready for interaction (page loaded and DOM available)."
+        }
+      }
+    },
+    "EvaluateRequest": {
+      "type": "object",
+      "description": "Request to evaluate a JavaScript expression in a WebView context.",
+      "required": [
+        "expression"
+      ],
+      "properties": {
+        "expression": {
+          "type": "string",
+          "description": "JavaScript expression to evaluate."
+        },
+        "contextId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target WebView context identifier. If null, uses the default or only available context."
+        },
+        "returnByValue": {
+          "type": "boolean",
+          "description": "Whether to return the result by value (serialized) rather than by reference.",
+          "default": true
+        }
+      }
+    },
+    "EvaluateResponse": {
+      "type": "object",
+      "description": "Response from evaluating a JavaScript expression.",
+      "properties": {
+        "result": {
+          "description": "The result of the JavaScript evaluation as a JSON value."
+        },
+        "exceptionDetails": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "Exception details if the evaluation threw an error.",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Exception message text."
+            },
+            "lineNumber": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Line number where the exception occurred.",
+              "minimum": 0
+            },
+            "columnNumber": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Column number where the exception occurred.",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "DomQueryRequest": {
+      "type": "object",
+      "description": "Request to query the DOM using a CSS selector.",
+      "required": [
+        "selector"
+      ],
+      "properties": {
+        "selector": {
+          "type": "string",
+          "description": "CSS selector to query the DOM."
+        },
+        "contextId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target WebView context identifier."
+        }
+      }
+    },
+    "WebViewNavigateRequest": {
+      "type": "object",
+      "description": "Request to navigate a WebView to a URL.",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL to navigate the WebView to."
+        },
+        "contextId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target WebView context identifier."
+        }
+      }
+    },
+    "WebViewInputClickRequest": {
+      "type": "object",
+      "description": "Request to click an element within a WebView using a CSS selector.",
+      "required": [
+        "selector"
+      ],
+      "properties": {
+        "selector": {
+          "type": "string",
+          "description": "CSS selector of the element to click."
+        },
+        "contextId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target WebView context identifier."
+        }
+      }
+    },
+    "WebViewInputFillRequest": {
+      "type": "object",
+      "description": "Request to fill text into a WebView input element identified by a CSS selector.",
+      "required": [
+        "selector",
+        "text"
+      ],
+      "properties": {
+        "selector": {
+          "type": "string",
+          "description": "CSS selector of the input element to fill."
+        },
+        "text": {
+          "type": "string",
+          "description": "Text content to fill into the input element."
+        },
+        "contextId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target WebView context identifier."
+        }
+      }
+    },
+    "WebViewInputTextRequest": {
+      "type": "object",
+      "description": "Request to type text into the currently focused element within a WebView.",
+      "required": [
+        "text"
+      ],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Text to type into the focused element."
+        },
+        "contextId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Target WebView context identifier."
+        }
+      }
+    }
+  }
+}

--- a/samples/DevFlow.Sample.Linux/MauiProgram.cs
+++ b/samples/DevFlow.Sample.Linux/MauiProgram.cs
@@ -8,6 +8,11 @@ namespace DevFlow.Sample;
 
 public static partial class MauiProgram
 {
+	static int ResolveAgentPort()
+		=> int.TryParse(Environment.GetEnvironmentVariable("DEVFLOW_TEST_PORT"), out var envPort)
+			? envPort
+			: 9223;
+
 	public static MauiApp CreateMauiApp()
 	{
 		var builder = MauiApp.CreateBuilder();
@@ -36,7 +41,11 @@ public static partial class MauiProgram
 
 #if DEBUG
 		builder.Logging.AddDebug();
-		builder.AddMauiDevFlowAgent(options => { options.Port = 9223; });
+		builder.AddMauiDevFlowAgent(options =>
+		{
+			options.Port = ResolveAgentPort();
+			options.EnableProfiler = true;
+		});
 		builder.AddMauiBlazorDevFlowTools();
 #endif
 

--- a/samples/DevFlow.Sample.MacOS/MauiProgram.cs
+++ b/samples/DevFlow.Sample.MacOS/MauiProgram.cs
@@ -8,6 +8,11 @@ namespace DevFlow.Sample;
 
 public static partial class MauiProgram
 {
+	static int ResolveAgentPort()
+		=> int.TryParse(Environment.GetEnvironmentVariable("DEVFLOW_TEST_PORT"), out var envPort)
+			? envPort
+			: 9223;
+
 	public static MauiApp CreateMauiApp()
 	{
 		var builder = MauiApp.CreateBuilder();
@@ -32,7 +37,11 @@ public static partial class MauiProgram
 
 #if DEBUG
 		builder.Logging.AddDebug();
-		builder.AddMauiDevFlowAgent();
+		builder.AddMauiDevFlowAgent(options =>
+		{
+			options.Port = ResolveAgentPort();
+			options.EnableProfiler = true;
+		});
 		builder.AddMauiBlazorDevFlowTools();
 #endif
 

--- a/samples/DevFlow.Sample/MauiProgram.cs
+++ b/samples/DevFlow.Sample/MauiProgram.cs
@@ -6,6 +6,11 @@ namespace DevFlow.Sample;
 
 public static class MauiProgram
 {
+	static int ResolveAgentPort()
+		=> int.TryParse(Environment.GetEnvironmentVariable("DEVFLOW_TEST_PORT"), out var envPort)
+			? envPort
+			: 9223;
+
 	public static MauiApp CreateMauiApp()
 	{
 		var builder = MauiApp.CreateBuilder();
@@ -33,7 +38,11 @@ public static class MauiProgram
 #if DEBUG
 		//builder.Services.AddBlazorWebViewDeveloperTools();
 		builder.Logging.AddDebug();
-		builder.AddMauiDevFlowAgent(options => { options.Port = 9223; });
+		builder.AddMauiDevFlowAgent(options =>
+		{
+			options.Port = ResolveAgentPort();
+			options.EnableProfiler = true;
+		});
 		builder.AddMauiBlazorDevFlowTools();
 #endif
 

--- a/samples/DevFlow.Sample/Platforms/Windows/App.xaml.cs
+++ b/samples/DevFlow.Sample/Platforms/Windows/App.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.UI.Xaml;
+using Microsoft.Maui.Handlers;
+using Microsoft.Web.WebView2.Core;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -17,6 +19,25 @@ public partial class App : MauiWinUIApplication
 	public App()
 	{
 		this.InitializeComponent();
+
+#if DEBUG
+		EnableWebView2Debugging();
+#endif
+	}
+
+	void EnableWebView2Debugging()
+	{
+		BlazorWebViewHandler.BlazorWebViewMapper.AppendToMapping("WebViewDebugging", async (handler, view) =>
+		{
+			if (handler.PlatformView is Microsoft.UI.Xaml.Controls.WebView2 webView2)
+			{
+				// Configure environment with remote debugging port for DevFlow CDP bridge
+				var options = new CoreWebView2EnvironmentOptions("--remote-debugging-port=9222");
+				var env = await CoreWebView2Environment.CreateAsync(null, null, options);
+
+				await webView2.EnsureCoreWebView2Async(env);
+			}
+		});
 	}
 
 	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -29,6 +29,16 @@ public class CommandConstructionTests
 		AssertNoWhitespaceAliases(devflowCommand);
 	}
 
+	[Fact]
+	public void DevFlowCommand_UsesMcpAsPrimaryCommandName()
+	{
+		var jsonOption = new Option<bool>("--json");
+		var devflowCommand = DevFlowCommands.CreateDevFlowCommand(jsonOption);
+
+		var mcpCommand = Assert.Single(devflowCommand.Subcommands, c => c.Name == "mcp");
+		Assert.Contains("mcp-serve", mcpCommand.Aliases);
+	}
+
 	private static void AssertNoWhitespaceAliases(Command command)
 	{
 		foreach (var option in command.Options)

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using Microsoft.Maui.Cli.UnitTests.Fixtures;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+[Collection("CLI")]
+public class DevFlowCliIntegrationTests
+{
+    private static async Task<(MockAgentServer server, CliTestHarness cli)> CreateFixturesAsync()
+    {
+        var server = new MockAgentServer();
+        await server.StartAsync();
+        var cli = new CliTestHarness(server.Port);
+        return (server, cli);
+    }
+
+    [Fact]
+    public async Task UiStatus_UsesV1AgentStatusRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "status", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.True(json.TryGetProperty("agent", out _));
+        Assert.True(json.GetProperty("running").GetBoolean());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/agent/status");
+        Assert.Equal("GET", request.Method);
+    }
+
+    [Fact]
+    public async Task UiTree_WithDepth_UsesV1TreeRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "tree", "--depth", "2", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal(JsonValueKind.Array, json.ValueKind);
+        Assert.NotEmpty(server.RecordedRequests);
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/ui/tree");
+        Assert.Contains("depth=2", request.QueryString);
+    }
+
+    [Fact]
+    public async Task UiQuery_ByAutomationId_UsesV1ElementsRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "query", "--automationId", "ClickMeButton", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal(JsonValueKind.Array, json.ValueKind);
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/ui/elements");
+        Assert.Contains("automationId=ClickMeButton", request.QueryString);
+    }
+
+    [Fact]
+    public async Task UiTap_UsesV1ActionRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "tap", "el-1", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/ui/actions/tap");
+        Assert.Equal("POST", request.Method);
+        Assert.Contains("el-1", request.Body);
+    }
+
+    [Fact]
+    public async Task StoragePreferencesSet_UsesPutV1Route()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "preferences", "set", "theme", "dark", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/preferences/theme");
+        Assert.Equal("PUT", request.Method);
+        Assert.Contains("dark", request.Body);
+    }
+
+    [Fact]
+    public async Task DeviceInfo_UsesV1DeviceEndpoint()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "device", "device-info", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal("Apple", json.GetProperty("manufacturer").GetString());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/device/info");
+        Assert.Equal("GET", request.Method);
+    }
+
+    [Fact]
+    public async Task WebViewBrowserGetVersion_UsesV1EvaluateEndpoint()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "webview", "Browser", "getVersion", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("protocolVersion", result.StdOut);
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/webview/evaluate");
+        Assert.Equal("POST", request.Method);
+        Assert.Contains("Browser.getVersion", request.Body);
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.Services;
@@ -228,7 +229,7 @@ public class DeviceManagerTests
 					IsEmulator = true,
 					IsRunning = true,
 					EmulatorId = "Pixel_6_API_35",
-					Details = new Dictionary<string, object> { ["avd"] = "Pixel_6_API_35" }
+					Details = new JsonObject { ["avd"] = "Pixel_6_API_35" }
 				}
 			},
 			Avds = new List<AvdInfo>
@@ -267,7 +268,7 @@ public class DeviceManagerTests
 					IsEmulator = true,
 					IsRunning = true,
 					EmulatorId = "Pixel_6_API_35",
-					Details = new Dictionary<string, object>()
+					Details = new JsonObject()
 				}
 			},
 			Avds = new List<AvdInfo>

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/CliCollection.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/CliCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests.Fixtures;
+
+[CollectionDefinition("CLI", DisableParallelization = true)]
+public sealed class CliCollection
+{
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/CliTestHarness.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/CliTestHarness.cs
@@ -1,0 +1,78 @@
+using System.CommandLine;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow;
+
+namespace Microsoft.Maui.Cli.UnitTests.Fixtures;
+
+public sealed class CliTestHarness
+{
+    private static readonly FieldInfo? s_errorOccurredField =
+        typeof(DevFlowCommands).GetField("_errorOccurred", BindingFlags.Static | BindingFlags.NonPublic);
+
+    private readonly RootCommand _rootCommand;
+    private readonly int _mockAgentPort;
+
+    public CliTestHarness(int mockAgentPort)
+    {
+        _mockAgentPort = mockAgentPort;
+        Program.ResetServices();
+        _rootCommand = Program.BuildRootCommand();
+    }
+
+    public Task<CliResult> InvokeAsync(params string[] args) =>
+        InvokeRawAsync(
+            [
+                .. args,
+                "--agent-host", "localhost",
+                "--agent-port", _mockAgentPort.ToString()
+            ]);
+
+    public async Task<CliResult> InvokeRawAsync(params string[] args)
+    {
+        var stdOut = new StringWriter();
+        var stdErr = new StringWriter();
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+
+        int exitCode;
+
+        try
+        {
+            Console.SetOut(stdOut);
+            Console.SetError(stdErr);
+            s_errorOccurredField?.SetValue(null, false);
+
+            var parseResult = _rootCommand.Parse(args);
+            exitCode = await parseResult.InvokeAsync();
+
+            if (s_errorOccurredField?.GetValue(null) is true)
+                exitCode = 1;
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+
+        return new CliResult
+        {
+            ExitCode = exitCode,
+            StdOut = stdOut.ToString().TrimEnd(),
+            StdErr = stdErr.ToString().TrimEnd()
+        };
+    }
+}
+
+public sealed class CliResult
+{
+    public int ExitCode { get; init; }
+    public string StdOut { get; init; } = string.Empty;
+    public string StdErr { get; init; } = string.Empty;
+
+    public JsonElement ParseJsonOutput()
+    {
+        using var document = JsonDocument.Parse(StdOut);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
@@ -1,0 +1,171 @@
+namespace Microsoft.Maui.Cli.UnitTests.Fixtures;
+
+internal static class MockAgentResponses
+{
+    public const string AgentStatus = """
+        {
+          "timestamp": "2026-04-01T12:00:00Z",
+          "agent": {
+            "name": "Microsoft.Maui.DevFlow.Agent",
+            "version": "0.1.0-test",
+            "framework": ".NET MAUI",
+            "frameworkVersion": "10.0.0"
+          },
+          "device": {
+            "platform": "MacCatalyst",
+            "deviceType": "Physical",
+            "idiom": "Desktop",
+            "displayDensity": 2.0,
+            "windowCount": 1,
+            "windowWidth": 1440,
+            "windowHeight": 900
+          },
+          "app": {
+            "name": "TestApp",
+            "packageId": "com.example.testapp",
+            "version": "1.0.0",
+            "build": "42"
+          },
+          "capabilities": {
+            "ui": true,
+            "screenshots": true,
+            "webview": true,
+            "network": true,
+            "logs": true,
+            "sensors": true,
+            "storage": true,
+            "profiler": true
+          },
+          "running": true,
+          "cdpReady": true,
+          "cdpWebViewCount": 1
+        }
+        """;
+
+    public const string AgentCapabilities = """
+        {
+          "ui": { "supported": true, "features": ["tree", "query", "tap", "fill", "batch"] },
+          "webview": { "supported": true, "features": ["contexts", "evaluate", "source"] },
+          "network": { "supported": true, "features": ["list", "detail", "clear"] },
+          "logs": { "supported": true, "features": ["list", "stream"] },
+          "sensors": { "supported": true, "features": ["list", "start", "stop"] },
+          "storage": { "supported": true, "features": ["preferences", "secure-storage"] },
+          "profiler": { "supported": true, "features": ["capabilities", "sessions", "samples"] }
+        }
+        """;
+
+    public const string VisualTree = """
+        [
+          {
+            "id": "el-root",
+            "type": "ContentPage",
+            "automationId": "MainPage",
+            "text": null,
+            "isVisible": true,
+            "isEnabled": true,
+            "children": [
+              {
+                "id": "el-1",
+                "type": "Button",
+                "automationId": "ClickMeButton",
+                "text": "Click Me",
+                "isVisible": true,
+                "isEnabled": true,
+                "children": []
+              }
+            ]
+          }
+        ]
+        """;
+
+    public const string QueryElements = """
+        [
+          {
+            "id": "el-1",
+            "type": "Button",
+            "automationId": "ClickMeButton",
+            "text": "Click Me",
+            "isVisible": true,
+            "isEnabled": true
+          }
+        ]
+        """;
+
+    public static string SingleElement(string id) => $$"""
+        {
+          "id": "{{id}}",
+          "type": "Button",
+          "automationId": "ClickMeButton",
+          "text": "Click Me",
+          "isVisible": true,
+          "isEnabled": true
+        }
+        """;
+
+    public const string HitTestResult = """
+        {
+          "id": "el-1",
+          "type": "Button",
+          "automationId": "ClickMeButton"
+        }
+        """;
+
+    public const string ActionSuccess = """{"success":true,"message":"ok"}""";
+
+    public const string DeviceInfo = """
+        {
+          "manufacturer": "Apple",
+          "model": "MacBookPro18,1",
+          "name": "My Mac",
+          "platform": "MacCatalyst",
+          "versionString": "15.0"
+        }
+        """;
+
+    public const string PreferencesList = """
+        ["theme", "launchCount"]
+        """;
+
+    public const string PreferenceValue = """
+        {
+          "key": "theme",
+          "value": "dark",
+          "type": "string"
+        }
+        """;
+
+    public const string SecureStorageValue = """
+        {
+          "key": "token",
+          "value": "secret-value"
+        }
+        """;
+
+    public static byte[] ScreenshotPng { get; } = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+
+    public const string WebViews = """
+        [
+          {
+            "id": "webview-1",
+            "title": "Main BlazorWebView",
+            "url": "https://0.0.0.0/",
+            "isReady": true
+          }
+        ]
+        """;
+
+    public static string WebViewEvaluate(string method) => method switch
+    {
+        "Browser.getVersion" => """{"result":{"protocolVersion":"1.3","product":"Chrome/120.0","userAgent":"Mozilla/5.0"}}""",
+        "Runtime.evaluate" => """{"result":{"result":{"type":"number","value":2,"description":"2"}}}""",
+        "DOM.getDocument" => """{"result":{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","childNodeCount":1}}}""",
+        "Page.reload" => """{"result":{}}""",
+        _ => """{"result":{}}"""
+    };
+
+    public const string WebViewSource = """
+        <!DOCTYPE html>
+        <html><body><div id="app">Hello Blazor</div></body></html>
+        """;
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Maui.Cli.UnitTests.Fixtures;
+
+public sealed class MockAgentServer : IAsyncDisposable
+{
+    private readonly List<RecordedRequest> _recordedRequests = [];
+    private readonly object _lock = new();
+    private WebApplication? _app;
+
+    public int Port { get; private set; }
+
+    public IReadOnlyList<RecordedRequest> RecordedRequests
+    {
+        get
+        {
+            lock (_lock)
+                return _recordedRequests.ToList();
+        }
+    }
+
+    public async Task StartAsync()
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.ConfigureKestrel(options => options.Listen(IPAddress.Loopback, 0));
+        builder.Logging.ClearProviders();
+
+        _app = builder.Build();
+
+        _app.Use(async (context, next) =>
+        {
+            string? body = null;
+            if (context.Request.ContentLength > 0 || context.Request.ContentType is not null)
+            {
+                context.Request.EnableBuffering();
+                using var reader = new StreamReader(context.Request.Body, Encoding.UTF8, leaveOpen: true);
+                body = await reader.ReadToEndAsync();
+                context.Request.Body.Position = 0;
+            }
+
+            lock (_lock)
+            {
+                _recordedRequests.Add(new RecordedRequest
+                {
+                    Method = context.Request.Method,
+                    Path = context.Request.Path.Value ?? string.Empty,
+                    QueryString = context.Request.QueryString.Value ?? string.Empty,
+                    Body = body
+                });
+            }
+
+            await next();
+        });
+
+        RegisterAgentEndpoints(_app);
+        RegisterUiEndpoints(_app);
+        RegisterDeviceEndpoints(_app);
+        RegisterStorageEndpoints(_app);
+        RegisterWebViewEndpoints(_app);
+        RegisterNetworkEndpoints(_app);
+
+        await _app.StartAsync();
+        Port = _app.Urls.Select(url => new Uri(url).Port).First();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app is null)
+            return;
+
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+
+    public void ClearRecordedRequests()
+    {
+        lock (_lock)
+            _recordedRequests.Clear();
+    }
+
+    private static void RegisterAgentEndpoints(WebApplication app)
+    {
+        app.MapGet("/api/v1/agent/status", () => Results.Content(MockAgentResponses.AgentStatus, "application/json"));
+        app.MapGet("/api/v1/agent/capabilities", () => Results.Content(MockAgentResponses.AgentCapabilities, "application/json"));
+    }
+
+    private static void RegisterUiEndpoints(WebApplication app)
+    {
+        app.MapGet("/api/v1/ui/tree", () => Results.Content(MockAgentResponses.VisualTree, "application/json"));
+        app.MapGet("/api/v1/ui/elements", () => Results.Content(MockAgentResponses.QueryElements, "application/json"));
+        app.MapGet("/api/v1/ui/elements/{id}", (string id) => Results.Content(MockAgentResponses.SingleElement(id), "application/json"));
+        app.MapGet("/api/v1/ui/hit-test", () => Results.Content(MockAgentResponses.HitTestResult, "application/json"));
+        app.MapGet("/api/v1/ui/screenshot", () => Results.File(MockAgentResponses.ScreenshotPng, "image/png"));
+
+        foreach (var action in new[] { "tap", "fill", "clear", "focus", "navigate", "scroll", "resize", "back", "key", "gesture", "batch" })
+            app.MapPost($"/api/v1/ui/actions/{action}", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+    }
+
+    private static void RegisterDeviceEndpoints(WebApplication app)
+    {
+        app.MapGet("/api/v1/device/info", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
+        app.MapGet("/api/v1/device/app", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
+        app.MapGet("/api/v1/device/display", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
+        app.MapGet("/api/v1/device/battery", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
+        app.MapGet("/api/v1/device/connectivity", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
+        app.MapGet("/api/v1/device/geolocation", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
+        app.MapGet("/api/v1/device/sensors", () => Results.Content("""["accelerometer","gyroscope"]""", "application/json"));
+        app.MapPost("/api/v1/device/sensors/{sensor}/start", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+        app.MapPost("/api/v1/device/sensors/{sensor}/stop", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+    }
+
+    private static void RegisterStorageEndpoints(WebApplication app)
+    {
+        app.MapGet("/api/v1/storage/preferences", () => Results.Content(MockAgentResponses.PreferencesList, "application/json"));
+        app.MapGet("/api/v1/storage/preferences/{key}", () => Results.Content(MockAgentResponses.PreferenceValue, "application/json"));
+        app.MapPut("/api/v1/storage/preferences/{key}", () => Results.Content(MockAgentResponses.PreferenceValue, "application/json"));
+        app.MapDelete("/api/v1/storage/preferences/{key}", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+        app.MapDelete("/api/v1/storage/preferences", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+
+        app.MapGet("/api/v1/storage/secure/{key}", () => Results.Content(MockAgentResponses.SecureStorageValue, "application/json"));
+        app.MapPut("/api/v1/storage/secure/{key}", () => Results.Content(MockAgentResponses.SecureStorageValue, "application/json"));
+        app.MapDelete("/api/v1/storage/secure/{key}", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+        app.MapDelete("/api/v1/storage/secure", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+    }
+
+    private static void RegisterWebViewEndpoints(WebApplication app)
+    {
+        app.MapGet("/api/v1/webview/contexts", () => Results.Content(MockAgentResponses.WebViews, "application/json"));
+        app.MapGet("/api/v1/webview/source", () => Results.Content(MockAgentResponses.WebViewSource, "text/html"));
+        app.MapGet("/api/v1/webview/dom", () => Results.Content("""{"root":{"tag":"html"}}""", "application/json"));
+        app.MapGet("/api/v1/webview/dom/query", () => Results.Content("""{"matches":[{"tag":"div","id":"app"}]}""", "application/json"));
+        app.MapGet("/api/v1/webview/network", () => Results.Content("""{"entries":[]}""", "application/json"));
+        app.MapGet("/api/v1/webview/console", () => Results.Content("""{"entries":[]}""", "application/json"));
+        app.MapGet("/api/v1/webview/screenshot", () => Results.File(MockAgentResponses.ScreenshotPng, "image/png"));
+
+        app.MapPost("/api/v1/webview/evaluate", async (HttpContext context) =>
+        {
+            using var reader = new StreamReader(context.Request.Body);
+            var body = await reader.ReadToEndAsync();
+            var method = JsonDocument.Parse(body).RootElement.GetProperty("method").GetString() ?? string.Empty;
+            return Results.Content(MockAgentResponses.WebViewEvaluate(method), "application/json");
+        });
+    }
+
+    private static void RegisterNetworkEndpoints(WebApplication app)
+    {
+        app.MapGet("/api/v1/network/requests", () => Results.Content("""[]""", "application/json"));
+        app.MapGet("/api/v1/network/requests/{id}", (string id) => Results.Content($$"""{"id":"{{id}}"}""", "application/json"));
+        app.MapDelete("/api/v1/network/requests", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+        app.MapGet("/api/v1/logs", () => Results.Content("""[{"level":"info","message":"ok"}]""", "application/json"));
+    }
+}
+
+public sealed class RecordedRequest
+{
+    public string Method { get; init; } = string.Empty;
+    public string Path { get; init; } = string.Empty;
+    public string QueryString { get; init; } = string.Empty;
+    public string? Body { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Maui.Cli\Microsoft.Maui.Cli.csproj" />
   </ItemGroup>
 

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/OutputFormatterTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/OutputFormatterTests.cs
@@ -59,6 +59,32 @@ public class OutputFormatterTests
 	}
 
 	[Fact]
+	public void JsonOutputFormatter_WriteCliCommandResult_ProducesValidJson()
+	{
+		var sb = new StringBuilder();
+		using var writer = new StringWriter(sb);
+		var formatter = new JsonOutputFormatter(writer);
+
+		formatter.Write(new CliCommandResult
+		{
+			Success = true,
+			Status = "requires_interaction",
+			Message = "Run the command in a terminal",
+			Command = "sdkmanager",
+			Arguments = "--licenses",
+			FullCommand = "sdkmanager --licenses"
+		});
+
+		var output = sb.ToString();
+		Assert.Contains("\"success\": true", output);
+		Assert.Contains("\"status\": \"requires_interaction\"", output);
+		Assert.Contains("\"message\": \"Run the command in a terminal\"", output);
+		Assert.Contains("\"command\": \"sdkmanager\"", output);
+		Assert.Contains("\"arguments\": \"--licenses\"", output);
+		Assert.Contains("\"full_command\": \"sdkmanager --licenses\"", output);
+	}
+
+	[Fact]
 	public void JsonOutputFormatter_WriteException_ConvertsToErrorResult()
 	{
 		var sb = new StringBuilder();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/OutputFormatterTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/OutputFormatterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using System.Text.Json.Nodes;
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Output;
@@ -43,7 +44,11 @@ public class OutputFormatterTests
 		using var writer = new StringWriter(sb);
 		var formatter = new JsonOutputFormatter(writer);
 
-		var data = new { name = "test", value = 42 };
+		var data = new JsonObject
+		{
+			["name"] = "test",
+			["value"] = 42
+		};
 		formatter.Write(data);
 
 		var output = sb.ToString();

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Emulator.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Emulator.cs
@@ -191,7 +191,13 @@ public static partial class AndroidCommands
 
 				if (useJson)
 				{
-					formatter.Write(new { success = true, name = name, package = package, device = device });
+					formatter.Write(new CliCommandResult
+					{
+						Success = true,
+						Name = name,
+						Package = package,
+						Device = device
+					});
 				}
 				else
 				{
@@ -282,7 +288,12 @@ public static partial class AndroidCommands
 
 				if (useJson)
 				{
-					formatter.Write(new { success = true, name = name, status = "started" });
+					formatter.Write(new CliCommandResult
+					{
+						Success = true,
+						Name = name,
+						Status = "started"
+					});
 				}
 				else
 				{
@@ -341,12 +352,12 @@ public static partial class AndroidCommands
 							.HighlightStyle(new Style(Color.DodgerBlue1))
 							.UseConverter(d =>
 							{
-								var avdName = d.Details?.TryGetValue("avd", out var avd) == true ? avd?.ToString() : null;
+								var avdName = d.Details?.TryGetPropertyValue("avd", out var avd) == true ? avd?.ToString() : null;
 								var label = avdName ?? d.Name ?? d.Id;
 								return $"[bold]{Markup.Escape(label)}[/]  [dim]{Markup.Escape(d.Id)}[/]";
 							})
 							.AddChoices(runningEmulators));
-					name = selectedDevice.Details?.TryGetValue("avd", out var avdVal) == true
+					name = selectedDevice.Details?.TryGetPropertyValue("avd", out var avdVal) == true
 						? avdVal?.ToString() ?? selectedDevice.Id
 						: selectedDevice.Id;
 				}
@@ -359,7 +370,7 @@ public static partial class AndroidCommands
 
 				var emulator = runningEmulators.FirstOrDefault(d =>
 					d.Details != null &&
-					d.Details.TryGetValue("avd", out var avd) &&
+					d.Details.TryGetPropertyValue("avd", out var avd) &&
 					string.Equals(avd?.ToString(), name, StringComparison.OrdinalIgnoreCase));
 
 				if (emulator == null)
@@ -398,7 +409,13 @@ public static partial class AndroidCommands
 
 				if (useJson)
 				{
-					formatter.Write(new { success = true, name = name, serial = serial, status = "stopped" });
+					formatter.Write(new CliCommandResult
+					{
+						Success = true,
+						Name = name,
+						Serial = serial,
+						Status = "stopped"
+					});
 				}
 				else
 				{
@@ -475,7 +492,12 @@ public static partial class AndroidCommands
 
 				if (useJson)
 				{
-					formatter.Write(new { success = true, name = name, status = "deleted" });
+					formatter.Write(new CliCommandResult
+					{
+						Success = true,
+						Name = name,
+						Status = "deleted"
+					});
 				}
 				else
 				{

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Jdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Jdk.cs
@@ -38,7 +38,7 @@ public static partial class AndroidCommands
 								 healthCheck.Status == Models.CheckStatus.Warning ? "⚠" : "✗";
 				formatter.WriteInfo($"{statusIcon} {healthCheck.Message}");
 
-				if (healthCheck.Details?.TryGetValue("path", out var path) == true)
+				if (healthCheck.Details?.TryGetPropertyValue("path", out var path) == true)
 					formatter.WriteProgress($"Path: {path}");
 			}
 		});
@@ -72,7 +72,12 @@ public static partial class AndroidCommands
 
 				if (useJson)
 				{
-					formatter.Write(new { success = true, version = version, path = jdkManager.DetectedJdkPath });
+					formatter.Write(new CliCommandResult
+					{
+						Success = true,
+						Version = version,
+						Path = jdkManager.DetectedJdkPath
+					});
 				}
 				else
 				{
@@ -99,7 +104,10 @@ public static partial class AndroidCommands
 			if (useJson)
 			{
 				var formatter = Program.GetFormatter(parseResult);
-				formatter.Write(new { versions = versions });
+				formatter.Write(new CliCommandResult
+				{
+					Versions = versions
+				});
 			}
 			else
 			{

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -396,11 +396,11 @@ public static partial class AndroidCommands
 				{
 					if (useJson)
 					{
-						formatter.Write(new
+						formatter.Write(new CliCommandResult
 						{
-							success = true,
-							status = "already_accepted",
-							message = "SDK licenses are already accepted"
+							Success = true,
+							Status = "already_accepted",
+							Message = "SDK licenses are already accepted"
 						});
 					}
 					else
@@ -416,11 +416,11 @@ public static partial class AndroidCommands
 				{
 					if (useJson)
 					{
-						formatter.Write(new
+						formatter.Write(new CliCommandResult
 						{
-							success = false,
-							status = "sdk_not_found",
-							message = "Android SDK not found. Run 'maui android install' first."
+							Success = false,
+							Status = "sdk_not_found",
+							Message = "Android SDK not found. Run 'maui android install' first."
 						});
 					}
 					else
@@ -433,14 +433,14 @@ public static partial class AndroidCommands
 				if (useJson)
 				{
 					// For IDE integration: return the command to run in a terminal
-					formatter.Write(new
+					formatter.Write(new CliCommandResult
 					{
-						success = true,
-						status = "requires_interaction",
-						message = "Run the following command in a terminal to accept licenses interactively",
-						command = licenseCommand.Value.Command,
-						arguments = licenseCommand.Value.Arguments,
-						full_command = $"{licenseCommand.Value.Command} {licenseCommand.Value.Arguments}"
+						Success = true,
+						Status = "requires_interaction",
+						Message = "Run the following command in a terminal to accept licenses interactively",
+						Command = licenseCommand.Value.Command,
+						Arguments = licenseCommand.Value.Arguments,
+						FullCommand = $"{licenseCommand.Value.Command} {licenseCommand.Value.Arguments}"
 					});
 				}
 				else

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -41,7 +41,7 @@ public static partial class AndroidCommands
 									 sdkCheck.Status == Models.CheckStatus.Warning ? "⚠" : "✗";
 					formatter.WriteInfo($"{statusIcon} {sdkCheck.Message ?? "Android SDK"}");
 
-					if (sdkCheck.Details?.TryGetValue("path", out var path) == true)
+					if (sdkCheck.Details?.TryGetPropertyValue("path", out var path) == true)
 						formatter.WriteProgress($"Path: {path}");
 				}
 			}
@@ -195,7 +195,12 @@ public static partial class AndroidCommands
 				if (TryRequestElevation(androidProvider, formatter, useJson))
 				{
 					if (useJson)
-						formatter.Write(new { success = true, installed = packages, elevated = true });
+						formatter.Write(new CliCommandResult
+						{
+							Success = true,
+							Installed = packages,
+							Elevated = true
+						});
 					else
 						formatter.WriteSuccess("Packages installed successfully (elevated)");
 					return 0;
@@ -232,7 +237,11 @@ public static partial class AndroidCommands
 
 				if (useJson)
 				{
-					formatter.Write(new { success = true, installed = packages });
+					formatter.Write(new CliCommandResult
+					{
+						Success = true,
+						Installed = packages
+					});
 				}
 				else
 				{
@@ -517,7 +526,11 @@ public static partial class AndroidCommands
 
 				if (useJson)
 				{
-					formatter.Write(new { success = true, uninstalled = packages });
+					formatter.Write(new CliCommandResult
+					{
+						Success = true,
+						Uninstalled = packages
+					});
 				}
 				else
 				{

--- a/src/Cli/Microsoft.Maui.Cli/Commands/VersionCommand.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/VersionCommand.cs
@@ -29,12 +29,7 @@ public static class VersionCommand
 			if (useJson)
 			{
 				var formatter = Program.GetFormatter(parseResult);
-				formatter.Write(new
-				{
-					version = version,
-					runtime = Environment.Version.ToString(),
-					os = Environment.OSVersion.ToString()
-				});
+				formatter.WriteVersion(version, Environment.Version.ToString(), Environment.OSVersion.ToString());
 			}
 			else
 			{

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -1370,10 +1370,10 @@ public class DevFlowCommands
         devflowCommand.Add(commandsCmd);
 
         // ===== MCP server command =====
-        var mcpServeCmd = new Command("mcp-serve", "Start MCP (Model Context Protocol) server for AI agent integration via stdio");
-        mcpServeCmd.Aliases.Add("mcp");
-        mcpServeCmd.SetAction(async (ctx, ct) => { await Mcp.McpServerHost.RunAsync(); });
-        devflowCommand.Add(mcpServeCmd);
+        var mcpCmd = new Command("mcp", "Start MCP (Model Context Protocol) server for AI agent integration via stdio");
+        mcpCmd.Aliases.Add("mcp-serve");
+        mcpCmd.SetAction(async (ctx, ct) => { await Mcp.McpServerHost.RunAsync(); });
+        devflowCommand.Add(mcpCmd);
 
         _devflowCommand = devflowCommand;
 
@@ -2117,7 +2117,7 @@ public class DevFlowCommands
         new("broker stop", "Stop the broker daemon", true),
         new("broker status", "Show broker status", false),
         new("broker log", "Show broker log", false),
-        new("mcp-serve", "Start the MCP server", false),
+        new("mcp", "Start the MCP server", false),
         new("commands", "List all available commands", false),
         new("version", "Show CLI version", false),
     };

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -51,9 +51,10 @@ public class DevFlowCommands
         noJsonOption.Recursive = true;
         devflowCommand.Add(noJsonOption);
 
-        // ===== CDP commands (Blazor WebView) =====
+        // ===== WebView commands (Blazor WebView / CDP) =====
         
-        var cdpCommand = new Command("cdp", "Blazor WebView automation via Chrome DevTools Protocol");
+        var cdpCommand = new Command("webview", "Blazor WebView automation via Chrome DevTools Protocol");
+        cdpCommand.Aliases.Add("cdp");
 
         var webviewOption = new Option<string?>("--webview", "-w") { Description = "Target WebView by index, AutomationId, or element ID (default: first WebView)", DefaultValueFactory = _ => null };
         webviewOption.Recursive = true;
@@ -266,9 +267,10 @@ public class DevFlowCommands
         
         devflowCommand.Add(cdpCommand);
         
-        // ===== MAUI Native commands =====
+        // ===== UI commands =====
 
-        var mauiCommand = new Command("MAUI", "Native MAUI app automation commands");
+        var mauiCommand = new Command("ui", "Native app UI automation commands");
+        mauiCommand.Aliases.Add("MAUI");
 
         // Shared window option for commands that target a specific window
         var windowOption = new Option<int?>("--window") { Description = "Window index (0-based, default: first window)" };
@@ -337,7 +339,8 @@ public class DevFlowCommands
         // MAUI hittest
         var hitTestXArg = new Argument<double>("x") { Description = "X coordinate" };
         var hitTestYArg = new Argument<double>("y") { Description = "Y coordinate" };
-        var mauiHitTestCmd = new Command("hittest", "Find elements at a point") { hitTestXArg, hitTestYArg, windowOption };
+        var mauiHitTestCmd = new Command("hit-test", "Find elements at a point") { hitTestXArg, hitTestYArg, windowOption };
+        mauiHitTestCmd.Aliases.Add("hittest");
         mauiHitTestCmd.SetAction(async (ctx, ct) =>
         {
             var host = ctx.GetValue(agentHostOption)!;
@@ -490,7 +493,7 @@ public class DevFlowCommands
         recordingStatusCmd.SetAction((ctx, ct) => { RecordingStatusAsync(); return Task.CompletedTask; });
         recordingCommand.Add(recordingStatusCmd);
 
-        mauiCommand.Add(recordingCommand);
+        devflowCommand.Add(recordingCommand);
 
         // MAUI property
         var propIdArg = new Argument<string>("elementId") { Description = "Element ID" };
@@ -755,7 +758,7 @@ public class DevFlowCommands
             else
                 await MauiLogsAsync(host, port, isJson, ctx.GetValue(logsLimitOption), ctx.GetValue(logsSkipOption), ctx.GetValue(logsSourceOption));
         });
-        mauiCommand.Add(mauiLogsCmd);
+        devflowCommand.Add(mauiLogsCmd);
 
         // ── Network monitoring command ──
         var networkCommand = new Command("network", "Monitor HTTP network requests");
@@ -822,9 +825,12 @@ public class DevFlowCommands
         });
         networkCommand.Add(networkClearCmd);
 
-        mauiCommand.Add(networkCommand);
+        devflowCommand.Add(networkCommand);
 
-        // ===== MAUI preferences subcommands =====
+        // ===== storage subcommands =====
+        var storageCommand = new Command("storage", "Manage app preferences and secure storage");
+
+        // ===== preferences subcommands =====
         var prefsCommand = new Command("preferences", "Manage app preferences (key-value store)");
 
         var prefsSharedNameOption = new Option<string?>("--sharedName") { Description = "Shared preferences container name" };
@@ -839,7 +845,7 @@ public class DevFlowCommands
             var sharedName = ctx.GetValue(prefsSharedNameOption);
             var isJson = output.ResolveJsonMode(json, noJson);
             var qs = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
-            await SimpleGetAsync(host, port, $"/api/preferences{qs}", isJson);
+            await SimpleGetAsync(host, port, $"/api/v1/storage/preferences{qs}", isJson);
         });
         prefsCommand.Add(prefsListCmd);
 
@@ -858,7 +864,7 @@ public class DevFlowCommands
             var isJson = output.ResolveJsonMode(json, noJson);
             var qs = $"?type={Uri.EscapeDataString(type)}";
             if (sharedName != null) qs += $"&sharedName={Uri.EscapeDataString(sharedName)}";
-            await SimpleGetAsync(host, port, $"/api/preferences/{Uri.EscapeDataString(key)}{qs}", isJson);
+            await SimpleGetAsync(host, port, $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}{qs}", isJson);
         });
         prefsCommand.Add(prefsGetCmd);
 
@@ -884,7 +890,7 @@ public class DevFlowCommands
                 ["type"] = type,
                 ["sharedName"] = sharedName
             };
-            await SimplePostAsync(host, port, $"/api/preferences/{Uri.EscapeDataString(key)}", body, isJson);
+            await SimplePutAsync(host, port, $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}", body, isJson);
         });
         prefsCommand.Add(prefsSetCmd);
 
@@ -901,7 +907,7 @@ public class DevFlowCommands
             var sharedName = ctx.GetValue(prefsDeleteSharedNameOption);
             var isJson = output.ResolveJsonMode(json, noJson);
             var qs = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
-            await SimpleDeleteAsync(host, port, $"/api/preferences/{Uri.EscapeDataString(key)}{qs}", isJson);
+            await SimpleDeleteAsync(host, port, $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}{qs}", isJson);
         });
         prefsCommand.Add(prefsDeleteCmd);
 
@@ -916,11 +922,11 @@ public class DevFlowCommands
             var sharedName = ctx.GetValue(prefsClearSharedNameOption);
             var isJson = output.ResolveJsonMode(json, noJson);
             var qs = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
-            await SimplePostAsync(host, port, $"/api/preferences/clear{qs}", null, isJson);
+            await SimpleDeleteAsync(host, port, $"/api/v1/storage/preferences{qs}", isJson);
         });
         prefsCommand.Add(prefsClearCmd);
 
-        mauiCommand.Add(prefsCommand);
+        storageCommand.Add(prefsCommand);
 
         // ===== MAUI secure-storage subcommands =====
         var secureCommand = new Command("secure-storage", "Manage secure storage (encrypted key-value store)");
@@ -935,7 +941,7 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var key = ctx.GetValue(secureGetKeyArg)!;
             var isJson = output.ResolveJsonMode(json, noJson);
-            await SimpleGetAsync(host, port, $"/api/secure-storage/{Uri.EscapeDataString(key)}", isJson);
+            await SimpleGetAsync(host, port, $"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", isJson);
         });
         secureCommand.Add(secureGetCmd);
 
@@ -951,7 +957,7 @@ public class DevFlowCommands
             var key = ctx.GetValue(secureSetKeyArg)!;
             var value = ctx.GetValue(secureSetValueArg)!;
             var isJson = output.ResolveJsonMode(json, noJson);
-            await SimplePostAsync(host, port, $"/api/secure-storage/{Uri.EscapeDataString(key)}", new JsonObject
+            await SimplePutAsync(host, port, $"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", new JsonObject
             {
                 ["value"] = value
             }, isJson);
@@ -968,7 +974,7 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var key = ctx.GetValue(secureDeleteKeyArg)!;
             var isJson = output.ResolveJsonMode(json, noJson);
-            await SimpleDeleteAsync(host, port, $"/api/secure-storage/{Uri.EscapeDataString(key)}", isJson);
+            await SimpleDeleteAsync(host, port, $"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", isJson);
         });
         secureCommand.Add(secureDeleteCmd);
 
@@ -980,14 +986,16 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var isJson = output.ResolveJsonMode(json, noJson);
-            await SimplePostAsync(host, port, "/api/secure-storage/clear", null, isJson);
+            await SimpleDeleteAsync(host, port, "/api/v1/storage/secure", isJson);
         });
         secureCommand.Add(secureClearCmd);
 
-        mauiCommand.Add(secureCommand);
+        storageCommand.Add(secureCommand);
+        devflowCommand.Add(storageCommand);
 
-        // ===== MAUI platform subcommands (read-only) =====
-        var platformCommand = new Command("platform", "Query platform features and device info");
+        // ===== device subcommands (read-only) =====
+        var platformCommand = new Command("device", "Query app, device, and sensor information");
+        platformCommand.Aliases.Add("platform");
 
         var platformAppInfoCmd = new Command("app-info", "Get app name, version, package name, theme");
         platformAppInfoCmd.SetAction(async (ctx, ct) =>
@@ -996,7 +1004,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/app-info", output.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/v1/device/app", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformAppInfoCmd);
 
@@ -1007,7 +1015,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/device-info", output.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/v1/device/info", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformDeviceInfoCmd);
 
@@ -1018,7 +1026,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/device-display", output.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/v1/device/display", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformDisplayCmd);
 
@@ -1029,7 +1037,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/battery", output.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/v1/device/battery", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformBatteryCmd);
 
@@ -1040,7 +1048,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/connectivity", output.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/v1/device/connectivity", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformConnectivityCmd);
 
@@ -1051,7 +1059,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/platform/version-tracking", output.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/v1/device/version-tracking", output.ResolveJsonMode(json, noJson));
         });
         platformCommand.Add(platformVersionTrackingCmd);
 
@@ -1066,8 +1074,8 @@ public class DevFlowCommands
             var permName = ctx.GetValue(platformPermsNameArg);
             var isJson = output.ResolveJsonMode(json, noJson);
             var path = permName != null
-            ? $"/api/platform/permissions/{Uri.EscapeDataString(permName)}"
-            : "/api/platform/permissions";
+            ? $"/api/v1/device/permissions/{Uri.EscapeDataString(permName)}"
+            : "/api/v1/device/permissions";
             await SimpleGetAsync(host, port, path, isJson);
         });
         platformCommand.Add(platformPermsCmd);
@@ -1084,11 +1092,11 @@ public class DevFlowCommands
             var accuracy = ctx.GetValue(platformGeoAccuracyOption)!;
             var timeout = ctx.GetValue(platformGeoTimeoutOption);
             var isJson = output.ResolveJsonMode(json, noJson);
-            await SimpleGetAsync(host, port, $"/api/platform/geolocation?accuracy={Uri.EscapeDataString(accuracy)}&timeout={timeout}", isJson);
+            await SimpleGetAsync(host, port, $"/api/v1/device/geolocation?accuracy={Uri.EscapeDataString(accuracy)}&timeout={timeout}", isJson);
         });
         platformCommand.Add(platformGeoCmd);
 
-        mauiCommand.Add(platformCommand);
+        devflowCommand.Add(platformCommand);
 
         // ===== MAUI sensors subcommands =====
         var sensorsCommand = new Command("sensors", "Monitor device sensors");
@@ -1100,7 +1108,7 @@ public class DevFlowCommands
             var port = ctx.GetValue(agentPortOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await SimpleGetAsync(host, port, "/api/sensors", output.ResolveJsonMode(json, noJson));
+            await SimpleGetAsync(host, port, "/api/v1/device/sensors", output.ResolveJsonMode(json, noJson));
         });
         sensorsCommand.Add(sensorsListCmd);
 
@@ -1116,7 +1124,7 @@ public class DevFlowCommands
             var sensor = ctx.GetValue(sensorsStartSensorArg)!;
             var speed = ctx.GetValue(sensorsStartSpeedOption)!;
             var isJson = output.ResolveJsonMode(json, noJson);
-            await SimplePostAsync(host, port, $"/api/sensors/{Uri.EscapeDataString(sensor)}/start?speed={Uri.EscapeDataString(speed)}", null, isJson);
+            await SimplePostAsync(host, port, $"/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/start?speed={Uri.EscapeDataString(speed)}", null, isJson);
         });
         sensorsCommand.Add(sensorsStartCmd);
 
@@ -1130,7 +1138,7 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var sensor = ctx.GetValue(sensorsStopSensorArg)!;
             var isJson = output.ResolveJsonMode(json, noJson);
-            await SimplePostAsync(host, port, $"/api/sensors/{Uri.EscapeDataString(sensor)}/stop", null, isJson);
+            await SimplePostAsync(host, port, $"/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/stop", null, isJson);
         });
         sensorsCommand.Add(sensorsStopCmd);
 
@@ -1154,7 +1162,7 @@ public class DevFlowCommands
         });
         sensorsCommand.Add(sensorsStreamCmd);
 
-        mauiCommand.Add(sensorsCommand);
+        platformCommand.Add(sensorsCommand);
 
         devflowCommand.Add(mauiCommand);
 
@@ -1260,6 +1268,60 @@ public class DevFlowCommands
         });
         devflowCommand.Add(waitCmd);
 
+        // ===== agent command family =====
+        var agentCommand = new Command("agent", "Discover and inspect connected DevFlow agents");
+
+        var agentStatusWindowOption = new Option<int?>("--window") { Description = "Window index (0-based, default: first window)" };
+        var agentStatusCmd = new Command("status", "Check the selected agent connection") { agentStatusWindowOption };
+        agentStatusCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            var window = ctx.GetValue(agentStatusWindowOption);
+            await MauiStatusAsync(host, port, output.ResolveJsonMode(json, noJson), window);
+        });
+        agentCommand.Add(agentStatusCmd);
+
+        var agentListCmd = new Command("list", "List all connected agents");
+        agentListCmd.SetAction(async (ctx, ct) =>
+        {
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson));
+        });
+        agentCommand.Add(agentListCmd);
+
+        var agentWaitTimeoutOption = new Option<int>("--timeout", "-t") { Description = "Maximum seconds to wait for an agent to connect", DefaultValueFactory = _ => 120 };
+        var agentWaitProjectOption = new Option<string?>("--project") { Description = "Filter by project path (csproj). Resolves to full path for matching.", DefaultValueFactory = _ => null };
+        var agentWaitPlatformOption = new Option<string?>("--platform") { Description = "Filter by platform (e.g., macOS, iOS, Android)", DefaultValueFactory = _ => null };
+        var agentWaitCmd = new Command("wait", "Wait for an agent to connect")
+        {
+            agentWaitTimeoutOption, agentWaitProjectOption, agentWaitPlatformOption
+        };
+        agentWaitCmd.SetAction(async (ctx, ct) =>
+        {
+            var timeout = ctx.GetValue(agentWaitTimeoutOption);
+            var project = ctx.GetValue(agentWaitProjectOption);
+            var waitPlatform = ctx.GetValue(agentWaitPlatformOption);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson));
+        });
+        agentCommand.Add(agentWaitCmd);
+
+        var agentDiagnoseCmd = new Command("diagnose", "Check DevFlow health: broker, agents, and project integration");
+        agentDiagnoseCmd.SetAction(async (ctx, ct) =>
+        {
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson));
+        });
+        agentCommand.Add(agentDiagnoseCmd);
+
+        devflowCommand.Add(agentCommand);
+
         // ===== batch command (interactive stdin/stdout) =====
         var batchDelayOption = new Option<int>("--delay") { Description = "Delay in ms between commands", DefaultValueFactory = _ => 250 };
         var batchContinueOption = new Option<bool>("--continue-on-error") { Description = "Continue executing after a command fails", DefaultValueFactory = _ => false };
@@ -1308,7 +1370,8 @@ public class DevFlowCommands
         devflowCommand.Add(commandsCmd);
 
         // ===== MCP server command =====
-        var mcpServeCmd = new Command("mcp", "Start MCP (Model Context Protocol) server for AI agent integration via stdio");
+        var mcpServeCmd = new Command("mcp-serve", "Start MCP (Model Context Protocol) server for AI agent integration via stdio");
+        mcpServeCmd.Aliases.Add("mcp");
         mcpServeCmd.SetAction(async (ctx, ct) => { await Mcp.McpServerHost.RunAsync(); });
         devflowCommand.Add(mcpServeCmd);
 
@@ -1562,7 +1625,7 @@ public class DevFlowCommands
         {
             using var http = new HttpClient();
             http.Timeout = TimeSpan.FromSeconds(5);
-            var response = await http.GetAsync($"http://{host}:{port}/api/status");
+            var response = await http.GetAsync($"http://{host}:{port}/api/v1/agent/status");
             var body = await response.Content.ReadAsStringAsync();
             var doc = JsonDocument.Parse(body);
             var root = doc.RootElement;
@@ -1761,6 +1824,28 @@ public class DevFlowCommands
         }
     }
 
+    private static async Task SimplePutAsync(string host, int port, string path, JsonNode? bodyObj, bool json)
+    {
+        try
+        {
+            using var http = new HttpClient();
+            http.Timeout = TimeSpan.FromSeconds(30);
+            using var content = new StringContent(
+                CliJson.SerializeUntyped(bodyObj ?? new JsonObject(), indented: false),
+                Encoding.UTF8,
+                "application/json");
+            var response = await http.PutAsync($"http://{host}:{port}{path}", content);
+            var body = await response.Content.ReadAsStringAsync();
+            Console.WriteLine(body);
+            if (!response.IsSuccessStatusCode) _errorOccurred = true;
+        }
+        catch (Exception ex)
+        {
+            Output.WriteError(ex.Message, json);
+            _errorOccurred = true;
+        }
+    }
+
     private static async Task SimpleDeleteAsync(string host, int port, string path, bool json)
     {
         try
@@ -1784,7 +1869,7 @@ public class DevFlowCommands
         try
         {
             using var client = new System.Net.WebSockets.ClientWebSocket();
-            var uri = new Uri($"ws://{host}:{port}/ws/sensors?sensor={Uri.EscapeDataString(sensor)}&speed={Uri.EscapeDataString(speed)}&throttleMs={throttleMs}");
+            var uri = new Uri($"ws://{host}:{port}/ws/v1/sensors?sensor={Uri.EscapeDataString(sensor)}&speed={Uri.EscapeDataString(speed)}&throttleMs={throttleMs}");
             using var cts = duration > 0
                 ? new CancellationTokenSource(TimeSpan.FromSeconds(duration))
                 : new CancellationTokenSource();
@@ -1851,7 +1936,7 @@ public class DevFlowCommands
                 if (type != null) criteria.Add($"type=\"{type}\"");
                 if (text != null) criteria.Add($"text=\"{text}\"");
                 Output.WriteError($"No elements found matching {string.Join(", ", criteria)}", json,
-                    suggestions: new[] { "Run 'MAUI tree' to see available elements", "Check automationId spelling" });
+                    suggestions: new[] { "Run 'ui tree' to see available elements", "Check automationId spelling" });
                 _errorOccurred = true;
                 return null;
             }
@@ -1882,14 +1967,14 @@ public class DevFlowCommands
         if (id.Any(c => c < 0x20))
         {
             Output.WriteError($"Element ID contains control characters: '{id}'", json, "InvocationError",
-                suggestions: new[] { "Element IDs should not contain control characters", "Run 'MAUI tree' to get valid IDs" });
+                suggestions: new[] { "Element IDs should not contain control characters", "Run 'ui tree' to get valid IDs" });
             _errorOccurred = true;
             return;
         }
         if (id.Contains('?') || id.Contains('#'))
         {
             Output.WriteError($"Element ID contains '?' or '#': '{id}' — this looks like a URL fragment, not an element ID", json, "InvocationError",
-                suggestions: new[] { "Run 'MAUI tree' to get valid element IDs" });
+                suggestions: new[] { "Run 'ui tree' to get valid element IDs" });
             _errorOccurred = true;
             return;
         }
@@ -1958,80 +2043,81 @@ public class DevFlowCommands
 
     private static List<CommandDescription> GetCommandDescriptions() => new()
     {
-        new("MAUI status", "Check agent connection and app info", false),
-        new("MAUI tree", "Dump visual element tree", false),
-        new("MAUI query", "Find elements by type, automationId, text, or CSS selector", false),
-        new("MAUI element", "Get detailed element info by ID", false),
-        new("MAUI hittest", "Find elements at screen coordinates", false),
-        new("MAUI tap", "Tap a UI element", true),
-        new("MAUI fill", "Fill text into an input element", true),
-        new("MAUI clear", "Clear text from an input element", true),
-        new("MAUI focus", "Set focus to an element", true),
-        new("MAUI navigate", "Navigate to a Shell route", true),
-        new("MAUI scroll", "Scroll content or scroll element into view", true),
-        new("MAUI resize", "Resize app window", true),
-        new("MAUI property", "Get element property value", false),
-        new("MAUI set-property", "Set element property value", true),
-        new("MAUI screenshot", "Take screenshot of app or element", false),
-        new("MAUI assert", "Assert element property equals expected value", false),
-        new("MAUI recording start", "Start screen recording", true),
-        new("MAUI recording stop", "Stop screen recording", true),
-        new("MAUI recording status", "Check recording status", false),
-        new("MAUI alert detect", "Check if a system dialog is visible", false),
-        new("MAUI alert dismiss", "Dismiss a system dialog", true),
-        new("MAUI alert tree", "Show accessibility tree for dialog detection", false),
-        new("MAUI permission grant", "Grant iOS simulator permission", true),
-        new("MAUI permission revoke", "Revoke iOS simulator permission", true),
-        new("MAUI permission reset", "Reset iOS simulator permission", true),
-        new("MAUI logs", "Fetch or stream application logs", false),
-        new("MAUI network", "Monitor HTTP network requests (live)", false),
-        new("MAUI network list", "List recent network requests", false),
-        new("MAUI network detail", "Show full network request details", false),
-        new("MAUI network clear", "Clear network request buffer", true),
-        new("MAUI preferences list", "List all known preference keys", false),
-        new("MAUI preferences get", "Get a preference value by key", false),
-        new("MAUI preferences set", "Set a preference value", true),
-        new("MAUI preferences delete", "Remove a preference", true),
-        new("MAUI preferences clear", "Clear all preferences", true),
-        new("MAUI secure-storage get", "Get a secure storage value", false),
-        new("MAUI secure-storage set", "Set a secure storage value", true),
-        new("MAUI secure-storage delete", "Remove a secure storage entry", true),
-        new("MAUI secure-storage clear", "Clear all secure storage", true),
-        new("MAUI platform app-info", "Get app name, version, theme", false),
-        new("MAUI platform device-info", "Get device manufacturer, model, OS", false),
-        new("MAUI platform display", "Get screen density, size, orientation", false),
-        new("MAUI platform battery", "Get battery level, state, power source", false),
-        new("MAUI platform connectivity", "Get network access and profiles", false),
-        new("MAUI platform version-tracking", "Get version history and launch info", false),
-        new("MAUI platform permissions", "Check permission status", false),
-        new("MAUI platform geolocation", "Get current GPS coordinates", false),
-        new("MAUI sensors list", "List available sensors and status", false),
-        new("MAUI sensors start", "Start a device sensor", true),
-        new("MAUI sensors stop", "Stop a device sensor", true),
-        new("MAUI sensors stream", "Stream sensor readings via WebSocket", false),
-        new("cdp webviews", "List available CDP WebViews", false),
-        new("cdp status", "Check CDP connection status", false),
-        new("cdp Browser getVersion", "Get browser version", false),
-        new("cdp Runtime evaluate", "Evaluate JavaScript expression", false),
-        new("cdp DOM getDocument", "Get DOM document tree", false),
-        new("cdp DOM querySelector", "Find element by CSS selector", false),
-        new("cdp DOM querySelectorAll", "Find all elements by CSS selector", false),
-        new("cdp DOM getOuterHTML", "Get element outer HTML", false),
-        new("cdp Input click", "Click element by CSS selector", true),
-        new("cdp Input insertText", "Insert text at cursor", true),
-        new("cdp Input fill", "Fill form field by CSS selector", true),
-        new("cdp Page navigate", "Navigate WebView to URL", true),
-        new("cdp Page reload", "Reload WebView page", true),
-        new("cdp Page captureScreenshot", "Take WebView screenshot", false),
-        new("cdp snapshot", "Get simplified DOM snapshot", false),
-        new("cdp source", "Get page HTML source", false),
-        new("list", "List all connected agents", false),
-        new("wait", "Wait for an agent to connect", false),
+        new("ui status", "Check agent connection and app info", false),
+        new("ui tree", "Dump visual element tree", false),
+        new("ui query", "Find elements by type, automationId, text, or CSS selector", false),
+        new("ui element", "Get detailed element info by ID", false),
+        new("ui hit-test", "Find elements at screen coordinates", false),
+        new("ui tap", "Tap a UI element", true),
+        new("ui fill", "Fill text into an input element", true),
+        new("ui clear", "Clear text from an input element", true),
+        new("ui focus", "Set focus to an element", true),
+        new("ui navigate", "Navigate to a Shell route", true),
+        new("ui scroll", "Scroll content or scroll element into view", true),
+        new("ui resize", "Resize app window", true),
+        new("ui property", "Get element property value", false),
+        new("ui set-property", "Set element property value", true),
+        new("ui screenshot", "Take screenshot of app or element", false),
+        new("ui assert", "Assert element property equals expected value", false),
+        new("recording start", "Start screen recording", true),
+        new("recording stop", "Stop screen recording", true),
+        new("recording status", "Check recording status", false),
+        new("ui alert detect", "Check if a system dialog is visible", false),
+        new("ui alert dismiss", "Dismiss a system dialog", true),
+        new("ui alert tree", "Show accessibility tree for dialog detection", false),
+        new("ui permission grant", "Grant iOS simulator permission", true),
+        new("ui permission revoke", "Revoke iOS simulator permission", true),
+        new("ui permission reset", "Reset iOS simulator permission", true),
+        new("logs", "Fetch or stream application logs", false),
+        new("network", "Monitor HTTP network requests (live)", false),
+        new("network list", "List recent network requests", false),
+        new("network detail", "Show full network request details", false),
+        new("network clear", "Clear network request buffer", true),
+        new("storage preferences list", "List all known preference keys", false),
+        new("storage preferences get", "Get a preference value by key", false),
+        new("storage preferences set", "Set a preference value", true),
+        new("storage preferences delete", "Remove a preference", true),
+        new("storage preferences clear", "Clear all preferences", true),
+        new("storage secure-storage get", "Get a secure storage value", false),
+        new("storage secure-storage set", "Set a secure storage value", true),
+        new("storage secure-storage delete", "Remove a secure storage entry", true),
+        new("storage secure-storage clear", "Clear all secure storage", true),
+        new("device app-info", "Get app name, version, theme", false),
+        new("device device-info", "Get device manufacturer, model, OS", false),
+        new("device display", "Get screen density, size, orientation", false),
+        new("device battery", "Get battery level, state, power source", false),
+        new("device connectivity", "Get network access and profiles", false),
+        new("device version-tracking", "Get version history and launch info", false),
+        new("device permissions", "Check permission status", false),
+        new("device geolocation", "Get current GPS coordinates", false),
+        new("device sensors list", "List available sensors and status", false),
+        new("device sensors start", "Start a device sensor", true),
+        new("device sensors stop", "Stop a device sensor", true),
+        new("device sensors stream", "Stream sensor readings via WebSocket", false),
+        new("webview webviews", "List available CDP WebViews", false),
+        new("webview status", "Check CDP connection status", false),
+        new("webview Browser getVersion", "Get browser version", false),
+        new("webview Runtime evaluate", "Evaluate JavaScript expression", false),
+        new("webview DOM getDocument", "Get DOM document tree", false),
+        new("webview DOM querySelector", "Find element by CSS selector", false),
+        new("webview DOM querySelectorAll", "Find all elements by CSS selector", false),
+        new("webview DOM getOuterHTML", "Get element outer HTML", false),
+        new("webview Input click", "Click element by CSS selector", true),
+        new("webview Input insertText", "Insert text at cursor", true),
+        new("webview Input fill", "Fill form field by CSS selector", true),
+        new("webview Page navigate", "Navigate WebView to URL", true),
+        new("webview Page reload", "Reload WebView page", true),
+        new("webview Page captureScreenshot", "Take WebView screenshot", false),
+        new("webview snapshot", "Get simplified DOM snapshot", false),
+        new("webview source", "Get page HTML source", false),
+        new("agent list", "List all connected agents", false),
+        new("agent wait", "Wait for an agent to connect", false),
         new("batch", "Execute commands from stdin", true),
         new("broker start", "Start the broker daemon", true),
         new("broker stop", "Stop the broker daemon", true),
         new("broker status", "Show broker status", false),
         new("broker log", "Show broker log", false),
+        new("mcp-serve", "Start the MCP server", false),
         new("commands", "List all available commands", false),
         new("version", "Show CLI version", false),
     };
@@ -2256,10 +2342,10 @@ public class DevFlowCommands
             }
             Output.WriteResult(status, json, s =>
             {
-                Console.WriteLine($"Agent: {s.Agent} v{s.Version}");
-                Console.WriteLine($"Platform: {s.Platform}");
-                Console.WriteLine($"Device: {s.DeviceType} ({s.Idiom})");
-                Console.WriteLine($"App: {s.AppName}");
+                Console.WriteLine($"Agent: {s.Agent?.Name ?? "unknown"} v{s.Agent?.Version ?? s.Version ?? "unknown"}");
+                Console.WriteLine($"Platform: {s.Device?.Platform ?? s.Platform ?? "unknown"}");
+                Console.WriteLine($"Device: {s.Device?.DeviceType ?? s.DeviceType ?? "unknown"} ({s.Device?.Idiom ?? s.Idiom ?? "unknown"})");
+                Console.WriteLine($"App: {s.App?.Name ?? s.AppName ?? "unknown"}");
             });
         }
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
@@ -2317,7 +2403,7 @@ public class DevFlowCommands
                         Output.WriteError(
                             $"Timeout after {timeout}s: condition '{waitUntil}' not met",
                             json, "RuntimeError", retryable: true,
-                            suggestions: new[] { "Increase --timeout", "Check element identifiers with 'MAUI tree'" });
+                            suggestions: new[] { "Increase --timeout", "Check element identifiers with 'ui tree'" });
                         _errorOccurred = true;
                         return;
                     }
@@ -2390,7 +2476,7 @@ public class DevFlowCommands
                 success ? $"Tapped: {elementId}" : $"Failed to tap: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'ui tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiFillAsync(string host, int port, bool json, string elementId, string text)
@@ -2403,7 +2489,7 @@ public class DevFlowCommands
                 success ? $"Filled: {elementId}" : $"Failed to fill: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'ui tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiClearAsync(string host, int port, bool json, string elementId)
@@ -2416,7 +2502,7 @@ public class DevFlowCommands
                 success ? $"Cleared: {elementId}" : $"Failed to clear: {elementId}");
             if (!success) _errorOccurred = true;
         }
-        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'MAUI tree' to refresh element IDs" }); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'ui tree' to refresh element IDs" }); _errorOccurred = true; }
     }
 
     private static async Task MauiScreenshotAsync(string host, int port, bool json, string? output, int? window, string? id, string? selector, bool overwrite = false, int? maxWidth = null, string? scale = null)
@@ -2679,7 +2765,7 @@ public class DevFlowCommands
             if (el == null)
             {
                 Output.WriteError($"Element '{elementId}' not found", json,
-                    suggestions: new[] { "Run 'MAUI tree' to refresh element IDs", "Element IDs are ephemeral — re-query after navigation" });
+                    suggestions: new[] { "Run 'ui tree' to refresh element IDs", "Element IDs are ephemeral — re-query after navigation" });
                 _errorOccurred = true;
                 return;
             }
@@ -2791,7 +2877,7 @@ public class DevFlowCommands
             queryParams.Add($"source={Uri.EscapeDataString(source)}");
         if (replay != 100)
             queryParams.Add($"replay={replay}");
-        var wsUrl = $"ws://{host}:{port}/ws/logs";
+        var wsUrl = $"ws://{host}:{port}/ws/v1/logs";
         if (queryParams.Count > 0)
             wsUrl += "?" + string.Join("&", queryParams);
 
@@ -2924,7 +3010,7 @@ public class DevFlowCommands
         Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
         int counter = 0;
-        var wsUrl = $"ws://{host}:{port}/ws/network";
+        var wsUrl = $"ws://{host}:{port}/ws/v1/network";
 
         while (!cts.Token.IsCancellationRequested)
         {
@@ -3434,10 +3520,11 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var status = await client.GetStatusAsync();
-            if (status?.AppName != null)
+            var appName = status?.App?.Name ?? status?.AppName;
+            if (!string.IsNullOrWhiteSpace(appName))
             {
                 // Find process by app name
-                var pgrepResult = await ProcessRunner.RunAsync("pgrep", new[] { "-f", status.AppName });
+                var pgrepResult = await ProcessRunner.RunAsync("pgrep", new[] { "-f", appName });
                 var lines = pgrepResult.StandardOutput.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries);
                 if (lines.Length > 0 && int.TryParse(lines[0].Trim(), out var resolved))
                     return resolved;
@@ -3456,16 +3543,17 @@ public class DevFlowCommands
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
             var status = await client.GetStatusAsync();
-            if (status?.AppName != null)
+            var appName = status?.App?.Name ?? status?.AppName;
+            if (!string.IsNullOrWhiteSpace(appName))
             {
-                var processes = System.Diagnostics.Process.GetProcessesByName(status.AppName);
+                var processes = System.Diagnostics.Process.GetProcessesByName(appName);
                 if (processes.Length > 0)
                     return processes[0].Id;
 
                 var match = System.Diagnostics.Process.GetProcesses()
                     .FirstOrDefault(p =>
                     {
-                        try { return p.ProcessName.Contains(status.AppName, StringComparison.OrdinalIgnoreCase); }
+                        try { return p.ProcessName.Contains(appName, StringComparison.OrdinalIgnoreCase); }
                         catch { return false; }
                     });
                 if (match != null)
@@ -3697,7 +3785,7 @@ public class DevFlowCommands
                 foreach (var a in agents)
                     Console.Error.WriteLine($"{a.Id,-15}{a.AppName,-20}{a.Platform,-15}{a.Tfm,-25}{a.Port,-7}");
                 Console.Error.WriteLine();
-                Console.Error.WriteLine("Example: maui devflow MAUI status --agent-port <port>");
+                Console.Error.WriteLine("Example: maui devflow ui status --agent-port <port>");
             }
         }
         catch { /* broker unavailable, fall through */ }
@@ -4064,9 +4152,9 @@ public class DevFlowCommands
                 if (args.Length == 0) continue;
 
                 var prefix = args[0].ToUpperInvariant();
-                if (prefix != "MAUI" && prefix != "CDP")
+                if (prefix != "UI" && prefix != "WEBVIEW" && prefix != "MAUI" && prefix != "CDP")
                 {
-                    var errMsg = $"Only MAUI and cdp commands are supported in batch mode, got: {args[0]}";
+                    var errMsg = $"Only ui and webview commands are supported in batch mode, got: {args[0]}";
                     if (human)
                     {
                         originalOut.WriteLine($"[{commandIndex}] {rawCmd}");

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -19,7 +19,7 @@ public static class McpServerHost
 		builder.Services
 			.AddMcpServer(options =>
 			{
-				options.ServerInfo = new() { Name = "maui-devflow", Version = version };
+				options.ServerInfo = new() { Name = "maui", Version = version };
 			})
 			.WithStdioServerTransport()
 			.WithTools<ScreenshotTool>()

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/NetworkMonitorTui.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/NetworkMonitorTui.cs
@@ -52,7 +52,7 @@ public static class NetworkMonitorTui
 {
     public static async Task RunAsync(string host, int port, string? filterHost, string? filterMethod)
     {
-        var wsUrl = $"ws://{host}:{port}/ws/network";
+        var wsUrl = $"ws://{host}:{port}/ws/v1/network";
         var status = new State<string?>("Connecting...");
         var detailText = new State<string?>("Select a request to view details.");
         var headerText = new State<string?>($"🌐 Network Monitor — {host}:{port}  [0 requests]");

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -11,6 +11,7 @@
     <Description>CLI for .NET MAUI development environment setup and device management</Description>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
+    <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1572;CS1573</NoWarn>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>

--- a/src/Cli/Microsoft.Maui.Cli/Models/Device.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Models/Device.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Maui.Cli.Models;
@@ -150,7 +151,7 @@ public record Device
 	/// </summary>
 	[JsonPropertyName("details")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	public Dictionary<string, object>? Details { get; init; }
+	public JsonObject? Details { get; init; }
 }
 
 public enum DeviceType

--- a/src/Cli/Microsoft.Maui.Cli/Models/DoctorReport.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Models/DoctorReport.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Maui.Cli.Models;
@@ -67,7 +68,7 @@ public record HealthCheck
 
 	[JsonPropertyName("details")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	public Dictionary<string, object>? Details { get; init; }
+	public JsonObject? Details { get; init; }
 
 	[JsonPropertyName("fix")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Cli/Microsoft.Maui.Cli/Models/ErrorResult.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Models/ErrorResult.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Maui.Cli.Models;
@@ -28,7 +29,7 @@ public record ErrorResult
 
 	[JsonPropertyName("context")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	public Dictionary<string, object>? Context { get; init; }
+	public JsonObject? Context { get; init; }
 
 	[JsonPropertyName("remediation")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -74,6 +75,7 @@ public record ErrorResult
 				Category = GetCategory(mex.Code),
 				Message = mex.Message,
 				NativeError = mex.NativeError,
+				Context = ToJsonObject(mex.Context),
 				Remediation = mex.Remediation != null ? new RemediationResult
 				{
 					Type = mex.Remediation.Type.ToString().ToLowerInvariant(),
@@ -89,6 +91,33 @@ public record ErrorResult
 			Category = "tool",
 			Message = exception.Message
 		};
+	}
+
+	static JsonObject? ToJsonObject(Dictionary<string, object>? context)
+	{
+		if (context is null || context.Count == 0)
+			return null;
+
+		var result = new JsonObject();
+
+		foreach (var (key, value) in context)
+		{
+			result[key] = value switch
+			{
+				null => null,
+				string text => text,
+				bool boolean => boolean,
+				int number => number,
+				long number => number,
+				double number => number,
+				float number => number,
+				decimal number => number,
+				IEnumerable<string> values => new JsonArray(values.Select(v => (JsonNode?)v).ToArray()),
+				_ => value.ToString()
+			};
+		}
+
+		return result;
 	}
 }
 

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputFormatter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputFormatter.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.Maui.Cli.Models;
 
@@ -11,22 +11,16 @@ namespace Microsoft.Maui.Cli.Output;
 /// <summary>
 /// JSON output formatter for machine-readable output.
 /// </summary>
-[UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "General-purpose CLI output formatter; full AOT migration tracked separately.")]
-[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "General-purpose CLI output formatter; full AOT migration tracked separately.")]
 public class JsonOutputFormatter : IOutputFormatter
 {
-	static readonly JsonSerializerOptions s_options = new()
+	static readonly JsonSerializerOptions s_nodeIndentedOptions = new(MauiCliJsonContext.Default.Options)
 	{
-		WriteIndented = true,
-		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-		Converters =
-		{
-			new JsonStringEnumConverter<DeviceType>(JsonNamingPolicy.SnakeCaseLower),
-			new JsonStringEnumConverter<DeviceState>(JsonNamingPolicy.SnakeCaseLower),
-			new JsonStringEnumConverter<HealthStatus>(JsonNamingPolicy.SnakeCaseLower),
-			new JsonStringEnumConverter<CheckStatus>(JsonNamingPolicy.SnakeCaseLower),
-		}
+		WriteIndented = true
+	};
+
+	static readonly JsonSerializerOptions s_nodeCompactOptions = new(MauiCliJsonContext.Default.Options)
+	{
+		WriteIndented = false
 	};
 
 	readonly TextWriter _output;
@@ -43,8 +37,7 @@ public class JsonOutputFormatter : IOutputFormatter
 
 	public void WriteResult<T>(T result)
 	{
-		var json = JsonSerializer.Serialize(result, s_options);
-		_output.WriteLine(json);
+		_output.WriteLine(SerializeUntyped(result));
 	}
 
 	public void WriteError(Exception exception)
@@ -59,22 +52,39 @@ public class JsonOutputFormatter : IOutputFormatter
 
 	public void WriteSuccess(string message)
 	{
-		WriteResult(new { status = "success", message });
+		WriteResult(new StatusMessageResult
+		{
+			Status = "success",
+			Message = message
+		});
 	}
 
 	public void WriteWarning(string message)
 	{
-		WriteResult(new { status = "warning", message });
+		WriteResult(new StatusMessageResult
+		{
+			Status = "warning",
+			Message = message
+		});
 	}
 
 	public void WriteInfo(string message)
 	{
-		WriteResult(new { status = "info", message });
+		WriteResult(new StatusMessageResult
+		{
+			Status = "info",
+			Message = message
+		});
 	}
 
 	public void WriteProgress(string message, int? percentage = null)
 	{
-		WriteResult(new { status = "progress", message, percentage });
+		WriteResult(new StatusMessageResult
+		{
+			Status = "progress",
+			Message = message,
+			Percentage = percentage
+		});
 	}
 
 	public void WriteTable<T>(IEnumerable<T> items, params (string Header, Func<T, string> Selector)[] columns)
@@ -86,16 +96,44 @@ public class JsonOutputFormatter : IOutputFormatter
 
 	public void WriteVersion(string version, string runtime, string os)
 	{
-		WriteResult(new { version, runtime, os });
+		WriteResult(new VersionResult
+		{
+			Version = version,
+			Runtime = runtime,
+			Os = os
+		});
 	}
 
 	/// <summary>
 	/// Serializes an object to JSON string.
 	/// </summary>
-	public static string Serialize<T>(T obj) => JsonSerializer.Serialize(obj, s_options);
+	public static string Serialize<T>(T obj) => SerializeUntyped(obj);
 
 	/// <summary>
 	/// Deserializes JSON string to object.
 	/// </summary>
-	public static T? Deserialize<T>(string json) => JsonSerializer.Deserialize<T>(json, s_options);
+	public static T? Deserialize<T>(string json) => (T?)JsonSerializer.Deserialize(json, typeof(T), MauiCliJsonContext.Default);
+
+	static string SerializeUntyped(object? value)
+	{
+		if (value is null)
+			return "null";
+
+		return value switch
+		{
+			JsonNode node => node.ToJsonString(s_nodeIndentedOptions),
+			JsonElement element => PrettyPrint(element),
+			JsonDocument document => PrettyPrint(document.RootElement),
+			_ => JsonSerializer.Serialize(value, value.GetType(), MauiCliJsonContext.Default)
+		};
+	}
+
+	static string PrettyPrint(JsonElement element)
+	{
+		using var stream = new MemoryStream();
+		using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+		element.WriteTo(writer);
+		writer.Flush();
+		return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
@@ -39,6 +39,10 @@ internal sealed record CliCommandResult
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string? Status { get; init; }
 
+	[JsonPropertyName("message")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Message { get; init; }
+
 	[JsonPropertyName("name")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string? Name { get; init; }
@@ -58,6 +62,18 @@ internal sealed record CliCommandResult
 	[JsonPropertyName("path")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string? Path { get; init; }
+
+	[JsonPropertyName("command")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Command { get; init; }
+
+	[JsonPropertyName("arguments")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Arguments { get; init; }
+
+	[JsonPropertyName("full_command")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? FullCommand { get; init; }
 
 	[JsonPropertyName("version")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.Cli.Output;
+
+internal sealed record StatusMessageResult
+{
+	[JsonPropertyName("status")]
+	public required string Status { get; init; }
+
+	[JsonPropertyName("message")]
+	public required string Message { get; init; }
+
+	[JsonPropertyName("percentage")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public int? Percentage { get; init; }
+}
+
+internal sealed record VersionResult
+{
+	[JsonPropertyName("version")]
+	public required string Version { get; init; }
+
+	[JsonPropertyName("runtime")]
+	public required string Runtime { get; init; }
+
+	[JsonPropertyName("os")]
+	public required string Os { get; init; }
+}
+
+internal sealed record CliCommandResult
+{
+	[JsonPropertyName("success")]
+	public bool Success { get; init; }
+
+	[JsonPropertyName("status")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Status { get; init; }
+
+	[JsonPropertyName("name")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Name { get; init; }
+
+	[JsonPropertyName("package")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Package { get; init; }
+
+	[JsonPropertyName("device")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Device { get; init; }
+
+	[JsonPropertyName("serial")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Serial { get; init; }
+
+	[JsonPropertyName("path")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Path { get; init; }
+
+	[JsonPropertyName("version")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public int? Version { get; init; }
+
+	[JsonPropertyName("elevated")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public bool? Elevated { get; init; }
+
+	[JsonPropertyName("installed")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string[]? Installed { get; init; }
+
+	[JsonPropertyName("uninstalled")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string[]? Uninstalled { get; init; }
+
+	[JsonPropertyName("versions")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public List<int>? Versions { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.Providers.Android;
+using Microsoft.Maui.Cli.Providers.Apple;
+
+namespace Microsoft.Maui.Cli.Output;
+
+[JsonSourceGenerationOptions(
+	DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+	PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+	UseStringEnumConverter = true,
+	WriteIndented = true)]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(List<string>))]
+[JsonSerializable(typeof(List<int>))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(List<Dictionary<string, string>>))]
+[JsonSerializable(typeof(JsonObject))]
+[JsonSerializable(typeof(JsonArray))]
+[JsonSerializable(typeof(DoctorReport))]
+[JsonSerializable(typeof(DoctorSummary))]
+[JsonSerializable(typeof(HealthCheck))]
+[JsonSerializable(typeof(List<HealthCheck>))]
+[JsonSerializable(typeof(FixInfo))]
+[JsonSerializable(typeof(ErrorResult))]
+[JsonSerializable(typeof(RemediationResult))]
+[JsonSerializable(typeof(Device))]
+[JsonSerializable(typeof(List<Device>))]
+[JsonSerializable(typeof(DeviceListResult))]
+[JsonSerializable(typeof(AvdInfo))]
+[JsonSerializable(typeof(List<AvdInfo>))]
+[JsonSerializable(typeof(SdkPackage))]
+[JsonSerializable(typeof(List<SdkPackage>))]
+[JsonSerializable(typeof(XcodeInstallation))]
+[JsonSerializable(typeof(List<XcodeInstallation>))]
+[JsonSerializable(typeof(RuntimeInfo))]
+[JsonSerializable(typeof(List<RuntimeInfo>))]
+[JsonSerializable(typeof(SimulatorInfo))]
+[JsonSerializable(typeof(List<SimulatorInfo>))]
+[JsonSerializable(typeof(StatusMessageResult))]
+[JsonSerializable(typeof(VersionResult))]
+[JsonSerializable(typeof(CliCommandResult))]
+internal sealed partial class MauiCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
@@ -4,6 +4,7 @@
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Utils;
+using System.Text.Json.Nodes;
 using Xamarin.Android.Tools;
 
 namespace Microsoft.Maui.Cli.Providers.Android;
@@ -65,7 +66,7 @@ public class Adb
 		var state = MapDeviceState(info.Status);
 		var isRunning = state == DeviceState.Connected || state == DeviceState.Booted;
 
-		var details = new Dictionary<string, object>();
+		var details = new JsonObject();
 		if (!string.IsNullOrEmpty(info.AvdName))
 			details["avd"] = info.AvdName;
 

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -4,6 +4,7 @@
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Utils;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Maui.Cli.Providers.Android;
 
@@ -85,7 +86,7 @@ public class AndroidProvider : IAndroidProvider
 			Category = "android",
 			Name = "Android SDK",
 			Status = CheckStatus.Ok,
-			Details = new Dictionary<string, object> { ["path"] = SdkPath! }
+			Details = new JsonObject { ["path"] = SdkPath! }
 		});
 
 		// Check SDK Manager

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/JdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/JdkManager.cs
@@ -4,6 +4,7 @@
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Utils;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Maui.Cli.Providers.Android;
 
@@ -116,7 +117,7 @@ public class JdkManager : IJdkManager
 					Name = "JDK",
 					Status = CheckStatus.Error,
 					Message = $"JDK {DetectedJdkVersion} is too old (minimum: {MinJdkVersion})",
-					Details = new Dictionary<string, object>
+					Details = new JsonObject
 					{
 						["path"] = DetectedJdkPath!,
 						["version"] = DetectedJdkVersion.Value
@@ -137,7 +138,7 @@ public class JdkManager : IJdkManager
 				Name = "JDK",
 				Status = CheckStatus.Ok,
 				Message = $"JDK {DetectedJdkVersion}",
-				Details = new Dictionary<string, object>
+				Details = new JsonObject
 				{
 					["path"] = DetectedJdkPath!,
 					["version"] = DetectedJdkVersion.Value
@@ -151,7 +152,7 @@ public class JdkManager : IJdkManager
 			Name = "JDK",
 			Status = CheckStatus.Warning,
 			Message = "JDK found but version unknown",
-			Details = new Dictionary<string, object>
+			Details = new JsonObject
 			{
 				["path"] = DetectedJdkPath!
 			}

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
@@ -4,6 +4,7 @@
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Utils;
+using System.Text.Json.Nodes;
 using Xamarin.MacDev;
 
 namespace Microsoft.Maui.Cli.Providers.Apple;
@@ -171,7 +172,7 @@ public class AppleProvider : IAppleProvider
 				Name = "Xcode",
 				Status = CheckStatus.Ok,
 				Message = $"Xcode {xcode.Version} ({xcode.Build}) at {xcode.Path}",
-				Details = new Dictionary<string, object>
+				Details = new JsonObject
 				{
 					["version"] = xcode.Version.ToString(),
 					["build"] = xcode.Build,
@@ -301,7 +302,7 @@ public class AppleProvider : IAppleProvider
 				Version = s.OSVersion,
 				VersionName = s.Platform != null ? $"{s.Platform} {s.OSVersion}" : s.OSVersion,
 				Idiom = s.DeviceTypeIdentifier?.Contains("iPad") == true ? DeviceIdiom.Tablet : DeviceIdiom.Phone,
-				Details = new Dictionary<string, object>
+				Details = new JsonObject
 				{
 					["runtime"] = s.RuntimeIdentifier ?? "",
 					["device_type"] = s.DeviceTypeIdentifier ?? "",

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.Providers.Apple;
 using Microsoft.Maui.Cli.Utils;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Maui.Cli.Services;
 
@@ -44,7 +45,7 @@ public class DeviceManager : IDeviceManager
 					d.IsEmulator &&
 					(
 						(d.Details != null &&
-						 d.Details.TryGetValue("avd", out var avdName) &&
+						 d.Details.TryGetPropertyValue("avd", out var avdName) &&
 						 string.Equals(avdName?.ToString(), avd.Name, StringComparison.OrdinalIgnoreCase))
 						||
 						string.Equals(d.EmulatorId, avd.Name, StringComparison.OrdinalIgnoreCase)
@@ -59,9 +60,7 @@ public class DeviceManager : IDeviceManager
 					// Merge AVD metadata into the running emulator device
 					var running = devices[runningIndex];
 					var subModel = AndroidEnvironment.MapTagIdToSubModel(tagId, playStoreEnabled);
-					var details = running.Details != null
-						? new Dictionary<string, object>(running.Details)
-						: new Dictionary<string, object>();
+					var details = running.Details?.DeepClone() as JsonObject ?? new JsonObject();
 					details["tag_id"] = tagId ?? "default";
 					details["target"] = avd.Target ?? "unknown";
 
@@ -98,7 +97,7 @@ public class DeviceManager : IDeviceManager
 						PlatformArchitecture = resolvedAbi,
 						RuntimeIdentifiers = AndroidEnvironment.GetRuntimeIdentifiers(architecture),
 						Idiom = DeviceIdiom.Phone,
-						Details = new Dictionary<string, object>
+						Details = new JsonObject
 						{
 							["avd"] = avd.Name,
 							["target"] = avd.Target ?? "unknown",

--- a/src/Cli/Microsoft.Maui.Cli/Services/DoctorService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DoctorService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Maui.Cli.Errors;
+using System.Text.Json.Nodes;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.Providers.Apple;
@@ -272,7 +273,7 @@ public class DoctorService : IDoctorService
 			Name = ".NET SDK",
 			Status = CheckStatus.Ok,
 			Message = $".NET {version}",
-			Details = new Dictionary<string, object>
+			Details = new JsonObject
 			{
 				["version"] = version,
 				["path"] = dotnetPath
@@ -373,7 +374,7 @@ public class DoctorService : IDoctorService
 			Name = "Windows SDK",
 			Status = CheckStatus.Ok,
 			Message = installedVersion != null ? $"Windows SDK {installedVersion}" : "Windows SDK found",
-			Details = new Dictionary<string, object>
+			Details = new JsonObject
 			{
 				["path"] = sdkPath,
 				["version"] = installedVersion ?? "unknown"

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -88,7 +88,7 @@ maui apple simulator delete "iPhone 16 Pro"
 | `maui devflow ui tree` | Dump the visual tree of a running app |
 | `maui devflow ui screenshot` | Take a screenshot of a running app |
 | `maui devflow webview` | Blazor WebView automation via Chrome DevTools Protocol |
-| `maui devflow mcp-serve` | Start the MCP server for AI agent integration |
+| `maui devflow mcp` | Start the MCP server for AI agent integration |
 | `maui devflow broker` | Manage the DevFlow agent broker |
 
 ## Global Options

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -84,11 +84,11 @@ maui apple simulator delete "iPhone 16 Pro"
 | `maui apple simulator start` | Boot a simulator (macOS only) |
 | `maui apple simulator stop` | Shut down a simulator (macOS only) |
 | `maui apple simulator delete` | Delete a simulator (macOS only) |
-| `maui devflow` | MAUI app automation via Agent API and Blazor WebViews via CDP |
-| `maui devflow MAUI tree` | Dump the visual tree of a running MAUI app |
-| `maui devflow MAUI screenshot` | Take a screenshot of a running MAUI app |
-| `maui devflow cdp` | Blazor WebView automation via Chrome DevTools Protocol |
-| `maui devflow mcp` | Start MCP server for AI agent integration |
+| `maui devflow` | MAUI app automation via the DevFlow agent and WebView tooling |
+| `maui devflow ui tree` | Dump the visual tree of a running app |
+| `maui devflow ui screenshot` | Take a screenshot of a running app |
+| `maui devflow webview` | Blazor WebView automation via Chrome DevTools Protocol |
+| `maui devflow mcp-serve` | Start the MCP server for AI agent integration |
 | `maui devflow broker` | Manage the DevFlow agent broker |
 
 ## Global Options

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentHttpServer.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentHttpServer.cs
@@ -20,6 +20,7 @@ public class AgentHttpServer : IDisposable
     private readonly int _port;
     private readonly Dictionary<string, Func<HttpRequest, Task<HttpResponse>>> _getRoutes = new();
     private readonly Dictionary<string, Func<HttpRequest, Task<HttpResponse>>> _postRoutes = new();
+    private readonly Dictionary<string, Func<HttpRequest, Task<HttpResponse>>> _putRoutes = new();
     private readonly Dictionary<string, Func<HttpRequest, Task<HttpResponse>>> _deleteRoutes = new();
     private readonly Dictionary<string, Func<TcpClient, NetworkStream, HttpRequest, CancellationToken, Task>> _wsRoutes = new();
 
@@ -36,6 +37,9 @@ public class AgentHttpServer : IDisposable
 
     public void MapPost(string path, Func<HttpRequest, Task<HttpResponse>> handler)
         => _postRoutes[path.TrimEnd('/')] = handler;
+
+    public void MapPut(string path, Func<HttpRequest, Task<HttpResponse>> handler)
+        => _putRoutes[path.TrimEnd('/')] = handler;
 
     public void MapDelete(string path, Func<HttpRequest, Task<HttpResponse>> handler)
         => _deleteRoutes[path.TrimEnd('/')] = handler;
@@ -229,6 +233,7 @@ public class AgentHttpServer : IDisposable
     private async Task<HttpResponse> RouteRequestAsync(HttpRequest request)
     {
         var routes = request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase) ? _postRoutes
+            : request.Method.Equals("PUT", StringComparison.OrdinalIgnoreCase) ? _putRoutes
             : request.Method.Equals("DELETE", StringComparison.OrdinalIgnoreCase) ? _deleteRoutes
             : _getRoutes;
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Maui;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
@@ -64,6 +65,8 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
     private readonly ConditionalWeakTable<Page, PageLifecycleState> _pageLifecycleStates = new();
     private readonly ConditionalWeakTable<VisualElement, ElementRenderState> _elementRenderStates = new();
     private readonly ConditionalWeakTable<BindableObject, ScrollBatchState> _scrollBatchStates = new();
+    private readonly List<UiEventSubscription> _uiEventSubscriptions = new();
+    private readonly object _uiEventSubscriptionGate = new();
 
     private sealed class UiHookState
     {
@@ -104,6 +107,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         public int? StartLastVisibleIndex { get; set; }
         public int? LastFirstVisibleIndex { get; set; }
         public int? LastLastVisibleIndex { get; set; }
+    }
+
+    private sealed class UiEventSubscription
+    {
+        public System.Collections.Concurrent.ConcurrentQueue<string> Queue { get; } = new();
+        public HashSet<string> Events { get; } = new(StringComparer.OrdinalIgnoreCase) { "all" };
     }
 
     /// <summary>
@@ -371,6 +380,11 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             // has not been associated with one yet.
         }
         Console.WriteLine("[Microsoft.Maui.DevFlow.Agent] Application bound to running agent");
+        PublishUiEvent("lifecycle", new
+        {
+            state = "started",
+            timestamp = DateTimeOffset.UtcNow.ToString("O")
+        });
     }
 
     public async Task StopAsync()
@@ -381,78 +395,95 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private void RegisterRoutes()
     {
-        _server.MapGet("/api/status", HandleStatus);
-        _server.MapGet("/api/tree", HandleTree);
-        _server.MapGet("/api/element/{id}", HandleElement);
-        _server.MapGet("/api/query", HandleQuery);
-        _server.MapGet("/api/hittest", HandleHitTest);
-        _server.MapGet("/api/screenshot", HandleScreenshot);
-        _server.MapGet("/api/property/{id}/{name}", HandleProperty);
-        _server.MapPost("/api/property/{id}/{name}", HandleSetProperty);
-        _server.MapPost("/api/action/tap", HandleTap);
-        _server.MapPost("/api/action/fill", HandleFill);
-        _server.MapPost("/api/action/clear", HandleClear);
-        _server.MapPost("/api/action/focus", HandleFocus);
-        _server.MapPost("/api/action/navigate", HandleNavigate);
-        _server.MapPost("/api/action/resize", HandleResize);
-        _server.MapPost("/api/action/scroll", HandleScroll);
-        _server.MapGet("/api/logs", HandleLogs);
-        _server.MapPost("/api/cdp", HandleCdp);
-        _server.MapGet("/api/cdp/webviews", HandleCdpWebViews);
-        _server.MapGet("/api/cdp/source", HandleCdpSource);
-        _server.MapGet("/api/profiler/capabilities", HandleProfilerCapabilities);
-        _server.MapPost("/api/profiler/start", HandleProfilerStart);
-        _server.MapPost("/api/profiler/stop", HandleProfilerStop);
-        _server.MapGet("/api/profiler/samples", HandleProfilerSamples);
-        _server.MapPost("/api/profiler/marker", HandleProfilerMarker);
-        _server.MapPost("/api/profiler/span", HandleProfilerSpan);
-        _server.MapGet("/api/profiler/hotspots", HandleProfilerHotspots);
+        // Canonical DevFlow v1 routes aligned with the formal spec.
+        _server.MapGet("/api/v1/agent/status", HandleStatus);
+        _server.MapGet("/api/v1/agent/capabilities", HandleCapabilities);
 
-        // Network monitoring
-        _server.MapGet("/api/network", HandleNetworkList);
-        _server.MapGet("/api/network/{id}", HandleNetworkDetail);
-        _server.MapPost("/api/network/clear", HandleNetworkClear);
+        _server.MapGet("/api/v1/ui/tree", HandleTree);
+        _server.MapGet("/api/v1/ui/elements", HandleQuery);
+        _server.MapGet("/api/v1/ui/elements/{id}", HandleElement);
+        _server.MapGet("/api/v1/ui/hit-test", HandleHitTest);
+        _server.MapGet("/api/v1/ui/screenshot", HandleScreenshot);
+        _server.MapGet("/api/v1/ui/elements/{id}/properties/{name}", HandleProperty);
+        _server.MapPut("/api/v1/ui/elements/{id}/properties/{name}", HandleSetProperty);
+        _server.MapPost("/api/v1/ui/actions/tap", HandleTap);
+        _server.MapPost("/api/v1/ui/actions/fill", HandleFill);
+        _server.MapPost("/api/v1/ui/actions/clear", HandleClear);
+        _server.MapPost("/api/v1/ui/actions/focus", HandleFocus);
+        _server.MapPost("/api/v1/ui/actions/navigate", HandleNavigate);
+        _server.MapPost("/api/v1/ui/actions/resize", HandleResize);
+        _server.MapPost("/api/v1/ui/actions/scroll", HandleScroll);
+        _server.MapPost("/api/v1/ui/actions/back", HandleBack);
+        _server.MapPost("/api/v1/ui/actions/key", HandleKey);
+        _server.MapPost("/api/v1/ui/actions/gesture", HandleGesture);
+        _server.MapPost("/api/v1/ui/actions/batch", HandleBatch);
 
-        // WebSocket: live network monitoring stream
-        _server.MapWebSocket("/ws/network", HandleNetworkWebSocket);
+        _server.MapGet("/api/v1/logs", HandleLogs);
+        _server.MapWebSocket("/ws/v1/logs", HandleLogsWebSocket);
 
-        // WebSocket: live log streaming
-        _server.MapWebSocket("/ws/logs", HandleLogsWebSocket);
+        _server.MapPost("/api/v1/webview/evaluate", HandleCdp);
+        _server.MapGet("/api/v1/webview/contexts", HandleCdpWebViews);
+        _server.MapGet("/api/v1/webview/source", HandleCdpSource);
+        _server.MapGet("/api/v1/webview/dom", HandleWebViewDom);
+        _server.MapPost("/api/v1/webview/dom/query", HandleWebViewDomQuery);
+        _server.MapPost("/api/v1/webview/navigate", HandleWebViewNavigate);
+        _server.MapPost("/api/v1/webview/input/click", HandleWebViewInputClick);
+        _server.MapPost("/api/v1/webview/input/fill", HandleWebViewInputFill);
+        _server.MapPost("/api/v1/webview/input/text", HandleWebViewInputText);
+        _server.MapGet("/api/v1/webview/network", HandleWebViewNetwork);
+        _server.MapGet("/api/v1/webview/console", HandleWebViewConsole);
+        _server.MapGet("/api/v1/webview/screenshot", HandleWebViewScreenshot);
 
-        // Preferences (CRUD)
-        _server.MapGet("/api/preferences", HandlePreferencesList);
-        _server.MapGet("/api/preferences/{key}", HandlePreferencesGet);
-        _server.MapPost("/api/preferences/{key}", HandlePreferencesSet);
-        _server.MapDelete("/api/preferences/{key}", HandlePreferencesDelete);
-        _server.MapPost("/api/preferences/clear", HandlePreferencesClear);
+        _server.MapGet("/api/v1/profiler/capabilities", HandleProfilerCapabilities);
+        _server.MapPost("/api/v1/profiler/sessions", HandleProfilerStart);
+        _server.MapDelete("/api/v1/profiler/sessions/{id}", HandleProfilerStop);
+        _server.MapGet("/api/v1/profiler/sessions/{id}/samples", HandleProfilerSamples);
+        _server.MapPost("/api/v1/profiler/markers", HandleProfilerMarker);
+        _server.MapPost("/api/v1/profiler/spans", HandleProfilerSpan);
+        _server.MapGet("/api/v1/profiler/hotspots", HandleProfilerHotspots);
+        _server.MapWebSocket("/ws/v1/profiler", HandleProfilerWebSocket);
 
-        // Secure Storage (CRUD)
-        _server.MapGet("/api/secure-storage/{key}", HandleSecureStorageGet);
-        _server.MapPost("/api/secure-storage/{key}", HandleSecureStorageSet);
-        _server.MapDelete("/api/secure-storage/{key}", HandleSecureStorageDelete);
-        _server.MapPost("/api/secure-storage/clear", HandleSecureStorageClear);
+        _server.MapGet("/api/v1/network/requests", HandleNetworkList);
+        _server.MapGet("/api/v1/network/requests/{id}", HandleNetworkDetail);
+        _server.MapDelete("/api/v1/network/requests", HandleNetworkClear);
+        _server.MapWebSocket("/ws/v1/network", HandleNetworkWebSocket);
 
-        // Platform info (read-only)
-        _server.MapGet("/api/platform/app-info", HandlePlatformAppInfo);
-        _server.MapGet("/api/platform/device-info", HandlePlatformDeviceInfo);
-        _server.MapGet("/api/platform/device-display", HandlePlatformDeviceDisplay);
-        _server.MapGet("/api/platform/battery", HandlePlatformBattery);
-        _server.MapGet("/api/platform/connectivity", HandlePlatformConnectivity);
-        _server.MapGet("/api/platform/version-tracking", HandlePlatformVersionTracking);
-        _server.MapGet("/api/platform/permissions", HandlePlatformPermissions);
-        _server.MapGet("/api/platform/permissions/{permission}", HandlePlatformPermissionCheck);
-        _server.MapGet("/api/platform/geolocation", HandlePlatformGeolocation);
+        _server.MapWebSocket("/ws/v1/ui/events", HandleUiEventsWebSocket);
 
-        // Sensors
-        _server.MapGet("/api/sensors", HandleSensorsList);
-        _server.MapPost("/api/sensors/{sensor}/start", HandleSensorStart);
-        _server.MapPost("/api/sensors/{sensor}/stop", HandleSensorStop);
-        _server.MapWebSocket("/ws/sensors", HandleSensorWebSocket);
+        _server.MapGet("/api/v1/device/app", HandlePlatformAppInfo);
+        _server.MapGet("/api/v1/device/info", HandlePlatformDeviceInfo);
+        _server.MapGet("/api/v1/device/display", HandlePlatformDeviceDisplay);
+        _server.MapGet("/api/v1/device/battery", HandlePlatformBattery);
+        _server.MapGet("/api/v1/device/connectivity", HandlePlatformConnectivity);
+        _server.MapGet("/api/v1/device/version-tracking", HandlePlatformVersionTracking);
+        _server.MapGet("/api/v1/device/permissions", HandlePlatformPermissions);
+        _server.MapGet("/api/v1/device/permissions/{permission}", HandlePlatformPermissionCheck);
+        _server.MapGet("/api/v1/device/geolocation", HandlePlatformGeolocation);
+        _server.MapGet("/api/v1/device/sensors", HandleSensorsList);
+        _server.MapPost("/api/v1/device/sensors/{sensor}/start", HandleSensorStart);
+        _server.MapPost("/api/v1/device/sensors/{sensor}/stop", HandleSensorStop);
+        _server.MapWebSocket("/ws/v1/sensors", HandleSensorWebSocket);
+
+        _server.MapGet("/api/v1/storage/preferences", HandlePreferencesList);
+        _server.MapGet("/api/v1/storage/preferences/{key}", HandlePreferencesGet);
+        _server.MapPut("/api/v1/storage/preferences/{key}", HandlePreferencesSet);
+        _server.MapDelete("/api/v1/storage/preferences/{key}", HandlePreferencesDelete);
+        _server.MapDelete("/api/v1/storage/preferences", HandlePreferencesClear);
+        _server.MapGet("/api/v1/storage/secure/{key}", HandleSecureStorageGet);
+        _server.MapPut("/api/v1/storage/secure/{key}", HandleSecureStorageSet);
+        _server.MapDelete("/api/v1/storage/secure/{key}", HandleSecureStorageDelete);
+        _server.MapDelete("/api/v1/storage/secure", HandleSecureStorageClear);
     }
 
     private async Task<HttpResponse> HandleStatus(HttpRequest request)
     {
         var windowIndex = ParseWindowIndex(request);
+        var appName = TryGetAppInfoString(() => AppInfo.Current.Name)
+            ?? _app?.GetType().Assembly.GetName().Name
+            ?? "unknown";
+        var packageId = TryGetAppInfoString(() => AppInfo.Current.PackageName) ?? "unknown";
+        var appVersion = TryGetAppInfoString(() => AppInfo.Current.VersionString) ?? "unknown";
+        var appBuild = TryGetAppInfoString(() => AppInfo.Current.BuildString) ?? "unknown";
         var result = await DispatchAsync(() =>
         {
             var window = GetWindow(windowIndex);
@@ -469,26 +500,116 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
 
             return new
             {
-                agent = "Microsoft.Maui.DevFlow.Agent",
-                version = typeof(DevFlowAgentService).Assembly
-                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
-                platform = PlatformName,
-                deviceType = DeviceTypeName,
-                idiom = IdiomName,
-                displayDensity = GetWindowDisplayDensity(window),
-                appName = _app?.GetType().Assembly.GetName().Name ?? "unknown",
+                timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                agent = new
+                {
+                    name = "Microsoft.Maui.DevFlow.Agent",
+                    version = typeof(DevFlowAgentService).Assembly
+                        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
+                    framework = ".NET MAUI",
+                    frameworkVersion = Environment.Version.ToString(),
+                },
+                device = new
+                {
+                    platform = PlatformName,
+                    deviceType = DeviceTypeName,
+                    idiom = IdiomName,
+                    displayDensity = GetWindowDisplayDensity(window),
+                    windowCount = _app?.Windows.Count ?? 0,
+                    windowWidth = double.IsFinite(w) ? w : 0,
+                    windowHeight = double.IsFinite(h) ? h : 0,
+                },
+                app = new
+                {
+                    name = appName,
+                    packageId = packageId,
+                    version = appVersion,
+                    build = appBuild,
+                },
+                capabilities = new
+                {
+                    ui = true,
+                    screenshots = true,
+                    webview = _cdpWebViews.Any(v => v.IsReady),
+                    network = true,
+                    logs = true,
+                    sensors = true,
+                    storage = true,
+                    profiler = IsProfilerFeatureAvailable,
+                },
                 running = _app != null,
-                cdpReady = _cdpWebViews.Any(w => w.IsReady),
+                cdpReady = _cdpWebViews.Any(v => v.IsReady),
                 cdpWebViewCount = _cdpWebViews.Count,
-                windowCount = _app?.Windows.Count ?? 0,
-                windowWidth = double.IsFinite(w) ? w : 0,
-                windowHeight = double.IsFinite(h) ? h : 0,
                 profiler = BuildProfilerCapabilitiesPayload(),
                 profilerSession = _profilerSessions.CurrentSession
             };
         });
 
         return HttpResponse.Json(result!);
+    }
+
+    private static string? TryGetAppInfoString(Func<string?> getter)
+    {
+        try
+        {
+            return getter();
+        }
+        catch (Exception ex) when (ex.GetType().Name == "NotImplementedInReferenceAssemblyException")
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private Task<HttpResponse> HandleCapabilities(HttpRequest request)
+    {
+        var result = new
+        {
+            ui = new
+            {
+                supported = true,
+                features = new[] { "tree", "query", "hit-test", "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "properties", "screenshot" }
+            },
+            webview = new
+            {
+                supported = _cdpWebViews.Any(v => v.IsReady),
+                features = _cdpWebViews.Any(v => v.IsReady)
+                    ? new[] { "evaluate", "contexts", "source", "dom", "dom-query", "network", "console", "screenshot" }
+                    : Array.Empty<string>()
+            },
+            network = new
+            {
+                supported = true,
+                features = new[] { "list", "detail", "clear", "stream" }
+            },
+            logs = new
+            {
+                supported = true,
+                features = new[] { "list", "stream" }
+            },
+            sensors = new
+            {
+                supported = true,
+                features = new[] { "list", "start", "stop", "stream" }
+            },
+            storage = new
+            {
+                supported = true,
+                features = new[] { "preferences", "secure-storage" }
+            },
+            profiler = new
+            {
+                supported = IsProfilerFeatureAvailable,
+                features = IsProfilerFeatureAvailable
+                    ? new[] { "capabilities", "sessions", "samples", "markers", "spans", "hotspots" }
+                    : Array.Empty<string>()
+            }
+        };
+
+        return Task.FromResult(HttpResponse.Json(result));
     }
 
     private async Task<HttpResponse> HandleTree(HttpRequest request)
@@ -771,7 +892,10 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         }
 
         // Element-level screenshot by ID
-        if (request.QueryParams.TryGetValue("id", out var elementId) && !string.IsNullOrWhiteSpace(elementId))
+        var hasElementId = request.QueryParams.TryGetValue("id", out var elementId)
+            || request.QueryParams.TryGetValue("elementId", out elementId);
+
+        if (hasElementId && !string.IsNullOrWhiteSpace(elementId))
         {
             try
             {
@@ -1136,6 +1260,18 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             result == "ok" ? null : result,
             id,
             new { property = propName });
+
+        if (result == "ok")
+        {
+            PublishUiEvent("treeChange", new
+            {
+                changeType = "modified",
+                elementId = id,
+                elementType = "property",
+                parentId = (string?)null,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+        }
 
         return result == "ok"
             ? HttpResponse.Json(new { id, property = propName, value = body.Value })
@@ -1517,6 +1653,18 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             body.ElementId,
             new { textLength = body.Text.Length });
 
+        if (result == "ok")
+        {
+            PublishUiEvent("treeChange", new
+            {
+                changeType = "modified",
+                elementId = body.ElementId,
+                elementType = "input",
+                parentId = (string?)null,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+        }
+
         return result == "ok" ? HttpResponse.Ok("Text set") : HttpResponse.Error(result);
     }
 
@@ -1557,6 +1705,18 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             success ? null : "Element does not accept text input",
             body.ElementId);
 
+        if (success)
+        {
+            PublishUiEvent("treeChange", new
+            {
+                changeType = "modified",
+                elementId = body.ElementId,
+                elementType = "input",
+                parentId = (string?)null,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+        }
+
         return success ? HttpResponse.Ok("Cleared") : HttpResponse.Error("Element does not accept text input");
     }
 
@@ -1596,6 +1756,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             return HttpResponse.Error("route is required");
 
         var startedAtUtc = DateTime.UtcNow;
+        var fromRoute = Shell.Current?.CurrentState?.Location?.ToString();
         Publish(new ProfilerMarker
         {
             TsUtc = DateTime.UtcNow,
@@ -1636,6 +1797,26 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             result == "ok" ? null : result,
             elementPath: body.Route,
             tags: new { route = body.Route });
+
+        if (result == "ok")
+        {
+            PublishUiEvent("navigation", new
+            {
+                from = fromRoute,
+                to = body.Route,
+                route = body.Route,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+        }
+        else
+        {
+            PublishUiEvent("error", new
+            {
+                message = result ?? "Navigation failed",
+                stackTrace = (string?)null,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+        }
 
         return result == "ok" ? HttpResponse.Ok($"Navigated to {body.Route}") : HttpResponse.Error(result ?? "Navigation failed");
     }
@@ -1694,6 +1875,354 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
     }
 
     private record ResizeRequest(int Width, int Height);
+
+    private sealed class KeyActionRequest
+    {
+        public string? ElementId { get; set; }
+        public string? Key { get; set; }
+        public string? Text { get; set; }
+    }
+
+    private sealed class GestureActionRequest
+    {
+        public string? ElementId { get; set; }
+        public string? Type { get; set; }
+        public string? Direction { get; set; }
+        public double Distance { get; set; } = 120;
+        public int DurationMs { get; set; } = 200;
+    }
+
+    private sealed class BatchRequest
+    {
+        public List<BatchActionRequest> Actions { get; set; } = [];
+        public bool ContinueOnError { get; set; }
+    }
+
+    private sealed class BatchActionRequest
+    {
+        public string? Action { get; set; }
+        public string? Type { get; set; }
+        public string? ElementId { get; set; }
+        public string? Text { get; set; }
+        public string? Route { get; set; }
+        public string? Property { get; set; }
+        public string? Value { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public double DeltaX { get; set; }
+        public double DeltaY { get; set; }
+        public int? ItemIndex { get; set; }
+        public int? GroupIndex { get; set; }
+        public string? ScrollToPosition { get; set; }
+        public bool Animated { get; set; } = true;
+        public string? Key { get; set; }
+        public string? Direction { get; set; }
+        public double Distance { get; set; } = 120;
+        public int DurationMs { get; set; } = 200;
+    }
+
+    private async Task<HttpResponse> HandleBack(HttpRequest request)
+    {
+        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+
+        var startedAtUtc = DateTime.UtcNow;
+        var windowIndex = ParseWindowIndex(request);
+        var result = await DispatchAsync(async () =>
+        {
+            try
+            {
+                if (Shell.Current != null)
+                {
+                    await Shell.Current.GoToAsync("..");
+                    return "ok";
+                }
+
+                var page = GetWindow(windowIndex)?.Page;
+                if (page?.Navigation?.ModalStack?.Count > 0)
+                {
+                    await page.Navigation.PopModalAsync();
+                    return "ok";
+                }
+
+                if (page?.Navigation?.NavigationStack?.Count > 1)
+                {
+                    await page.Navigation.PopAsync();
+                    return "ok";
+                }
+
+                return "No navigation stack available";
+            }
+            catch (Exception ex)
+            {
+                return ex.GetBaseException().Message;
+            }
+        });
+
+        PublishUiOperationSpan("action.back", startedAtUtc, result == "ok", result == "ok" ? null : result);
+
+        return result == "ok"
+            ? HttpResponse.Ok("Navigated back")
+            : HttpResponse.Error(result ?? "Back navigation failed");
+    }
+
+    private async Task<HttpResponse> HandleKey(HttpRequest request)
+    {
+        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+
+        var body = request.BodyAs<KeyActionRequest>();
+        if (body == null || (string.IsNullOrWhiteSpace(body.Key) && string.IsNullOrWhiteSpace(body.Text)))
+            return HttpResponse.Error("key or text is required");
+
+        var startedAtUtc = DateTime.UtcNow;
+        var keyValue = body.Key ?? body.Text ?? string.Empty;
+        var result = await DispatchAsync(() =>
+        {
+            object? el = null;
+            if (!string.IsNullOrWhiteSpace(body.ElementId))
+            {
+                el = _treeWalker.GetElementById(body.ElementId, _app);
+                if (el == null)
+                    return "Element not found";
+            }
+
+            var normalizedKey = keyValue.Trim().ToLowerInvariant();
+            var text = body.Text ?? (keyValue.Length == 1 ? keyValue : null);
+
+            switch (el)
+            {
+                case Entry entry:
+                    if (normalizedKey is "enter" or "return")
+                    {
+                        entry.SendCompleted();
+                        return "ok";
+                    }
+                    if (normalizedKey is "backspace" or "delete")
+                    {
+                        entry.Text = entry.Text?.Length > 0 ? entry.Text[..^1] : string.Empty;
+                        return "ok";
+                    }
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        entry.Text += text;
+                        return "ok";
+                    }
+                    return $"Unsupported key '{keyValue}' for Entry";
+
+                case Editor editor:
+                    if (normalizedKey is "backspace" or "delete")
+                    {
+                        editor.Text = editor.Text?.Length > 0 ? editor.Text[..^1] : string.Empty;
+                        return "ok";
+                    }
+                    if (normalizedKey is "enter" or "return")
+                    {
+                        editor.Text += Environment.NewLine;
+                        return "ok";
+                    }
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        editor.Text += text;
+                        return "ok";
+                    }
+                    return $"Unsupported key '{keyValue}' for Editor";
+
+                case SearchBar searchBar:
+                    if (normalizedKey is "backspace" or "delete")
+                    {
+                        searchBar.Text = searchBar.Text?.Length > 0 ? searchBar.Text[..^1] : string.Empty;
+                        return "ok";
+                    }
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        searchBar.Text += text;
+                        return "ok";
+                    }
+                    return normalizedKey is "enter" or "return"
+                        ? "ok"
+                        : $"Unsupported key '{keyValue}' for SearchBar";
+
+                case null:
+                    return "ok";
+
+                default:
+                    return $"Element '{body.ElementId}' does not accept keyboard input";
+            }
+        });
+
+        PublishUiOperationSpan(
+            "action.key",
+            startedAtUtc,
+            result == "ok",
+            result == "ok" ? null : result,
+            body.ElementId,
+            new { key = keyValue, text = body.Text });
+
+        return result == "ok"
+            ? HttpResponse.Json(new { success = true, key = keyValue, text = body.Text, elementId = body.ElementId })
+            : HttpResponse.Error(result ?? "Key action failed");
+    }
+
+    private async Task<HttpResponse> HandleGesture(HttpRequest request)
+    {
+        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+
+        var body = request.BodyAs<GestureActionRequest>();
+        if (body == null || string.IsNullOrWhiteSpace(body.Type))
+            return HttpResponse.Error("type is required");
+
+        var gestureType = body.Type.Trim().ToLowerInvariant();
+
+        return gestureType switch
+        {
+            "tap" => await HandleTap(new HttpRequest
+            {
+                Method = "POST",
+                Body = JsonSerializer.Serialize(new ActionRequest { ElementId = body.ElementId })
+            }),
+            "longpress" or "long-press" => await HandleTap(new HttpRequest
+            {
+                Method = "POST",
+                Body = JsonSerializer.Serialize(new ActionRequest { ElementId = body.ElementId })
+            }),
+            "swipe" => await HandleScroll(new HttpRequest
+            {
+                Method = "POST",
+                Body = JsonSerializer.Serialize(new ScrollRequest
+                {
+                    ElementId = body.ElementId,
+                    DeltaX = body.Direction?.Equals("left", StringComparison.OrdinalIgnoreCase) == true ? -body.Distance :
+                        body.Direction?.Equals("right", StringComparison.OrdinalIgnoreCase) == true ? body.Distance : 0,
+                    DeltaY = body.Direction?.Equals("up", StringComparison.OrdinalIgnoreCase) == true ? -body.Distance :
+                        body.Direction?.Equals("down", StringComparison.OrdinalIgnoreCase) == true ? body.Distance : 0,
+                    Animated = body.DurationMs <= 0 || body.DurationMs < 400
+                })
+            }),
+            _ => HttpResponse.Error($"Gesture '{body.Type}' is not supported")
+        };
+    }
+
+    private async Task<HttpResponse> HandleBatch(HttpRequest request)
+    {
+        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+
+        var body = request.BodyAs<BatchRequest>();
+        if (body?.Actions == null || body.Actions.Count == 0)
+            return HttpResponse.Error("actions are required");
+
+        var results = new List<object>(body.Actions.Count);
+        var allSucceeded = true;
+
+        foreach (var action in body.Actions)
+        {
+            var actionName = (action.Action ?? action.Type ?? string.Empty).Trim().ToLowerInvariant();
+            HttpResponse response;
+
+            switch (actionName)
+            {
+                case "tap":
+                    response = await HandleTap(new HttpRequest { Method = "POST", Body = JsonSerializer.Serialize(new ActionRequest { ElementId = action.ElementId }) });
+                    break;
+                case "fill":
+                    response = await HandleFill(new HttpRequest
+                    {
+                        Method = "POST",
+                        Body = JsonSerializer.Serialize(new FillRequest { ElementId = action.ElementId, Text = action.Text ?? string.Empty })
+                    });
+                    break;
+                case "clear":
+                    response = await HandleClear(new HttpRequest { Method = "POST", Body = JsonSerializer.Serialize(new ActionRequest { ElementId = action.ElementId }) });
+                    break;
+                case "focus":
+                    response = await HandleFocus(new HttpRequest { Method = "POST", Body = JsonSerializer.Serialize(new ActionRequest { ElementId = action.ElementId }) });
+                    break;
+                case "navigate":
+                    response = await HandleNavigate(new HttpRequest
+                    {
+                        Method = "POST",
+                        Body = JsonSerializer.Serialize(new NavigateRequest { Route = action.Route ?? string.Empty })
+                    });
+                    break;
+                case "resize":
+                    response = await HandleResize(new HttpRequest { Method = "POST", Body = JsonSerializer.Serialize(new ResizeRequest(action.Width, action.Height)) });
+                    break;
+                case "scroll":
+                    response = await HandleScroll(new HttpRequest
+                    {
+                        Method = "POST",
+                        Body = JsonSerializer.Serialize(new ScrollRequest
+                        {
+                            ElementId = action.ElementId,
+                            DeltaX = action.DeltaX,
+                            DeltaY = action.DeltaY,
+                            ItemIndex = action.ItemIndex,
+                            GroupIndex = action.GroupIndex,
+                            ScrollToPosition = action.ScrollToPosition,
+                            Animated = action.Animated
+                        })
+                    });
+                    break;
+                case "back":
+                    response = await HandleBack(new HttpRequest { Method = "POST" });
+                    break;
+                case "key":
+                    response = await HandleKey(new HttpRequest
+                    {
+                        Method = "POST",
+                        Body = JsonSerializer.Serialize(new KeyActionRequest { ElementId = action.ElementId, Key = action.Key, Text = action.Text })
+                    });
+                    break;
+                case "gesture":
+                    response = await HandleGesture(new HttpRequest
+                    {
+                        Method = "POST",
+                        Body = JsonSerializer.Serialize(new GestureActionRequest
+                        {
+                            ElementId = action.ElementId,
+                            Type = action.Type ?? action.Action,
+                            Direction = action.Direction,
+                            Distance = action.Distance,
+                            DurationMs = action.DurationMs
+                        })
+                    });
+                    break;
+                case "set-property":
+                case "set_property":
+                    response = await HandleSetProperty(new HttpRequest
+                    {
+                        Method = "PUT",
+                        RouteParams = new Dictionary<string, string>
+                        {
+                            ["id"] = action.ElementId ?? string.Empty,
+                            ["name"] = action.Property ?? string.Empty
+                        },
+                        Body = JsonSerializer.Serialize(new SetPropertyRequest { Value = action.Value ?? string.Empty })
+                    });
+                    break;
+                default:
+                    response = HttpResponse.Error($"Unsupported batch action '{actionName}'");
+                    break;
+            }
+
+            var succeeded = response.StatusCode < 400;
+            allSucceeded &= succeeded;
+            results.Add(new
+            {
+                action = actionName,
+                success = succeeded,
+                statusCode = response.StatusCode,
+                response = response.Body
+            });
+
+            if (!succeeded && !body.ContinueOnError)
+                break;
+        }
+
+        return HttpResponse.Json(new
+        {
+            success = allSucceeded,
+            results
+        });
+    }
 
     private async Task<HttpResponse> HandleScroll(HttpRequest request)
     {
@@ -2076,6 +2605,27 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         };
     }
 
+    private string GetRequestedProfilerSessionId(HttpRequest request)
+    {
+        if (request.RouteParams.TryGetValue("id", out var routeId) && !string.IsNullOrWhiteSpace(routeId))
+            return routeId;
+        if (request.QueryParams.TryGetValue("sessionId", out var sessionId) && !string.IsNullOrWhiteSpace(sessionId))
+            return sessionId;
+        return "current";
+    }
+
+    private HttpResponse? ValidateProfilerSessionRequest(HttpRequest request, out string requestedSessionId)
+    {
+        requestedSessionId = GetRequestedProfilerSessionId(request);
+        if (requestedSessionId.Equals("current", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var currentSession = _profilerSessions.CurrentSession;
+        return currentSession != null && currentSession.SessionId.Equals(requestedSessionId, StringComparison.Ordinal)
+            ? null
+            : HttpResponse.NotFound($"Profiler session '{requestedSessionId}' not found");
+    }
+
     private Task<HttpResponse> HandleProfilerCapabilities(HttpRequest request)
         => Task.FromResult(HttpResponse.Json(BuildProfilerCapabilitiesPayload()));
 
@@ -2095,12 +2645,20 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleProfilerStop(HttpRequest request)
     {
+        var validationError = ValidateProfilerSessionRequest(request, out _);
+        if (validationError != null)
+            return validationError;
+
         var session = await StopProfilerAsync();
         return HttpResponse.Json(new { session, stoppedAtUtc = DateTime.UtcNow });
     }
 
     private Task<HttpResponse> HandleProfilerSamples(HttpRequest request)
     {
+        var validationError = ValidateProfilerSessionRequest(request, out _);
+        if (validationError != null)
+            return Task.FromResult(validationError);
+
         if (!long.TryParse(request.QueryParams.GetValueOrDefault("sampleCursor", "0"), out var sampleCursor))
             sampleCursor = 0;
         if (!long.TryParse(request.QueryParams.GetValueOrDefault("markerCursor", "0"), out var markerCursor))
@@ -2982,6 +3540,13 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             PayloadJson = JsonSerializer.Serialize(new { route, source, page = currentPage })
         });
         RememberUserAction("navigation.route", route, endedAtUtc);
+        PublishUiEvent("navigation", new
+        {
+            from = (string?)null,
+            to = route,
+            route,
+            timestamp = endedAtUtc.ToString("O")
+        });
 
         PublishUiOperationSpan(
             "navigation.shell.completed",
@@ -3046,6 +3611,75 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                 currentRoute = route,
                 page = page.GetType().Name
             });
+    }
+
+    private void PublishUiEvent(string type, object data)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            type,
+            timestamp = DateTimeOffset.UtcNow.ToString("O"),
+            data
+        });
+
+        lock (_uiEventSubscriptionGate)
+        {
+            foreach (var subscription in _uiEventSubscriptions)
+            {
+                if (subscription.Events.Contains("all") || subscription.Events.Contains(type))
+                    subscription.Queue.Enqueue(payload);
+            }
+        }
+    }
+
+    private static void ApplyUiEventSubscriptionMessage(UiEventSubscription subscription, JsonElement message)
+    {
+        if (!message.TryGetProperty("type", out var typeElement))
+            return;
+
+        var messageType = typeElement.GetString();
+        if (!message.TryGetProperty("data", out var dataElement) ||
+            !dataElement.TryGetProperty("events", out var eventsElement) ||
+            eventsElement.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        var events = eventsElement.EnumerateArray()
+            .Select(static e => e.GetString())
+            .Where(static e => !string.IsNullOrWhiteSpace(e))
+            .Select(static e => e!)
+            .ToArray();
+
+        if (events.Length == 0)
+            return;
+
+        if (string.Equals(messageType, "subscribe", StringComparison.OrdinalIgnoreCase))
+        {
+            if (events.Contains("all", StringComparer.OrdinalIgnoreCase))
+            {
+                subscription.Events.Clear();
+                subscription.Events.Add("all");
+                return;
+            }
+
+            if (subscription.Events.Contains("all"))
+                subscription.Events.Clear();
+
+            foreach (var eventName in events)
+                subscription.Events.Add(eventName);
+        }
+        else if (string.Equals(messageType, "unsubscribe", StringComparison.OrdinalIgnoreCase))
+        {
+            if (events.Contains("all", StringComparer.OrdinalIgnoreCase))
+            {
+                subscription.Events.Clear();
+                return;
+            }
+
+            foreach (var eventName in events)
+                subscription.Events.Remove(eventName);
+        }
     }
 
     private void TrackUiInteraction(string name, Element? element, object? tags = null)
@@ -3527,6 +4161,253 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         }
     }
 
+    private async Task HandleProfilerWebSocket(
+        System.Net.Sockets.TcpClient client,
+        System.Net.Sockets.NetworkStream stream,
+        HttpRequest request,
+        CancellationToken ct)
+    {
+        var requestedSessionId = request.QueryParams.GetValueOrDefault("sessionId");
+        if (string.IsNullOrWhiteSpace(requestedSessionId))
+        {
+            await AgentHttpServer.WebSocketSendTextAsync(stream,
+                JsonSerializer.Serialize(new { error = "sessionId query parameter is required" }), ct);
+            return;
+        }
+
+        if (!long.TryParse(request.QueryParams.GetValueOrDefault("sampleCursor", "0"), out var sampleCursor))
+            sampleCursor = 0;
+        if (!long.TryParse(request.QueryParams.GetValueOrDefault("markerCursor", "0"), out var markerCursor))
+            markerCursor = 0;
+        if (!long.TryParse(request.QueryParams.GetValueOrDefault("spanCursor", "0"), out var spanCursor))
+            spanCursor = 0;
+        if (!int.TryParse(request.QueryParams.GetValueOrDefault("limit", "500"), out var limit))
+            limit = 500;
+
+        limit = Math.Clamp(limit, 1, 5000);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        try
+        {
+            var readTask = Task.Run(async () =>
+            {
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    var msg = await AgentHttpServer.WebSocketReadTextAsync(stream, cts.Token);
+                    if (msg == null)
+                    {
+                        await cts.CancelAsync();
+                        break;
+                    }
+                }
+            }, cts.Token);
+
+            var sentInitialBatch = false;
+            var lastPing = DateTime.UtcNow;
+
+            while (!cts.Token.IsCancellationRequested)
+            {
+                var currentSession = _profilerSessions.CurrentSession;
+                if (currentSession == null)
+                {
+                    await AgentHttpServer.WebSocketSendTextAsync(stream, JsonSerializer.Serialize(new
+                    {
+                        type = "stopped",
+                        timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                        data = new { sessionId = requestedSessionId }
+                    }), cts.Token);
+                    break;
+                }
+
+                if (!requestedSessionId.Equals("current", StringComparison.OrdinalIgnoreCase) &&
+                    !requestedSessionId.Equals(currentSession.SessionId, StringComparison.Ordinal))
+                {
+                    await AgentHttpServer.WebSocketSendTextAsync(stream, JsonSerializer.Serialize(new
+                    {
+                        error = $"Profiler session '{requestedSessionId}' not found"
+                    }), cts.Token);
+                    break;
+                }
+
+                var batch = _profilerSessions.GetBatch(sampleCursor, markerCursor, limit, spanCursor);
+                var hasNewData = batch.SampleCursor != sampleCursor ||
+                    batch.MarkerCursor != markerCursor ||
+                    batch.SpanCursor != spanCursor;
+
+                if (!sentInitialBatch || hasNewData)
+                {
+                    sampleCursor = batch.SampleCursor;
+                    markerCursor = batch.MarkerCursor;
+                    spanCursor = batch.SpanCursor;
+                    sentInitialBatch = true;
+
+                    await AgentHttpServer.WebSocketSendTextAsync(stream, JsonSerializer.Serialize(new
+                    {
+                        type = "batch",
+                        timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                        data = batch
+                    }), cts.Token);
+                }
+
+                if (!batch.IsActive)
+                {
+                    await AgentHttpServer.WebSocketSendTextAsync(stream, JsonSerializer.Serialize(new
+                    {
+                        type = "stopped",
+                        timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                        data = new { sessionId = batch.SessionId }
+                    }), cts.Token);
+                    break;
+                }
+
+                if ((DateTime.UtcNow - lastPing).TotalSeconds >= 15)
+                {
+                    try
+                    {
+                        await AgentHttpServer.WebSocketSendPingAsync(stream, cts.Token);
+                        lastPing = DateTime.UtcNow;
+                    }
+                    catch
+                    {
+                        await cts.CancelAsync();
+                        break;
+                    }
+                }
+
+                try
+                {
+                    await Task.Delay(Math.Max(100, currentSession.SampleIntervalMs / 2), cts.Token);
+                }
+                catch
+                {
+                    break;
+                }
+            }
+
+            await readTask;
+        }
+        catch
+        {
+            await cts.CancelAsync();
+        }
+    }
+
+    private async Task HandleUiEventsWebSocket(
+        System.Net.Sockets.TcpClient client,
+        System.Net.Sockets.NetworkStream stream,
+        HttpRequest request,
+        CancellationToken ct)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var subscription = new UiEventSubscription();
+
+        lock (_uiEventSubscriptionGate)
+        {
+            _uiEventSubscriptions.Add(subscription);
+        }
+
+        try
+        {
+            var now = DateTimeOffset.UtcNow.ToString("O");
+            subscription.Queue.Enqueue(JsonSerializer.Serialize(new
+            {
+                type = "lifecycle",
+                timestamp = now,
+                data = new
+                {
+                    state = _app != null ? "started" : "stopped",
+                    timestamp = now
+                }
+            }));
+
+            var currentRoute = Shell.Current?.CurrentState?.Location?.ToString();
+            if (!string.IsNullOrWhiteSpace(currentRoute))
+            {
+                subscription.Queue.Enqueue(JsonSerializer.Serialize(new
+                {
+                    type = "navigation",
+                    timestamp = now,
+                    data = new
+                    {
+                        from = (string?)null,
+                        to = currentRoute,
+                        route = currentRoute,
+                        timestamp = now
+                    }
+                }));
+            }
+
+            var readTask = Task.Run(async () =>
+            {
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    var msg = await AgentHttpServer.WebSocketReadTextAsync(stream, cts.Token);
+                    if (msg == null)
+                    {
+                        await cts.CancelAsync();
+                        break;
+                    }
+
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(msg);
+                        lock (_uiEventSubscriptionGate)
+                        {
+                            ApplyUiEventSubscriptionMessage(subscription, doc.RootElement);
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }
+            }, cts.Token);
+
+            var lastPing = DateTime.UtcNow;
+            while (!cts.Token.IsCancellationRequested)
+            {
+                while (subscription.Queue.TryDequeue(out var message))
+                {
+                    try
+                    {
+                        await AgentHttpServer.WebSocketSendTextAsync(stream, message, cts.Token);
+                    }
+                    catch
+                    {
+                        await cts.CancelAsync();
+                        break;
+                    }
+                }
+
+                if ((DateTime.UtcNow - lastPing).TotalSeconds >= 15)
+                {
+                    try
+                    {
+                        await AgentHttpServer.WebSocketSendPingAsync(stream, cts.Token);
+                        lastPing = DateTime.UtcNow;
+                    }
+                    catch
+                    {
+                        await cts.CancelAsync();
+                        break;
+                    }
+                }
+
+                try { await Task.Delay(50, cts.Token); }
+                catch { break; }
+            }
+
+            await readTask;
+        }
+        finally
+        {
+            lock (_uiEventSubscriptionGate)
+            {
+                _uiEventSubscriptions.Remove(subscription);
+            }
+        }
+    }
+
     private Task<HttpResponse> HandleLogs(HttpRequest request)
     {
         if (_logProvider == null)
@@ -3543,19 +4424,84 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         return Task.FromResult(HttpResponse.Json(entries));
     }
 
-    private async Task<HttpResponse> HandleCdp(HttpRequest request)
+    private static string? GetRequestedWebViewId(HttpRequest request, string? contextId = null)
+        => request.QueryParams.GetValueOrDefault("webview")
+            ?? request.QueryParams.GetValueOrDefault("contextId")
+            ?? contextId;
+
+    private bool TryResolveReadyCdpWebView(
+        string? webviewId,
+        [NotNullWhen(true)] out CdpWebViewInfo? webView,
+        [NotNullWhen(false)] out HttpResponse? error)
     {
         if (_cdpWebViews.Count == 0)
-            return HttpResponse.Error("CDP not available (no Blazor WebViews registered)");
+        {
+            webView = null;
+            error = HttpResponse.Error("CDP not available (no Blazor WebViews registered)");
+            return false;
+        }
 
-        request.QueryParams.TryGetValue("webview", out var webviewId);
-        var webView = ResolveCdpWebView(webviewId);
-
+        webView = ResolveCdpWebView(webviewId);
         if (webView == null)
-            return HttpResponse.Error($"WebView '{webviewId}' not found. Use GET /api/cdp/webviews to list available WebViews.");
+        {
+            error = HttpResponse.Error($"WebView '{webviewId}' not found. Use GET /api/v1/webview/contexts to list available WebViews.");
+            return false;
+        }
 
         if (!webView.IsReady)
-            return HttpResponse.Error($"CDP not ready on WebView {webView.Index} (WebView not initialized)");
+        {
+            error = HttpResponse.Error($"CDP not ready on WebView {webView.Index} (WebView not initialized)");
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static string BuildCdpCommand(int id, string method, object? parameters = null)
+        => JsonSerializer.Serialize(new { id, method, @params = parameters });
+
+    private static string? TryGetCdpError(JsonElement root)
+    {
+        if (!root.TryGetProperty("error", out var errorElement))
+            return null;
+
+        return errorElement.ValueKind switch
+        {
+            JsonValueKind.String => errorElement.GetString(),
+            JsonValueKind.Object when errorElement.TryGetProperty("message", out var messageElement) => messageElement.GetString(),
+            _ => errorElement.GetRawText()
+        };
+    }
+
+    private async Task<JsonElement?> EvaluateWebViewExpressionAsync(CdpWebViewInfo webView, string expression, int id = 99996)
+    {
+        var resultJson = await webView.CommandHandler(BuildCdpCommand(id, "Runtime.evaluate", new
+        {
+            expression,
+            returnByValue = true
+        }));
+
+        using var doc = JsonDocument.Parse(resultJson);
+        var error = TryGetCdpError(doc.RootElement);
+        if (!string.IsNullOrWhiteSpace(error))
+            throw new InvalidOperationException(error);
+
+        if (doc.RootElement.TryGetProperty("result", out var result) &&
+            result.TryGetProperty("result", out var innerResult) &&
+            innerResult.TryGetProperty("value", out var value))
+        {
+            return value.Clone();
+        }
+
+        return null;
+    }
+
+    private async Task<HttpResponse> HandleCdp(HttpRequest request)
+    {
+        request.QueryParams.TryGetValue("webview", out var webviewId);
+        if (!TryResolveReadyCdpWebView(webviewId, out var webView, out var error))
+            return error!;
 
         if (string.IsNullOrEmpty(request.Body))
             return HttpResponse.Error("Missing CDP command body");
@@ -3575,14 +4521,320 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         }
     }
 
+    private sealed class WebViewDomQueryRequest
+    {
+        public string? Selector { get; set; }
+        public string? ContextId { get; set; }
+    }
+
+    private async Task<HttpResponse> HandleWebViewNavigate(HttpRequest request)
+    {
+        var body = request.BodyAs<WebViewNavigateRequest>();
+        if (string.IsNullOrWhiteSpace(body?.Url))
+            return HttpResponse.Error("url is required");
+
+        var webviewId = GetRequestedWebViewId(request, body.ContextId);
+        if (!TryResolveReadyCdpWebView(webviewId, out var webView, out var error))
+            return error!;
+
+        try
+        {
+            var resultJson = await webView!.CommandHandler(BuildCdpCommand(99995, "Page.navigate", new { url = body.Url }));
+            using var doc = JsonDocument.Parse(resultJson);
+            var cdpError = TryGetCdpError(doc.RootElement);
+            if (!string.IsNullOrWhiteSpace(cdpError))
+                return HttpResponse.Error($"WebView navigation failed: {cdpError}");
+
+            webView.Url = body.Url;
+            PublishUiEvent("navigation", new
+            {
+                from = (string?)null,
+                to = body.Url,
+                route = body.Url,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+
+            return HttpResponse.Json(new
+            {
+                success = true,
+                contextId = webviewId ?? webView.Index.ToString(),
+                url = body.Url
+            });
+        }
+        catch (Exception ex)
+        {
+            return HttpResponse.Error($"WebView navigation failed: {ex.Message}");
+        }
+    }
+
+    private async Task<HttpResponse> HandleWebViewInputClick(HttpRequest request)
+    {
+        var body = request.BodyAs<WebViewInputClickRequest>();
+        if (string.IsNullOrWhiteSpace(body?.Selector))
+            return HttpResponse.Error("selector is required");
+
+        var webviewId = GetRequestedWebViewId(request, body.ContextId);
+        if (!TryResolveReadyCdpWebView(webviewId, out var webView, out var error))
+            return error!;
+
+        try
+        {
+            var selectorJson = JsonSerializer.Serialize(body.Selector);
+            var value = await EvaluateWebViewExpressionAsync(
+                webView!,
+                $@"(function() {{
+                    const el = document.querySelector({selectorJson});
+                    if (!el) return {{ success: false, error: 'Element not found' }};
+                    if (typeof el.scrollIntoView === 'function') el.scrollIntoView({{ block: 'center', inline: 'center' }});
+                    if (typeof el.focus === 'function') el.focus();
+                    if (typeof el.click === 'function') el.click();
+                    else el.dispatchEvent(new MouseEvent('click', {{ bubbles: true, cancelable: true, view: window }}));
+                    return {{ success: true, tagName: el.tagName ? el.tagName.toLowerCase() : null }};
+                }})()");
+
+            if (value is not JsonElement clickResult)
+                return HttpResponse.Error("Click did not return a result");
+
+            if (clickResult.ValueKind == JsonValueKind.Object &&
+                clickResult.TryGetProperty("success", out var successElement) &&
+                !successElement.GetBoolean())
+            {
+                return HttpResponse.NotFound($"No element matches selector '{body.Selector}'");
+            }
+
+            return new HttpResponse
+            {
+                ContentType = "application/json",
+                Body = clickResult.GetRawText()
+            };
+        }
+        catch (Exception ex)
+        {
+            return HttpResponse.Error($"WebView click failed: {ex.Message}");
+        }
+    }
+
+    private async Task<HttpResponse> HandleWebViewInputFill(HttpRequest request)
+    {
+        var body = request.BodyAs<WebViewInputFillRequest>();
+        if (string.IsNullOrWhiteSpace(body?.Selector))
+            return HttpResponse.Error("selector is required");
+        if (body.Text == null)
+            return HttpResponse.Error("text is required");
+
+        var webviewId = GetRequestedWebViewId(request, body.ContextId);
+        if (!TryResolveReadyCdpWebView(webviewId, out var webView, out var error))
+            return error!;
+
+        try
+        {
+            var selectorJson = JsonSerializer.Serialize(body.Selector);
+            var textJson = JsonSerializer.Serialize(body.Text);
+            var value = await EvaluateWebViewExpressionAsync(
+                webView!,
+                $@"(function() {{
+                    const el = document.querySelector({selectorJson});
+                    if (!el) return {{ success: false, error: 'Element not found' }};
+                    if (typeof el.focus === 'function') el.focus();
+
+                    if ('value' in el) el.value = {textJson};
+                    else if (el.isContentEditable) el.textContent = {textJson};
+                    else return {{ success: false, error: 'Element does not accept text input' }};
+
+                    el.dispatchEvent(new Event('input', {{ bubbles: true }}));
+                    el.dispatchEvent(new Event('change', {{ bubbles: true }}));
+                    return {{ success: true, textLength: {body.Text.Length} }};
+                }})()");
+
+            if (value is not JsonElement fillResult)
+                return HttpResponse.Error("Fill did not return a result");
+
+            if (fillResult.ValueKind == JsonValueKind.Object &&
+                fillResult.TryGetProperty("success", out var successElement) &&
+                !successElement.GetBoolean())
+            {
+                var errorMessage = fillResult.TryGetProperty("error", out var errorElement)
+                    ? errorElement.GetString()
+                    : null;
+
+                return string.Equals(errorMessage, "Element not found", StringComparison.OrdinalIgnoreCase)
+                    ? HttpResponse.NotFound($"No element matches selector '{body.Selector}'")
+                    : HttpResponse.Error(errorMessage ?? "WebView fill failed");
+            }
+
+            PublishUiEvent("treeChange", new
+            {
+                changeType = "modified",
+                elementId = body.Selector,
+                elementType = "webview-input",
+                parentId = (string?)null,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+
+            return new HttpResponse
+            {
+                ContentType = "application/json",
+                Body = fillResult.GetRawText()
+            };
+        }
+        catch (Exception ex)
+        {
+            return HttpResponse.Error($"WebView fill failed: {ex.Message}");
+        }
+    }
+
+    private async Task<HttpResponse> HandleWebViewInputText(HttpRequest request)
+    {
+        var body = request.BodyAs<WebViewInputTextRequest>();
+        if (body?.Text == null)
+            return HttpResponse.Error("text is required");
+
+        var webviewId = GetRequestedWebViewId(request, body.ContextId);
+        if (!TryResolveReadyCdpWebView(webviewId, out var webView, out var error))
+            return error!;
+
+        try
+        {
+            var resultJson = await webView!.CommandHandler(BuildCdpCommand(99994, "Input.insertText", new { text = body.Text }));
+            using var doc = JsonDocument.Parse(resultJson);
+            var cdpError = TryGetCdpError(doc.RootElement);
+            if (!string.IsNullOrWhiteSpace(cdpError))
+                return HttpResponse.Error($"WebView text input failed: {cdpError}");
+
+            PublishUiEvent("treeChange", new
+            {
+                changeType = "modified",
+                elementId = body.ContextId ?? webviewId ?? webView.Index.ToString(),
+                elementType = "webview-input",
+                parentId = (string?)null,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+
+            return HttpResponse.Json(new
+            {
+                success = true,
+                textLength = body.Text.Length
+            });
+        }
+        catch (Exception ex)
+        {
+            return HttpResponse.Error($"WebView text input failed: {ex.Message}");
+        }
+    }
+
+    private Task<HttpResponse> HandleWebViewDom(HttpRequest request)
+        => HandleCdpSource(request);
+
+    private async Task<HttpResponse> HandleWebViewDomQuery(HttpRequest request)
+    {
+        var body = request.BodyAs<WebViewDomQueryRequest>();
+        if (string.IsNullOrWhiteSpace(body?.Selector))
+            return HttpResponse.Error("selector is required");
+
+        var webviewId = GetRequestedWebViewId(request, body.ContextId);
+        if (!TryResolveReadyCdpWebView(webviewId, out var webView, out var error))
+            return error!;
+
+        try
+        {
+            var selectorJson = JsonSerializer.Serialize(body.Selector);
+            var cdpCommand = JsonSerializer.Serialize(new
+            {
+                id = 99998,
+                method = "Runtime.evaluate",
+                @params = new
+                {
+                    expression = $@"(function() {{
+                        return Array.from(document.querySelectorAll({selectorJson})).map((el, index) => ({{
+                            index,
+                            tagName: el.tagName ? el.tagName.toLowerCase() : null,
+                            id: el.id || null,
+                            className: el.className || null,
+                            text: (el.innerText || el.textContent || '').trim(),
+                            html: el.outerHTML
+                        }}));
+                    }})()",
+                    returnByValue = true
+                }
+            });
+
+            var resultJson = await webView.CommandHandler(cdpCommand);
+            using var doc = JsonDocument.Parse(resultJson);
+            if (doc.RootElement.TryGetProperty("result", out var result) &&
+                result.TryGetProperty("result", out var innerResult) &&
+                innerResult.TryGetProperty("value", out var value))
+            {
+                return new HttpResponse
+                {
+                    ContentType = "application/json",
+                    Body = value.GetRawText()
+                };
+            }
+
+            return HttpResponse.Error("Failed to query DOM");
+        }
+        catch (Exception ex)
+        {
+            return HttpResponse.Error($"DOM query failed: {ex.Message}");
+        }
+    }
+
+    private Task<HttpResponse> HandleWebViewNetwork(HttpRequest request)
+        => HandleNetworkList(request);
+
+    private Task<HttpResponse> HandleWebViewConsole(HttpRequest request)
+    {
+        request.QueryParams["source"] = "webview";
+        return HandleLogs(request);
+    }
+
+    private async Task<HttpResponse> HandleWebViewScreenshot(HttpRequest request)
+    {
+        var webviewId = GetRequestedWebViewId(request);
+        if (!TryResolveReadyCdpWebView(webviewId, out var webView, out var error))
+            return error!;
+
+        try
+        {
+            var cdpCommand = JsonSerializer.Serialize(new
+            {
+                id = 99997,
+                method = "Page.captureScreenshot",
+                @params = new { format = "png" }
+            });
+
+            var resultJson = await webView.CommandHandler(cdpCommand);
+            using var doc = JsonDocument.Parse(resultJson);
+            if (doc.RootElement.TryGetProperty("result", out var result) &&
+                result.TryGetProperty("data", out var data) &&
+                data.GetString() is { Length: > 0 } base64)
+            {
+                return HttpResponse.Png(Convert.FromBase64String(base64));
+            }
+
+            return HttpResponse.Error("Failed to capture WebView screenshot");
+        }
+        catch (Exception ex)
+        {
+            return HttpResponse.Error($"WebView screenshot failed: {ex.Message}");
+        }
+    }
+
     private Task<HttpResponse> HandleCdpWebViews(HttpRequest request)
     {
         var webviews = _cdpWebViews.Select(w => new
         {
+            id = !string.IsNullOrWhiteSpace(w.AutomationId)
+                ? w.AutomationId
+                : !string.IsNullOrWhiteSpace(w.ElementId)
+                    ? w.ElementId
+                    : w.Index.ToString(),
             index = w.Index,
             automationId = w.AutomationId,
             elementId = w.ElementId,
             url = w.Url,
+            title = (string?)null,
+            ready = w.IsReady,
             isReady = w.IsReady,
         }).ToList();
 
@@ -3591,17 +4843,9 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleCdpSource(HttpRequest request)
     {
-        if (_cdpWebViews.Count == 0)
-            return HttpResponse.Error("CDP not available (no Blazor WebViews registered)");
-
-        request.QueryParams.TryGetValue("webview", out var webviewId);
-        var webView = ResolveCdpWebView(webviewId);
-
-        if (webView == null)
-            return HttpResponse.Error($"WebView '{webviewId}' not found. Use GET /api/cdp/webviews to list available WebViews.");
-
-        if (!webView.IsReady)
-            return HttpResponse.Error($"CDP not ready on WebView {webView.Index} (WebView not initialized)");
+        var webviewId = GetRequestedWebViewId(request);
+        if (!TryResolveReadyCdpWebView(webviewId, out var webView, out var error))
+            return error!;
 
         try
         {
@@ -4488,6 +5732,31 @@ public class FillRequest
 public class NavigateRequest
 {
     public string? Route { get; set; }
+}
+
+public class WebViewNavigateRequest
+{
+    public string? Url { get; set; }
+    public string? ContextId { get; set; }
+}
+
+public class WebViewInputClickRequest
+{
+    public string? Selector { get; set; }
+    public string? ContextId { get; set; }
+}
+
+public class WebViewInputFillRequest
+{
+    public string? Selector { get; set; }
+    public string? Text { get; set; }
+    public string? ContextId { get; set; }
+}
+
+public class WebViewInputTextRequest
+{
+    public string? Text { get; set; }
+    public string? ContextId { get; set; }
 }
 
 public class SetPropertyRequest

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -3998,6 +3998,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         var replayMsg = JsonSerializer.Serialize(new
         {
             type = "replay",
+            timestamp = DateTimeOffset.UtcNow.ToString("O"),
             entries = recent.Select(e => e.ToSummary())
         });
         await AgentHttpServer.WebSocketSendTextAsync(stream, replayMsg, ct);
@@ -4028,7 +4029,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                         {
                             var id = idEl.GetString();
                             var entry = id != null ? NetworkStore.GetById(id) : null;
-                            var resp = JsonSerializer.Serialize(new { type = "details", entry });
+                            var resp = JsonSerializer.Serialize(new
+                            {
+                                type = "details",
+                                timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                                entry
+                            });
                             await AgentHttpServer.WebSocketSendTextAsync(stream, resp, cts.Token);
                         }
                         else if (msgType == "clear")
@@ -4048,7 +4054,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                 {
                     try
                     {
-                        var json = JsonSerializer.Serialize(new { type = "request", entry = entry.ToSummary() });
+                        var json = JsonSerializer.Serialize(new
+                        {
+                            type = "request",
+                            timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                            entry = entry.ToSummary()
+                        });
                         await AgentHttpServer.WebSocketSendTextAsync(stream, json, cts.Token);
                     }
                     catch { await cts.CancelAsync(); break; }
@@ -4097,7 +4108,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         if (replayCount > 0)
         {
             var recent = _logProvider.Reader.Read(replayCount, 0, sourceFilter);
-            var replayMsg = JsonSerializer.Serialize(new { type = "replay", entries = recent });
+            var replayMsg = JsonSerializer.Serialize(new
+            {
+                type = "replay",
+                timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                entries = recent
+            });
             await AgentHttpServer.WebSocketSendTextAsync(stream, replayMsg, ct);
         }
 
@@ -4133,7 +4149,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                 {
                     try
                     {
-                        var json = JsonSerializer.Serialize(new { type = "log", entry });
+                        var json = JsonSerializer.Serialize(new
+                        {
+                            type = "log",
+                            timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                            entry
+                        });
                         await AgentHttpServer.WebSocketSendTextAsync(stream, json, cts.Token);
                     }
                     catch { await cts.CancelAsync(); break; }
@@ -4171,7 +4192,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         if (string.IsNullOrWhiteSpace(requestedSessionId))
         {
             await AgentHttpServer.WebSocketSendTextAsync(stream,
-                JsonSerializer.Serialize(new { error = "sessionId query parameter is required" }), ct);
+                JsonSerializer.Serialize(new
+                {
+                    type = "error",
+                    timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                    error = "sessionId query parameter is required"
+                }), ct);
             return;
         }
 
@@ -4225,6 +4251,8 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                 {
                     await AgentHttpServer.WebSocketSendTextAsync(stream, JsonSerializer.Serialize(new
                     {
+                        type = "error",
+                        timestamp = DateTimeOffset.UtcNow.ToString("O"),
                         error = $"Profiler session '{requestedSessionId}' not found"
                     }), cts.Token);
                     break;
@@ -5636,7 +5664,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         if (string.IsNullOrEmpty(sensorName))
         {
             await AgentHttpServer.WebSocketSendTextAsync(stream,
-                JsonSerializer.Serialize(new { error = "sensor query parameter is required (e.g., ?sensor=accelerometer)" }), ct);
+                JsonSerializer.Serialize(new
+                {
+                    type = "error",
+                    timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                    error = "sensor query parameter is required (e.g., ?sensor=accelerometer)"
+                }), ct);
             return;
         }
 
@@ -5657,7 +5690,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         if (startError != null)
         {
             await AgentHttpServer.WebSocketSendTextAsync(stream,
-                JsonSerializer.Serialize(new { error = startError }), ct);
+                JsonSerializer.Serialize(new
+                {
+                    type = "error",
+                    timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                    error = startError
+                }), ct);
             return;
         }
 
@@ -5668,8 +5706,22 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         try
         {
             // Confirm subscription
+            var subscribedAt = DateTimeOffset.UtcNow.ToString("O");
             await AgentHttpServer.WebSocketSendTextAsync(stream,
-                JsonSerializer.Serialize(new { type = "subscribed", sensor = sensorName, speed = speed.ToString(), throttleMs = Sensors.ThrottleMs }), ct);
+                JsonSerializer.Serialize(new
+                {
+                    type = "subscribed",
+                    timestamp = subscribedAt,
+                    sensor = new
+                    {
+                        name = sensorName,
+                        available = Sensors.SupportedSensors.Contains(sensorName),
+                        active = true
+                    },
+                    sensorName = sensorName,
+                    speed = speed.ToString(),
+                    throttleMs = Sensors.ThrottleMs
+                }), ct);
 
             // Read loop (detects disconnection)
             var readTask = Task.Run(async () =>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/ElementInfo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/ElementInfo.cs
@@ -19,6 +19,9 @@ public class ElementInfo
     [JsonPropertyName("fullType")]
     public string FullType { get; set; } = string.Empty;
 
+    [JsonPropertyName("framework")]
+    public string Framework { get; set; } = "maui";
+
     [JsonPropertyName("automationId")]
     public string? AutomationId { get; set; }
 
@@ -28,6 +31,14 @@ public class ElementInfo
     [JsonPropertyName("value")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Value { get; set; }
+
+    [JsonPropertyName("role")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Role
+    {
+        get => _role ?? InferRole();
+        set => _role = value;
+    }
 
     [JsonPropertyName("isVisible")]
     public bool IsVisible { get; set; }
@@ -40,6 +51,38 @@ public class ElementInfo
 
     [JsonPropertyName("opacity")]
     public double Opacity { get; set; } = 1.0;
+
+    [JsonPropertyName("traits")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Traits
+    {
+        get => _traits ?? BuildTraits();
+        set => _traits = value;
+    }
+
+    [JsonPropertyName("state")]
+    public ElementStateInfo State
+    {
+        get => new()
+        {
+            Displayed = IsVisible,
+            Enabled = IsEnabled,
+            Selected = IsSelected,
+            Focused = IsFocused,
+            Opacity = Opacity
+        };
+        set
+        {
+            if (value == null)
+                return;
+
+            IsVisible = value.Displayed;
+            IsEnabled = value.Enabled;
+            IsSelected = value.Selected;
+            IsFocused = value.Focused;
+            Opacity = value.Opacity;
+        }
+    }
 
     [JsonPropertyName("bounds")]
     public BoundsInfo? Bounds { get; set; }
@@ -56,6 +99,14 @@ public class ElementInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? StyleClass { get; set; }
 
+    [JsonPropertyName("style")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ElementStyleInfo? Style
+    {
+        get => StyleClass is { Count: > 0 } ? new ElementStyleInfo { Classes = StyleClass } : null;
+        set => StyleClass = value?.Classes;
+    }
+
     [JsonPropertyName("nativeType")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? NativeType { get; set; }
@@ -64,8 +115,73 @@ public class ElementInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string?>? NativeProperties { get; set; }
 
+    [JsonPropertyName("nativeView")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ElementNativeViewInfo? NativeView
+    {
+        get => NativeType != null || NativeProperties != null
+            ? new ElementNativeViewInfo
+            {
+                Type = NativeType,
+                Properties = NativeProperties
+            }
+            : null;
+        set
+        {
+            NativeType = value?.Type;
+            NativeProperties = value?.Properties;
+        }
+    }
+
+    [JsonPropertyName("frameworkProperties")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, string?>? FrameworkProperties { get; set; }
+
     [JsonPropertyName("children")]
     public List<ElementInfo>? Children { get; set; }
+
+    [JsonIgnore]
+    public bool IsSelected { get; set; }
+
+    private string? _role;
+    private List<string>? _traits;
+
+    private string? InferRole() => Type switch
+    {
+        "Window" => "window",
+        "Button" or "ImageButton" => "button",
+        "Entry" or "Editor" or "SearchBar" => "textbox",
+        "CheckBox" => "checkbox",
+        "RadioButton" => "radio",
+        "Switch" => "switch",
+        "Image" => "image",
+        "CollectionView" or "ListView" or "CarouselView" => "list",
+        "Label" when Gestures?.Contains("tap") == true => "link",
+        _ => null
+    };
+
+    private List<string>? BuildTraits()
+    {
+        var traits = new List<string>();
+        var role = Role;
+
+        if (role is "button" or "textbox" or "checkbox" or "radio" or "switch" or "link")
+            traits.Add("interactive");
+
+        if (Gestures is { Count: > 0 } && !traits.Contains("interactive"))
+            traits.Add("interactive");
+
+        if (role is "button" or "textbox" or "checkbox" or "radio" or "switch" or "link" or "window" || IsFocused)
+            traits.Add("focusable");
+
+        if (Type is "ScrollView" or "CollectionView" or "ListView" or "CarouselView")
+            traits.Add("scrollable");
+
+        if (role == "heading")
+            traits.Add("header");
+
+        return traits.Count > 0 ? traits : null;
+    }
 }
 
 /// <summary>
@@ -84,6 +200,42 @@ public class BoundsInfo
 
     [JsonPropertyName("height")]
     public double Height { get; set; }
+}
+
+public class ElementStateInfo
+{
+    [JsonPropertyName("displayed")]
+    public bool Displayed { get; set; }
+
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    [JsonPropertyName("selected")]
+    public bool Selected { get; set; }
+
+    [JsonPropertyName("focused")]
+    public bool Focused { get; set; }
+
+    [JsonPropertyName("opacity")]
+    public double Opacity { get; set; } = 1.0;
+}
+
+public class ElementStyleInfo
+{
+    [JsonPropertyName("classes")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Classes { get; set; }
+}
+
+public class ElementNativeViewInfo
+{
+    [JsonPropertyName("type")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("properties")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, string?>? Properties { get; set; }
 }
 
 /// <summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/SensorManager.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/SensorManager.cs
@@ -178,11 +178,19 @@ public class SensorManager : IDisposable
             return;
         _lastBroadcast[sensorName] = now;
 
+        var timestamp = now.ToString("O");
         var json = JsonSerializer.Serialize(new
         {
+            type = "reading",
+            timestamp,
             sensor = sensorName,
-            timestamp = now.ToString("O"),
-            data
+            data,
+            reading = new
+            {
+                sensor = sensorName,
+                timestamp,
+                values = data
+            }
         });
 
         if (_subscribers.TryGetValue(sensorName, out var subs))

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
@@ -938,6 +938,7 @@ public class VisualTreeWalker
                         Text = bsi.Title,
                         IsVisible = bsi.IsVisible,
                         IsEnabled = bsi.IsEnabled,
+                        IsSelected = isSelected,
                         IsFocused = isSelected,
                     };
                     // Enrich with route info
@@ -977,6 +978,7 @@ public class VisualTreeWalker
                             Text = section.Title,
                             IsVisible = section.IsVisible,
                             IsEnabled = section.IsEnabled,
+                            IsSelected = isSelected,
                             IsFocused = isSelected,
                         };
                         var tabProps = new Dictionary<string, string?>();
@@ -1086,6 +1088,7 @@ public class VisualTreeWalker
                         Text = tabPage.Title,
                         IsVisible = true,
                         IsEnabled = true,
+                        IsSelected = isSelected,
                         IsFocused = isSelected,
                     };
                     if (tabPage.IconImageSource is FileImageSource tpIcon)
@@ -1305,6 +1308,15 @@ public class VisualTreeWalker
             TimePicker tp => tp.Time.ToString(),
             RadioButton rb => rb.IsChecked.ToString(),
             _ => null
+        };
+
+        info.IsSelected = element switch
+        {
+            CheckBox cb => cb.IsChecked,
+            RadioButton rb => rb.IsChecked,
+            Switch sw => sw.IsToggled,
+            Picker pk => pk.SelectedIndex >= 0,
+            _ => info.IsSelected
         };
 
         // Populate gesture recognizer metadata

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/GtkAgentServiceExtensions.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/GtkAgentServiceExtensions.cs
@@ -51,7 +51,7 @@ public static class GtkAgentServiceExtensions
         }
 
         // Fall back to assembly metadata port if broker didn't assign one
-        if (brokerReg?.AssignedPort == null)
+        if (!hasCustomPort && brokerReg?.AssignedPort == null)
         {
             var metaPort = ReadAssemblyMetadataPort();
             if (metaPort.HasValue)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/AgentMetadataTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/AgentMetadataTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "Metadata")]
+public class AgentMetadataTests : IntegrationTestBase
+{
+    public AgentMetadataTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task Status_ReturnsValidAgentInfo()
+    {
+        var status = await Client.GetStatusAsync();
+
+        Assert.NotNull(status);
+        Assert.True(status!.Running);
+        Assert.NotNull(status.Agent);
+        Assert.NotNull(status.Agent!.Version);
+    }
+
+    [Fact]
+    public async Task Status_ContainsPlatformInfo()
+    {
+        var status = await Client.GetStatusAsync();
+
+        Assert.NotNull(status);
+        Assert.NotNull(status!.Platform);
+
+        var expected = Platform switch
+        {
+            "maccatalyst" => "catalyst",
+            "ios" => "ios",
+            "android" => "android",
+            "windows" => "win",
+            _ => Platform
+        };
+
+        Assert.Contains(expected, status.Platform!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Status_ContainsDeviceInfo()
+    {
+        var status = await Client.GetStatusAsync();
+
+        Assert.NotNull(status);
+        Assert.NotNull(status!.Device);
+        Assert.NotNull(status.Device!.Platform);
+        Assert.NotNull(status.Device.Idiom);
+    }
+
+    [Fact]
+    public async Task Status_ContainsAppInfo()
+    {
+        var status = await Client.GetStatusAsync();
+
+        Assert.NotNull(status);
+        Assert.NotNull(status!.App);
+        Assert.NotNull(status.App!.Name);
+        Assert.NotNull(status.App.PackageId);
+    }
+
+    [Fact]
+    public async Task Capabilities_ReturnsKnownFeatures()
+    {
+        var json = await Client.GetCapabilitiesAsync();
+
+        var text = json.ToString();
+        Assert.Contains("ui", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("webview", text, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/DeviceTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/DeviceTests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "Device")]
+public class DeviceTests : IntegrationTestBase
+{
+    public DeviceTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task AppInfo_ReturnsValidInfo()
+    {
+        var json = await Client.GetPlatformInfoAsync("app");
+
+        Assert.True(json.ValueKind != JsonValueKind.Undefined);
+        Assert.Contains("name", json.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AppInfo_NameMatchesSample()
+    {
+        var json = await Client.GetPlatformInfoAsync("app");
+        var text = json.ToString();
+
+        Assert.True(
+            text.Contains("MauiTodo", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("DevFlow", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("mauitodo", StringComparison.OrdinalIgnoreCase),
+            $"Expected app name to contain 'MauiTodo' or 'DevFlow', got: {text}");
+    }
+
+    [Fact]
+    public async Task DeviceInfo_ReturnsPlatformInfo()
+    {
+        var json = await Client.GetPlatformInfoAsync("info");
+
+        Assert.True(json.ValueKind != JsonValueKind.Undefined);
+        Output.WriteLine($"Device info: {json}");
+    }
+
+    [Fact]
+    public async Task Display_ReturnsMetrics()
+    {
+        var json = await Client.GetPlatformInfoAsync("display");
+        var text = json.ToString();
+
+        Assert.True(json.ValueKind != JsonValueKind.Undefined);
+        Assert.True(
+            text.Contains("width", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("density", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("height", StringComparison.OrdinalIgnoreCase),
+            $"Display info should contain dimension data, got: {text}");
+    }
+
+    [Fact]
+    public async Task Battery_ReturnsInfo()
+    {
+        var json = await Client.GetPlatformInfoAsync("battery");
+
+        Assert.True(json.ValueKind != JsonValueKind.Undefined);
+    }
+
+    [Fact]
+    public async Task Connectivity_ReturnsState()
+    {
+        var json = await Client.GetPlatformInfoAsync("connectivity");
+
+        Assert.True(json.ValueKind != JsonValueKind.Undefined);
+    }
+
+    [Fact]
+    public async Task Permissions_ReturnsList()
+    {
+        var response = await GetRawAsync("/api/v1/device/permissions");
+
+        Assert.True(response.IsSuccessStatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.NotEmpty(body);
+    }
+
+    [Fact]
+    public async Task Permission_SpecificPermission_ReturnsStatus()
+    {
+        var response = await GetRawAsync("/api/v1/device/permissions/camera");
+
+        if (response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            Output.WriteLine($"Camera permission: {body}");
+        }
+    }
+
+    [Fact]
+    public async Task Geolocation_ReturnsOrHandlesGracefully()
+    {
+        try
+        {
+            var json = await Client.GetGeolocationAsync(accuracy: "Low", timeoutSeconds: 5);
+            Output.WriteLine($"Geolocation: {json}");
+        }
+        catch (HttpRequestException ex)
+        {
+            Output.WriteLine($"Geolocation not available: {ex.Message}");
+        }
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
@@ -1,0 +1,370 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Fixture that builds and launches the DevFlow sample app on an Android emulator.
+/// </summary>
+public sealed class AndroidEmulatorFixture : AppFixtureBase
+{
+    const string PackageId = "com.companyname.mauitodo";
+
+    Process? _emulatorProcess;
+    bool _weStartedEmulator;
+    string? _serialNumber;
+    int _apiLevel;
+    string _sdkRoot = null!;
+
+    public override string Platform => "android";
+
+    protected override async Task InitializePlatformAsync()
+    {
+        _sdkRoot = ResolveSdkRoot();
+        _apiLevel = GetTargetApiLevel();
+        var avdName = GetTargetAvdName(_apiLevel);
+
+        await EnsureAvdExistsAsync(avdName, _apiLevel);
+        _serialNumber = await EnsureEmulatorRunningAsync(avdName);
+
+        await WithBuildLockAsync(async () =>
+        {
+            var projectPath = GetSampleProjectPath();
+            await BuildSampleAsync(projectPath, "net10.0-android",
+                $"-p:EmbedAssembliesIntoApk=true -p:MauiDevFlowPort={AgentPort}");
+
+            var apkPath = FindApk();
+            await InstallApkAsync(apkPath);
+
+            await AdbCheckedAsync($"forward tcp:{AgentPort} tcp:{AgentPort}", timeoutSeconds: 15);
+            await LaunchAppAsync();
+        });
+    }
+
+    protected override async Task DisposePlatformAsync()
+    {
+        if (_serialNumber != null)
+        {
+            try { await AdbAsync($"shell am force-stop {PackageId}", timeoutSeconds: 5); } catch { }
+            try { await RunProcessAsync(AdbPath(), $"-s {_serialNumber} forward --remove tcp:{AgentPort}", timeoutSeconds: 5); } catch { }
+        }
+
+        if (_weStartedEmulator && _emulatorProcess is { HasExited: false })
+        {
+            try { await AdbAsync("emu kill", timeoutSeconds: 10); } catch { }
+
+            try
+            {
+                _emulatorProcess.Kill(entireProcessTree: true);
+                await _emulatorProcess.WaitForExitAsync(new CancellationTokenSource(10000).Token);
+            }
+            catch
+            {
+            }
+        }
+
+        _emulatorProcess?.Dispose();
+    }
+
+    static string ResolveSdkRoot()
+    {
+        var root = Environment.GetEnvironmentVariable("ANDROID_HOME")
+            ?? Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT");
+
+        if (string.IsNullOrEmpty(root))
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var candidates = new[]
+            {
+                Path.Combine(home, "Library", "Android", "sdk"),
+                Path.Combine(home, "Android", "Sdk"),
+                @"C:\Users\" + Environment.UserName + @"\AppData\Local\Android\Sdk",
+            };
+
+            root = candidates.FirstOrDefault(Directory.Exists)
+                ?? throw new InvalidOperationException(
+                    "Android SDK not found. Set ANDROID_HOME or ANDROID_SDK_ROOT.");
+        }
+
+        if (!Directory.Exists(root))
+            throw new InvalidOperationException($"Android SDK directory not found at: {root}");
+
+        return root;
+    }
+
+    string AdbPath() => Path.Combine(_sdkRoot, "platform-tools", OperatingSystem.IsWindows() ? "adb.exe" : "adb");
+    string EmulatorPath() => Path.Combine(_sdkRoot, "emulator", OperatingSystem.IsWindows() ? "emulator.exe" : "emulator");
+
+    string AvdManagerPath()
+    {
+        var cmdlineToolsDir = Path.Combine(_sdkRoot, "cmdline-tools");
+        if (!Directory.Exists(cmdlineToolsDir))
+            throw new InvalidOperationException($"cmdline-tools not found at: {cmdlineToolsDir}");
+
+        var latestVersion = Directory.GetDirectories(cmdlineToolsDir)
+            .Select(Path.GetFileName)
+            .Where(n => n != "latest")
+            .OrderByDescending(n => n, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault() ?? "latest";
+
+        return Path.Combine(cmdlineToolsDir, latestVersion, "bin", OperatingSystem.IsWindows() ? "avdmanager.bat" : "avdmanager");
+    }
+
+    string SdkManagerPath()
+    {
+        var cmdlineToolsDir = Path.Combine(_sdkRoot, "cmdline-tools");
+        var latestVersion = Directory.GetDirectories(cmdlineToolsDir)
+            .Select(Path.GetFileName)
+            .Where(n => n != "latest")
+            .OrderByDescending(n => n, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault() ?? "latest";
+
+        return Path.Combine(cmdlineToolsDir, latestVersion, "bin", OperatingSystem.IsWindows() ? "sdkmanager.bat" : "sdkmanager");
+    }
+
+    Task<(string Stdout, string Stderr, int ExitCode)> AdbAsync(string arguments, int timeoutSeconds = 30) =>
+        RunProcessAsync(AdbPath(), $"-s {_serialNumber} {arguments}", timeoutSeconds: timeoutSeconds);
+
+    Task<string> AdbCheckedAsync(string arguments, int timeoutSeconds = 30) =>
+        RunProcessCheckedAsync(AdbPath(), $"-s {_serialNumber} {arguments}", timeoutSeconds: timeoutSeconds);
+
+    static int GetTargetApiLevel()
+    {
+        var apiStr = Environment.GetEnvironmentVariable("DEVFLOW_TEST_ANDROID_API") ?? "35";
+        var first = apiStr.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)[0];
+        return int.Parse(first);
+    }
+
+    static string GetTargetAvdName(int apiLevel) =>
+        Environment.GetEnvironmentVariable("DEVFLOW_TEST_ANDROID_AVD")
+        ?? $"devflow-tests-api{apiLevel}";
+
+    async Task EnsureAvdExistsAsync(string avdName, int apiLevel)
+    {
+        var (stdout, _, _) = await RunProcessAsync(AvdManagerPath(), "list avd -c");
+        var existingAvds = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (existingAvds.Any(a => a.Equals(avdName, StringComparison.OrdinalIgnoreCase)))
+            return;
+
+        var systemImage = $"system-images;android-{apiLevel};google_apis;arm64-v8a";
+        await RunProcessCheckedAsync(SdkManagerPath(), $"--install \"{systemImage}\"", timeoutSeconds: 600);
+
+        var psi = new ProcessStartInfo(AvdManagerPath(), $"create avd -n {avdName} -k \"{systemImage}\" -d pixel_6 --force")
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start avdmanager");
+
+        await process.StandardInput.WriteLineAsync("no");
+        process.StandardInput.Close();
+
+        await process.WaitForExitAsync();
+        if (process.ExitCode != 0)
+        {
+            var stderr = await process.StandardError.ReadToEndAsync();
+            throw new InvalidOperationException($"avdmanager create failed: {stderr}");
+        }
+    }
+
+    async Task<string> EnsureEmulatorRunningAsync(string avdName)
+    {
+        var adb = AdbPath();
+        var requestedSerial = Environment.GetEnvironmentVariable("DEVFLOW_TEST_ANDROID_SERIAL");
+
+        if (!string.IsNullOrWhiteSpace(requestedSerial))
+        {
+            var (avdOutput, _, exitCode) = await RunProcessAsync(adb,
+                $"-s {requestedSerial} emu avd name", timeoutSeconds: 10);
+
+            if (exitCode == 0 && avdOutput.Trim().StartsWith(avdName, StringComparison.OrdinalIgnoreCase))
+            {
+                _weStartedEmulator = false;
+                return requestedSerial;
+            }
+
+            throw new InvalidOperationException(
+                $"Requested Android serial '{requestedSerial}' is not running AVD '{avdName}'.");
+        }
+
+        var (devicesOutput, _, _) = await RunProcessAsync(adb, "devices");
+        var runningEmulators = devicesOutput
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Where(l => l.StartsWith("emulator-") && l.Contains("device"))
+            .Select(l => l.Split('\t')[0].Trim())
+            .ToList();
+
+        foreach (var serial in runningEmulators)
+        {
+            var (avdOutput, _, exitCode) = await RunProcessAsync(adb, $"-s {serial} emu avd name", timeoutSeconds: 5);
+            if (exitCode == 0 && avdOutput.Trim().StartsWith(avdName, StringComparison.OrdinalIgnoreCase))
+            {
+                _weStartedEmulator = false;
+                return serial;
+            }
+        }
+
+        var emulatorPort = GetEmulatorConsolePort();
+        var expectedSerial = $"emulator-{emulatorPort}";
+
+        var psi = new ProcessStartInfo(EmulatorPath(), $"-avd {avdName} -port {emulatorPort} -no-snapshot -no-audio -no-window -gpu swiftshader_indirect")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        _emulatorProcess = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start emulator for AVD {avdName}");
+        _weStartedEmulator = true;
+
+        var newSerial = await WaitForEmulatorSerialAsync(adb, expectedSerial, avdName, timeoutSeconds: 120);
+        await WaitForDeviceBootAsync(adb, newSerial, timeoutSeconds: 180);
+        return newSerial;
+    }
+
+    static int GetEmulatorConsolePort()
+    {
+        if (int.TryParse(Environment.GetEnvironmentVariable("DEVFLOW_TEST_ANDROID_EMULATOR_PORT"), out var configuredPort))
+            return configuredPort;
+
+        // Android emulator console ports must be even and reserve the next odd port too.
+        for (var port = 5580; port <= 5680; port += 2)
+        {
+            if (IsPortAvailable(port) && IsPortAvailable(port + 1))
+                return port;
+        }
+
+        throw new InvalidOperationException("Could not find a free Android emulator port in the 5580-5680 range.");
+    }
+
+    static bool IsPortAvailable(int port)
+    {
+        try
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            listener.Stop();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    async Task<string> WaitForEmulatorSerialAsync(string adb, string expectedSerial, string avdName, int timeoutSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_emulatorProcess is { HasExited: true })
+                throw new InvalidOperationException(
+                    $"Emulator process exited with code {_emulatorProcess.ExitCode} before becoming ready.");
+
+            var (output, _, _) = await RunProcessAsync(adb, "devices");
+            var emulatorSerials = output
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Where(l => l.StartsWith("emulator-") && l.Contains("device"))
+                .Select(l => l.Split('\t')[0].Trim())
+                .ToList();
+
+            if (emulatorSerials.Contains(expectedSerial, StringComparer.OrdinalIgnoreCase))
+                return expectedSerial;
+
+            foreach (var serial in emulatorSerials)
+            {
+                var (avdOutput, _, exitCode) = await RunProcessAsync(adb, $"-s {serial} emu avd name", timeoutSeconds: 5);
+                if (exitCode == 0 && avdOutput.Trim().StartsWith(avdName, StringComparison.OrdinalIgnoreCase))
+                    return serial;
+            }
+
+            await Task.Delay(2000);
+        }
+
+        throw new TimeoutException(
+            $"Emulator for AVD '{avdName}' did not appear in 'adb devices' within {timeoutSeconds}s.");
+    }
+
+    static async Task WaitForDeviceBootAsync(string adb, string serial, int timeoutSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var (output, _, exitCode) = await RunProcessAsync(adb, $"-s {serial} shell getprop sys.boot_completed", timeoutSeconds: 5);
+            if (exitCode == 0 && output.Trim() == "1")
+                return;
+
+            await Task.Delay(3000);
+        }
+
+        throw new TimeoutException($"Device {serial} did not finish booting within {timeoutSeconds}s.");
+    }
+
+    static string FindApk()
+    {
+        var binDir = Path.Combine(GetSampleBuildOutputRoot(), "net10.0-android");
+
+        if (!Directory.Exists(binDir))
+            throw new InvalidOperationException($"Android build output not found at: {binDir}");
+
+        var apks = Directory.GetFiles(binDir, "*-Signed.apk", SearchOption.AllDirectories);
+        if (apks.Length == 0)
+            apks = Directory.GetFiles(binDir, "*.apk", SearchOption.AllDirectories);
+
+        if (apks.Length == 0)
+            throw new InvalidOperationException($"No APK found under {binDir}");
+
+        return apks[0];
+    }
+
+    Task InstallApkAsync(string apkPath) =>
+        AdbCheckedAsync($"install -r \"{apkPath}\"", timeoutSeconds: 120);
+
+    async Task LaunchAppAsync()
+    {
+        var output = await AdbCheckedAsync(
+            $"shell cmd package resolve-activity --brief -c android.intent.category.LAUNCHER {PackageId}",
+            timeoutSeconds: 10);
+
+        var activityLine = output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault(l => l.Contains('/'));
+
+        if (string.IsNullOrEmpty(activityLine))
+            throw new InvalidOperationException(
+                $"Could not resolve launcher activity for {PackageId}. Output: {output}");
+
+        await AdbCheckedAsync($"shell am force-stop {PackageId}", timeoutSeconds: 10);
+        var launchOutput = await AdbCheckedAsync($"shell am start -W -n {activityLine}", timeoutSeconds: 30);
+
+        if (launchOutput.Contains("Error:", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Failed to launch {PackageId}: {launchOutput}");
+
+        await WaitForAppProcessAsync(timeoutSeconds: 30);
+    }
+
+    async Task WaitForAppProcessAsync(int timeoutSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var (output, _, exitCode) = await AdbAsync($"shell pidof {PackageId}", timeoutSeconds: 5);
+            if (exitCode == 0 && !string.IsNullOrWhiteSpace(output))
+                return;
+
+            await Task.Delay(1000);
+        }
+
+        throw new TimeoutException($"Android app process '{PackageId}' did not appear within {timeoutSeconds}s.");
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixture.cs
@@ -1,0 +1,27 @@
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// xUnit collection fixture wrapper that selects a platform-specific
+/// fixture based on DEVFLOW_TEST_PLATFORM.
+/// </summary>
+public sealed class AppFixture : IAppFixture, IAsyncLifetime
+{
+    readonly IAppFixture _inner;
+
+    public AppFixture()
+    {
+        _inner = AppFixtureFactory.Create();
+    }
+
+    public Driver.AgentClient Client => _inner.Client;
+    public HttpClient Http => _inner.Http;
+    public int AgentPort => _inner.AgentPort;
+    public string AgentBaseUrl => _inner.AgentBaseUrl;
+    public string Platform => _inner.Platform;
+
+    public Task InitializeAsync() => _inner.InitializeAsync();
+    public Task DisposeAsync() => _inner.DisposeAsync();
+}
+
+[CollectionDefinition("AgentIntegration")]
+public class AgentIntegrationCollection : ICollectionFixture<AppFixture>;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureBase.cs
@@ -1,0 +1,294 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Shared base class for platform-specific app fixtures. Handles port allocation,
+/// agent readiness polling, sample app build invocation, and client setup.
+/// </summary>
+public abstract class AppFixtureBase : IAppFixture
+{
+    bool _disposed;
+
+    public AgentClient Client { get; private set; } = null!;
+    public HttpClient Http { get; private set; } = null!;
+    public int AgentPort { get; private set; }
+    public string AgentBaseUrl => $"http://localhost:{AgentPort}";
+    public abstract string Platform { get; }
+
+    protected AppFixtureBase()
+    {
+        AgentPort = int.TryParse(
+            Environment.GetEnvironmentVariable("DEVFLOW_TEST_PORT"), out var port) ? port : 0;
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (AgentPort > 0)
+        {
+            SetupClients();
+
+            if (await IsAgentReadyAsync())
+                return;
+        }
+
+        if (AgentPort == 0)
+            AgentPort = FindFreePort();
+
+        SetupClients();
+
+        await InitializePlatformAsync();
+        await WaitForAgentAsync(timeoutSeconds: 120);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        Http?.Dispose();
+        Client?.Dispose();
+
+        await DisposePlatformAsync();
+    }
+
+    protected abstract Task InitializePlatformAsync();
+    protected abstract Task DisposePlatformAsync();
+
+    void SetupClients()
+    {
+        Http?.Dispose();
+        Client?.Dispose();
+
+        Http = new HttpClient
+        {
+            BaseAddress = new Uri(AgentBaseUrl),
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+        Client = new AgentClient("localhost", AgentPort);
+    }
+
+    protected async Task<bool> IsAgentReadyAsync()
+    {
+        try
+        {
+            var status = await Client.GetStatusAsync();
+            return status != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    protected async Task WaitForAgentAsync(int timeoutSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        Exception? lastException = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var status = await Client.GetStatusAsync();
+                if (status != null)
+                    return;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
+
+            await Task.Delay(1000);
+        }
+
+        throw new TimeoutException(
+            $"Agent did not become ready within {timeoutSeconds}s on port {AgentPort}. " +
+            $"Last error: {lastException?.GetType().Name}: {lastException?.Message}");
+    }
+
+    protected static async Task BuildSampleAsync(string projectPath, string targetFramework, string? extraArgs = null)
+    {
+        CleanBuildOutputs(projectPath, targetFramework);
+
+        var dotnetPath = File.Exists("/usr/local/share/dotnet/dotnet")
+            ? "/usr/local/share/dotnet/dotnet"
+            : "dotnet";
+
+        var args = $"build \"{projectPath}\" -f {targetFramework} -c Debug --nologo -v q";
+        if (!string.IsNullOrEmpty(extraArgs))
+            args += $" {extraArgs}";
+
+        var psi = new ProcessStartInfo(dotnetPath, args)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start dotnet build");
+
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"dotnet build failed (exit code {process.ExitCode}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+        }
+    }
+
+    protected static async Task WithBuildLockAsync(Func<Task> action, TimeSpan? timeout = null)
+    {
+        var repoRoot = FindRepoRoot();
+        var lockFilePath = Path.Combine(repoRoot, "artifacts", ".devflow-integration-build.lock");
+        await using var buildLock = await AcquireBuildLockAsync(lockFilePath, timeout ?? TimeSpan.FromMinutes(10));
+        await action();
+    }
+
+    private static async Task<FileStream> AcquireBuildLockAsync(string lockFilePath, TimeSpan timeout)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(lockFilePath)!);
+        var deadline = DateTime.UtcNow.Add(timeout);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                return new FileStream(lockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException)
+            {
+                await Task.Delay(250);
+            }
+        }
+
+        throw new TimeoutException($"Timed out waiting for integration build lock: {lockFilePath}");
+    }
+
+    private static void CleanBuildOutputs(string projectPath, string targetFramework)
+    {
+        var projectDir = Path.GetDirectoryName(projectPath)
+            ?? throw new InvalidOperationException($"Could not determine project directory for '{projectPath}'.");
+        var projectName = Path.GetFileNameWithoutExtension(projectPath);
+        var repoRoot = FindRepoRoot();
+
+        var paths = new[]
+        {
+            Path.Combine(repoRoot, "artifacts", "bin", projectName, "Debug", targetFramework),
+            Path.Combine(repoRoot, "artifacts", "obj", projectName, "Debug", targetFramework),
+            Path.Combine(projectDir, "bin", "Debug", targetFramework),
+            Path.Combine(projectDir, "obj", "Debug", targetFramework),
+        };
+
+        foreach (var path in paths)
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+    }
+
+    protected static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "MauiLabs.slnx")))
+                return dir;
+
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        throw new InvalidOperationException(
+            "Could not find repository root (looked for MauiLabs.slnx). " +
+            "Ensure tests are run from within the repository.");
+    }
+
+    protected static string GetSampleProjectPath()
+    {
+        var repoRoot = FindRepoRoot();
+        var path = Path.Combine(repoRoot, "samples", "DevFlow.Sample", "DevFlow.Sample.csproj");
+        if (!File.Exists(path))
+            throw new InvalidOperationException($"Sample project not found at: {path}");
+
+        return path;
+    }
+
+    protected static string GetSampleBuildOutputRoot()
+    {
+        var repoRoot = FindRepoRoot();
+        var artifactsPath = Path.Combine(repoRoot, "artifacts", "bin", "DevFlow.Sample", "Debug");
+        if (Directory.Exists(artifactsPath))
+            return artifactsPath;
+
+        var projectBinPath = Path.Combine(repoRoot, "samples", "DevFlow.Sample", "bin", "Debug");
+        if (Directory.Exists(projectBinPath))
+            return projectBinPath;
+
+        throw new InvalidOperationException(
+            $"Could not locate DevFlow.Sample build output. Checked '{artifactsPath}' and '{projectBinPath}'.");
+    }
+
+    protected static int FindFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    protected static async Task<(string Stdout, string Stderr, int ExitCode)> RunProcessAsync(
+        string fileName,
+        string arguments,
+        IDictionary<string, string>? envVars = null,
+        int timeoutSeconds = 300)
+    {
+        var psi = new ProcessStartInfo(fileName, arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        if (envVars != null)
+        {
+            foreach (var (key, value) in envVars)
+                psi.Environment[key] = value;
+        }
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start: {fileName} {arguments}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        var stdout = await process.StandardOutput.ReadToEndAsync(cts.Token);
+        var stderr = await process.StandardError.ReadToEndAsync(cts.Token);
+        await process.WaitForExitAsync(cts.Token);
+
+        return (stdout, stderr, process.ExitCode);
+    }
+
+    protected static async Task<string> RunProcessCheckedAsync(
+        string fileName,
+        string arguments,
+        IDictionary<string, string>? envVars = null,
+        int timeoutSeconds = 300)
+    {
+        var (stdout, stderr, exitCode) = await RunProcessAsync(fileName, arguments, envVars, timeoutSeconds);
+
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Process failed: {fileName} {arguments} (exit code {exitCode})\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+        }
+
+        return stdout;
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureFactory.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureFactory.cs
@@ -1,0 +1,30 @@
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Factory that creates the appropriate platform fixture based on
+/// the DEVFLOW_TEST_PLATFORM environment variable.
+/// </summary>
+public static class AppFixtureFactory
+{
+    public static IAppFixture Create()
+    {
+        var platform = Environment.GetEnvironmentVariable("DEVFLOW_TEST_PLATFORM")?.ToLowerInvariant();
+
+        if (string.IsNullOrEmpty(platform))
+        {
+            platform = OperatingSystem.IsWindows() ? "windows" : "maccatalyst";
+        }
+
+        return platform switch
+        {
+            "maccatalyst" or "mac" or "catalyst" => new MacCatalystFixture(),
+            "ios" => new iOSSimulatorFixture(),
+            "android" => new AndroidEmulatorFixture(),
+            "windows" => new WindowsFixture(),
+            _ => throw new InvalidOperationException(
+                $"Unknown test platform '{platform}'. " +
+                "Supported values: maccatalyst, ios, android, windows. " +
+                "Set the DEVFLOW_TEST_PLATFORM environment variable.")
+        };
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IAppFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IAppFixture.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Represents a platform-specific fixture that manages the lifecycle
+/// of the DevFlow sample app for integration testing.
+/// </summary>
+public interface IAppFixture : IAsyncLifetime
+{
+    Driver.AgentClient Client { get; }
+    HttpClient Http { get; }
+    int AgentPort { get; }
+    string AgentBaseUrl { get; }
+    string Platform { get; }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IntegrationTestBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IntegrationTestBase.cs
@@ -1,0 +1,169 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Maui.DevFlow.Driver;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Base class for all agent integration tests. Provides AgentClient access
+/// plus raw HTTP helpers for endpoints not wrapped by the client.
+/// </summary>
+public abstract class IntegrationTestBase
+{
+    static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    protected AppFixture App { get; }
+    protected AgentClient Client => App.Client;
+    protected HttpClient Http => App.Http;
+    protected ITestOutputHelper Output { get; }
+    protected string Platform => App.Platform;
+
+    protected IntegrationTestBase(AppFixture app, ITestOutputHelper output)
+    {
+        App = app;
+        Output = output;
+    }
+
+    protected async Task<JsonElement> GetJsonAsync(string path)
+    {
+        var response = await Http.GetAsync(path);
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(body, JsonOptions);
+    }
+
+    protected Task<HttpResponseMessage> GetRawAsync(string path) => Http.GetAsync(path);
+
+    protected async Task<JsonElement> PostJsonAsync(string path, object? body = null)
+    {
+        var content = body != null
+            ? new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json")
+            : null;
+        var response = await Http.PostAsync(path, content);
+        response.EnsureSuccessStatusCode();
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(responseBody, JsonOptions);
+    }
+
+    protected Task<HttpResponseMessage> PostRawAsync(string path, object? body = null)
+    {
+        var content = body != null
+            ? new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json")
+            : null;
+        return Http.PostAsync(path, content);
+    }
+
+    protected async Task<JsonElement> PutJsonAsync(string path, object? body = null)
+    {
+        var content = body != null
+            ? new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json")
+            : null;
+        var response = await Http.PutAsync(path, content);
+        response.EnsureSuccessStatusCode();
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(responseBody, JsonOptions);
+    }
+
+    protected Task<HttpResponseMessage> DeleteRawAsync(string path) => Http.DeleteAsync(path);
+
+    protected async Task<JsonElement> DeleteJsonAsync(string path)
+    {
+        var response = await Http.DeleteAsync(path);
+        response.EnsureSuccessStatusCode();
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(responseBody, JsonOptions);
+    }
+
+    protected async Task<ElementInfo> FindElementAsync(string automationId, int timeoutMs = 5000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        List<ElementInfo>? results = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            results = await Client.QueryAsync(automationId: automationId);
+            if (results.Count > 0)
+                return results[0];
+            await Task.Delay(250);
+        }
+
+        throw new TimeoutException(
+            $"Element with AutomationId '{automationId}' not found within {timeoutMs}ms. " +
+            $"Last query returned {results?.Count ?? 0} results.");
+    }
+
+    protected async Task<ElementInfo?> TryFindElementAsync(string automationId)
+    {
+        var results = await Client.QueryAsync(automationId: automationId);
+        return results.Count > 0 ? results[0] : null;
+    }
+
+    protected async Task NavigateToPageAsync(string route, string? expectedAutomationId = null, int timeoutMs = 5000)
+    {
+        await Client.NavigateAsync(route);
+
+        if (expectedAutomationId != null)
+            await FindElementAsync(expectedAutomationId, timeoutMs);
+        else
+            await Task.Delay(500);
+    }
+
+    protected Task NavigateToMainPageAsync() => NavigateToPageAsync("//native", "AddButton");
+
+    protected async Task WaitForAsync(Func<Task<bool>> condition, int timeoutMs = 5000, int pollIntervalMs = 250)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+                return;
+            await Task.Delay(pollIntervalMs);
+        }
+
+        throw new TimeoutException($"Condition not met within {timeoutMs}ms.");
+    }
+
+    protected static Task SettleAsync(int ms = 500) => Task.Delay(ms);
+
+    protected async Task<bool> WaitForCdpReadyAsync(int timeoutMs = 15000, int pollIntervalMs = 500)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var status = await Client.GetStatusAsync();
+                if (status?.Capabilities?.WebView == true)
+                {
+                    var probe = await Client.SendCdpCommandAsync(
+                        "Runtime.evaluate",
+                        JsonNode.Parse("""{"expression":"1 + 1"}"""));
+
+                    var probeText = probe.ToString();
+                    if (!probeText.Contains("\"error\"", StringComparison.OrdinalIgnoreCase) &&
+                        probeText.Contains("2", StringComparison.Ordinal))
+                    {
+                        var source = await Client.GetCdpSourceAsync();
+                        if (!string.IsNullOrWhiteSpace(source) && source.Contains('<'))
+                            return true;
+                    }
+                }
+            }
+            catch
+            {
+                // Not ready yet.
+            }
+
+            await Task.Delay(pollIntervalMs);
+        }
+
+        return false;
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/MacCatalystFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/MacCatalystFixture.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Fixture that builds and launches the DevFlow sample app as a Mac Catalyst app.
+/// </summary>
+public sealed class MacCatalystFixture : AppFixtureBase
+{
+    Process? _appProcess;
+    bool _weOwnTheProcess;
+
+    public override string Platform => "maccatalyst";
+
+    protected override async Task InitializePlatformAsync()
+    {
+        await WithBuildLockAsync(async () =>
+        {
+            var projectPath = GetSampleProjectPath();
+            await BuildSampleAsync(projectPath, "net10.0-maccatalyst");
+
+            var appPath = FindAppBundle();
+            LaunchApp(appPath);
+            _weOwnTheProcess = true;
+        });
+    }
+
+    protected override async Task DisposePlatformAsync()
+    {
+        if (_weOwnTheProcess && _appProcess is { HasExited: false })
+        {
+            _appProcess.Kill(entireProcessTree: true);
+            try { await _appProcess.WaitForExitAsync(new CancellationTokenSource(5000).Token); } catch { }
+        }
+
+        _appProcess?.Dispose();
+    }
+
+    static string FindAppBundle()
+    {
+        var sampleBinDir = Path.Combine(GetSampleBuildOutputRoot(), "net10.0-maccatalyst");
+
+        if (!Directory.Exists(sampleBinDir))
+            throw new InvalidOperationException($"Build output directory not found: {sampleBinDir}");
+
+        var appBundles = Directory.GetDirectories(sampleBinDir, "*.app", SearchOption.AllDirectories);
+
+        if (appBundles.Length == 0)
+            throw new InvalidOperationException($"No .app bundle found under {sampleBinDir}");
+
+        return appBundles[0];
+    }
+
+    void LaunchApp(string appBundlePath)
+    {
+        var macosDir = Path.Combine(appBundlePath, "Contents", "MacOS");
+
+        if (!Directory.Exists(macosDir))
+            throw new InvalidOperationException($"MacOS directory not found at: {macosDir}");
+
+        var executables = Directory.GetFiles(macosDir)
+            .Where(f => !Path.GetFileName(f).StartsWith('.'))
+            .ToArray();
+
+        if (executables.Length == 0)
+            throw new InvalidOperationException($"No executables found in {macosDir}");
+
+        var executablePath = executables[0];
+
+        var psi = new ProcessStartInfo(executablePath)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        psi.Environment["DEVFLOW_TEST_PORT"] = AgentPort.ToString();
+
+        _appProcess = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to launch {executablePath}");
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/WindowsFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/WindowsFixture.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Fixture that builds and launches the DevFlow sample app on Windows.
+/// </summary>
+public sealed class WindowsFixture : AppFixtureBase
+{
+    Process? _appProcess;
+
+    public override string Platform => "windows";
+
+    protected override async Task InitializePlatformAsync()
+    {
+        await WithBuildLockAsync(async () =>
+        {
+            var projectPath = GetSampleProjectPath();
+            await BuildSampleAsync(projectPath, "net10.0-windows10.0.19041.0");
+
+            var exePath = FindExecutable();
+            var psi = new ProcessStartInfo(exePath)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+
+            psi.Environment["DEVFLOW_TEST_PORT"] = AgentPort.ToString();
+
+            _appProcess = Process.Start(psi)
+                ?? throw new InvalidOperationException($"Failed to launch {exePath}");
+        });
+    }
+
+    protected override async Task DisposePlatformAsync()
+    {
+        if (_appProcess is { HasExited: false })
+        {
+            _appProcess.Kill(entireProcessTree: true);
+            try { await _appProcess.WaitForExitAsync(new CancellationTokenSource(5000).Token); } catch { }
+        }
+
+        _appProcess?.Dispose();
+    }
+
+    static string FindExecutable()
+    {
+        var binDir = GetSampleBuildOutputRoot();
+        var exes = Directory.GetFiles(binDir, "DevFlow.Sample.exe", SearchOption.AllDirectories);
+
+        if (exes.Length == 0)
+            throw new InvalidOperationException($"No DevFlow.Sample.exe found under {binDir}");
+
+        return exes[0];
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/iOSSimulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/iOSSimulatorFixture.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Fixture that builds and launches the DevFlow sample app on an iOS Simulator.
+/// </summary>
+public sealed class iOSSimulatorFixture : AppFixtureBase
+{
+    string? _simulatorUdid;
+    bool _weBootedSimulator;
+    string? _appBundleId;
+
+    public override string Platform => "ios";
+
+    protected override async Task InitializePlatformAsync()
+    {
+        var (udid, alreadyBooted) = await FindOrBootSimulatorAsync();
+        _simulatorUdid = udid;
+        _weBootedSimulator = !alreadyBooted;
+
+        await WithBuildLockAsync(async () =>
+        {
+            var projectPath = GetSampleProjectPath();
+            await BuildSampleAsync(projectPath, "net10.0-ios",
+                "-p:_DeviceTarget=simulator -p:RuntimeIdentifier=iossimulator-arm64");
+
+            var appBundle = FindSimulatorAppBundle();
+            _appBundleId = ReadBundleId(appBundle);
+
+            await InstallAppAsync(appBundle);
+            await LaunchAppAsync();
+        });
+    }
+
+    protected override async Task DisposePlatformAsync()
+    {
+        if (_simulatorUdid != null && _appBundleId != null)
+        {
+            try
+            {
+                await RunProcessAsync("xcrun", $"simctl terminate {_simulatorUdid} {_appBundleId}", timeoutSeconds: 10);
+            }
+            catch
+            {
+            }
+        }
+
+        if (_weBootedSimulator && _simulatorUdid != null)
+        {
+            try
+            {
+                await RunProcessAsync("xcrun", $"simctl shutdown {_simulatorUdid}", timeoutSeconds: 15);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    async Task<(string Udid, bool AlreadyBooted)> FindOrBootSimulatorAsync()
+    {
+        var versionPattern = Environment.GetEnvironmentVariable("DEVFLOW_TEST_IOS_VERSION");
+
+        var json = await RunProcessCheckedAsync("xcrun", "simctl list devices --json");
+        var doc = JsonDocument.Parse(json);
+        var devicesRoot = doc.RootElement.GetProperty("devices");
+
+        var candidates = new List<(string Udid, string Name, string Runtime, string State)>();
+
+        foreach (var runtime in devicesRoot.EnumerateObject())
+        {
+            if (!runtime.Name.Contains("iOS", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var osVersion = ExtractOsVersion(runtime.Name);
+            if (osVersion == null)
+                continue;
+
+            if (versionPattern != null && !MatchesVersionPattern(osVersion, versionPattern))
+                continue;
+
+            foreach (var device in runtime.Value.EnumerateArray())
+            {
+                var name = device.GetProperty("name").GetString() ?? string.Empty;
+                var udid = device.GetProperty("udid").GetString() ?? string.Empty;
+                var state = device.GetProperty("state").GetString() ?? string.Empty;
+                var isAvailable = !device.TryGetProperty("isAvailable", out var available) || available.GetBoolean();
+
+                if (!isAvailable || !name.Contains("iPhone", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                candidates.Add((udid, name, osVersion, state));
+            }
+        }
+
+        if (candidates.Count == 0)
+            throw new InvalidOperationException(versionPattern != null
+                ? $"No iPhone simulators found matching iOS version pattern '{versionPattern}'"
+                : "No iPhone simulators found");
+
+        var booted = candidates.Where(c => c.State == "Booted").ToList();
+        if (booted.Count > 0)
+        {
+            var best = SelectBestDevice(booted);
+            return (best.Udid, true);
+        }
+
+        var selected = SelectBestDevice(candidates);
+        await RunProcessCheckedAsync("xcrun", $"simctl boot {selected.Udid}", timeoutSeconds: 60);
+        return (selected.Udid, false);
+    }
+
+    static (string Udid, string Name, string Runtime, string State) SelectBestDevice(
+        List<(string Udid, string Name, string Runtime, string State)> devices) =>
+        devices
+            .OrderByDescending(d => ExtractIPhoneModelNumber(d.Name))
+            .ThenByDescending(d => d.Runtime)
+            .First();
+
+    static int ExtractIPhoneModelNumber(string name)
+    {
+        var match = Regex.Match(name, @"iPhone\s+(\d+)");
+        return match.Success ? int.Parse(match.Groups[1].Value) : 0;
+    }
+
+    static string? ExtractOsVersion(string runtimeId)
+    {
+        var match = Regex.Match(runtimeId, @"iOS[- ](\d+)[- ](\d+)");
+        if (match.Success)
+            return $"{match.Groups[1].Value}.{match.Groups[2].Value}";
+
+        match = Regex.Match(runtimeId, @"iOS[- ](\d+)");
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    static bool MatchesVersionPattern(string version, string pattern)
+    {
+        var regexPattern = "^" + Regex.Escape(pattern).Replace("x", @"\d+") + "$";
+        return Regex.IsMatch(version, regexPattern, RegexOptions.IgnoreCase);
+    }
+
+    static string FindSimulatorAppBundle()
+    {
+        var binDir = Path.Combine(GetSampleBuildOutputRoot(), "net10.0-ios", "iossimulator-arm64");
+
+        if (!Directory.Exists(binDir))
+            throw new InvalidOperationException($"iOS simulator build output not found at: {binDir}");
+
+        var appBundles = Directory.GetDirectories(binDir, "*.app", SearchOption.AllDirectories);
+        if (appBundles.Length == 0)
+            throw new InvalidOperationException($"No .app bundle found under {binDir}");
+
+        return appBundles[0];
+    }
+
+    static string ReadBundleId(string appBundlePath)
+    {
+        var plistPath = Path.Combine(appBundlePath, "Info.plist");
+        if (!File.Exists(plistPath))
+            throw new InvalidOperationException($"Info.plist not found at: {plistPath}");
+
+        var result = RunProcessAsync("/usr/libexec/PlistBuddy",
+            $"-c \"Print :CFBundleIdentifier\" \"{plistPath}\"").Result;
+
+        if (result.ExitCode != 0)
+            throw new InvalidOperationException($"Failed to read bundle ID from {plistPath}");
+
+        return result.Stdout.Trim();
+    }
+
+    Task InstallAppAsync(string appBundlePath) =>
+        RunProcessCheckedAsync("xcrun", $"simctl install {_simulatorUdid} \"{appBundlePath}\"", timeoutSeconds: 60);
+
+    Task LaunchAppAsync()
+    {
+        var envVars = new Dictionary<string, string>
+        {
+            ["SIMCTL_CHILD_DEVFLOW_TEST_PORT"] = AgentPort.ToString()
+        };
+
+        return RunProcessCheckedAsync("xcrun",
+            $"simctl launch {_simulatorUdid} {_appBundleId}",
+            envVars: envVars,
+            timeoutSeconds: 30);
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/LogTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/LogTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "Logs")]
+public class LogTests : IntegrationTestBase
+{
+    public LogTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task Logs_ReturnsEntries()
+    {
+        var logs = await Client.GetLogsAsync();
+
+        Assert.NotNull(logs);
+        Output.WriteLine($"Log output length: {logs.Length} chars");
+    }
+
+    [Fact]
+    public async Task Logs_WithLimit_RespectsLimit()
+    {
+        var allLogs = await Client.GetLogsAsync(limit: 100);
+        var limitedLogs = await Client.GetLogsAsync(limit: 5);
+
+        Assert.NotNull(allLogs);
+        Assert.NotNull(limitedLogs);
+        Assert.True(limitedLogs.Length <= allLogs.Length,
+            $"Limited logs ({limitedLogs.Length}) should be <= all logs ({allLogs.Length})");
+    }
+
+    [Fact]
+    public async Task Logs_WithSource_FiltersResults()
+    {
+        var nativeLogs = await Client.GetLogsAsync(source: "native");
+
+        Assert.NotNull(nativeLogs);
+        Output.WriteLine($"Native source logs length: {nativeLogs.Length} chars");
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Microsoft.Maui.DevFlow.Agent.IntegrationTests.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Microsoft.Maui.DevFlow.Agent.IntegrationTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Maui.DevFlow.Driver\Microsoft.Maui.DevFlow.Driver.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/NetworkTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/NetworkTests.cs
@@ -1,0 +1,121 @@
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Microsoft.Maui.DevFlow.Driver;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "Network")]
+public class NetworkTests : IntegrationTestBase
+{
+    public NetworkTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    private async Task<List<NetworkRequest>?> TryCaptureRequestsAsync(int timeoutMs = 20000)
+    {
+        await NavigateToMainPageAsync();
+        await SettleAsync(500);
+        await NavigateToPageAsync("//network", "GetPostsButton");
+        await SettleAsync(1000);
+
+        await Client.ClearNetworkRequestsAsync();
+        await SettleAsync(500);
+
+        var button = await FindElementAsync("GetPostsButton");
+        await Client.TapAsync(button.Id);
+
+        try
+        {
+            await WaitForAsync(async () =>
+            {
+                var requests = await Client.GetNetworkRequestsAsync();
+                return requests.Count > 0;
+            }, timeoutMs: timeoutMs, pollIntervalMs: 1000);
+        }
+        catch (TimeoutException)
+        {
+            Output.WriteLine("No network requests captured — network monitoring appears unavailable in this run.");
+            await NavigateToMainPageAsync();
+            return null;
+        }
+
+        return await Client.GetNetworkRequestsAsync();
+    }
+
+    [Fact]
+    public async Task TriggerRequest_CapturedByAgent()
+    {
+        var captured = await TryCaptureRequestsAsync();
+        if (captured is null)
+            return;
+
+        Assert.NotEmpty(captured);
+
+        foreach (var request in captured)
+            Output.WriteLine($"  {request.Method} {request.Url} -> {request.StatusCode}");
+
+        await NavigateToMainPageAsync();
+    }
+
+    [Fact]
+    public async Task Requests_ReturnsRequestList()
+    {
+        var requests = await Client.GetNetworkRequestsAsync();
+        Assert.NotNull(requests);
+        Output.WriteLine($"Current captured requests: {requests.Count}");
+    }
+
+    [Fact]
+    public async Task Requests_WithHostFilter_FiltersResults()
+    {
+        var requests = await TryCaptureRequestsAsync();
+        if (requests is null)
+            return;
+
+        var filtered = await Client.GetNetworkRequestsAsync(host: "jsonplaceholder");
+        var unfiltered = requests;
+
+        Assert.True(filtered.Count <= unfiltered.Count);
+        Assert.All(filtered, request =>
+            Assert.Contains("jsonplaceholder", request.Url ?? request.Host ?? string.Empty, StringComparison.OrdinalIgnoreCase));
+
+        await NavigateToMainPageAsync();
+    }
+
+    [Fact]
+    public async Task RequestDetail_ReturnsFullInfo()
+    {
+        var requests = await TryCaptureRequestsAsync();
+        if (requests is null)
+            return;
+
+        Assert.NotEmpty(requests);
+
+        var detail = await Client.GetNetworkRequestDetailAsync(requests[0].Id);
+        Assert.NotNull(detail);
+        Assert.NotNull(detail!.Method);
+        Assert.NotNull(detail.Url);
+
+        await NavigateToMainPageAsync();
+    }
+
+    [Fact]
+    public async Task Clear_RemovesRequests()
+    {
+        var before = await TryCaptureRequestsAsync();
+        if (before is null)
+            return;
+
+        Assert.NotEmpty(before);
+
+        var cleared = await Client.ClearNetworkRequestsAsync();
+        Assert.True(cleared);
+
+        await WaitForAsync(async () => (await Client.GetNetworkRequestsAsync()).Count == 0, timeoutMs: 5000, pollIntervalMs: 250);
+
+        var after = await Client.GetNetworkRequestsAsync();
+        Assert.Empty(after);
+
+        await NavigateToMainPageAsync();
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/PreferencesTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/PreferencesTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "Preferences")]
+public class PreferencesTests : IntegrationTestBase
+{
+    const string TestKeyPrefix = "integration_test_";
+
+    public PreferencesTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task Set_StoresValue()
+    {
+        var key = $"{TestKeyPrefix}set_test";
+        var result = await Client.SetPreferenceAsync(key, "hello world");
+
+        Assert.True(result.ValueKind != JsonValueKind.Undefined);
+        await Client.DeletePreferenceAsync(key);
+    }
+
+    [Fact]
+    public async Task Get_RetrievesStoredValue()
+    {
+        var key = $"{TestKeyPrefix}get_test";
+
+        await Client.SetPreferenceAsync(key, "test_value_123");
+
+        var result = await Client.GetPreferenceAsync(key);
+        Assert.Contains("test_value_123", result.ToString());
+
+        await Client.DeletePreferenceAsync(key);
+    }
+
+    [Fact]
+    public async Task List_IncludesSetKey()
+    {
+        var key = $"{TestKeyPrefix}list_test";
+
+        await Client.SetPreferenceAsync(key, "list_value");
+
+        var list = await Client.GetPreferencesAsync();
+        Assert.Contains(key, list.ToString());
+
+        await Client.DeletePreferenceAsync(key);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesKey()
+    {
+        var key = $"{TestKeyPrefix}delete_test";
+
+        await Client.SetPreferenceAsync(key, "to_delete");
+        await Client.DeletePreferenceAsync(key);
+
+        await WaitForAsync(async () =>
+        {
+            var list = await Client.GetPreferencesAsync();
+            return !list.ToString().Contains(key, StringComparison.Ordinal);
+        }, timeoutMs: 5000, pollIntervalMs: 250);
+    }
+
+    [Fact]
+    public async Task Clear_RemovesAllTestKeys()
+    {
+        var key1 = $"{TestKeyPrefix}clear_1";
+        var key2 = $"{TestKeyPrefix}clear_2";
+
+        await Client.SetPreferenceAsync(key1, "value1");
+        await Client.SetPreferenceAsync(key2, "value2");
+
+        var cleared = await Client.ClearPreferencesAsync();
+        Assert.True(cleared);
+
+        var list = await Client.GetPreferencesAsync();
+        var text = list.ToString();
+        Assert.DoesNotContain(key1, text);
+        Assert.DoesNotContain(key2, text);
+    }
+
+    [Fact]
+    public async Task Get_NonExistentKey_HandlesGracefully()
+    {
+        try
+        {
+            var result = await Client.GetPreferenceAsync($"{TestKeyPrefix}nonexistent_999");
+            Output.WriteLine($"Non-existent preference result: {result}");
+        }
+        catch (HttpRequestException ex)
+        {
+            Output.WriteLine($"Non-existent preference error (expected): {ex.Message}");
+        }
+    }
+
+    [Fact]
+    public async Task Set_TypedValue_Works()
+    {
+        var key = $"{TestKeyPrefix}typed_test";
+
+        var result = await Client.SetPreferenceAsync(key, "42", type: "int");
+        Assert.True(result.ValueKind != JsonValueKind.Undefined);
+
+        var value = await Client.GetPreferenceAsync(key, type: "int");
+        Assert.Contains("42", value.ToString());
+
+        await Client.DeletePreferenceAsync(key);
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/ProfilerTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/ProfilerTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "Profiler")]
+public class ProfilerTests : IntegrationTestBase
+{
+    public ProfilerTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task Capabilities_ReturnsInfo()
+    {
+        var capabilities = await Client.GetProfilerCapabilitiesAsync();
+
+        Assert.NotNull(capabilities);
+        Assert.NotNull(capabilities!.Platform);
+    }
+
+    [Fact]
+    public async Task FullLifecycle_StartSampleStop()
+    {
+        var session = await Client.StartProfilerAsync(sampleIntervalMs: 500);
+        Assert.NotNull(session);
+        Assert.NotNull(session!.SessionId);
+
+        if (!session.IsActive)
+        {
+            Output.WriteLine("Got existing stopped session — profiler tests may conflict with each other.");
+            return;
+        }
+
+        await Task.Delay(2000);
+
+        var batch = await Client.GetProfilerSamplesAsync(session.SessionId);
+        Assert.NotNull(batch);
+        Assert.Equal(session.SessionId, batch!.SessionId);
+
+        var stopped = await Client.StopProfilerAsync(session.SessionId);
+        Assert.NotNull(stopped);
+        Assert.False(stopped!.IsActive);
+    }
+
+    [Fact]
+    public async Task StartSession_ReturnsSessionId()
+    {
+        var session = await Client.StartProfilerAsync(sampleIntervalMs: 1000);
+        Assert.NotNull(session);
+        Assert.NotNull(session!.SessionId);
+
+        if (session.IsActive)
+            await Client.StopProfilerAsync(session.SessionId);
+    }
+
+    [Fact]
+    public async Task GetSamples_AfterDelay_HasData()
+    {
+        var session = await Client.StartProfilerAsync(sampleIntervalMs: 200);
+        Assert.NotNull(session);
+
+        if (!session!.IsActive)
+        {
+            Output.WriteLine("Got existing stopped session — skipping sample collection test.");
+            return;
+        }
+
+        await Task.Delay(1500);
+
+        var batch = await Client.GetProfilerSamplesAsync(session.SessionId);
+        Assert.NotNull(batch);
+
+        if (batch!.Samples.Count > 0)
+            Assert.True(batch.Samples[0].TsUtc > DateTime.MinValue);
+
+        await Client.StopProfilerAsync(session.SessionId);
+    }
+
+    [Fact]
+    public async Task PublishMarker_Succeeds()
+    {
+        var session = await Client.StartProfilerAsync(sampleIntervalMs: 500);
+        Assert.NotNull(session);
+
+        var result = await Client.PublishProfilerMarkerAsync(
+            "test_marker",
+            "integration.test",
+            """{"source":"integration-tests"}""");
+        Assert.True(result);
+
+        if (session!.IsActive)
+            await Client.StopProfilerAsync(session.SessionId);
+    }
+
+    [Fact]
+    public async Task PublishSpan_Succeeds()
+    {
+        var session = await Client.StartProfilerAsync(sampleIntervalMs: 500);
+        Assert.NotNull(session);
+
+        var now = DateTime.UtcNow;
+        var response = await PostRawAsync("/api/v1/profiler/spans", new
+        {
+            name = "test_span",
+            kind = "integration.test",
+            startTsUtc = now.AddMilliseconds(-100).ToString("O"),
+            endTsUtc = now.ToString("O"),
+            status = "ok",
+        });
+        Assert.True(response.IsSuccessStatusCode);
+
+        if (session!.IsActive)
+            await Client.StopProfilerAsync(session.SessionId);
+    }
+
+    [Fact]
+    public async Task Hotspots_ReturnsArray()
+    {
+        var hotspots = await Client.GetProfilerHotspotsAsync();
+
+        Assert.NotNull(hotspots);
+    }
+
+    [Fact]
+    public async Task StopSession_InvalidId_HandlesGracefully()
+    {
+        var result = await Client.StopProfilerAsync("nonexistent-session-id");
+        Output.WriteLine($"Stop nonexistent session result: {(result == null ? "null" : "not null")}");
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/SecureStorageTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/SecureStorageTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "SecureStorage")]
+public class SecureStorageTests : IntegrationTestBase
+{
+    const string TestKeyPrefix = "integration_test_secure_";
+
+    public SecureStorageTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task Set_StoresValue()
+    {
+        var key = $"{TestKeyPrefix}set";
+        var result = await Client.SetSecureStorageAsync(key, "secure_value");
+
+        Assert.True(result.ValueKind != JsonValueKind.Undefined);
+        await Client.DeleteSecureStorageAsync(key);
+    }
+
+    [Fact]
+    public async Task Get_RetrievesStoredValue()
+    {
+        var key = $"{TestKeyPrefix}get";
+
+        await Client.SetSecureStorageAsync(key, "my_secret_123");
+
+        var result = await Client.GetSecureStorageAsync(key);
+        var text = result.ToString();
+        Assert.True(
+            text.Contains("my_secret_123", StringComparison.Ordinal) || text.Contains("value", StringComparison.OrdinalIgnoreCase),
+            $"Expected response to contain stored value or 'value' key, got: {text}");
+
+        await Client.DeleteSecureStorageAsync(key);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesValue()
+    {
+        var key = $"{TestKeyPrefix}delete";
+
+        await Client.SetSecureStorageAsync(key, "to_remove");
+        var deleteResult = await Client.DeleteSecureStorageAsync(key);
+        Output.WriteLine($"Delete result: {deleteResult}");
+
+        try
+        {
+            var result = await Client.GetSecureStorageAsync(key);
+            Assert.DoesNotContain("to_remove", result.ToString());
+        }
+        catch (HttpRequestException)
+        {
+            // 404 is acceptable.
+        }
+    }
+
+    [Fact]
+    public async Task Clear_RemovesAll()
+    {
+        var key = $"{TestKeyPrefix}clear";
+
+        await Client.SetSecureStorageAsync(key, "clear_me");
+
+        var cleared = await Client.ClearSecureStorageAsync();
+        Assert.True(cleared);
+
+        try
+        {
+            var result = await Client.GetSecureStorageAsync(key);
+            Assert.DoesNotContain("clear_me", result.ToString());
+        }
+        catch (HttpRequestException)
+        {
+            // Expected.
+        }
+    }
+
+    [Fact]
+    public async Task Get_NonExistentKey_HandlesGracefully()
+    {
+        try
+        {
+            var result = await Client.GetSecureStorageAsync($"{TestKeyPrefix}nonexistent_999");
+            Output.WriteLine($"Non-existent secure storage result: {result}");
+        }
+        catch (HttpRequestException ex)
+        {
+            Output.WriteLine($"Non-existent secure key error (expected): {ex.Message}");
+        }
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/SensorTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/SensorTests.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "Sensors")]
+public class SensorTests : IntegrationTestBase
+{
+    public SensorTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task List_ReturnsSensors()
+    {
+        var json = await Client.GetSensorsAsync();
+
+        Assert.True(json.ValueKind != JsonValueKind.Undefined);
+        Output.WriteLine($"Sensors: {json}");
+    }
+
+    [Fact]
+    public async Task Start_Accelerometer_HandlesGracefully()
+    {
+        try
+        {
+            var result = await Client.StartSensorAsync("accelerometer", speed: "UI");
+            Output.WriteLine($"Start accelerometer result: {result}");
+
+            if (result)
+                await Client.StopSensorAsync("accelerometer");
+        }
+        catch (HttpRequestException ex)
+        {
+            Output.WriteLine($"Accelerometer not available: {ex.Message}");
+        }
+    }
+
+    [Fact]
+    public async Task Stop_UnstartedSensor_HandlesGracefully()
+    {
+        try
+        {
+            var result = await Client.StopSensorAsync("accelerometer");
+            Output.WriteLine($"Stop unstarted sensor result: {result}");
+        }
+        catch (HttpRequestException ex)
+        {
+            Output.WriteLine($"Stop sensor error (expected): {ex.Message}");
+        }
+    }
+
+    [Fact]
+    public async Task StartStop_Lifecycle_Works()
+    {
+        var sensorsJson = await Client.GetSensorsAsync();
+        var sensorsText = sensorsJson.ToString();
+
+        if (sensorsText.Contains("accelerometer", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var started = await Client.StartSensorAsync("accelerometer");
+                Output.WriteLine($"Started: {started}");
+
+                await SettleAsync();
+
+                var stopped = await Client.StopSensorAsync("accelerometer");
+                Output.WriteLine($"Stopped: {stopped}");
+            }
+            catch (HttpRequestException ex)
+            {
+                Output.WriteLine($"Sensor lifecycle not supported: {ex.Message}");
+            }
+        }
+        else
+        {
+            Output.WriteLine("No accelerometer available — skipping lifecycle test.");
+        }
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
@@ -1,0 +1,302 @@
+using System.Net;
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "UiActions")]
+public class UiActionTests : IntegrationTestBase
+{
+    public UiActionTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task Fill_Entry_SetsText()
+    {
+        await NavigateToMainPageAsync();
+        var entry = await FindElementAsync("NewTodoEntry");
+
+        var result = await Client.FillAsync(entry.Id, "Integration test text");
+        if (!result)
+        {
+            await SettleAsync();
+            entry = await FindElementAsync("NewTodoEntry");
+            result = await Client.FillAsync(entry.Id, "Integration test text");
+        }
+
+        Assert.True(result);
+
+        await SettleAsync();
+        var updated = await FindElementAsync("NewTodoEntry");
+        Assert.Equal("Integration test text", updated.Text);
+
+        await Client.ClearAsync(entry.Id);
+    }
+
+    [Fact]
+    public async Task Clear_Entry_RemovesText()
+    {
+        await NavigateToMainPageAsync();
+        var entry = await FindElementAsync("NewTodoEntry");
+
+        await Client.FillAsync(entry.Id, "Text to clear");
+        await SettleAsync();
+
+        var result = await Client.ClearAsync(entry.Id);
+        Assert.True(result);
+
+        await SettleAsync();
+        var updated = await FindElementAsync("NewTodoEntry");
+        Assert.True(string.IsNullOrEmpty(updated.Text));
+    }
+
+    [Fact]
+    public async Task Focus_Entry_SetsFocus()
+    {
+        await NavigateToMainPageAsync();
+        var entry = await FindElementAsync("NewTodoEntry");
+
+        var result = await Client.FocusAsync(entry.Id);
+        if (!result)
+        {
+            await SettleAsync();
+            entry = await FindElementAsync("NewTodoEntry");
+            result = await Client.FocusAsync(entry.Id);
+        }
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Tap_Button_TriggersAction()
+    {
+        await NavigateToMainPageAsync();
+        var entry = await FindElementAsync("NewTodoEntry");
+        var addButton = await FindElementAsync("AddButton");
+
+        await Client.FillAsync(entry.Id, "Integration Test Todo");
+        await SettleAsync();
+
+        var tapResult = await Client.TapAsync(addButton.Id);
+        Assert.True(tapResult);
+
+        await SettleAsync();
+        var countLabel = await FindElementAsync("CountLabel");
+        Assert.NotNull(countLabel.Text);
+        Assert.Contains("items", countLabel.Text!);
+
+        await CleanupAddedTodoAsync("Integration Test Todo");
+    }
+
+    [Fact]
+    public async Task Navigate_ToRoute_ChangesPage()
+    {
+        await NavigateToPageAsync("//interactions", "StatusLabel");
+        var statusLabel = await TryFindElementAsync("StatusLabel");
+        Assert.NotNull(statusLabel);
+
+        await NavigateToMainPageAsync();
+    }
+
+    [Fact]
+    public async Task Back_Action_GoesBack()
+    {
+        await NavigateToMainPageAsync();
+        await Client.NavigateAsync("//interactions");
+        await SettleAsync();
+
+        var response = await PostRawAsync("/api/v1/ui/actions/back", new { });
+        Assert.True(response.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task Scroll_Element_Succeeds()
+    {
+        await NavigateToMainPageAsync();
+        var todoList = await TryFindElementAsync("TodoList");
+
+        if (todoList == null)
+        {
+            Output.WriteLine("TodoList not found — skipping scroll test.");
+            return;
+        }
+
+        var result = await Client.ScrollAsync(todoList.Id, deltaY: 100);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Resize_Window_Succeeds()
+    {
+        var result = await Client.ResizeAsync(800, 600);
+        Assert.True(result);
+
+        await SettleAsync();
+        await Client.ResizeAsync(1024, 768);
+    }
+
+    [Fact]
+    public async Task Tap_CheckBox_TogglesState()
+    {
+        await NavigateToMainPageAsync();
+        await SettleAsync();
+
+        var checkBoxes = await Client.QueryAsync(automationId: "TodoCheckBox");
+        if (checkBoxes.Count == 0)
+        {
+            Output.WriteLine("No TodoCheckBox found — skipping checkbox toggle test.");
+            return;
+        }
+
+        var checkBox = checkBoxes[0];
+        var tapResult = await Client.TapAsync(checkBox.Id);
+        Assert.True(tapResult);
+
+        await SettleAsync();
+
+        checkBoxes = await Client.QueryAsync(automationId: "TodoCheckBox");
+        if (checkBoxes.Count > 0)
+            await Client.TapAsync(checkBoxes[0].Id);
+    }
+
+    [Fact]
+    public async Task Tap_InteractionPageButton_UpdatesStatus()
+    {
+        await NavigateToPageAsync("//interactions", "StatusLabel");
+
+        var button = await FindElementAsync("TestButton");
+        await Client.TapAsync(button.Id);
+
+        await SettleAsync();
+        var statusLabel = await FindElementAsync("StatusLabel");
+        Assert.NotNull(statusLabel.Text);
+        Assert.Contains("button", statusLabel.Text!, StringComparison.OrdinalIgnoreCase);
+
+        await NavigateToMainPageAsync();
+    }
+
+    [Fact]
+    public async Task Tap_Switch_TogglesState()
+    {
+        await NavigateToPageAsync("//interactions", "TestSwitch");
+
+        var sw = await FindElementAsync("TestSwitch");
+        var tapResult = await Client.TapAsync(sw.Id);
+        Assert.True(tapResult);
+
+        await SettleAsync();
+        var statusLabel = await FindElementAsync("StatusLabel");
+        Assert.NotNull(statusLabel.Text);
+        Assert.Contains("switch", statusLabel.Text!, StringComparison.OrdinalIgnoreCase);
+
+        sw = await FindElementAsync("TestSwitch");
+        await Client.TapAsync(sw.Id);
+
+        await NavigateToMainPageAsync();
+    }
+
+    [Fact]
+    public async Task Tap_ImageButton_TriggersAction()
+    {
+        await NavigateToPageAsync("//interactions", "TestImageButton");
+
+        var imageButton = await FindElementAsync("TestImageButton");
+        var tapResult = await Client.TapAsync(imageButton.Id);
+        Assert.True(tapResult);
+
+        await SettleAsync();
+        var statusLabel = await FindElementAsync("StatusLabel");
+        Assert.NotNull(statusLabel.Text);
+        Assert.Contains("image button", statusLabel.Text!, StringComparison.OrdinalIgnoreCase);
+
+        await NavigateToMainPageAsync();
+    }
+
+    [Fact]
+    public async Task Batch_MultipleActions_ExecutesAll()
+    {
+        await NavigateToMainPageAsync();
+        var entry = await FindElementAsync("NewTodoEntry");
+        var addButton = await FindElementAsync("AddButton");
+
+        var response = await PostRawAsync("/api/v1/ui/actions/batch", new
+        {
+            actions = new object[]
+            {
+                new { action = "fill", elementId = entry.Id, text = "Batch Test Todo" },
+                new { action = "tap", elementId = addButton.Id },
+            },
+            continueOnError = false,
+        });
+
+        Assert.True(response.IsSuccessStatusCode);
+        await SettleAsync();
+
+        await CleanupAddedTodoAsync("Batch Test Todo");
+    }
+
+    [Fact]
+    public async Task Key_ReturnsExpectedResponse()
+    {
+        var response = await PostRawAsync("/api/v1/ui/actions/key", new { key = "Return" });
+
+        Assert.True(
+            response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotImplemented,
+            $"Expected 200 or 501, got {(int)response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task Gesture_ReturnsExpectedResponse()
+    {
+        var response = await PostRawAsync("/api/v1/ui/actions/gesture", new
+        {
+            type = "swipe",
+            direction = "up",
+            distance = 100,
+        });
+
+        Assert.True(
+            response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotImplemented,
+            $"Expected 200 or 501, got {(int)response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task Fill_MultipleEntries_SetsAllText()
+    {
+        await NavigateToMainPageAsync();
+        var titleEntry = await FindElementAsync("NewTodoEntry");
+        var descEntry = await FindElementAsync("NewDescriptionEntry");
+
+        await Client.FillAsync(titleEntry.Id, "Title text");
+        await Client.FillAsync(descEntry.Id, "Description text");
+        await SettleAsync();
+
+        var updatedTitle = await FindElementAsync("NewTodoEntry");
+        var updatedDesc = await FindElementAsync("NewDescriptionEntry");
+
+        Assert.Equal("Title text", updatedTitle.Text);
+        Assert.Equal("Description text", updatedDesc.Text);
+
+        await Client.ClearAsync(titleEntry.Id);
+        await Client.ClearAsync(descEntry.Id);
+    }
+
+    async Task CleanupAddedTodoAsync(string todoTitle)
+    {
+        try
+        {
+            await SettleAsync();
+            var deleteButtons = await Client.QueryAsync(automationId: "DeleteButton");
+            if (deleteButtons.Count > 0)
+            {
+                await Client.TapAsync(deleteButtons[^1].Id);
+                await SettleAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Output.WriteLine($"Cleanup warning: Could not delete todo '{todoTitle}': {ex.Message}");
+        }
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiInspectionTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiInspectionTests.cs
@@ -1,0 +1,201 @@
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Microsoft.Maui.DevFlow.Driver;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "UiInspection")]
+public class UiInspectionTests : IntegrationTestBase
+{
+    public UiInspectionTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task Tree_ReturnsNonEmptyTree()
+    {
+        await NavigateToMainPageAsync();
+        var tree = await Client.GetTreeAsync();
+
+        Assert.NotNull(tree);
+        Assert.NotEmpty(tree);
+    }
+
+    [Fact]
+    public async Task Tree_WithDepth_LimitsChildren()
+    {
+        await NavigateToMainPageAsync();
+        var shallow = await Client.GetTreeAsync(maxDepth: 1);
+        var deep = await Client.GetTreeAsync(maxDepth: 10);
+
+        Assert.NotEmpty(shallow);
+
+        static int CountNodes(IEnumerable<ElementInfo> elements)
+        {
+            var count = 0;
+            foreach (var element in elements)
+            {
+                count++;
+                if (element.Children != null)
+                    count += CountNodes(element.Children);
+            }
+            return count;
+        }
+
+        Assert.True(CountNodes(shallow) <= CountNodes(deep),
+            "Depth-limited tree should not have more nodes than a deeper tree.");
+    }
+
+    [Fact]
+    public async Task Tree_ElementsHaveBounds()
+    {
+        await NavigateToMainPageAsync();
+        var tree = await Client.GetTreeAsync(maxDepth: 3);
+
+        static ElementInfo? FindWithBounds(IEnumerable<ElementInfo> elements)
+        {
+            foreach (var element in elements)
+            {
+                if (element.Bounds is { Width: > 0, Height: > 0 })
+                    return element;
+
+                if (element.Children != null)
+                {
+                    var found = FindWithBounds(element.Children);
+                    if (found != null)
+                        return found;
+                }
+            }
+
+            return null;
+        }
+
+        var elementWithBounds = FindWithBounds(tree);
+        Assert.NotNull(elementWithBounds);
+        Output.WriteLine($"Found element with bounds: {elementWithBounds!.Type} ({elementWithBounds.Bounds!.Width}x{elementWithBounds.Bounds.Height})");
+    }
+
+    [Fact]
+    public async Task Query_ByType_ReturnsElements()
+    {
+        await NavigateToMainPageAsync();
+        var buttons = await Client.QueryAsync(type: "Button");
+
+        Assert.NotEmpty(buttons);
+        Assert.All(buttons, button => Assert.Equal("Button", button.Type));
+    }
+
+    [Fact]
+    public async Task Query_ByAutomationId_ReturnsExactElement()
+    {
+        await NavigateToMainPageAsync();
+        var elements = await Client.QueryAsync(automationId: "AddButton");
+
+        Assert.Single(elements);
+        Assert.Equal("AddButton", elements[0].AutomationId);
+    }
+
+    [Fact]
+    public async Task Query_ByAutomationId_HasCorrectProperties()
+    {
+        await NavigateToMainPageAsync();
+        var element = await FindElementAsync("HeaderLabel");
+
+        Assert.Equal("HeaderLabel", element.AutomationId);
+        Assert.NotNull(element.Text);
+        Assert.Contains("Todos", element.Text!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Query_ByText_ReturnsElements()
+    {
+        await NavigateToMainPageAsync();
+        var elements = await Client.QueryAsync(text: "Todos");
+
+        Assert.NotEmpty(elements);
+        Assert.Contains(elements, element => element.Text != null && element.Text.Contains("Todos", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Query_ByCssSelector_ReturnsElements()
+    {
+        await NavigateToMainPageAsync();
+        var elements = await Client.QueryCssAsync("Button#AddButton");
+
+        Assert.NotEmpty(elements);
+        Assert.Contains(elements, element => element.AutomationId == "AddButton");
+    }
+
+    [Fact]
+    public async Task Query_NoResults_ReturnsEmpty()
+    {
+        var elements = await Client.QueryAsync(type: "NonExistentControlType99");
+        Assert.Empty(elements);
+    }
+
+    [Fact]
+    public async Task Element_ById_ReturnsElement()
+    {
+        await NavigateToMainPageAsync();
+        var addButton = await FindElementAsync("AddButton");
+
+        var element = await Client.GetElementAsync(addButton.Id);
+
+        Assert.NotNull(element);
+        Assert.Equal(addButton.Id, element!.Id);
+        Assert.Equal("AddButton", element.AutomationId);
+    }
+
+    [Fact]
+    public async Task HitTest_AtKnownCoordinates_ReturnsElement()
+    {
+        await NavigateToMainPageAsync();
+        var addButton = await FindElementAsync("AddButton");
+        Assert.NotNull(addButton.Bounds);
+
+        var centerX = addButton.Bounds!.X + (addButton.Bounds.Width / 2);
+        var centerY = addButton.Bounds.Y + (addButton.Bounds.Height / 2);
+
+        var elementId = await Client.HitTestAsync(centerX, centerY);
+
+        Assert.NotNull(elementId);
+        Assert.NotEmpty(elementId);
+    }
+
+    [Fact]
+    public async Task Screenshot_ReturnsValidPng()
+    {
+        var bytes = await Client.ScreenshotAsync();
+
+        if (bytes == null)
+        {
+            var raw = await GetRawAsync("/api/v1/ui/screenshot");
+            var body = await raw.Content.ReadAsStringAsync();
+            Output.WriteLine($"Screenshot raw response: {(int)raw.StatusCode} — {body}");
+            Output.WriteLine("Screenshot not available on this platform.");
+            return;
+        }
+
+        Assert.True(bytes.Length > 100, "Screenshot should have reasonable size");
+        Assert.Equal((byte)0x89, bytes[0]);
+        Assert.Equal((byte)0x50, bytes[1]);
+        Assert.Equal((byte)0x4E, bytes[2]);
+        Assert.Equal((byte)0x47, bytes[3]);
+    }
+
+    [Fact]
+    public async Task Screenshot_OfElement_ReturnsImage()
+    {
+        await NavigateToMainPageAsync();
+        var addButton = await FindElementAsync("AddButton");
+
+        var bytes = await Client.ScreenshotAsync(elementId: addButton.Id);
+        if (bytes == null)
+        {
+            Output.WriteLine("Element screenshot not available on this platform.");
+            return;
+        }
+
+        Assert.True(bytes.Length > 0);
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiPropertyTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiPropertyTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "UiProperties")]
+public class UiPropertyTests : IntegrationTestBase
+{
+    public UiPropertyTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task GetProperty_Text_ReturnsValue()
+    {
+        await NavigateToMainPageAsync();
+        var header = await FindElementAsync("HeaderLabel");
+
+        var text = await Client.GetPropertyAsync(header.Id, "Text");
+
+        Assert.NotNull(text);
+        Assert.Contains("Todos", text!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetProperty_IsVisible_ReturnsTrue()
+    {
+        await NavigateToMainPageAsync();
+        var addButton = await FindElementAsync("AddButton");
+
+        var value = await Client.GetPropertyAsync(addButton.Id, "IsVisible");
+
+        Assert.NotNull(value);
+        Assert.Contains("true", value!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SetProperty_Text_UpdatesValue()
+    {
+        await NavigateToMainPageAsync();
+        var header = await FindElementAsync("HeaderLabel");
+        var originalText = await Client.GetPropertyAsync(header.Id, "Text");
+
+        var result = await Client.SetPropertyAsync(header.Id, "Text", "Modified Header");
+        Assert.True(result);
+
+        await SettleAsync();
+        var newText = await Client.GetPropertyAsync(header.Id, "Text");
+        Assert.Equal("Modified Header", newText);
+
+        if (originalText != null)
+            await Client.SetPropertyAsync(header.Id, "Text", originalText);
+    }
+
+    [Fact]
+    public async Task GetProperty_Opacity_ReturnsNumericValue()
+    {
+        await NavigateToMainPageAsync();
+        var addButton = await FindElementAsync("AddButton");
+
+        var value = await Client.GetPropertyAsync(addButton.Id, "Opacity");
+
+        if (value == null)
+        {
+            Output.WriteLine("Opacity property returned null — trying IsVisible instead.");
+            var isVisible = await Client.GetPropertyAsync(addButton.Id, "IsVisible");
+            if (isVisible == null)
+            {
+                Output.WriteLine("IsVisible also returned null — property access may not be supported for this element type.");
+                return;
+            }
+
+            Assert.NotNull(isVisible);
+            return;
+        }
+
+        Assert.True(double.TryParse(value, out var opacity), $"Expected numeric opacity, got: {value}");
+        Assert.InRange(opacity, 0.0, 1.0);
+    }
+
+    [Fact]
+    public async Task GetProperty_NonExistentProperty_HandlesGracefully()
+    {
+        await NavigateToMainPageAsync();
+        var addButton = await FindElementAsync("AddButton");
+
+        var value = await Client.GetPropertyAsync(addButton.Id, "NonExistentProperty12345");
+        Output.WriteLine($"Non-existent property returned: '{value ?? "(null)"}'");
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/WebViewTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/WebViewTests.cs
@@ -1,0 +1,271 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "WebView")]
+public class WebViewTests : IntegrationTestBase
+{
+    public WebViewTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    async Task EnsureOnBlazorPageAsync()
+    {
+        await NavigateToPageAsync("//blazor", "BlazorWebView");
+        var cdpReady = await WaitForCdpReadyAsync(timeoutMs: 30000);
+        if (!cdpReady)
+            Output.WriteLine("WARNING: CDP not ready after 30s — WebView tests may fail.");
+    }
+
+    Task<bool> IsCdpReady(int timeoutMs = 10000)
+        => WaitForCdpReadyAsync(timeoutMs: timeoutMs, pollIntervalMs: 500);
+
+    async Task<string> GetCdpSourceWithRetryAsync()
+    {
+        try { return await Client.GetCdpSourceAsync(); }
+        catch (HttpRequestException) when (Platform == "android")
+        {
+            Output.WriteLine("Initial CDP source request failed on Android; waiting and retrying once.");
+            await WaitForCdpReadyAsync(timeoutMs: 15000);
+            return await Client.GetCdpSourceAsync();
+        }
+    }
+
+    async Task<JsonElement> SendCdpCommandWithRetryAsync(string method, JsonNode? paramsJson = null)
+    {
+        var result = await Client.SendCdpCommandAsync(method, paramsJson);
+        if (Platform == "android" &&
+            result.ValueKind == JsonValueKind.Object &&
+            result.TryGetProperty("error", out _))
+        {
+            Output.WriteLine($"Initial CDP command '{method}' returned an error on Android; waiting and retrying once.");
+            await WaitForCdpReadyAsync(timeoutMs: 15000);
+            result = await Client.SendCdpCommandAsync(method, paramsJson);
+        }
+
+        return result;
+    }
+
+    [Fact]
+    public async Task Contexts_ReturnsAtLeastOneWebView()
+    {
+        await EnsureOnBlazorPageAsync();
+        var json = await Client.GetCdpWebViewsAsync();
+
+        Assert.True(json.ValueKind == JsonValueKind.Object || json.ValueKind == JsonValueKind.Array);
+    }
+
+    [Fact]
+    public async Task Evaluate_DocumentTitle_ReturnsResult()
+    {
+        await EnsureOnBlazorPageAsync();
+
+        var paramsJson = JsonNode.Parse("""{"expression": "document.title"}""");
+        var result = await SendCdpCommandWithRetryAsync("Runtime.evaluate", paramsJson);
+
+        Assert.True(result.ValueKind != JsonValueKind.Undefined);
+    }
+
+    [Fact]
+    public async Task Evaluate_SimpleExpression_ReturnsResult()
+    {
+        await EnsureOnBlazorPageAsync();
+        if (!await IsCdpReady(timeoutMs: 30000))
+        {
+            Output.WriteLine("CDP not ready — skipping.");
+            return;
+        }
+
+        var paramsJson = JsonNode.Parse("""{"expression": "1 + 1"}""");
+        var result = await SendCdpCommandWithRetryAsync("Runtime.evaluate", paramsJson);
+
+        Assert.Contains("2", result.ToString());
+    }
+
+    [Fact]
+    public async Task Source_ReturnsHtmlContent()
+    {
+        await EnsureOnBlazorPageAsync();
+        if (!await IsCdpReady(timeoutMs: 30000))
+        {
+            Output.WriteLine("CDP not ready — skipping.");
+            return;
+        }
+
+        var source = await GetCdpSourceWithRetryAsync();
+        Assert.NotNull(source);
+        Assert.NotEmpty(source);
+        Assert.Contains("<", source);
+    }
+
+    [Fact]
+    public async Task Dom_ReturnsOuterHtml()
+    {
+        await EnsureOnBlazorPageAsync();
+        if (!await IsCdpReady())
+        {
+            Output.WriteLine("CDP not ready — skipping.");
+            return;
+        }
+
+        var response = await GetRawAsync("/api/v1/webview/dom");
+        Assert.True(response.IsSuccessStatusCode);
+
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.NotEmpty(html);
+        Assert.Contains("<", html);
+    }
+
+    [Fact]
+    public async Task DomQuery_ReturnsElements()
+    {
+        await EnsureOnBlazorPageAsync();
+        if (!await IsCdpReady())
+        {
+            Output.WriteLine("CDP not ready — skipping.");
+            return;
+        }
+
+        var response = await PostRawAsync("/api/v1/webview/dom/query", new
+        {
+            selector = "button",
+            contextId = "0",
+        });
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Output.WriteLine($"DOM query not available on this platform: {(int)response.StatusCode}");
+            return;
+        }
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.NotEmpty(body);
+    }
+
+    [Fact]
+    public async Task WebViewNavigate_Succeeds()
+    {
+        await EnsureOnBlazorPageAsync();
+        if (!await IsCdpReady())
+        {
+            Output.WriteLine("CDP not ready — skipping.");
+            return;
+        }
+
+        var response = await PostRawAsync("/api/v1/webview/navigate", new
+        {
+            url = "/counter",
+            contextId = "0",
+        });
+
+        Assert.True(response.IsSuccessStatusCode, $"WebView navigate failed with status {(int)response.StatusCode}");
+        await SettleAsync(1000);
+
+        await PostRawAsync("/api/v1/webview/navigate", new
+        {
+            url = "/",
+            contextId = "0",
+        });
+        await SettleAsync(1000);
+    }
+
+    [Fact]
+    public async Task InputClick_Button_Succeeds()
+    {
+        await EnsureOnBlazorPageAsync();
+        if (!await IsCdpReady())
+        {
+            Output.WriteLine("CDP not ready — skipping.");
+            return;
+        }
+
+        await PostRawAsync("/api/v1/webview/navigate", new { url = "/counter", contextId = "0" });
+        await SettleAsync(1000);
+
+        var response = await PostRawAsync("/api/v1/webview/input/click", new
+        {
+            selector = "button",
+            contextId = "0",
+        });
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Output.WriteLine($"Input click not available on this platform: {(int)response.StatusCode}");
+            return;
+        }
+
+        await PostRawAsync("/api/v1/webview/navigate", new { url = "/", contextId = "0" });
+        await SettleAsync(500);
+    }
+
+    [Fact]
+    public async Task InputFill_TextInput_Succeeds()
+    {
+        await EnsureOnBlazorPageAsync();
+        var response = await PostRawAsync("/api/v1/webview/input/fill", new
+        {
+            selector = "input",
+            text = "Blazor fill test",
+            contextId = "0",
+        });
+
+        Output.WriteLine($"Input fill status: {(int)response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task InputText_InsertsText()
+    {
+        await EnsureOnBlazorPageAsync();
+
+        var response = await PostRawAsync("/api/v1/webview/input/text", new
+        {
+            text = "Hello from test",
+            contextId = "0",
+        });
+
+        Output.WriteLine($"Input text status: {(int)response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task Screenshot_WebView_ReturnsImage()
+    {
+        await EnsureOnBlazorPageAsync();
+
+        var response = await GetRawAsync("/api/v1/webview/screenshot?contextId=0");
+        if (response.IsSuccessStatusCode)
+        {
+            var bytes = await response.Content.ReadAsByteArrayAsync();
+            Assert.NotEmpty(bytes);
+        }
+        else
+        {
+            Output.WriteLine($"WebView screenshot not available: {(int)response.StatusCode}");
+        }
+    }
+
+    [Fact]
+    public async Task Evaluate_WithDomAccess_Works()
+    {
+        await EnsureOnBlazorPageAsync();
+
+        var paramsJson = JsonNode.Parse("""{"expression": "document.querySelectorAll('*').length"}""");
+        var result = await Client.SendCdpCommandAsync("Runtime.evaluate", paramsJson);
+
+        Assert.True(result.ValueKind != JsonValueKind.Undefined);
+    }
+
+    [Fact]
+    public async Task MultiBlazorPage_HasMultipleContexts()
+    {
+        await NavigateToPageAsync("//multiblazor", "BlazorLeft");
+        await SettleAsync(2000);
+
+        var json = await Client.GetCdpWebViewsAsync();
+        Assert.True(json.ValueKind != JsonValueKind.Undefined);
+
+        await NavigateToMainPageAsync();
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/AgentServiceExtensions.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/AgentServiceExtensions.cs
@@ -78,7 +78,7 @@ public static class AgentServiceExtensions
         }
 
         // Fall back to assembly metadata port if broker didn't assign one
-        if (brokerReg?.AssignedPort == null)
+        if (!hasCustomPort && brokerReg?.AssignedPort == null)
         {
             var metaPort = ReadAssemblyMetadataPort();
             if (metaPort.HasValue)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/AgentServiceExtensions.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/AgentServiceExtensions.cs
@@ -32,7 +32,7 @@ public static class AgentServiceExtensions
         // to avoid deadlock with SynchronizationContext — AddMauiDevFlowAgent runs on
         // the main thread). When a custom port is set, we tell the broker our port so it
         // uses it instead of assigning from the pool; the agent stays discoverable via
-        // `maui-devflow list` regardless of port configuration.
+        // `maui devflow list` regardless of port configuration.
         BrokerRegistration? brokerReg = null;
         bool hasCustomPort = options.Port != AgentOptions.DefaultPort;
         try

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Blazor/BlazorWebViewDebugService.Android.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Blazor/BlazorWebViewDebugService.Android.cs
@@ -14,6 +14,11 @@ public class BlazorWebViewDebugService : BlazorWebViewDebugServiceBase
 {
     public BlazorWebViewDebugService() { }
 
+    /// <summary>
+    /// Override to give Android WebView more time to load Blazor and inject chobitsu.
+    /// </summary>
+    protected override int GetWebViewLoadDelayMs() => 5000;
+
     public override void ConfigureHandler()
     {
         Log("[BlazorDevFlow] ConfigureHandler called (Android)");
@@ -57,6 +62,15 @@ public class BlazorWebViewDebugService : BlazorWebViewDebugServiceBase
                     (url) => MainThread.BeginInvokeOnMainThread(() => androidWebView.LoadUrl(url)),
                     automationId);
                 Log($"[BlazorDevFlow] Android WebView captured as bridge {idx} (automationId={automationId})");
+
+                // Install WebViewClient to detect page load completion and re-inject
+                // API level 26 is required, but MAUI min target is API 24. Suppress warning as MAUI
+                // practically requires a higher level and this is a dev-time tool.
+#pragma warning disable CA1416
+                var existingClient = androidWebView.WebViewClient;
+#pragma warning restore CA1416
+                androidWebView.SetWebViewClient(new DevFlowWebViewClient(this, idx, existingClient));
+
                 await InitializeBridgeAsync(idx);
             }
             else
@@ -82,6 +96,50 @@ internal class JsValueCallback : Java.Lang.Object, IValueCallback
     public void OnReceiveValue(Java.Lang.Object? value)
     {
         _callback(value?.ToString());
+    }
+}
+
+/// <summary>
+/// Custom WebViewClient that detects page load completion and triggers chobitsu re-injection.
+/// </summary>
+internal class DevFlowWebViewClient : WebViewClient
+{
+    private readonly BlazorWebViewDebugServiceBase _service;
+    private readonly int _bridgeIndex;
+    private readonly WebViewClient? _innerClient;
+
+    public DevFlowWebViewClient(BlazorWebViewDebugServiceBase service, int bridgeIndex, WebViewClient? innerClient)
+    {
+        _service = service;
+        _bridgeIndex = bridgeIndex;
+        _innerClient = innerClient;
+    }
+
+    public override void OnPageFinished(AWebView? view, string? url)
+    {
+        base.OnPageFinished(view, url);
+        _innerClient?.OnPageFinished(view, url);
+
+        if (url?.Contains("about:blank") == false)
+        {
+            _service.Log($"[BlazorDevFlow] Android OnPageFinished: {url} — re-initializing bridge {_bridgeIndex}");
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await _service.ResetAndReinitializeBridgeAsync(_bridgeIndex);
+                }
+                catch (Exception ex)
+                {
+                    _service.LogError($"[BlazorDevFlow] Failed to reinitialize bridge {_bridgeIndex}", ex);
+                }
+            });
+        }
+    }
+
+    public override bool ShouldOverrideUrlLoading(AWebView? view, IWebResourceRequest? request)
+    {
+        return _innerClient?.ShouldOverrideUrlLoading(view, request) ?? base.ShouldOverrideUrlLoading(view, request);
     }
 }
 #endif

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Blazor/BlazorWebViewDebugServiceBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Blazor/BlazorWebViewDebugServiceBase.cs
@@ -69,6 +69,12 @@ public abstract class BlazorWebViewDebugServiceBase : IDisposable
     public abstract void ConfigureHandler();
 
     /// <summary>
+    /// Platform-specific delay in milliseconds to wait for WebView to load before injecting debug scripts.
+    /// Default is 2000ms. Override in platform subclasses if more time is needed.
+    /// </summary>
+    protected virtual int GetWebViewLoadDelayMs() => 2000;
+
+    /// <summary>
     /// Register a new WebView bridge. Called by platform subclasses when a WebView is captured.
     /// Returns the bridge index.
     /// </summary>
@@ -89,10 +95,29 @@ public abstract class BlazorWebViewDebugServiceBase : IDisposable
         if (bridgeIndex < 0 || bridgeIndex >= _bridges.Count) return;
         var bridge = _bridges[bridgeIndex];
 
-        Log($"[BlazorDevFlow] Waiting 2s for WebView {bridgeIndex} to load...");
-        await Task.Delay(2000);
+        var delayMs = GetWebViewLoadDelayMs();
+        Log($"[BlazorDevFlow] Waiting {delayMs}ms for WebView {bridgeIndex} to load...");
+        await Task.Delay(delayMs);
 
         Log($"[BlazorDevFlow] Injecting debug script into WebView {bridgeIndex}...");
+        await bridge.InjectDebugScriptAsync();
+    }
+
+    /// <summary>
+    /// Reset bridge state and re-inject debug scripts after page navigation.
+    /// Called by platform-specific navigation detection (e.g., Android OnPageFinished).
+    /// </summary>
+    internal async Task ResetAndReinitializeBridgeAsync(int bridgeIndex)
+    {
+        if (bridgeIndex < 0 || bridgeIndex >= _bridges.Count) return;
+        var bridge = _bridges[bridgeIndex];
+
+        var delayMs = GetWebViewLoadDelayMs();
+        Log($"[BlazorDevFlow] Re-initialization: waiting {delayMs}ms for WebView {bridgeIndex} to settle...");
+        await Task.Delay(delayMs);
+
+        Log($"[BlazorDevFlow] Re-injecting debug script into WebView {bridgeIndex}...");
+        bridge.ResetReadyState();
         await bridge.InjectDebugScriptAsync();
     }
 
@@ -187,6 +212,14 @@ public abstract class BlazorWebViewDebugServiceBase : IDisposable
             {
                 _injecting = false;
             }
+        }
+
+        /// <summary>
+        /// Reset the ready state so the script can be re-injected after page navigation.
+        /// </summary>
+        internal void ResetReadyState()
+        {
+            _chobitsuLoaded = false;
         }
 
         private async Task InjectDebugScriptCoreAsync()
@@ -288,7 +321,7 @@ public abstract class BlazorWebViewDebugServiceBase : IDisposable
                 await Task.Delay(50);
 
                 string? result = null;
-                for (int i = 0; i < 60; i++)
+                for (int i = 0; i < 200; i++)
                 {
                     result = await _owner.RunOnMainThreadAsync(async () =>
                     {
@@ -305,7 +338,7 @@ public abstract class BlazorWebViewDebugServiceBase : IDisposable
                     await Task.Delay(50);
                 }
 
-                _owner.Log($"[BlazorDevFlow] SendCdpCommand: no response after polling");
+                _owner.Log($"[BlazorDevFlow] SendCdpCommand: no response after polling (10s timeout)");
                 return "{\"error\":\"cdp timeout\"}";
             }
             catch (Exception ex)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -9,6 +9,14 @@ namespace Microsoft.Maui.DevFlow.Driver;
 /// </summary>
 public class AgentClient : IDisposable
 {
+    private const string ApiV1 = "/api/v1";
+    private const string AgentApi = $"{ApiV1}/agent";
+    private const string UiApi = $"{ApiV1}/ui";
+    private const string WebViewApi = $"{ApiV1}/webview";
+    private const string ProfilerApi = $"{ApiV1}/profiler";
+    private const string StorageApi = $"{ApiV1}/storage";
+    private const string DeviceApi = $"{ApiV1}/device";
+    private const string NetworkApi = $"{ApiV1}/network";
     private readonly HttpClient _http;
     private readonly string _baseUrl;
     private bool _disposed;
@@ -26,10 +34,13 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<AgentStatus?> GetStatusAsync(int? window = null)
     {
-        var url = window != null ? $"/api/status?window={window}" : "/api/status";
+        var url = window != null ? $"{AgentApi}/status?window={window}" : $"{AgentApi}/status";
         var response = await GetAsync<AgentStatus>(url);
         return response;
     }
+
+    public Task<JsonElement> GetCapabilitiesAsync()
+        => GetJsonAsync($"{AgentApi}/capabilities");
 
     /// <summary>
     /// Get the visual tree from the running app.
@@ -39,7 +50,7 @@ public class AgentClient : IDisposable
         var parts = new List<string>();
         if (maxDepth > 0) parts.Add($"depth={maxDepth}");
         if (window != null) parts.Add($"window={window}");
-        var url = parts.Count > 0 ? $"/api/tree?{string.Join("&", parts)}" : "/api/tree";
+        var url = parts.Count > 0 ? $"{UiApi}/tree?{string.Join("&", parts)}" : $"{UiApi}/tree";
         return await GetAsync<List<ElementInfo>>(url) ?? new();
     }
 
@@ -48,7 +59,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<ElementInfo?> GetElementAsync(string id)
     {
-        return await GetAsync<ElementInfo>($"/api/element/{id}");
+        return await GetAsync<ElementInfo>($"{UiApi}/elements/{id}");
     }
 
     /// <summary>
@@ -61,7 +72,9 @@ public class AgentClient : IDisposable
         if (automationId != null) queryParts.Add($"automationId={Uri.EscapeDataString(automationId)}");
         if (text != null) queryParts.Add($"text={Uri.EscapeDataString(text)}");
 
-        var url = $"/api/query?{string.Join("&", queryParts)}";
+        var url = queryParts.Count > 0
+            ? $"{UiApi}/elements?{string.Join("&", queryParts)}"
+            : $"{UiApi}/elements";
         return await GetAsync<List<ElementInfo>>(url) ?? new();
     }
 
@@ -70,7 +83,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<List<ElementInfo>> QueryCssAsync(string selector)
     {
-        var url = $"{_baseUrl}/api/query?selector={Uri.EscapeDataString(selector)}";
+        var url = $"{_baseUrl}{UiApi}/elements?selector={Uri.EscapeDataString(selector)}";
         var response = await _http.GetAsync(url);
         var body = await response.Content.ReadAsStringAsync();
         var json = DriverJson.ParseElement(body);
@@ -88,7 +101,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> TapAsync(string elementId)
     {
-        return await PostActionAsync("/api/action/tap", new JsonObject
+        return await PostActionAsync($"{UiApi}/actions/tap", new JsonObject
         {
             ["elementId"] = elementId
         });
@@ -99,7 +112,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> FillAsync(string elementId, string text)
     {
-        return await PostActionAsync("/api/action/fill", new JsonObject
+        return await PostActionAsync($"{UiApi}/actions/fill", new JsonObject
         {
             ["elementId"] = elementId,
             ["text"] = text
@@ -111,7 +124,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> ClearAsync(string elementId)
     {
-        return await PostActionAsync("/api/action/clear", new JsonObject
+        return await PostActionAsync($"{UiApi}/actions/clear", new JsonObject
         {
             ["elementId"] = elementId
         });
@@ -122,7 +135,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> FocusAsync(string elementId)
     {
-        return await PostActionAsync("/api/action/focus", new JsonObject
+        return await PostActionAsync($"{UiApi}/actions/focus", new JsonObject
         {
             ["elementId"] = elementId
         });
@@ -133,10 +146,55 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> NavigateAsync(string route)
     {
-        return await PostActionAsync("/api/action/navigate", new JsonObject
+        return await PostActionAsync($"{UiApi}/actions/navigate", new JsonObject
         {
             ["route"] = route
         });
+    }
+
+    public async Task<bool> BackAsync()
+    {
+        return await PostActionAsync($"{UiApi}/actions/back", new JsonObject());
+    }
+
+    public async Task<bool> KeyAsync(string key, string? elementId = null, string? text = null)
+    {
+        return await PostActionAsync($"{UiApi}/actions/key", new JsonObject
+        {
+            ["elementId"] = elementId,
+            ["key"] = key,
+            ["text"] = text
+        });
+    }
+
+    public async Task<bool> GestureAsync(string type, string? elementId = null, string? direction = null, double? distance = null, int? durationMs = null)
+    {
+        return await PostActionAsync($"{UiApi}/actions/gesture", new JsonObject
+        {
+            ["elementId"] = elementId,
+            ["type"] = type,
+            ["direction"] = direction,
+            ["distance"] = distance,
+            ["durationMs"] = durationMs
+        });
+    }
+
+    public async Task<JsonElement> BatchAsync(IEnumerable<JsonObject> actions, bool continueOnError = false)
+    {
+        var items = new JsonArray();
+        foreach (var action in actions)
+            items.Add((JsonNode?)action.DeepClone());
+
+        var body = new JsonObject
+        {
+            ["continueOnError"] = continueOnError,
+            ["actions"] = items
+        };
+
+        using var content = DriverJson.CreateJsonContent(body);
+        var response = await _http.PostAsync($"{_baseUrl}{UiApi}/actions/batch", content);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return DriverJson.ParseElement(responseBody);
     }
 
     /// <summary>
@@ -144,7 +202,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> ScrollAsync(string? elementId = null, double deltaX = 0, double deltaY = 0, bool animated = true, int? window = null, int? itemIndex = null, int? groupIndex = null, string? scrollToPosition = null)
     {
-        var url = "/api/action/scroll";
+        var url = $"{UiApi}/actions/scroll";
         if (window != null) url += $"?window={window}";
         return await PostActionAsync(url, new JsonObject
         {
@@ -163,7 +221,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<bool> ResizeAsync(int width, int height, int? window = null)
     {
-        var url = "/api/action/resize";
+        var url = $"{UiApi}/actions/resize";
         if (window != null) url += $"?window={window}";
         return await PostActionAsync(url, new JsonObject
         {
@@ -182,14 +240,14 @@ public class AgentClient : IDisposable
         {
             var queryParams = new List<string>();
             if (window != null) queryParams.Add($"window={window}");
-            if (elementId != null) queryParams.Add($"id={Uri.EscapeDataString(elementId)}");
+            if (elementId != null) queryParams.Add($"elementId={Uri.EscapeDataString(elementId)}");
             if (selector != null) queryParams.Add($"selector={Uri.EscapeDataString(selector)}");
             if (maxWidth != null) queryParams.Add($"maxWidth={maxWidth}");
             if (scale != null) queryParams.Add($"scale={Uri.EscapeDataString(scale)}");
 
             var url = queryParams.Count > 0
-                ? $"{_baseUrl}/api/screenshot?{string.Join("&", queryParams)}"
-                : $"{_baseUrl}/api/screenshot";
+                ? $"{_baseUrl}{UiApi}/screenshot?{string.Join("&", queryParams)}"
+                : $"{_baseUrl}{UiApi}/screenshot";
 
             var response = await _http.GetAsync(url);
             if (!response.IsSuccessStatusCode) return null;
@@ -203,7 +261,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<string?> GetPropertyAsync(string elementId, string propertyName)
     {
-        var result = await GetJsonAsync($"/api/property/{elementId}/{propertyName}");
+        var result = await GetJsonAsync($"{UiApi}/elements/{elementId}/properties/{propertyName}");
         if (result.ValueKind == JsonValueKind.Object && result.TryGetProperty("value", out var val))
             return val.GetString();
         return null;
@@ -220,7 +278,7 @@ public class AgentClient : IDisposable
             {
                 ["value"] = value
             });
-            var response = await _http.PostAsync($"{_baseUrl}/api/property/{elementId}/{propertyName}", content);
+            var response = await _http.PutAsync($"{_baseUrl}{UiApi}/elements/{elementId}/properties/{propertyName}", content);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -231,7 +289,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<string> GetLogsAsync(int limit = 100, int skip = 0, string? source = null)
     {
-        var path = $"/api/logs?limit={limit}&skip={skip}";
+        var path = $"{ApiV1}/logs?limit={limit}&skip={skip}";
         if (!string.IsNullOrEmpty(source) && source != "all")
             path += $"&source={Uri.EscapeDataString(source)}";
         return await _http.GetStringAsync($"{_baseUrl}{path}");
@@ -242,7 +300,7 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<JsonElement> SendCdpCommandAsync(string method, JsonNode? @params = null, string? webviewId = null)
     {
-        var path = "/api/cdp";
+        var path = $"{WebViewApi}/evaluate";
         if (!string.IsNullOrEmpty(webviewId))
             path += $"?webview={Uri.EscapeDataString(webviewId)}";
 
@@ -251,7 +309,7 @@ public class AgentClient : IDisposable
             ["method"] = method
         };
         if (@params != null)
-            body["params"] = @params;
+            body["params"] = @params.DeepClone();
 
         using var content = DriverJson.CreateJsonContent(body);
         var response = await _http.PostAsync($"{_baseUrl}{path}", content);
@@ -264,20 +322,73 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<JsonElement> GetCdpWebViewsAsync()
     {
-        return await GetJsonAsync("/api/cdp/webviews");
+        return await GetJsonAsync($"{WebViewApi}/contexts");
     }
 
     public async Task<string> GetCdpSourceAsync(string? webviewId = null)
     {
-        var path = "/api/cdp/source";
+        var path = $"{WebViewApi}/source";
         if (!string.IsNullOrEmpty(webviewId))
             path += $"?webview={Uri.EscapeDataString(webviewId)}";
         return await _http.GetStringAsync($"{_baseUrl}{path}");
     }
 
+    public async Task<bool> NavigateWebViewAsync(string url, string? contextId = null)
+    {
+        var payload = new JsonObject
+        {
+            ["url"] = url
+        };
+
+        if (!string.IsNullOrWhiteSpace(contextId))
+            payload["contextId"] = contextId;
+
+        return await PostActionAsync($"{WebViewApi}/navigate", payload);
+    }
+
+    public async Task<bool> ClickWebViewAsync(string selector, string? contextId = null)
+    {
+        var payload = new JsonObject
+        {
+            ["selector"] = selector
+        };
+
+        if (!string.IsNullOrWhiteSpace(contextId))
+            payload["contextId"] = contextId;
+
+        return await PostActionAsync($"{WebViewApi}/input/click", payload);
+    }
+
+    public async Task<bool> FillWebViewAsync(string selector, string text, string? contextId = null)
+    {
+        var payload = new JsonObject
+        {
+            ["selector"] = selector,
+            ["text"] = text
+        };
+
+        if (!string.IsNullOrWhiteSpace(contextId))
+            payload["contextId"] = contextId;
+
+        return await PostActionAsync($"{WebViewApi}/input/fill", payload);
+    }
+
+    public async Task<bool> InsertWebViewTextAsync(string text, string? contextId = null)
+    {
+        var payload = new JsonObject
+        {
+            ["text"] = text
+        };
+
+        if (!string.IsNullOrWhiteSpace(contextId))
+            payload["contextId"] = contextId;
+
+        return await PostActionAsync($"{WebViewApi}/input/text", payload);
+    }
+
     public async Task<string> HitTestAsync(double x, double y, int? window = null)
     {
-        var path = $"/api/hittest?x={x}&y={y}";
+        var path = $"{UiApi}/hit-test?x={x}&y={y}";
         if (window.HasValue)
             path += $"&window={window.Value}";
         return await _http.GetStringAsync($"{_baseUrl}{path}");
@@ -285,7 +396,7 @@ public class AgentClient : IDisposable
 
     public async Task<ProfilerCapabilities?> GetProfilerCapabilitiesAsync()
     {
-        return await GetAsync<ProfilerCapabilities>("/api/profiler/capabilities");
+        return await GetAsync<ProfilerCapabilities>($"{ProfilerApi}/capabilities");
     }
 
     public async Task<ProfilerSessionInfo?> StartProfilerAsync(int? sampleIntervalMs = null)
@@ -294,13 +405,13 @@ public class AgentClient : IDisposable
         if (sampleIntervalMs.HasValue)
             payload["sampleIntervalMs"] = sampleIntervalMs.Value;
 
-        var response = await PostJsonAsync<ProfilerSessionEnvelope>("/api/profiler/start", payload);
+        var response = await PostJsonAsync<ProfilerSessionEnvelope>($"{ProfilerApi}/sessions", payload);
         return response?.Session;
     }
 
-    public async Task<ProfilerSessionInfo?> StopProfilerAsync()
+    public async Task<ProfilerSessionInfo?> StopProfilerAsync(string? sessionId = null)
     {
-        var response = await PostJsonAsync<ProfilerSessionEnvelope>("/api/profiler/stop", new JsonObject());
+        var response = await DeleteJsonAsync<ProfilerSessionEnvelope>($"{ProfilerApi}/sessions/{Uri.EscapeDataString(sessionId ?? "current")}");
         return response?.Session;
     }
 
@@ -309,8 +420,17 @@ public class AgentClient : IDisposable
         long markerCursor = 0,
         long spanCursor = 0,
         int limit = 500)
+        => await GetProfilerSamplesAsync(null, sampleCursor, markerCursor, spanCursor, limit);
+
+    public async Task<ProfilerBatch?> GetProfilerSamplesAsync(
+        string? sessionId,
+        long sampleCursor = 0,
+        long markerCursor = 0,
+        long spanCursor = 0,
+        int limit = 500)
     {
-        var url = $"/api/profiler/samples?sampleCursor={sampleCursor}&markerCursor={markerCursor}&spanCursor={spanCursor}&limit={limit}";
+        var resolvedSessionId = Uri.EscapeDataString(sessionId ?? "current");
+        var url = $"{ProfilerApi}/sessions/{resolvedSessionId}/samples?sampleCursor={sampleCursor}&markerCursor={markerCursor}&spanCursor={spanCursor}&limit={limit}";
         return await GetAsync<ProfilerBatch>(url);
     }
 
@@ -319,7 +439,7 @@ public class AgentClient : IDisposable
         string type = "user.action",
         string? payloadJson = null)
     {
-        return await PostActionAsync("/api/profiler/marker", new JsonObject
+        return await PostActionAsync($"{ProfilerApi}/markers", new JsonObject
         {
             ["name"] = name,
             ["type"] = type,
@@ -335,7 +455,7 @@ public class AgentClient : IDisposable
         limit = Math.Clamp(limit, 1, 200);
         minDurationMs = Math.Clamp(minDurationMs, 0, 60_000);
 
-        var path = $"/api/profiler/hotspots?limit={limit}&minDurationMs={minDurationMs}";
+        var path = $"{ProfilerApi}/hotspots?limit={limit}&minDurationMs={minDurationMs}";
         if (!string.IsNullOrWhiteSpace(kind))
             path += $"&kind={Uri.EscapeDataString(kind)}";
         return await GetAsync<List<ProfilerHotspot>>(path) ?? new();
@@ -397,11 +517,45 @@ public class AgentClient : IDisposable
         }
     }
 
+    private async Task<T?> DeleteJsonAsync<T>(string path) where T : class
+    {
+        try
+        {
+            var response = await _http.DeleteAsync($"{_baseUrl}{path}");
+            if (!response.IsSuccessStatusCode)
+                return null;
+            var responseBody = await response.Content.ReadAsStringAsync();
+            return DriverJson.Deserialize<T>(responseBody);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task<bool> DeleteActionAsync(string path)
+    {
+        try
+        {
+            var response = await _http.DeleteAsync($"{_baseUrl}{path}");
+            if (!response.IsSuccessStatusCode)
+                return false;
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            var result = DriverJson.Deserialize<ActionResponse>(responseBody);
+            return result?.Success == true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     // ── Preferences ──
 
     public async Task<JsonElement> GetPreferencesAsync(string? sharedName = null)
     {
-        var path = "/api/preferences";
+        var path = $"{StorageApi}/preferences";
         if (!string.IsNullOrEmpty(sharedName))
             path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
         return await GetJsonAsync(path);
@@ -409,7 +563,7 @@ public class AgentClient : IDisposable
 
     public async Task<JsonElement> GetPreferenceAsync(string key, string? type = null, string? sharedName = null)
     {
-        var path = $"/api/preferences/{Uri.EscapeDataString(key)}";
+        var path = $"{StorageApi}/preferences/{Uri.EscapeDataString(key)}";
         var qs = new List<string>();
         if (!string.IsNullOrEmpty(type)) qs.Add($"type={Uri.EscapeDataString(type)}");
         if (!string.IsNullOrEmpty(sharedName)) qs.Add($"sharedName={Uri.EscapeDataString(sharedName)}");
@@ -427,14 +581,14 @@ public class AgentClient : IDisposable
         if (!string.IsNullOrEmpty(sharedName)) body["sharedName"] = sharedName;
 
         using var content = DriverJson.CreateJsonContent(body);
-        var response = await _http.PostAsync($"{_baseUrl}/api/preferences/{Uri.EscapeDataString(key)}", content);
+        var response = await _http.PutAsync($"{_baseUrl}{StorageApi}/preferences/{Uri.EscapeDataString(key)}", content);
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
 
     public async Task<JsonElement> DeletePreferenceAsync(string key, string? sharedName = null)
     {
-        var path = $"/api/preferences/{Uri.EscapeDataString(key)}";
+        var path = $"{StorageApi}/preferences/{Uri.EscapeDataString(key)}";
         if (!string.IsNullOrEmpty(sharedName))
             path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
         var response = await _http.DeleteAsync($"{_baseUrl}{path}");
@@ -444,17 +598,17 @@ public class AgentClient : IDisposable
 
     public async Task<bool> ClearPreferencesAsync(string? sharedName = null)
     {
-        var path = "/api/preferences/clear";
+        var path = $"{StorageApi}/preferences";
         if (!string.IsNullOrEmpty(sharedName))
             path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
-        return await PostActionAsync(path, new JsonObject());
+        return await DeleteActionAsync(path);
     }
 
     // ── Secure Storage ──
 
     public async Task<JsonElement> GetSecureStorageAsync(string key)
     {
-        return await GetJsonAsync($"/api/secure-storage/{Uri.EscapeDataString(key)}");
+        return await GetJsonAsync($"{StorageApi}/secure/{Uri.EscapeDataString(key)}");
     }
 
     public async Task<JsonElement> SetSecureStorageAsync(string key, string value)
@@ -463,33 +617,40 @@ public class AgentClient : IDisposable
         {
             ["value"] = value
         });
-        var response = await _http.PostAsync($"{_baseUrl}/api/secure-storage/{Uri.EscapeDataString(key)}", content);
+        var response = await _http.PutAsync($"{_baseUrl}{StorageApi}/secure/{Uri.EscapeDataString(key)}", content);
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
 
     public async Task<JsonElement> DeleteSecureStorageAsync(string key)
     {
-        var response = await _http.DeleteAsync($"{_baseUrl}/api/secure-storage/{Uri.EscapeDataString(key)}");
+        var response = await _http.DeleteAsync($"{_baseUrl}{StorageApi}/secure/{Uri.EscapeDataString(key)}");
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
 
     public async Task<bool> ClearSecureStorageAsync()
     {
-        return await PostActionAsync("/api/secure-storage/clear", new JsonObject());
+        return await DeleteActionAsync($"{StorageApi}/secure");
     }
 
     // ── Platform info ──
 
     public async Task<JsonElement> GetPlatformInfoAsync(string endpoint)
     {
-        return await GetJsonAsync($"/api/platform/{endpoint}");
+        var normalizedEndpoint = endpoint switch
+        {
+            "app-info" => "app",
+            "device-info" => "info",
+            "device-display" => "display",
+            _ => endpoint
+        };
+        return await GetJsonAsync($"{DeviceApi}/{normalizedEndpoint}");
     }
 
     public async Task<JsonElement> GetGeolocationAsync(string? accuracy = null, int? timeoutSeconds = null)
     {
-        var path = "/api/platform/geolocation";
+        var path = $"{DeviceApi}/geolocation";
         var qs = new List<string>();
         if (!string.IsNullOrEmpty(accuracy)) qs.Add($"accuracy={Uri.EscapeDataString(accuracy)}");
         if (timeoutSeconds.HasValue) qs.Add($"timeout={timeoutSeconds.Value}");
@@ -501,12 +662,12 @@ public class AgentClient : IDisposable
 
     public async Task<JsonElement> GetSensorsAsync()
     {
-        return await GetJsonAsync("/api/sensors");
+        return await GetJsonAsync($"{DeviceApi}/sensors");
     }
 
     public async Task<bool> StartSensorAsync(string sensor, string? speed = null)
     {
-        var path = $"/api/sensors/{Uri.EscapeDataString(sensor)}/start";
+        var path = $"{DeviceApi}/sensors/{Uri.EscapeDataString(sensor)}/start";
         if (!string.IsNullOrEmpty(speed))
             path += $"?speed={Uri.EscapeDataString(speed)}";
         return await PostActionAsync(path, new JsonObject());
@@ -514,7 +675,7 @@ public class AgentClient : IDisposable
 
     public async Task<bool> StopSensorAsync(string sensor)
     {
-        return await PostActionAsync($"/api/sensors/{Uri.EscapeDataString(sensor)}/stop", new JsonObject());
+        return await PostActionAsync($"{DeviceApi}/sensors/{Uri.EscapeDataString(sensor)}/stop", new JsonObject());
     }
 
     public void Dispose()
@@ -531,7 +692,7 @@ public class AgentClient : IDisposable
     {
         try
         {
-            var url = $"{_baseUrl}/api/network?limit={limit}";
+            var url = $"{_baseUrl}{NetworkApi}/requests?limit={limit}";
             if (!string.IsNullOrEmpty(host)) url += $"&host={Uri.EscapeDataString(host)}";
             if (!string.IsNullOrEmpty(method)) url += $"&method={Uri.EscapeDataString(method)}";
 
@@ -545,7 +706,7 @@ public class AgentClient : IDisposable
     {
         try
         {
-            var response = await _http.GetStringAsync($"{_baseUrl}/api/network/{Uri.EscapeDataString(id)}");
+            var response = await _http.GetStringAsync($"{_baseUrl}{NetworkApi}/requests/{Uri.EscapeDataString(id)}");
             return DriverJson.Deserialize<NetworkRequest>(response);
         }
         catch { return null; }
@@ -553,7 +714,7 @@ public class AgentClient : IDisposable
 
     public async Task<bool> ClearNetworkRequestsAsync()
     {
-        return await PostActionAsync("/api/network/clear", new JsonObject());
+        return await DeleteActionAsync($"{NetworkApi}/requests");
     }
 
     /// <summary>
@@ -562,7 +723,7 @@ public class AgentClient : IDisposable
     public string GetNetworkWebSocketUrl()
     {
         var wsBase = _baseUrl.Replace("http://", "ws://").Replace("https://", "wss://");
-        return $"{wsBase}/ws/network";
+        return $"{wsBase}/ws/v1/network";
     }
 
     internal sealed class ProfilerSessionEnvelope
@@ -581,19 +742,90 @@ public class AgentClient : IDisposable
 public class AgentStatus
 {
     [System.Text.Json.Serialization.JsonPropertyName("agent")]
-    public string? Agent { get; set; }
+    public AgentDescriptor? Agent { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("device")]
+    public DeviceDescriptor? Device { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("app")]
+    public AppDescriptor? App { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("capabilities")]
+    public AgentCapabilities? Capabilities { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("timestamp")]
+    public string? Timestamp { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("running")]
+    public bool Running { get; set; }
+
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? Version => Agent?.Version;
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? Platform => Device?.Platform;
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? DeviceType => Device?.DeviceType;
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? Idiom => Device?.Idiom;
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? AppName => App?.Name;
+}
+
+public class AgentDescriptor
+{
+    [System.Text.Json.Serialization.JsonPropertyName("name")]
+    public string? Name { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("version")]
     public string? Version { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("framework")]
+    public string? Framework { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("frameworkVersion")]
+    public string? FrameworkVersion { get; set; }
+}
+
+public class DeviceDescriptor
+{
     [System.Text.Json.Serialization.JsonPropertyName("platform")]
     public string? Platform { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("deviceType")]
     public string? DeviceType { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("idiom")]
     public string? Idiom { get; set; }
-    [System.Text.Json.Serialization.JsonPropertyName("appName")]
-    public string? AppName { get; set; }
-    [System.Text.Json.Serialization.JsonPropertyName("running")]
-    public bool Running { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("displayDensity")]
+    public double? DisplayDensity { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("windowWidth")]
+    public double? WindowWidth { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("windowHeight")]
+    public double? WindowHeight { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("windowCount")]
+    public int? WindowCount { get; set; }
+}
+
+public class AppDescriptor
+{
+    [System.Text.Json.Serialization.JsonPropertyName("name")]
+    public string? Name { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("packageId")]
+    public string? PackageId { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("version")]
+    public string? Version { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("build")]
+    public string? Build { get; set; }
+}
+
+public class AgentCapabilities
+{
+    [System.Text.Json.Serialization.JsonPropertyName("ui")]
+    public bool Ui { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("screenshots")]
+    public bool Screenshots { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("webview")]
+    public bool WebView { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("network")]
+    public bool Network { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("logs")]
+    public bool Logs { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("sensors")]
+    public bool Sensors { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("storage")]
+    public bool Storage { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("profiler")]
+    public bool Profiler { get; set; }
 }
 
 public class NetworkRequest

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ElementInfo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ElementInfo.cs
@@ -19,11 +19,26 @@ public class ElementInfo
     [JsonPropertyName("fullType")]
     public string FullType { get; set; } = string.Empty;
 
+    [JsonPropertyName("framework")]
+    public string Framework { get; set; } = "maui";
+
     [JsonPropertyName("automationId")]
     public string? AutomationId { get; set; }
 
     [JsonPropertyName("text")]
     public string? Text { get; set; }
+
+    [JsonPropertyName("value")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Value { get; set; }
+
+    [JsonPropertyName("role")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Role
+    {
+        get => _role ?? InferRole();
+        set => _role = value;
+    }
 
     [JsonPropertyName("isVisible")]
     public bool IsVisible { get; set; }
@@ -37,11 +52,55 @@ public class ElementInfo
     [JsonPropertyName("opacity")]
     public double Opacity { get; set; }
 
+    [JsonPropertyName("traits")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Traits
+    {
+        get => _traits ?? BuildTraits();
+        set => _traits = value;
+    }
+
+    [JsonPropertyName("state")]
+    public ElementStateInfo State
+    {
+        get => new()
+        {
+            Displayed = IsVisible,
+            Enabled = IsEnabled,
+            Selected = IsSelected,
+            Focused = IsFocused,
+            Opacity = Opacity
+        };
+        set
+        {
+            if (value == null)
+                return;
+
+            IsVisible = value.Displayed;
+            IsEnabled = value.Enabled;
+            IsSelected = value.Selected;
+            IsFocused = value.Focused;
+            Opacity = value.Opacity;
+        }
+    }
+
     [JsonPropertyName("bounds")]
     public BoundsInfo? Bounds { get; set; }
 
     [JsonPropertyName("gestures")]
     public List<string>? Gestures { get; set; }
+
+    [JsonPropertyName("styleClass")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? StyleClass { get; set; }
+
+    [JsonPropertyName("style")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ElementStyleInfo? Style
+    {
+        get => StyleClass is { Count: > 0 } ? new ElementStyleInfo { Classes = StyleClass } : null;
+        set => StyleClass = value?.Classes;
+    }
 
     [JsonPropertyName("nativeType")]
     public string? NativeType { get; set; }
@@ -49,8 +108,73 @@ public class ElementInfo
     [JsonPropertyName("nativeProperties")]
     public Dictionary<string, string?>? NativeProperties { get; set; }
 
+    [JsonPropertyName("nativeView")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ElementNativeViewInfo? NativeView
+    {
+        get => NativeType != null || NativeProperties != null
+            ? new ElementNativeViewInfo
+            {
+                Type = NativeType,
+                Properties = NativeProperties
+            }
+            : null;
+        set
+        {
+            NativeType = value?.Type;
+            NativeProperties = value?.Properties;
+        }
+    }
+
+    [JsonPropertyName("frameworkProperties")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, string?>? FrameworkProperties { get; set; }
+
     [JsonPropertyName("children")]
     public List<ElementInfo>? Children { get; set; }
+
+    [JsonIgnore]
+    public bool IsSelected { get; set; }
+
+    private string? _role;
+    private List<string>? _traits;
+
+    private string? InferRole() => Type switch
+    {
+        "Window" => "window",
+        "Button" or "ImageButton" => "button",
+        "Entry" or "Editor" or "SearchBar" => "textbox",
+        "CheckBox" => "checkbox",
+        "RadioButton" => "radio",
+        "Switch" => "switch",
+        "Image" => "image",
+        "CollectionView" or "ListView" or "CarouselView" => "list",
+        "Label" when Gestures?.Contains("tap") == true => "link",
+        _ => null
+    };
+
+    private List<string>? BuildTraits()
+    {
+        var traits = new List<string>();
+        var role = Role;
+
+        if (role is "button" or "textbox" or "checkbox" or "radio" or "switch" or "link")
+            traits.Add("interactive");
+
+        if (Gestures is { Count: > 0 } && !traits.Contains("interactive"))
+            traits.Add("interactive");
+
+        if (role is "button" or "textbox" or "checkbox" or "radio" or "switch" or "link" or "window" || IsFocused)
+            traits.Add("focusable");
+
+        if (Type is "ScrollView" or "CollectionView" or "ListView" or "CarouselView")
+            traits.Add("scrollable");
+
+        if (role == "heading")
+            traits.Add("header");
+
+        return traits.Count > 0 ? traits : null;
+    }
 }
 
 public class BoundsInfo
@@ -66,4 +190,40 @@ public class BoundsInfo
 
     [JsonPropertyName("height")]
     public double Height { get; set; }
+}
+
+public class ElementStateInfo
+{
+    [JsonPropertyName("displayed")]
+    public bool Displayed { get; set; }
+
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    [JsonPropertyName("selected")]
+    public bool Selected { get; set; }
+
+    [JsonPropertyName("focused")]
+    public bool Focused { get; set; }
+
+    [JsonPropertyName("opacity")]
+    public double Opacity { get; set; }
+}
+
+public class ElementStyleInfo
+{
+    [JsonPropertyName("classes")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Classes { get; set; }
+}
+
+public class ElementNativeViewInfo
+{
+    [JsonPropertyName("type")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("properties")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, string?>? Properties { get; set; }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Maui.DevFlow.Agent.Core;
 
 namespace Microsoft.Maui.DevFlow.Tests;
@@ -39,9 +40,9 @@ public class AgentHttpServerTests : IDisposable
             var read = await stream.ReadAsync(buffer);
             var request = Encoding.UTF8.GetString(buffer, 0, read);
 
-            Assert.Contains("GET /api/status", request);
+            Assert.Contains("GET /api/v1/agent/status", request);
 
-            var body = """{"agent":"test","version":"1.0","running":true}""";
+            var body = """{"agent":{"name":"test","version":"1.0"},"device":{"platform":"Test"},"app":{"name":"Sample"},"running":true}""";
             var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
             await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
             client.Close();
@@ -51,7 +52,7 @@ public class AgentHttpServerTests : IDisposable
         var status = await agentClient.GetStatusAsync();
 
         Assert.NotNull(status);
-        Assert.Equal("test", status.Agent);
+        Assert.Equal("test", status.Agent?.Name);
         Assert.True(status.Running);
 
         listener.Stop();
@@ -105,7 +106,7 @@ public class AgentHttpServerTests : IDisposable
             var read = await stream.ReadAsync(buffer);
             var request = Encoding.UTF8.GetString(buffer, 0, read);
 
-            Assert.Contains("POST /api/action/tap", request);
+            Assert.Contains("POST /api/v1/ui/actions/tap", request);
             Assert.Contains("elementId", request);
 
             var body = """{"success":true,"message":"Tapped"}""";
@@ -135,7 +136,7 @@ public class AgentHttpServerTests : IDisposable
             var read = await stream.ReadAsync(buffer);
             var request = Encoding.UTF8.GetString(buffer, 0, read);
 
-            Assert.Contains("POST /api/action/fill", request);
+            Assert.Contains("POST /api/v1/ui/actions/fill", request);
             Assert.Contains("hello world", request);
 
             var body = """{"success":true,"message":"Text set"}""";
@@ -148,6 +149,210 @@ public class AgentHttpServerTests : IDisposable
         var result = await agentClient.FillAsync("entry1", "hello world");
         Assert.True(result);
 
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task WebViewNavigateEndpoint_SendsPostWithUrl()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("POST /api/v1/webview/navigate", request);
+            Assert.Contains("https://example.com", request);
+            Assert.Contains("BlazorMain", request);
+
+            var body = """{"success":true}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.NavigateWebViewAsync("https://example.com", "BlazorMain");
+
+        Assert.True(result);
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task WebViewClickEndpoint_SendsSelector()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("POST /api/v1/webview/input/click", request);
+            Assert.Contains("#submit", request);
+
+            var body = """{"success":true}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.ClickWebViewAsync("#submit");
+
+        Assert.True(result);
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task WebViewFillEndpoint_SendsSelectorAndText()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("POST /api/v1/webview/input/fill", request);
+            Assert.Contains("#email", request);
+            Assert.Contains("user@example.com", request);
+
+            var body = """{"success":true}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.FillWebViewAsync("#email", "user@example.com");
+
+        Assert.True(result);
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task WebViewTextEndpoint_SendsText()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("POST /api/v1/webview/input/text", request);
+            Assert.Contains("hello from tests", request);
+
+            var body = """{"success":true}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.InsertWebViewTextAsync("hello from tests");
+
+        Assert.True(result);
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task CapabilitiesEndpoint_ReturnsStructuredCapabilities()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("GET /api/v1/agent/capabilities", request);
+
+            var body = """
+            {
+              "ui": { "supported": true, "features": ["tree", "tap", "batch"] },
+              "webview": { "supported": true, "features": ["contexts", "evaluate"] },
+              "network": { "supported": true, "features": ["list", "clear"] }
+            }
+            """;
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var capabilities = await agentClient.GetCapabilitiesAsync();
+
+        Assert.True(capabilities.GetProperty("ui").GetProperty("supported").GetBoolean());
+        Assert.Contains("batch", capabilities.GetProperty("ui").GetProperty("features").EnumerateArray().Select(x => x.GetString()));
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task BatchEndpoint_SendsV1BatchPayload()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("POST /api/v1/ui/actions/batch", request);
+            Assert.Contains("\"continueOnError\":true", request);
+            Assert.Contains("\"type\":\"tap\"", request);
+            Assert.Contains("\"elementId\":\"btn1\"", request);
+
+            var body = """{"success":true,"results":[{"success":true}]}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.BatchAsync(
+            [
+                new JsonObject
+                {
+                    ["type"] = "tap",
+                    ["elementId"] = "btn1"
+                }
+            ],
+            continueOnError: true);
+
+        Assert.True(result.GetProperty("success").GetBoolean());
+
+        await acceptTask;
         listener.Stop();
     }
 
@@ -239,7 +444,7 @@ public class AgentHttpServerTests : IDisposable
             var read = await stream.ReadAsync(buffer);
             var request = Encoding.UTF8.GetString(buffer, 0, read);
 
-            Assert.Contains("GET /api/platform/battery", request);
+            Assert.Contains("GET /api/v1/device/battery", request);
 
             var body = """
             {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ProfilerAgentClientTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ProfilerAgentClientTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Text;
+using Microsoft.Maui.DevFlow.Agent.Core;
+using Microsoft.Maui.DevFlow.Agent.Core.Profiling;
 
 namespace Microsoft.Maui.DevFlow.Tests;
 
@@ -21,7 +24,7 @@ public class ProfilerAgentClientTests
                 using var stream = client.GetStream();
                 var request = await ReadRequestAsync(stream);
 
-                if (request.Contains("POST /api/profiler/start", StringComparison.Ordinal))
+                if (request.Contains("POST /api/v1/profiler/sessions", StringComparison.Ordinal))
                 {
                     var body = """
                     {
@@ -40,7 +43,7 @@ public class ProfilerAgentClientTests
                     continue;
                 }
 
-                if (request.Contains("GET /api/profiler/samples", StringComparison.Ordinal))
+                if (request.Contains("GET /api/v1/profiler/sessions/s-1/samples", StringComparison.Ordinal))
                 {
                     var body = """
                     {
@@ -95,7 +98,7 @@ public class ProfilerAgentClientTests
                     continue;
                 }
 
-                if (request.Contains("POST /api/profiler/stop", StringComparison.Ordinal))
+                if (request.Contains("DELETE /api/v1/profiler/sessions/s-1", StringComparison.Ordinal))
                 {
                     var body = """
                     {
@@ -122,7 +125,7 @@ public class ProfilerAgentClientTests
         Assert.Equal("s-1", started.SessionId);
         Assert.True(started.IsActive);
 
-        var batch = await client.GetProfilerSamplesAsync();
+        var batch = await client.GetProfilerSamplesAsync(started.SessionId);
         Assert.NotNull(batch);
         Assert.Equal("s-1", batch.SessionId);
         Assert.Single(batch.Samples);
@@ -136,11 +139,46 @@ public class ProfilerAgentClientTests
         Assert.Equal(1, batch.MarkerCursor);
         Assert.Equal(1, batch.SpanCursor);
 
-        var stopped = await client.StopProfilerAsync();
+        var stopped = await client.StopProfilerAsync(started.SessionId);
         Assert.NotNull(stopped);
         Assert.False(stopped.IsActive);
 
         await serverTask;
+    }
+
+    [Fact]
+    public async Task Profiler_SessionHandlers_RejectUnknownSessionIds()
+    {
+        using var service = new DevFlowAgentService(new AgentOptions { Enabled = false, EnableProfiler = true });
+
+        var storeField = typeof(DevFlowAgentService).GetField("_profilerSessions", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(storeField);
+
+        var store = Assert.IsType<ProfilerSessionStore>(storeField.GetValue(service));
+        var session = store.Start(250);
+
+        var method = typeof(DevFlowAgentService).GetMethod("HandleProfilerSamples", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var missingSessionRequest = new HttpRequest
+        {
+            RouteParams = new Dictionary<string, string> { ["id"] = "other-session" },
+            QueryParams = new Dictionary<string, string>()
+        };
+
+        var missingSessionResponse = await ((Task<HttpResponse>)method.Invoke(service, [missingSessionRequest])!);
+        Assert.Equal(404, missingSessionResponse.StatusCode);
+        Assert.Contains("other-session", missingSessionResponse.Body);
+
+        var currentSessionRequest = new HttpRequest
+        {
+            RouteParams = new Dictionary<string, string> { ["id"] = session.SessionId },
+            QueryParams = new Dictionary<string, string>()
+        };
+
+        var currentSessionResponse = await ((Task<HttpResponse>)method.Invoke(service, [currentSessionRequest])!);
+        Assert.Equal(200, currentSessionResponse.StatusCode);
+        Assert.Contains(session.SessionId, currentSessionResponse.Body);
     }
 
     private static async Task<string> ReadRequestAsync(NetworkStream stream)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
@@ -171,11 +171,14 @@ public class ElementInfoTests
         Assert.Equal(string.Empty, info.Id);
         Assert.Null(info.ParentId);
         Assert.Equal(string.Empty, info.Type);
+        Assert.Equal("maui", info.Framework);
         Assert.Null(info.AutomationId);
         Assert.Null(info.Text);
         Assert.False(info.IsVisible);
         Assert.False(info.IsEnabled);
         Assert.False(info.IsFocused);
+        Assert.NotNull(info.State);
+        Assert.False(info.State.Displayed);
         Assert.Null(info.Bounds);
         Assert.Null(info.Children);
     }
@@ -188,10 +191,14 @@ public class ElementInfoTests
             Id = "btn1",
             Type = "Button",
             FullType = "Microsoft.Maui.Controls.Button",
+            Framework = "maui",
             AutomationId = "SubmitBtn",
             Text = "Submit",
             IsVisible = true,
             IsEnabled = true,
+            StyleClass = ["primary-button"],
+            NativeType = "UIButton",
+            NativeProperties = new Dictionary<string, string?> { ["title"] = "Submit" },
             Bounds = new BoundsInfo { X = 10, Y = 20, Width = 100, Height = 44 }
         };
 
@@ -199,13 +206,60 @@ public class ElementInfoTests
         var deserialized = System.Text.Json.JsonSerializer.Deserialize<ElementInfo>(json);
 
         Assert.NotNull(deserialized);
+        Assert.Contains("\"framework\":\"maui\"", json);
+        Assert.Contains("\"role\":\"button\"", json);
+        Assert.Contains("\"traits\":", json);
+        Assert.Contains("\"state\":", json);
+        Assert.Contains("\"style\":", json);
+        Assert.Contains("\"nativeView\":", json);
         Assert.Equal("btn1", deserialized.Id);
         Assert.Equal("Button", deserialized.Type);
+        Assert.Equal("maui", deserialized.Framework);
         Assert.Equal("SubmitBtn", deserialized.AutomationId);
         Assert.Equal("Submit", deserialized.Text);
         Assert.True(deserialized.IsVisible);
+        Assert.NotNull(deserialized.State);
+        Assert.True(deserialized.State.Displayed);
+        Assert.False(deserialized.State.Selected);
+        Assert.Equal("button", deserialized.Role);
+        Assert.NotNull(deserialized.Traits);
+        Assert.Contains("interactive", deserialized.Traits!);
+        Assert.NotNull(deserialized.Style);
+        Assert.Contains("primary-button", deserialized.Style!.Classes!);
+        Assert.NotNull(deserialized.NativeView);
+        Assert.Equal("UIButton", deserialized.NativeView!.Type);
         Assert.NotNull(deserialized.Bounds);
         Assert.Equal(100, deserialized.Bounds.Width);
+    }
+
+    [Fact]
+    public void Deserialization_MapsSpecStyleAndStateShape()
+    {
+        var json = """
+        {
+          "id":"btn1",
+          "type":"Button",
+          "fullType":"Microsoft.Maui.Controls.Button",
+          "framework":"maui",
+          "text":"Submit",
+          "state":{"displayed":true,"enabled":true,"selected":false,"focused":false,"opacity":1.0},
+          "style":{"classes":["primary-button"]},
+          "nativeView":{"type":"UIButton","properties":{"title":"Submit"}},
+          "bounds":{"x":10,"y":20,"width":100,"height":44}
+        }
+        """;
+
+        var deserialized = System.Text.Json.JsonSerializer.Deserialize<ElementInfo>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.True(deserialized.IsVisible);
+        Assert.True(deserialized.IsEnabled);
+        Assert.Equal("maui", deserialized.Framework);
+        Assert.NotNull(deserialized.StyleClass);
+        Assert.Contains("primary-button", deserialized.StyleClass);
+        Assert.Equal("UIButton", deserialized.NativeType);
+        Assert.NotNull(deserialized.NativeProperties);
+        Assert.Equal("Submit", deserialized.NativeProperties["title"]);
     }
 }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
@@ -214,11 +214,11 @@ public class AgentStatusTests
     [Fact]
     public void Deserialization_Works()
     {
-        var json = """{"agent":"Microsoft.Maui.DevFlow.Agent","version":"1.0.0","platform":"MacCatalyst","deviceType":"Virtual","idiom":"Desktop","appName":"SampleMauiApp","running":true}""";
+        var json = """{"agent":{"name":"Microsoft.Maui.DevFlow.Agent","version":"1.0.0","framework":".NET MAUI","frameworkVersion":"10.0"},"device":{"platform":"MacCatalyst","deviceType":"Virtual","idiom":"Desktop"},"app":{"name":"SampleMauiApp"},"running":true}""";
         var status = System.Text.Json.JsonSerializer.Deserialize<AgentStatus>(json);
 
         Assert.NotNull(status);
-        Assert.Equal("Microsoft.Maui.DevFlow.Agent", status.Agent);
+        Assert.Equal("Microsoft.Maui.DevFlow.Agent", status.Agent?.Name);
         Assert.Equal("1.0.0", status.Version);
         Assert.Equal("MacCatalyst", status.Platform);
         Assert.True(status.Running);

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -13,7 +13,7 @@ A comprehensive testing, automation, and debugging toolkit for .NET MAUI applica
 | **Microsoft.Maui.DevFlow.Agent.Gtk** | GTK/Linux agent for Maui.Gtk apps. |
 | **Microsoft.Maui.DevFlow.Blazor** | Blazor WebView CDP bridge. Enables Chrome DevTools Protocol access for Blazor Hybrid content via Chobitsu. |
 | **Microsoft.Maui.DevFlow.Blazor.Gtk** | Blazor CDP bridge for WebKitGTK on Linux. |
-| **Microsoft.Maui.DevFlow.CLI** | Global CLI tool (`maui-devflow`) with 50+ commands for automation, debugging, and MCP server support. |
+| **Microsoft.Maui.DevFlow.CLI** | DevFlow command implementation used by the unified `maui devflow` CLI surface for automation, debugging, and MCP server support. |
 | **Microsoft.Maui.DevFlow.Driver** | Platform-aware app driver for iOS, Android, Mac Catalyst, Windows, and Linux. |
 | **Microsoft.Maui.DevFlow.Logging** | Buffered rotating JSONL file logger. No MAUI dependency. |
 
@@ -44,26 +44,26 @@ public static MauiApp CreateMauiApp()
 }
 ```
 
-### 3. Install the CLI tool
+### 3. Install the unified CLI tool
 
 ```bash
-dotnet tool install -g Microsoft.Maui.DevFlow.CLI
+dotnet tool install -g Microsoft.Maui.Cli --prerelease
 ```
 
 ### 4. Interact with your running app
 
 ```bash
 # Visual tree
-maui-devflow ui tree
+maui devflow ui tree
 
 # Take a screenshot
-maui-devflow ui screenshot -o screenshot.png
+maui devflow ui screenshot -o screenshot.png
 
 # Tap an element
-maui-devflow ui tap --automationid "MyButton"
+maui devflow ui tap --automationid "MyButton"
 
 # Start MCP server for AI agent integration
-maui-devflow mcp
+maui devflow mcp
 ```
 
 ## Features

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -63,7 +63,7 @@ maui-devflow ui screenshot -o screenshot.png
 maui-devflow ui tap --automationid "MyButton"
 
 # Start MCP server for AI agent integration
-maui-devflow mcp-serve
+maui-devflow mcp
 ```
 
 ## Features

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -54,16 +54,16 @@ dotnet tool install -g Microsoft.Maui.DevFlow.CLI
 
 ```bash
 # Visual tree
-maui-devflow agent tree
+maui-devflow ui tree
 
 # Take a screenshot
-maui-devflow agent screenshot -o screenshot.png
+maui-devflow ui screenshot -o screenshot.png
 
 # Tap an element
-maui-devflow agent interact tap --automationid "MyButton"
+maui-devflow ui tap --automationid "MyButton"
 
 # Start MCP server for AI agent integration
-maui-devflow mcp
+maui-devflow mcp-serve
 ```
 
 ## Features
@@ -91,6 +91,7 @@ maui-devflow mcp
 ## Documentation
 
 - [Broker Architecture](../../docs/DevFlow/broker.md)
+- [Protocol Spec](../../docs/DevFlow/spec/README.md)
 - [Android Setup](../../docs/DevFlow/setup-guides/android-setup.md)
 - [Apple Platforms Setup](../../docs/DevFlow/setup-guides/apple-platforms-setup.md)
 - [Windows Setup](../../docs/DevFlow/setup-guides/windows-setup.md)
@@ -107,6 +108,28 @@ dotnet build src/DevFlow/DevFlow.slnf
 # Run tests
 dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/
 ```
+
+### Real app integration tests
+
+The simulator/emulator-driven suite is kept separate from the fast PR test pass and is intended to be run explicitly:
+
+```bash
+# Mac Catalyst
+DEVFLOW_TEST_PLATFORM=maccatalyst dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/
+
+# iOS Simulator
+DEVFLOW_TEST_PLATFORM=ios DEVFLOW_TEST_IOS_VERSION=18.x dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/
+
+# Android Emulator
+DEVFLOW_TEST_PLATFORM=android DEVFLOW_TEST_ANDROID_API=35 DEVFLOW_TEST_ANDROID_AVD=devflow-tests-api35 DEVFLOW_TEST_ANDROID_SERIAL=emulator-5580 dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/
+
+# Windows (run on a Windows machine)
+DEVFLOW_TEST_PLATFORM=windows dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/
+```
+
+For local reliability, prefer running one platform suite at a time from a given repo worktree. Android fixture selection can be pinned with `DEVFLOW_TEST_ANDROID_AVD` and `DEVFLOW_TEST_ANDROID_SERIAL` when you want the harness to use a known emulator instance.
+
+There is also a manual GitHub Actions workflow at `.github/workflows/devflow-integration.yml` for running the same suite in CI.
 
 ## Version
 


### PR DESCRIPTION
## Summary
- import the formal DevFlow protocol spec into docs/DevFlow/spec/ and keep the public terminology DevFlow/MAUI-specific
- align the DevFlow agent, driver, and maui devflow CLI with the versioned v1 protocol and command shape
- port the stronger CLI request-level tests and the real-app MAUI integration harness used to validate the agent end-to-end
- harden the CLI JSON serialization paths for AOT/trimming and fix platform issues surfaced by the broader integration pass

## Breaking changes
- the canonical DevFlow HTTP/WebSocket surface is now the versioned /api/v1/* and /ws/v1/* API
- maui devflow command organization now follows the new grouped CLI layout

## Validation
- dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj
- dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/Microsoft.Maui.DevFlow.Tests.csproj
- real integration validation completed for Mac Catalyst (93/93), iOS Simulator (93/93), and Android Emulator (93/93)
