### PR TITLE
Port Maui.Gtk PR #17: replace DllImports in CairoCanvas

### DIFF
--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoCanvas.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoCanvas.cs
@@ -1,7 +1,13 @@
 using System.Numerics;
-using System.Runtime.InteropServices;
+using Cairo;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Text;
+using Pango;
+using Attribute = Pango.Attribute;
+using Color = Microsoft.Maui.Graphics.Color;
+using LineCap = Microsoft.Maui.Graphics.LineCap;
+using LineJoin = Microsoft.Maui.Graphics.LineJoin;
+using Style = Pango.Style;
 
 namespace Microsoft.Maui.Platforms.Linux.Gtk4.Graphics;
 
@@ -219,10 +225,9 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 
 		// Apply text attributes (bold, italic, color, etc.)
 		var attrList = BuildPangoAttrList(value);
-		if (attrList != IntPtr.Zero)
+		if (attrList is not null)
 		{
-			pango_layout_set_attributes(layout.Handle.DangerousGetHandle(), attrList);
-			// attrList ownership transfers to layout
+			layout.SetAttributes(attrList);
 		}
 
 		_cr.MoveTo(x, y);
@@ -311,8 +316,8 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 		if (surface == null)
 			return;
 
-		int imgW = cairo_image_surface_get_width(surface.Handle.DangerousGetHandle());
-		int imgH = cairo_image_surface_get_height(surface.Handle.DangerousGetHandle());
+		int imgW = surface.Width;
+		int imgH = surface.Height;
 		if (imgW <= 0 || imgH <= 0)
 			return;
 
@@ -507,16 +512,9 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 		double x1 = rect.X + paint.EndPoint.X * rect.Width;
 		double y1 = rect.Y + paint.EndPoint.Y * rect.Height;
 
-		var patternHandle = cairo_pattern_create_linear(x0, y0, x1, y1);
-		try
-		{
-			AddGradientStops(patternHandle, paint.GradientStops);
-			cairo_set_source(_cr.Handle.DangerousGetHandle(), patternHandle);
-		}
-		finally
-		{
-			cairo_pattern_destroy(patternHandle);
-		}
+		using var gradient = new LinearGradient(x0, y0, x1, y1);
+		AddGradientStops(gradient, paint.GradientStops);
+		_cr.SetSource(gradient);
 	}
 
 	private void ApplyRadialGradient(RadialGradientPaint paint, RectF rect)
@@ -525,26 +523,19 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 		double cy = rect.Y + paint.Center.Y * rect.Height;
 		double radius = Math.Max(rect.Width, rect.Height) * paint.Radius;
 
-		var patternHandle = cairo_pattern_create_radial(cx, cy, 0, cx, cy, radius);
-		try
-		{
-			AddGradientStops(patternHandle, paint.GradientStops);
-			cairo_set_source(_cr.Handle.DangerousGetHandle(), patternHandle);
-		}
-		finally
-		{
-			cairo_pattern_destroy(patternHandle);
-		}
+		using var gradient = new RadialGradient(cx, cy, 0, cx, cy, radius);
+		AddGradientStops(gradient, paint.GradientStops);
+		_cr.SetSource(gradient);
 	}
 
