### PR TITLE
docs: Update READMEs with missing command groups and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Experimental packages and tooling for .NET MAUI. This repository hosts pre-relea
 A command-line tool for .NET MAUI development environment setup, device management, and app automation.
 
 - **Environment diagnostics** (`maui doctor`) with auto-fix capabilities
-- **Android SDK and JDK management** — install, update, and configure
-- **Emulator management** — create, start, stop, and delete Android emulators
-- **Apple platform management** (macOS) — Xcode, simulator, and runtime management
-- **Device listing** across all connected platforms (Android emulators + iOS simulators)
-- **DevFlow app automation** (`maui devflow`) — visual tree inspection, screenshots, CDP, MCP server
-- **JSON output** (`--json`) for CI pipelines and scripting
+- **Android SDK and JDK management** (`maui android`) — install, update, and configure
+- **Emulator management** (`maui android emulator`) — create, start, stop, and delete Android emulators
+- **Apple platform management** (`maui apple`) — Xcode, simulator, and runtime management (macOS)
+- **Device listing** (`maui device list`) across all connected platforms
+- **DevFlow app automation** (`maui devflow`) — visual tree inspection, element interaction, screenshots, WebView/CDP automation, network monitoring, profiling, storage access, real-time log/sensor streaming, and MCP server for AI agents
+- **Version info** (`maui version`)
+- **Global options** — `--json` for CI pipelines, `--verbose`, `--dry-run`, `--ci`
 
 | Package | Description |
 |---------|-------------|
@@ -37,6 +38,9 @@ A comprehensive MAUI testing, automation, and debugging toolkit. The DevFlow CLI
 - **MCP server** for AI agent integration (via `maui devflow mcp`)
 - **Platform drivers** for iOS, Android, Mac Catalyst, Windows, and Linux/GTK
 - **Network monitoring** and **performance profiling**
+- **Real-time streaming** — WebSocket channels for logs, network requests, sensor data, profiler samples, and UI events
+- **Storage access** — read/write app preferences and secure storage
+- **Device introspection** — battery, connectivity, geolocation, display info, and permissions
 
 | Package | Description |
 |---------|-------------|

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -70,26 +70,43 @@ maui apple simulator delete "iPhone 16 Pro"
 | `maui doctor` | Run environment diagnostics and auto-fix issues |
 | `maui device list` | List connected devices and emulators |
 | `maui version` | Display version information |
+| **Android** | |
 | `maui android install` | Full interactive Android environment setup |
 | `maui android sdk list` | List available and installed Android SDK packages |
 | `maui android sdk install` | Install Android SDK packages |
+| `maui android sdk check` | Check Android SDK installation status |
+| `maui android sdk uninstall` | Uninstall Android SDK packages |
+| `maui android sdk accept-licenses` | Accept Android SDK licenses interactively |
 | `maui android jdk install` | Install and manage JDK versions |
+| `maui android jdk check` | Check JDK installation status |
+| `maui android jdk list` | List available JDK versions |
 | `maui android emulator create` | Create an Android emulator |
 | `maui android emulator start` | Start an Android emulator |
 | `maui android emulator stop` | Stop a running emulator |
 | `maui android emulator delete` | Delete an emulator |
-| `maui apple xcode list` | List installed Xcode versions (macOS only) |
-| `maui apple runtime list` | List installed simulator runtimes (macOS only) |
-| `maui apple simulator list` | List simulator devices (macOS only) |
-| `maui apple simulator start` | Boot a simulator (macOS only) |
-| `maui apple simulator stop` | Shut down a simulator (macOS only) |
-| `maui apple simulator delete` | Delete a simulator (macOS only) |
-| `maui devflow` | MAUI app automation via the DevFlow agent and WebView tooling |
-| `maui devflow ui tree` | Dump the visual tree of a running app |
-| `maui devflow ui screenshot` | Take a screenshot of a running app |
+| `maui android emulator list` | List available emulators |
+| **Apple (macOS only)** | |
+| `maui apple xcode list` | List installed Xcode versions |
+| `maui apple runtime list` | List installed simulator runtimes |
+| `maui apple simulator list` | List simulator devices |
+| `maui apple simulator start` | Boot a simulator |
+| `maui apple simulator stop` | Shut down a simulator |
+| `maui apple simulator delete` | Delete a simulator |
+| **DevFlow** | |
+| `maui devflow ui` | Visual tree inspection, interaction, screenshots, recording |
 | `maui devflow webview` | Blazor WebView automation via Chrome DevTools Protocol |
+| `maui devflow logs` | Fetch and stream application logs |
+| `maui devflow network` | Monitor HTTP network requests |
+| `maui devflow storage` | Access app preferences and secure storage |
+| `maui devflow agent` | Discover and inspect connected DevFlow agents |
+| `maui devflow broker` | Manage the DevFlow agent broker (start, stop, status, log) |
+| `maui devflow batch` | Execute commands from stdin for scripting |
+| `maui devflow commands` | List all available commands (schema discovery) |
+| `maui devflow diagnose` | Check DevFlow agent health |
+| `maui devflow wait` | Wait for an agent to connect |
 | `maui devflow mcp` | Start the MCP server for AI agent integration |
-| `maui devflow broker` | Manage the DevFlow agent broker |
+
+Run `maui <command> --help` for detailed options on any command.
 
 ## Global Options
 

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -93,7 +93,8 @@ maui apple simulator delete "iPhone 16 Pro"
 | `maui apple simulator stop` | Shut down a simulator |
 | `maui apple simulator delete` | Delete a simulator |
 | **DevFlow** | |
