### PR TITLE
Port Maui.Gtk PR #19: refactor CairoPlatformImage stream handling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
     <PackageVersion Include="Platform.Maui.Linux.Gtk4" Version="$(PlatformMauiLinuxGtk4Version)" />
     <PackageVersion Include="Platform.Maui.Linux.Gtk4.BlazorWebView" Version="$(PlatformMauiLinuxGtk4BlazorWebViewVersion)" />
     <PackageVersion Include="Platform.Maui.Linux.Gtk4.Essentials" Version="$(PlatformMauiLinuxGtk4EssentialsVersion)" />
+    <PackageVersion Include="GirCore.GdkPixbuf-2.0" Version="0.7.0" />
   </ItemGroup>
 
   <!-- Testing (Microsoft.NET.Test.Sdk and xunit.runner.visualstudio are

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoGraphicsServices.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoGraphicsServices.cs
@@ -118,7 +118,7 @@ internal class CairoBitmapExportContext : global::Microsoft.Maui.Graphics.Bitmap
 }
 
 /// <summary>
-/// IImageLoadingService implementation using Cairo PNG loading.
+/// IImageLoadingService implementation using Cairo and GdkPixbuf image loading.
 /// </summary>
 internal class CairoImageLoadingService : global::Microsoft.Maui.Graphics.IImageLoadingService
 {

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoGraphicsServices.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoGraphicsServices.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platforms.Linux.Gtk4.Graphics;
 
@@ -106,18 +105,8 @@ internal class CairoBitmapExportContext : global::Microsoft.Maui.Graphics.Bitmap
 	public override void WriteToStream(Stream stream)
 	{
 		Cairo.Internal.Surface.Flush(_surface.Handle);
-
-		var tmpPath = Path.Combine(Path.GetTempPath(), $"maui_export_{Guid.NewGuid():N}.png");
-		try
-		{
-			cairo_surface_write_to_png(_surface.Handle.DangerousGetHandle(), tmpPath);
-			using var fs = File.OpenRead(tmpPath);
-			fs.CopyTo(stream);
-		}
-		finally
-		{
-			try { File.Delete(tmpPath); } catch { }
-		}
+		using var pixbuf = _surface.CreatePixbuf();
+		pixbuf.SaveToStream(stream);
 	}
 
 	public override void Dispose()
@@ -126,9 +115,6 @@ internal class CairoBitmapExportContext : global::Microsoft.Maui.Graphics.Bitmap
 		// Don't dispose _surface here — it may still be referenced via Image
 	}
 
-	[DllImport("libcairo.so.2")]
-	private static extern int cairo_surface_write_to_png(nint surface,
-		[MarshalAs(UnmanagedType.LPUTF8Str)] string filename);
 }
 
 /// <summary>
@@ -140,7 +126,7 @@ internal class CairoImageLoadingService : global::Microsoft.Maui.Graphics.IImage
 	{
 		ArgumentNullException.ThrowIfNull(stream);
 
-		var image = CairoPlatformImage.FromStream(stream);
+		var image = CairoPlatformImage.FromStream(stream, format);
 		if (image == null)
 			throw new ArgumentException("Could not decode image from stream.");
 

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoPlatformImage.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoPlatformImage.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Platforms.Linux.Gtk4.Graphics;
@@ -16,8 +15,8 @@ internal class CairoPlatformImage : global::Microsoft.Maui.Graphics.IImage
 
 	internal Cairo.ImageSurface Surface { get; }
 
-	public float Width => cairo_image_surface_get_width(Surface.Handle.DangerousGetHandle());
-	public float Height => cairo_image_surface_get_height(Surface.Handle.DangerousGetHandle());
+	public float Width => Surface.Width;
+	public float Height => Surface.Height;
 
 	public global::Microsoft.Maui.Graphics.IImage Downsize(float maxWidthOrHeight, bool disposeOriginal = false)
 	{
@@ -101,17 +100,8 @@ internal class CairoPlatformImage : global::Microsoft.Maui.Graphics.IImage
 
 	public void Save(Stream stream, ImageFormat format = ImageFormat.Png, float quality = 1)
 	{
-		var tmpPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"maui_img_{Guid.NewGuid():N}.png");
-		try
-		{
-			cairo_surface_write_to_png(Surface.Handle.DangerousGetHandle(), tmpPath);
-			using var fs = File.OpenRead(tmpPath);
-			fs.CopyTo(stream);
-		}
-		finally
-		{
-			try { File.Delete(tmpPath); } catch { }
-		}
+		using var pixbuf = Surface.CreatePixbuf();
+		pixbuf.SaveToStream(stream, format);
 	}
 
 	public Task SaveAsync(Stream stream, ImageFormat format = ImageFormat.Png, float quality = 1)
@@ -121,38 +111,19 @@ internal class CairoPlatformImage : global::Microsoft.Maui.Graphics.IImage
 	}
 
 	/// <summary>
