### PR TITLE
Port Maui.Gtk PR #21: use shared GTK color conversion

### DIFF
--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ListViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/ListViewHandler.cs
@@ -306,7 +306,7 @@ public class ListViewHandler : GtkViewHandler<ListView, Gtk.ScrolledWindow>
 		{
 			var c = cell.TextColor;
 			var css = Gtk.CssProvider.New();
-			css.LoadFromString($"label {{ color: rgba({(int)(c.Red*255)},{(int)(c.Green*255)},{(int)(c.Blue*255)},{c.Alpha}); }}");
+			css.LoadFromString($"label {{ color: {ToGtkColor(c)}; }}");
 			textLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 		}
 		row.Append(textLabel);
@@ -317,7 +317,7 @@ public class ListViewHandler : GtkViewHandler<ListView, Gtk.ScrolledWindow>
 			detailLabel.SetHalign(Gtk.Align.Start);
 			var detailCss = Gtk.CssProvider.New();
 			var dc = cell.DetailColor ?? Colors.Gray;
-			detailCss.LoadFromString($"label {{ font-size: 12px; color: rgba({(int)(dc.Red*255)},{(int)(dc.Green*255)},{(int)(dc.Blue*255)},{dc.Alpha}); }}");
+			detailCss.LoadFromString($"label {{ font-size: 12px; color: {ToGtkColor(dc)}; }}");
 			detailLabel.GetStyleContext().AddProvider(detailCss, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 			row.Append(detailLabel);
 		}
@@ -385,7 +385,7 @@ public class ListViewHandler : GtkViewHandler<ListView, Gtk.ScrolledWindow>
 			{
 				var c = label.TextColor;
 				var css = Gtk.CssProvider.New();
-				css.LoadFromString($"label {{ color: rgba({(int)(c.Red*255)},{(int)(c.Green*255)},{(int)(c.Blue*255)},{c.Alpha}); }}");
+				css.LoadFromString($"label {{ color: {ToGtkColor(c)}; }}");
 				gtkLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 			}
 			if (label.FontAttributes.HasFlag(FontAttributes.Bold))

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SwipeViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/SwipeViewHandler.cs
@@ -216,7 +216,7 @@ public class SwipeViewHandler : GtkViewHandler<IView, Gtk.Box>
 			var bg = item.BackgroundColor ?? Colors.LightGray;
 			var cssProvider = Gtk.CssProvider.New();
 			cssProvider.LoadFromString(
-				$"button {{ background-image: none; background-color: rgba({(int)(bg.Red*255)},{(int)(bg.Green*255)},{(int)(bg.Blue*255)},{bg.Alpha}); color: white; border-radius: 0; border: none; }}");
+				$"button {{ background-image: none; background-color: {ToGtkColor(bg)}; color: white; border-radius: 0; border: none; }}");
 			btn.GetStyleContext().AddProvider(cssProvider, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
 			var capturedItem = item;

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/TableViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/TableViewHandler.cs
@@ -132,7 +132,7 @@ public class TableViewHandler : GtkViewHandler<TableView, Gtk.ScrolledWindow>
 		{
 			var c = cell.TextColor;
 			var css = Gtk.CssProvider.New();
-			css.LoadFromString($"label {{ color: rgba({(int)(c.Red*255)},{(int)(c.Green*255)},{(int)(c.Blue*255)},{c.Alpha}); }}");
+			css.LoadFromString($"label {{ color: {ToGtkColor(c)}; }}");
 			textLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 		}
 		box.Append(textLabel);
@@ -143,7 +143,7 @@ public class TableViewHandler : GtkViewHandler<TableView, Gtk.ScrolledWindow>
 			detailLabel.SetHalign(Gtk.Align.Start);
 			var dc = cell.DetailColor ?? Colors.Gray;
 			var css = Gtk.CssProvider.New();
-			css.LoadFromString($"label {{ font-size: 12px; color: rgba({(int)(dc.Red*255)},{(int)(dc.Green*255)},{(int)(dc.Blue*255)},{dc.Alpha}); }}");
+			css.LoadFromString($"label {{ font-size: 12px; color: {ToGtkColor(dc)}; }}");
 			detailLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 			box.Append(detailLabel);
 		}
@@ -252,7 +252,7 @@ public class TableViewHandler : GtkViewHandler<TableView, Gtk.ScrolledWindow>
 			{
 				var c = label.TextColor;
 				var css = Gtk.CssProvider.New();
-				css.LoadFromString($"label {{ color: rgba({(int)(c.Red*255)},{(int)(c.Green*255)},{(int)(c.Blue*255)},{c.Alpha}); }}");
+				css.LoadFromString($"label {{ color: {ToGtkColor(c)}; }}");
 				gtkLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 			}
 			if (label.FontAttributes.HasFlag(FontAttributes.Bold))


### PR DESCRIPTION
## Summary
- port Redth/Maui.Gtk PR #21 to the migrated GTK4 handlers in `platforms/Linux.Gtk4/`
- replace the remaining inline `rgba(...)` CSS generation with the shared `ToGtkColor(...)` helper in `ListViewHandler`, `SwipeViewHandler`, and `TableViewHandler`
- keep the change behavior-preserving and narrowly scoped

Original PR: https://github.com/Redth/Maui.Gtk/pull/21