-| `maui devflow ui` | Visual tree inspection, interaction, screenshots, recording |
+| `maui devflow ui` | Visual tree inspection, interaction, and screenshots |
+| `maui devflow recording` | Manage UI recording sessions (start, stop, status) |
 | `maui devflow webview` | Blazor WebView automation via Chrome DevTools Protocol |
 | `maui devflow logs` | Fetch and stream application logs |
 | `maui devflow network` | Monitor HTTP network requests |

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -69,14 +69,48 @@ maui devflow mcp
 ## Features
 
 - **Visual Tree Inspection** — query the full MAUI visual tree via HTTP API or CLI
-- **Element Interaction** — tap, fill, scroll, navigate, and mutate properties
-- **Screenshots** — capture PNG screenshots from any platform
+- **Element Interaction** — tap, fill, scroll, navigate, focus, resize, and mutate properties
+- **Screenshots** — capture PNG screenshots from any platform (full window or per-element)
+- **Screen Recording** — start/stop video recording of app sessions
 - **Network Monitoring** — intercept and inspect HTTP requests/responses
-- **Performance Profiling** — CPU, memory, GC, and jank detection
-- **Blazor CDP Bridge** — Chrome DevTools Protocol for Blazor WebViews
+- **Performance Profiling** — CPU, memory, GC, and jank detection with markers and spans
+- **Blazor CDP Bridge** — Chrome DevTools Protocol for Blazor WebViews (DOM, JS eval, navigation, input)
 - **MCP Server** — 50+ structured tools for AI agent integration (Claude, etc.)
 - **Logging** — buffered JSONL file logging with WebView JS console capture
+- **Real-time Streaming** — WebSocket channels for logs, network, sensors, profiler, and UI events
+- **Storage Access** — read/write app preferences and secure storage remotely
+- **Device Introspection** — battery, connectivity, geolocation, display, permissions, and sensor data
+- **Dialog Handling** — detect and dismiss alerts/action sheets programmatically
+- **Batch Operations** — execute command sequences from stdin for scripting
 - **Multi-Platform** — iOS, Android, Mac Catalyst, Windows, Linux/GTK
+
+## CLI Commands
+
+All DevFlow commands are available under `maui devflow`. Run `maui devflow <command> --help` for details.
+
+| Command Group | Description |
+|---------------|-------------|
+| `ui` | Visual tree, element interaction, screenshots, recording, alerts, assertions |
+| `webview` | Blazor WebView automation — DOM, JS eval, navigation, input, screenshots |
+| `logs` | Fetch and stream application logs |
+| `network` | Monitor and inspect HTTP requests |
+| `storage` | Read/write app preferences and secure storage |
+| `agent` | Discover and inspect connected agents (status, list, wait, diagnose) |
+| `broker` | Manage the agent broker (start, stop, status, log) |
+| `batch` | Execute command sequences from stdin |
+| `commands` | List all available commands (schema discovery) |
+| `mcp` | Start the MCP server for AI agent integration |
+
+### DevFlow Global Options
+
+These options apply to all `maui devflow` subcommands:
+
+| Option | Description |
+|--------|-------------|
+| `--agent-port`, `-ap` | Agent HTTP port (default: 9223) |
+| `--agent-host`, `-ah` | Agent HTTP host (default: localhost) |
+| `--platform`, `-p` | Target platform (maccatalyst, android, ios, windows) |
+| `--no-json` | Force human-readable output |
 
 ## Platform Support
 

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -90,7 +90,8 @@ All DevFlow commands are available under `maui devflow`. Run `maui devflow <comm
 
 | Command Group | Description |
 |---------------|-------------|
-| `ui` | Visual tree, element interaction, screenshots, recording, alerts, assertions |
+| `ui` | Visual tree, element interaction, screenshots, alerts, assertions |
+| `recording` | Start, stop, and manage screen recordings of app sessions |
 | `webview` | Blazor WebView automation — DOM, JS eval, navigation, input, screenshots |
 | `logs` | Fetch and stream application logs |
 | `network` | Monitor and inspect HTTP requests |
@@ -107,7 +108,7 @@ These options apply to all `maui devflow` subcommands:
 
 | Option | Description |
 |--------|-------------|
-| `--agent-port`, `-ap` | Agent HTTP port (default: 9223) |
+| `--agent-port`, `-ap` | Agent HTTP port (auto-discovered via broker/.mauidevflow; falls back to 9223) |
 | `--agent-host`, `-ah` | Agent HTTP host (default: localhost) |
 | `--platform`, `-p` | Target platform (maccatalyst, android, ios, windows) |
 | `--no-json` | Force human-readable output |


### PR DESCRIPTION
Improves discoverability across all three READMEs without turning them into exhaustive references.

**Root  Added command names (`maui android`, `maui apple`, `maui device`, `maui version`), expanded DevFlow description to mention streaming/storage/device, added global options.README** 

**CLI  Added 5 missing android subcommands, 12 missing devflow command groups (logs, network, storage, agent, broker, batch, etc.), organized table with section headers.README** 

**DevFlow  Added 6 missing feature categories (screen recording, real-time streaming, storage access, device introspection, dialog handling, batch operations), CLI command categories table, devflow global options.README** 

Philosophy: mention command groups so users can *discover* they exist, then let `--help` and the [protocol spec](docs/DevFlow/spec/README.md) do the heavy lifting.