-	/// Creates a CairoPlatformImage from a PNG stream.
+	/// Creates a CairoPlatformImage from a stream.
 	/// </summary>
-	public static CairoPlatformImage? FromStream(Stream stream)
+	public static CairoPlatformImage? FromStream(Stream stream, ImageFormat format = ImageFormat.Png)
 	{
-		var tmpPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"maui_img_{Guid.NewGuid():N}.png");
-		try
-		{
-			using (var fs = File.Create(tmpPath))
-				stream.CopyTo(fs);
+		using var pixbuf = PixbufExtensions.LoadFromStream(stream);
+		if (pixbuf is null)
+			return null;
 
-			var surfaceHandle = cairo_image_surface_create_from_png(tmpPath);
-			if (surfaceHandle == nint.Zero)
-				return null;
+		var surface = new Cairo.ImageSurface(Cairo.Format.Argb32, pixbuf.Width, pixbuf.Height);
+		using var cr = new Cairo.Context(surface);
+		cr.PaintPixbuf(pixbuf);
 
-			// Wrap the unmanaged surface handle. We use an ImageSurface that manages its own lifetime.
-			var surface = new Cairo.ImageSurface(Cairo.Format.Argb32,
-				cairo_image_surface_get_width(surfaceHandle),
-				cairo_image_surface_get_height(surfaceHandle));
-
-			// Copy the PNG data onto our managed surface
-			var cr = new Cairo.Context(surface);
-			cairo_set_source_surface(cr.Handle.DangerousGetHandle(), surfaceHandle, 0, 0);
-			Cairo.Internal.Context.Paint(cr.Handle);
-			cr.Dispose();
-			cairo_surface_destroy(surfaceHandle);
-
-			return new CairoPlatformImage(surface);
-		}
-		finally
-		{
-			try { File.Delete(tmpPath); } catch { }
-		}
+		return new CairoPlatformImage(surface);
 	}
 
 	private bool _disposed;
@@ -163,22 +134,4 @@ internal class CairoPlatformImage : global::Microsoft.Maui.Graphics.IImage
 		_disposed = true;
 		Surface?.Dispose();
 	}
-
-	[DllImport("libcairo.so.2")]
-	private static extern int cairo_surface_write_to_png(nint surface, [MarshalAs(UnmanagedType.LPUTF8Str)] string filename);
-
-	[DllImport("libcairo.so.2")]
-	private static extern nint cairo_image_surface_create_from_png([MarshalAs(UnmanagedType.LPUTF8Str)] string filename);
-
-	[DllImport("libcairo.so.2")]
-	private static extern int cairo_image_surface_get_width(nint surface);
-
-	[DllImport("libcairo.so.2")]
-	private static extern int cairo_image_surface_get_height(nint surface);
-
-	[DllImport("libcairo.so.2")]
-	private static extern void cairo_set_source_surface(nint cr, nint surface, double x, double y);
-
-	[DllImport("libcairo.so.2")]
-	private static extern void cairo_surface_destroy(nint surface);
 }

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoPlatformImage.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/CairoPlatformImage.cs
@@ -112,10 +112,12 @@ internal class CairoPlatformImage : global::Microsoft.Maui.Graphics.IImage
 
 	/// <summary>
 	/// Creates a CairoPlatformImage from a stream.
