### PR TITLE
Switch docs-check workflow from create-pull-request to create-issue

### DIFF
--- a/.github/workflows/pr-docs-check.lock.yml
+++ b/.github/workflows/pr-docs-check.lock.yml
@@ -23,10 +23,11 @@
 #
 # Analyzes merged pull requests for documentation needs. When a PR is merged,
 # this workflow reviews the changes and determines if documentation updates are
-# needed on dotnet/docs-maui. If updates are needed, it opens a draft PR directly
-# on docs-maui. If not, it comments on the source PR explaining why.
+# needed on dotnet/docs-maui. If updates are needed, it opens an issue on
+# docs-maui describing the suggested changes. If not, it comments on the source
+# PR explaining why.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"e44f3b14641b355646e272cbd8c191073fa8b12120cd0c2d64dcbccd547446db","compiler_version":"v0.53.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"bccd9707220610aace0db957ab957186eb6eae9f381d044ccb5e997f112583de","compiler_version":"v0.53.5"}
 
 name: "PR Documentation Check"
 "on":
@@ -171,10 +172,7 @@ jobs:
           cat "/opt/gh-aw/prompts/safe_outputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
-          Tools: add_comment, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_EOF
-          cat "/opt/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_EOF'
+          Tools: add_comment, create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -368,10 +366,59 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1},"create_pull_request":{"draft":true,"expires":30,"max":1,"target-repo":"dotnet/docs-maui","title_prefix":"[maui-labs] "},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"add_comment":{"max":1},"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
+            {
+              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[maui-labs docs] \". Labels [\"docs-from-code\"] will be automatically added. Issues will be created in repository \"dotnet/docs-maui\".",
+              "inputSchema": {
+                "additionalProperties": false,
+                "properties": {
+                  "body": {
+                    "description": "Detailed issue description in Markdown. Do NOT repeat the title as a heading since it already appears as the issue's h1. Include context, reproduction steps, or acceptance criteria as appropriate.",
+                    "type": "string"
+                  },
+                  "integrity": {
+                    "description": "Trustworthiness level of the message source (e.g., \"low\", \"medium\", \"high\").",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "description": "Labels to categorize the issue (e.g., 'bug', 'enhancement'). Labels must exist in the repository.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "parent": {
+                    "description": "Parent issue number for creating sub-issues. This is the numeric ID from the GitHub URL (e.g., 42 in github.com/owner/repo/issues/42). Can also be a temporary_id (e.g., 'aw_abc123', 'aw_Test123') from a previously created issue in the same workflow run.",
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  },
+                  "secrecy": {
+                    "description": "Confidentiality level of the message content (e.g., \"public\", \"internal\", \"private\").",
+                    "type": "string"
+                  },
+                  "temporary_id": {
+                    "description": "Unique temporary identifier for referencing this issue before it's created. Format: 'aw_' followed by 3 to 12 alphanumeric characters (e.g., 'aw_abc1', 'aw_Test123'). Use '#aw_ID' in body text to reference other issues by their temporary_id; these are replaced with actual issue numbers after creation.",
+                    "pattern": "^aw_[A-Za-z0-9]{3,12}$",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Concise issue title summarizing the bug, feature, or task. The title appears as the main heading, so keep it brief and descriptive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ],
+                "type": "object"
+              },
+              "name": "create_issue"
+            },
             {
               "description": "Add a comment to an existing GitHub issue, pull request, or discussion. Use this to provide feedback, answer questions, or add information to an existing conversation. For creating new items, use create_issue, create_discussion, or create_pull_request instead. IMPORTANT: Comments are subject to validation constraints enforced by the MCP server - maximum 65536 characters for the complete comment (including footer which is added automatically), 10 mentions (@username), and 50 links. Exceeding these limits will result in an immediate error with specific guidance. NOTE: By default, this tool requires discussions:write permission. If your GitHub App lacks Discussions permission, set 'discussions: false' in the workflow's safe-outputs.add-comment configuration to exclude this permission. CONSTRAINTS: Maximum 1 comment(s) can be added.",
               "inputSchema": {
@@ -408,55 +455,6 @@ jobs:
                 "type": "object"
               },
               "name": "add_comment"
-            },
-            {
-              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[maui-labs] \". Labels [\"docs-from-code\"] will be automatically added. PRs will be created as drafts.",
-              "inputSchema": {
-                "additionalProperties": false,
-                "properties": {
-                  "body": {
-                    "description": "Detailed PR description in Markdown. Include what changes were made, why, testing notes, and any breaking changes. Do NOT repeat the title as a heading.",
-                    "type": "string"
-                  },
-                  "branch": {
-                    "description": "Source branch name containing the changes. If omitted, uses the current working branch.",
-                    "type": "string"
-                  },
-                  "draft": {
-                    "description": "Whether to create the PR as a draft. Draft PRs cannot be merged until marked as ready for review. Use mark_pull_request_as_ready_for_review to convert a draft PR. Default: true.",
-                    "type": "boolean"
-                  },
-                  "integrity": {
-                    "description": "Trustworthiness level of the message source (e.g., \"low\", \"medium\", \"high\").",
-                    "type": "string"
-                  },
-                  "labels": {
-                    "description": "Labels to categorize the PR (e.g., 'enhancement', 'bugfix'). Labels must exist in the repository.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "repo": {
-                    "description": "Target repository in 'owner/repo' format. For multi-repo workflows where the target repo differs from the workflow repo, this must match a repo in the allowed-repos list or the configured target-repo. If omitted, defaults to the configured target-repo (from safe-outputs config), NOT the workflow repository. In most cases, you should omit this parameter and let the system use the configured default.",
-                    "type": "string"
-                  },
-                  "secrecy": {
-                    "description": "Confidentiality level of the message content (e.g., \"public\", \"internal\", \"private\").",
-                    "type": "string"
-                  },
-                  "title": {
-                    "description": "Concise PR title describing the changes. Follow repository conventions (e.g., conventional commits). The title appears as the main heading.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "title",
-                  "body"
-                ],
-                "type": "object"
-              },
-              "name": "create_pull_request"
             },
             {
               "description": "Report that a tool or capability needed to complete the task is not available, or share any information you deem important about missing functionality or limitations. Use this when you cannot accomplish what was requested because the required functionality is missing or access is restricted.",
@@ -573,7 +571,7 @@ jobs:
                 }
               }
             },