-	private void AddGradientStops(nint pattern, PaintGradientStop[]? stops)
+	private void AddGradientStops(Gradient pattern, PaintGradientStop[]? stops)
 	{
 		if (stops == null) return;
 
 		foreach (var stop in stops)
 		{
 			var color = stop.Color;
-			cairo_pattern_add_color_stop_rgba(pattern, stop.Offset,
+			pattern.AddColorStopRgba(stop.Offset,
 				color.Red, color.Green, color.Blue, color.Alpha * _alpha);
 		}
 	}
@@ -587,14 +578,14 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 
 	/// <summary>
 	/// Builds a PangoAttrList from IAttributedText runs.
-	/// Returns IntPtr.Zero if no attributes to apply.
+	/// Returns null if no attributes to apply.
 	/// </summary>
-	private static IntPtr BuildPangoAttrList(IAttributedText attributedText)
+	private static AttrList? BuildPangoAttrList(IAttributedText attributedText)
 	{
 		if (attributedText.Runs == null || attributedText.Runs.Count == 0)
-			return IntPtr.Zero;
+			return null;
 
-		var attrList = pango_attr_list_new();
+		var attrList = AttrList.New();
 		var text = attributedText.Text;
 
 		foreach (var run in attributedText.Runs)
@@ -607,21 +598,21 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 			if (attrs == null) continue;
 
 			if (attrs.ContainsKey(TextAttribute.Bold))
-				InsertPangoAttr(attrList, pango_attr_weight_new(700), byteStart, byteEnd);
+				InsertPangoAttr(attrList, Pango.Functions.AttrWeightNew(Weight.Bold), byteStart, byteEnd);
 
 			if (attrs.ContainsKey(TextAttribute.Italic))
-				InsertPangoAttr(attrList, pango_attr_style_new(2), byteStart, byteEnd);
+				InsertPangoAttr(attrList, Pango.Functions.AttrStyleNew(Style.Italic), byteStart, byteEnd);
 
 			if (attrs.ContainsKey(TextAttribute.Underline))
-				InsertPangoAttr(attrList, pango_attr_underline_new(1), byteStart, byteEnd);
+				InsertPangoAttr(attrList, Pango.Functions.AttrUnderlineNew(Underline.Single), byteStart, byteEnd);
 
 			if (attrs.ContainsKey(TextAttribute.Strikethrough))
-				InsertPangoAttr(attrList, pango_attr_strikethrough_new(true), byteStart, byteEnd);
+				InsertPangoAttr(attrList, Pango.Functions.AttrStrikethroughNew(true), byteStart, byteEnd);
 
 			if (attrs.TryGetValue(TextAttribute.FontSize, out var fontSizeStr)
 				&& float.TryParse(fontSizeStr, out float attrFontSize))
 			{
-				InsertPangoAttr(attrList, pango_attr_size_new((int)(attrFontSize * Pango.Constants.SCALE)), byteStart, byteEnd);
+				InsertPangoAttr(attrList, Pango.Functions.AttrSizeNew((int)(attrFontSize * Pango.Constants.SCALE)), byteStart, byteEnd);
 			}
 
 			if (attrs.TryGetValue(TextAttribute.Color, out var colorStr))
@@ -631,7 +622,7 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 					ushort r = (ushort)(color.Red * 65535);
 					ushort g = (ushort)(color.Green * 65535);
 					ushort b = (ushort)(color.Blue * 65535);
-					InsertPangoAttr(attrList, pango_attr_foreground_new(r, g, b), byteStart, byteEnd);
+					InsertPangoAttr(attrList, Pango.Functions.AttrForegroundNew(r, g, b), byteStart, byteEnd);
 				}
 			}
 		}
@@ -641,14 +632,12 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 
 	/// <summary>
 	/// Sets start/end byte indices on a PangoAttribute and inserts it into the list.
-	/// PangoAttribute struct layout: klass (ptr), start_index (uint), end_index (uint)
 	/// </summary>
-	private static void InsertPangoAttr(IntPtr attrList, IntPtr attr, int byteStart, int byteEnd)
+	private static void InsertPangoAttr(AttrList attrList, Attribute attr, int byteStart, int byteEnd)
 	{
-		if (attr == IntPtr.Zero) return;
-		Marshal.WriteInt32(attr, IntPtr.Size, byteStart);
-		Marshal.WriteInt32(attr, IntPtr.Size + 4, byteEnd);
-		pango_attr_list_insert(attrList, attr);
+		attr.StartIndex = (uint)byteStart;
+		attr.EndIndex = (uint)byteEnd;
+		attrList.Insert(attr);
 	}
 
 	private void ApplyOperator()
@@ -766,55 +755,4 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 		}
 	}
 