+	/// The format value is validated for GTK support, while GdkPixbuf
+	/// detects the actual decoder from the stream contents.
 	/// </summary>
 	public static CairoPlatformImage? FromStream(Stream stream, ImageFormat format = ImageFormat.Png)
 	{
-		using var pixbuf = PixbufExtensions.LoadFromStream(stream);
+		using var pixbuf = PixbufExtensions.LoadFromStream(stream, format);
 		if (pixbuf is null)
 			return null;
 

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
@@ -152,7 +152,8 @@ internal static class PixbufExtensions
 		}
 
 		loader.Close();
-		return loader.GetPixbuf();
+		var pixbuf = loader.GetPixbuf();
+		return pixbuf?.Copy();
 	}
 
 	private static string? ToImageExtension(this ImageFormat imageFormat) =>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
@@ -123,8 +123,7 @@ internal static class PixbufExtensions
 		if (pixbuf is null)
 			throw new InvalidOperationException("Unable to create an image buffer from the Cairo surface.");
 
-		var format = imageFormat.ToImageExtension()
-			?? throw new NotSupportedException($"Image format '{imageFormat}' is not supported on GTK.");
+		var format = GetImageExtension(imageFormat);
 
 		using var outputStream = MemoryOutputStream.NewResizable();
 		var success = pixbuf.SaveToStreamv(outputStream, format, null, null, null);
@@ -136,9 +135,10 @@ internal static class PixbufExtensions
 		stream.Write(bytes.GetRegionSpan<byte>(0, bytes.GetSize()));
 	}
 
-	public static Pixbuf? LoadFromStream(Stream stream)
+	public static Pixbuf? LoadFromStream(Stream stream, ImageFormat imageFormat = ImageFormat.Png)
 	{
 		ArgumentNullException.ThrowIfNull(stream);
+		_ = GetImageExtension(imageFormat);
 
 		using var loader = PixbufLoader.New();
 		const int bufferSize = 8192;
@@ -157,6 +157,10 @@ internal static class PixbufExtensions
 		var pixbuf = loader.GetPixbuf();
 		return pixbuf?.Copy();
 	}
+
+	private static string GetImageExtension(ImageFormat imageFormat) =>
+		imageFormat.ToImageExtension()
+		?? throw new NotSupportedException($"Image format '{imageFormat}' is not supported on GTK.");
 
 	private static string? ToImageExtension(this ImageFormat imageFormat) =>
 		imageFormat switch

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Cairo;
 using GdkPixbuf;
 using Gio;
@@ -142,15 +143,22 @@ internal static class PixbufExtensions
 
 		using var loader = PixbufLoader.New();
 		const int bufferSize = 8192;
-		var buffer = new byte[bufferSize];
+		var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
 
-		while (true)
+		try
 		{
-			var bytesRead = stream.Read(buffer, 0, bufferSize);
-			if (bytesRead == 0)
-				break;
+			while (true)
+			{
+				var bytesRead = stream.Read(buffer, 0, bufferSize);
+				if (bytesRead == 0)
+					break;
 
-			loader.Write(buffer.AsSpan(0, bytesRead));
+				loader.Write(buffer.AsSpan(0, bytesRead));
+			}
+		}
+		finally
+		{
+			ArrayPool<byte>.Shared.Return(buffer);
 		}
 
 		loader.Close();

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
@@ -148,14 +148,13 @@ internal static class PixbufExtensions
 		_ = GetImageExtension(imageFormat);
 
 		using var loader = PixbufLoader.New();