-            "create_pull_request": {
+            "create_issue": {
               "defaultMax": 1,
               "fields": {
                 "body": {
@@ -582,24 +580,21 @@ jobs:
                   "sanitize": true,
                   "maxLength": 65000
                 },
-                "branch": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 256
-                },
-                "draft": {
-                  "type": "boolean"
-                },
                 "labels": {
                   "type": "array",
                   "itemType": "string",
                   "itemSanitize": true,
                   "itemMaxLength": 128
                 },
+                "parent": {
+                  "issueOrPRNumber": true
+                },
                 "repo": {
                   "type": "string",
                   "maxLength": 256
+                },
+                "temporary_id": {
+                  "type": "string"
                 },
                 "title": {
                   "required": true,
@@ -935,7 +930,6 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
-            /tmp/gh-aw/aw-*.patch
           if-no-files-found: ignore
       # --- Threat Detection (inline) ---
       - name: Check if detection needed
@@ -974,7 +968,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           WORKFLOW_NAME: "PR Documentation Check"
-          WORKFLOW_DESCRIPTION: "Analyzes merged pull requests for documentation needs. When a PR is merged,\nthis workflow reviews the changes and determines if documentation updates are\nneeded on dotnet/docs-maui. If updates are needed, it opens a draft PR directly\non docs-maui. If not, it comments on the source PR explaining why."
+          WORKFLOW_DESCRIPTION: "Analyzes merged pull requests for documentation needs. When a PR is merged,\nthis workflow reviews the changes and determines if documentation updates are\nneeded on dotnet/docs-maui. If updates are needed, it opens an issue on\ndocs-maui describing the suggested changes. If not, it comments on the source\nPR explaining why."
           HAS_PATCH: ${{ steps.collect_output.outputs.has_patch }}
         with:
           script: |
@@ -1062,7 +1056,7 @@ jobs:
     if: (always()) && (needs.agent.result != 'skipped')
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
       discussions: write
       issues: write
       pull-requests: write
@@ -1130,8 +1124,6 @@ jobs:
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
-          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
-          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
@@ -1157,20 +1149,6 @@ jobs:
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/handle_noop_message.cjs');
-            await main();
-      - name: Handle Create Pull Request Error
-        id: handle_create_pr_error
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "PR Documentation Check"
-          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          github-token: ${{ secrets.MAUI_BOT_TOKEN }}
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/handle_create_pr_error.cjs');
             await main();
 
   pre_activation:
@@ -1200,13 +1178,11 @@ jobs:
             await main();
 
   safe_outputs:
-    needs:
-      - activation
-      - agent
+    needs: agent
     if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.agent.outputs.detection_success == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
       discussions: write
       issues: write
       pull-requests: write
@@ -1223,8 +1199,8 @@ jobs:
       comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
-      created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
-      created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
+      created_issue_number: ${{ steps.process_safe_outputs.outputs.created_issue_number }}
+      created_issue_url: ${{ steps.process_safe_outputs.outputs.created_issue_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
@@ -1245,35 +1221,6 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs/
           find "/tmp/gh-aw/safeoutputs/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
-      - name: Download patch artifact
-        continue-on-error: true
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
-        with:
-          name: agent-artifacts
-          path: /tmp/gh-aw/
-      - name: Checkout repository
-        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: dotnet/docs-maui
-          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
-          token: ${{ secrets.MAUI_BOT_TOKEN }}
-          persist-credentials: false
-          fetch-depth: 1
-      - name: Configure Git credentials
-        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
-        env:
-          REPO_NAME: "dotnet/docs-maui"
-          SERVER_URL: ${{ github.server_url }}
-          GIT_TOKEN: ${{ secrets.MAUI_BOT_TOKEN }}
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git config --global am.keepcr true
-          # Re-authenticate git with GitHub token
-          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
-          echo "Git configured with standard GitHub Actions identity"
       - name: Process Safe Outputs
         id: process_safe_outputs
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -1282,8 +1229,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"create_pull_request\":{\"draft\":true,\"expires\":30,\"labels\":[\"docs-from-code\"],\"max\":1,\"max_patch_size\":1024,\"target-repo\":\"dotnet/docs-maui\",\"title_prefix\":\"[maui-labs] \"},\"missing_data\":{},\"missing_tool\":{}}"
-          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"create_issue\":{\"labels\":[\"docs-from-code\"],\"max\":1,\"target-repo\":\"dotnet/docs-maui\",\"title_prefix\":\"[maui-labs docs] \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.MAUI_BOT_TOKEN }}
           script: |

--- a/.github/workflows/pr-docs-check.md
+++ b/.github/workflows/pr-docs-check.md
@@ -2,8 +2,9 @@
 description: |
   Analyzes merged pull requests for documentation needs. When a PR is merged,
   this workflow reviews the changes and determines if documentation updates are
-  needed on dotnet/docs-maui. If updates are needed, it opens a draft PR directly
-  on docs-maui. If not, it comments on the source PR explaining why.
+  needed on dotnet/docs-maui. If updates are needed, it opens an issue on
+  docs-maui describing the suggested changes. If not, it comments on the source
+  PR explaining why.
 
 on:
   pull_request:
@@ -55,12 +56,10 @@ tools:
 
 safe-outputs:
   github-token: ${{ secrets.MAUI_BOT_TOKEN }}
-  create-pull-request:
-    title-prefix: "[maui-labs] "
+  create-issue:
+    title-prefix: "[maui-labs docs] "
     labels: [docs-from-code]
-    draft: true
     target-repo: "dotnet/docs-maui"
-    expires: 30
   add-comment:
     hide-older-comments: true
 
@@ -165,35 +164,25 @@ Also check:
 - `docs/developer-tools/index.md` — Landing page for the developer-tools section
 - `docs/TOC.yml` — Table of contents (update if adding new pages)
 
-Before making changes, check if there are any open draft PRs on `dotnet/docs-maui`
-with the `docs-from-code` label from recent maui-labs merges. If so, note any
-potential conflicts in your PR description.
+### 4b: Open an Issue on docs-maui
 
-The documentation is written in Microsoft Learn Markdown format:
-- Use `> [!NOTE]`, `> [!WARNING]`, `> [!TIP]` for callout boxes
-- Use `ms.date: MM/DD/YYYY` format in frontmatter
-- Code blocks use triple backticks with language identifier
-- Tables use pipe syntax
+Create an issue on `dotnet/docs-maui` describing the documentation updates needed.
+The issue should include:
 
-### 4b: Open a Draft PR on docs-maui
+- **Which pages** need updating (reference the file paths above)
+- **What changed** — summarize the user-facing changes from the PR
+- **Suggested content** — provide the specific text, code blocks, or table rows
+  to add or modify so a docs author can apply the changes directly
+- If a new page is needed, suggest the filename and where it fits in `docs/TOC.yml`
 
-Make the changes to the appropriate documentation files and open a draft pull
-request on `dotnet/docs-maui`. Match changes to the right page:
-- CLI command changes → update the relevant `docs/developer-tools/cli/` page
-- DevFlow feature changes → update the relevant `docs/developer-tools/devflow/` page
-- New capabilities that don't fit existing pages → create a new page and add it to `docs/TOC.yml`
-
-The PR should:
-- Update the `ms.date` field in the frontmatter of changed files to today's date
-- Include a clear PR title describing the documentation update
-- In the PR body, link to the source PR in `dotnet/maui-labs` that triggered the change
-- Keep changes minimal — only update what's needed for this specific PR
+The issue body should be self-contained — a docs author should be able to make
+the update without reading the full source PR diff.
 
 ### 4c: Comment on the Source PR
 
 Comment on the original PR in `dotnet/maui-labs` with:
-- A summary of the documentation changes made
-- A link to the draft PR on `dotnet/docs-maui`
+- A summary of the documentation changes suggested
+- A link to the issue opened on `dotnet/docs-maui`
 
 ## Step 5: If Documentation is NOT Needed
 


### PR DESCRIPTION
The `pr-docs-check` workflow cannot push branches to `dotnet/docs-maui` cross-repo, so `create-pull-request` fails silently.

Switches to `create-issue` instead — the workflow now opens an issue on docs-maui with suggested doc changes. This only requires `issues:write` permission, which the `MAUI_BOT_TOKEN` already has.

### Changes
- `.github/workflows/pr-docs-check.md` — source: `create-pull-request` → `create-issue`, updated prompt to describe changes in an issue body
- `.github/workflows/pr-docs-check.lock.yml` — compiled output from `gh aw compile`

Triggered by the attempt 1 failure in https://github.com/dotnet/maui-labs/actions/runs/24514374639