-	// --- Cairo P/Invoke for gradient patterns ---
-
-	[DllImport("libcairo.so.2")]
-	private static extern nint cairo_pattern_create_linear(double x0, double y0, double x1, double y1);
-
-	[DllImport("libcairo.so.2")]
-	private static extern nint cairo_pattern_create_radial(double cx0, double cy0, double radius0, double cx1, double cy1, double radius1);
-
-	[DllImport("libcairo.so.2")]
-	private static extern void cairo_pattern_add_color_stop_rgba(nint pattern, double offset, double red, double green, double blue, double alpha);
-
-	[DllImport("libcairo.so.2")]
-	private static extern void cairo_pattern_destroy(nint pattern);
-
-	[DllImport("libcairo.so.2")]
-	private static extern void cairo_set_source(nint cr, nint pattern);
-
-	[DllImport("libcairo.so.2")]
-	private static extern int cairo_image_surface_get_width(nint surface);
-
-	[DllImport("libcairo.so.2")]
-	private static extern int cairo_image_surface_get_height(nint surface);
-
-	// --- Pango P/Invoke for attributed text ---
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern IntPtr pango_attr_list_new();
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern void pango_attr_list_insert(IntPtr list, IntPtr attr);
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern void pango_layout_set_attributes(IntPtr layout, IntPtr attrs);
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern IntPtr pango_attr_weight_new(int weight);
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern IntPtr pango_attr_style_new(int style);
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern IntPtr pango_attr_underline_new(int underline);
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern IntPtr pango_attr_strikethrough_new(bool strikethrough);
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern IntPtr pango_attr_size_new(int size);
-
-	[DllImport("libpango-1.0.so.0")]
-	private static extern IntPtr pango_attr_foreground_new(ushort red, ushort green, ushort blue);
 }

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoCanvas.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoCanvas.cs
@@ -585,7 +585,7 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 		if (attributedText.Runs == null || attributedText.Runs.Count == 0)
 			return null;
 
-		var attrList = AttrList.New();
+		AttrList? attrList = null;
 		var text = attributedText.Text;
 
 		foreach (var run in attributedText.Runs)
@@ -598,20 +598,33 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 			if (attrs == null) continue;
 
 			if (attrs.ContainsKey(TextAttribute.Bold))
+			{
+				attrList ??= AttrList.New();
 				InsertPangoAttr(attrList, Pango.Functions.AttrWeightNew(Weight.Bold), byteStart, byteEnd);
+			}
 
 			if (attrs.ContainsKey(TextAttribute.Italic))
+			{
+				attrList ??= AttrList.New();
 				InsertPangoAttr(attrList, Pango.Functions.AttrStyleNew(Style.Italic), byteStart, byteEnd);
+			}
 
 			if (attrs.ContainsKey(TextAttribute.Underline))
+			{
+				attrList ??= AttrList.New();
 				InsertPangoAttr(attrList, Pango.Functions.AttrUnderlineNew(Underline.Single), byteStart, byteEnd);
+			}
 
 			if (attrs.ContainsKey(TextAttribute.Strikethrough))
+			{
+				attrList ??= AttrList.New();
 				InsertPangoAttr(attrList, Pango.Functions.AttrStrikethroughNew(true), byteStart, byteEnd);
+			}
 
 			if (attrs.TryGetValue(TextAttribute.FontSize, out var fontSizeStr)
 				&& float.TryParse(fontSizeStr, out float attrFontSize))
 			{
+				attrList ??= AttrList.New();
 				InsertPangoAttr(attrList, Pango.Functions.AttrSizeNew((int)(attrFontSize * Pango.Constants.SCALE)), byteStart, byteEnd);
 			}
 
@@ -622,6 +635,7 @@ internal class CairoCanvas : global::Microsoft.Maui.Graphics.ICanvas
 					ushort r = (ushort)(color.Red * 65535);
 					ushort g = (ushort)(color.Green * 65535);
 					ushort b = (ushort)(color.Blue * 65535);
+					attrList ??= AttrList.New();
 					InsertPangoAttr(attrList, Pango.Functions.AttrForegroundNew(r, g, b), byteStart, byteEnd);
 				}
 			}


### PR DESCRIPTION
Ports the CairoCanvas managed-API refactor from the old Maui.Gtk repo.

Original PR: https://github.com/Redth/Maui.Gtk/pull/17

This removes the remaining low-level Cairo and Pango interop in `CairoCanvas` in favor of the managed bindings already used elsewhere in the GTK backend.