-		const int bufferSize = 8192;
-		var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+		var buffer = ArrayPool<byte>.Shared.Rent(8192);
 
 		try
 		{
 			while (true)
 			{
-				var bytesRead = stream.Read(buffer, 0, bufferSize);
+				var bytesRead = stream.Read(buffer, 0, buffer.Length);
 				if (bytesRead == 0)
 					break;
 

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
@@ -46,6 +46,8 @@ internal static class PixbufExtensions
 		if (surface is null)
 			return null;
 
+		Cairo.Internal.Surface.Flush(surface.Handle);
+
 		var surfaceData = surface.GetData();
 		var bytesPerPixel = surface.Format == Format.Argb32 ? 4 : 3;
 		var pixbufData = new byte[surfaceData.Length / 4 * bytesPerPixel];

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
@@ -1,0 +1,168 @@
+using Cairo;
+using GdkPixbuf;
+using Gio;
+using GLib;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Platforms.Linux.Gtk4.Graphics;
+
+internal static class PixbufExtensions
+{
+	public static void PaintPixbuf(this Context context, Pixbuf pixbuf, double x = 0, double y = 0, double? width = null, double? height = null)
+	{
+		ArgumentNullException.ThrowIfNull(context);
+		ArgumentNullException.ThrowIfNull(pixbuf);
+
+		var translate = x != 0 || y != 0;
+		var scale = width.HasValue && height.HasValue && (width.Value != pixbuf.Width || height.Value != pixbuf.Height);
+
+		if (translate || scale)
+			context.Save();
+
+		if (translate)
+			context.Translate(x, y);
+
+		if (scale)
+			context.Scale(width!.Value / pixbuf.Width, height!.Value / pixbuf.Height);
+
+		Gdk.Functions.CairoSetSourcePixbuf(context, pixbuf, 0, 0);
+
+		using var source = context.GetSource();
+		if (source is SurfacePattern pattern)
+		{
+			pattern.Filter = width > pixbuf.Width || height > pixbuf.Height
+				? Filter.Fast
+				: Filter.Good;
+		}
+
+		context.Paint();
+
+		if (translate || scale)
+			context.Restore();
+	}
+
+	public static Pixbuf? CreatePixbuf(this ImageSurface? surface)
+	{
+		if (surface is null)
+			return null;
+
+		var surfaceData = surface.GetData();
+		var bytesPerPixel = surface.Format == Format.Argb32 ? 4 : 3;
+		var pixbufData = new byte[surfaceData.Length / 4 * bytesPerPixel];
+
+		var readIndex = 0;
+		var writeIndex = 0;
+		var stride = surface.Stride;
+		var width = surface.Width;
+
+		if (BitConverter.IsLittleEndian)
+		{
+			for (var row = 0; row < surface.Height; row++)
+			{
+				var rowStart = readIndex;
+				for (var col = 0; col < width; col++)
+				{
+					var alpha = bytesPerPixel == 4 ? surfaceData[readIndex + 3] : (byte)255;
+					var alphaFactor = alpha > 0 ? 255d / alpha : 0d;
+
+					pixbufData[writeIndex] = (byte)(surfaceData[readIndex + 2] * alphaFactor + 0.5);
+					pixbufData[writeIndex + 1] = (byte)(surfaceData[readIndex + 1] * alphaFactor + 0.5);
+					pixbufData[writeIndex + 2] = (byte)(surfaceData[readIndex] * alphaFactor + 0.5);
+
+					if (bytesPerPixel == 4)
+						pixbufData[writeIndex + 3] = alpha;
+
+					readIndex += 4;
+					writeIndex += bytesPerPixel;
+				}
+
+				readIndex = rowStart + stride;
+			}
+		}
+		else
+		{
+			for (var row = 0; row < surface.Height; row++)
+			{
+				var rowStart = readIndex;
+				for (var col = 0; col < width; col++)
+				{
+					var alpha = bytesPerPixel == 4 ? surfaceData[readIndex] : (byte)255;
+					var alphaFactor = alpha > 0 ? 255d / alpha : 0d;
+
+					pixbufData[writeIndex] = (byte)(surfaceData[readIndex + 1] * alphaFactor + 0.5);
+					pixbufData[writeIndex + 1] = (byte)(surfaceData[readIndex + 2] * alphaFactor + 0.5);
+					pixbufData[writeIndex + 2] = (byte)(surfaceData[readIndex + 3] * alphaFactor + 0.5);
+
+					if (bytesPerPixel == 4)
+						pixbufData[writeIndex + 3] = alpha;
+
+					readIndex += 4;
+					writeIndex += bytesPerPixel;
+				}
+
+				readIndex = rowStart + stride;
+			}
+		}
+
+		return Pixbuf.NewFromBytes(
+			Bytes.New(pixbufData),
+			Colorspace.Rgb,
+			bytesPerPixel == 4,
+			8,
+			surface.Width,
+			surface.Height,
+			surface.Width * bytesPerPixel);
+	}
+
+	public static void SaveToStream(this Pixbuf? pixbuf, Stream stream, ImageFormat imageFormat = ImageFormat.Png)
+	{
+		ArgumentNullException.ThrowIfNull(stream);
+
+		if (pixbuf is null)
+			throw new InvalidOperationException("Unable to create an image buffer from the Cairo surface.");
+
+		var format = imageFormat.ToImageExtension()
+			?? throw new NotSupportedException($"Image format '{imageFormat}' is not supported on GTK.");
+
+		using var outputStream = MemoryOutputStream.NewResizable();
+		var success = pixbuf.SaveToStreamv(outputStream, format, null, null, null);
+
+		if (!success)
+			throw new InvalidOperationException("Failed to save image data to the target stream.");
+
+		using var bytes = outputStream.StealAsBytes();
+		stream.Write(bytes.GetRegionSpan<byte>(0, bytes.GetSize()));
+	}
+
+	public static Pixbuf? LoadFromStream(Stream stream)
+	{
+		ArgumentNullException.ThrowIfNull(stream);
+
+		using var loader = PixbufLoader.New();
+		const int bufferSize = 8192;
+		var buffer = new byte[bufferSize];
+
+		while (true)
+		{
+			var bytesRead = stream.Read(buffer, 0, bufferSize);
+			if (bytesRead == 0)
+				break;
+
+			loader.Write(buffer.AsSpan(0, bytesRead));
+		}
+
+		loader.Close();
+		return loader.GetPixbuf();
+	}
+
+	private static string? ToImageExtension(this ImageFormat imageFormat) =>
+		imageFormat switch
+		{
+			ImageFormat.Bmp => "bmp",
+			ImageFormat.Png => "png",
+			ImageFormat.Jpeg => "jpeg",
+			ImageFormat.Gif => "gif",
+			ImageFormat.Tiff => "tiff",
+			_ => null,
+		};
+}

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Graphics/PixbufExtensions.cs
@@ -17,29 +17,35 @@ internal static class PixbufExtensions
 		var translate = x != 0 || y != 0;
 		var scale = width.HasValue && height.HasValue && (width.Value != pixbuf.Width || height.Value != pixbuf.Height);
 
-		if (translate || scale)
+		var saved = translate || scale;
+		if (saved)
 			context.Save();
 
-		if (translate)
-			context.Translate(x, y);
-
-		if (scale)
-			context.Scale(width!.Value / pixbuf.Width, height!.Value / pixbuf.Height);
-
-		Gdk.Functions.CairoSetSourcePixbuf(context, pixbuf, 0, 0);
-
-		using var source = context.GetSource();
-		if (source is SurfacePattern pattern)
+		try
 		{
-			pattern.Filter = width > pixbuf.Width || height > pixbuf.Height
-				? Filter.Fast
-				: Filter.Good;
+			if (translate)
+				context.Translate(x, y);
+
+			if (scale)
+				context.Scale(width!.Value / pixbuf.Width, height!.Value / pixbuf.Height);
+
+			Gdk.Functions.CairoSetSourcePixbuf(context, pixbuf, 0, 0);
+
+			using var source = context.GetSource();
+			if (source is SurfacePattern pattern)
+			{
+				pattern.Filter = width > pixbuf.Width || height > pixbuf.Height
+					? Filter.Fast
+					: Filter.Good;
+			}
+
+			context.Paint();
 		}
-
-		context.Paint();
-
-		if (translate || scale)
-			context.Restore();
+		finally
+		{
+			if (saved)
+				context.Restore();
+		}
 	}
 
 	public static Pixbuf? CreatePixbuf(this ImageSurface? surface)

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="GirCore.Gtk-4.0" Version="0.7.0" />
+    <PackageReference Include="GirCore.GdkPixbuf-2.0" Version="0.7.0" />
     <PackageReference Include="GirCore.WebKit-6.0" Version="0.7.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Ports the Cairo image stream and pixbuf refactor from the old Maui.Gtk repo.

Original PR: https://github.com/Redth/Maui.Gtk/pull/19

This removes the temp-file-heavy image stream path in favor of Pixbuf-backed load/save helpers and the matching GTK dependency wiring.