### PR TITLE
Rename marketplace from dotnet-maui-labs-skills to dotnet-maui-labs

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "dotnet-maui-labs-skills",
+  "name": "dotnet-maui-labs",
   "owner": {
     "name": ".NET MAUI Team"
   },

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This repository is also a marketplace for distributable agent skills for .NET MA
 ```bash
 # Install via Copilot CLI
 /plugin marketplace add dotnet/maui-labs
-/plugin install dotnet-maui@dotnet-maui-labs-skills
+/plugin install dotnet-maui@dotnet-maui-labs
 ```
 
 See [plugins/](plugins/) for the full catalog and [plugins/CONTRIBUTING.md](plugins/CONTRIBUTING.md) for how to add skills.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -15,7 +15,7 @@ Distributable agent skills for .NET MAUI development. Installable via the Copilo
 /plugin marketplace add dotnet/maui-labs
 
 # Install the plugin
-/plugin install dotnet-maui@dotnet-maui-labs-skills
+/plugin install dotnet-maui@dotnet-maui-labs
 ```
 
 ## Adding Skills


### PR DESCRIPTION
The `-skills` suffix is unnecessarily narrow — the plugin marketplace will host more than just skills (prompts, tools, etc.). Drops the suffix to keep the name future-proof.

### Changes
- `.github/plugin/marketplace.json` — marketplace `name` field
- `plugins/README.md` — install command
- `README.md` — install command

Follow-up to #58.