### PR TITLE
Clarify non-disruptive guidance in maui-ai-debugging skill

### DIFF
--- a/.claude/skills/maui-ai-debugging/SKILL.md
+++ b/.claude/skills/maui-ai-debugging/SKILL.md
@@ -6,9 +6,11 @@ description: >
   macOS (AppKit), or Linux/GTK, (2) Inspecting or interacting with a running app's UI (visual tree, tapping,
   filling text, screenshots, property queries), (3) Debugging Blazor WebView content via CDP, (4) Managing
   simulators or emulators, (5) Setting up MauiDevFlow in a MAUI project, (6) Completing a build-deploy-inspect-fix
-  feedback loop, (7) Handling permission dialogs and system alerts, (8) Managing multiple simultaneous apps via
-  the broker daemon. Covers: the unified `maui devflow` CLI, androidsdk.tool, appledev.tools, adb, xcrun simctl, xdotool,
-  and dotnet build/run for all MAUI target platforms including macOS (AppKit) and Linux/GTK.
+  feedback loop, (7) Handling permission dialogs and in-app/simulator alerts, (8) Managing multiple simultaneous
+  apps via the broker daemon. Covers: the unified `maui devflow` CLI, androidsdk.tool, appledev.tools, adb,
+  xcrun simctl, Linux `xdotool`-backed driver caveats, and dotnet build/run for all MAUI target platforms
+  including macOS (AppKit) and Linux/GTK. Do not use for generic desktop automation, AppleScript macros, or
+  arbitrary host-level `xdotool` control unrelated to MAUI app debugging.
 ---
 
 # MAUI AI Debugging
@@ -282,7 +284,8 @@ maui devflow ui fill <entryId> "Hello World"
 maui devflow recording stop
 ```
 
-**Platform tools used automatically:**
+**Platform tools used automatically by MauiDevFlow's recording backend** (implementation detail —
+do not invoke these directly unless the user explicitly asked for host-level recording):
 - **Android:** `adb screenrecord` (max 180s, capped with warning)
 - **iOS Simulator:** `xcrun simctl io recordVideo`
 - **Mac Catalyst / macOS (AppKit):** `screencapture -v` (targets app window when possible)
@@ -547,18 +550,22 @@ For detailed platform-specific setup, simulator/emulator management, and trouble
 **CRITICAL:** Never run commands that steal focus, move windows, simulate mouse/keyboard input,
 or otherwise disrupt the user's desktop. The user is likely working on the same computer.
 
-**Never use:**
-- `osascript` to focus/activate windows, click UI elements, or send keystrokes
+Some platform reference notes mention `osascript` or `xdotool`. Treat those as **implementation
+details or explicit-consent edge cases**, not the default debugging workflow.
+
+**Never directly use:**
+- `osascript` to focus/activate windows, click UI elements, send keystrokes, or change host macOS appearance without the user's approval
 - `screencapture` interactively (the MauiDevFlow screenshot command captures in-process instead)
-- `xdotool` focus/activate/key commands that affect the active window
+- `xdotool` focus/activate/key commands from the shell that affect the active window
 - Any command that moves the mouse cursor or simulates input at the OS level
 - `open -a` to bring apps to the foreground (use `open` only to launch, not to focus)
 
 **Instead:** All inspection and interaction goes through `maui devflow` CLI commands, which
-communicate with the in-app agent over HTTP — no foreground focus required. If you need
-something that would require OS-level control (e.g., dismissing a system dialog outside the
-app), **ask the user** to do it manually rather than attempting automation that would hijack
-their input.
+communicate with the in-app agent over HTTP — no foreground focus required. Simulator-scoped
+commands such as `xcrun simctl privacy`, `xcrun simctl ui <UDID> appearance ...`, and
+`xcrun simctl io screenshot` are fine because they target the simulator rather than the user's
+desktop. If recovery requires OS-level control outside the app, **ask the user** to do it
+manually or get explicit approval before making a disruptive host-level change.
 
 ## Tips
 

--- a/.claude/skills/maui-ai-debugging/references/ios-and-mac.md
+++ b/.claude/skills/maui-ai-debugging/references/ios-and-mac.md
@@ -206,10 +206,9 @@ Key subcommands beyond the basics:
   ```bash
   rm -rf ~/Library/Saved\ Application\ State/<bundle-id>.savedState
   ```
-  Or detect and dismiss via AppleScript:
-  ```bash
-  osascript -e 'tell application "System Events" to tell process "AppName" to click button "Reopen" of window 1'
-  ```
+  If the "Reopen windows?" dialog is already on screen, ask the user to dismiss it manually,
+  then relaunch. Do not use AppleScript here by default — it steals focus from the user's
+  desktop session.
 - **"Unable to lookup in current state: Shutdown"**: Simulator not booted. Run `xcrun simctl boot <UDID>`.
 - **Build error NETSDK1005 "Assets file doesn't have a target"**: Wrong TFM. Check
   `<TargetFrameworks>` in .csproj and use matching version (e.g. `net10.0-ios` not `net9.0-ios`).
@@ -306,14 +305,16 @@ Use these to test and validate dialog detection and dismissal workflows.
 
 ### Toggle dark mode
 ```bash
-# macOS (affects Mac Catalyst apps)
-osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to true'
-osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to false'
-
-# iOS Simulator
+# Preferred when available: use an in-app theme toggle so the host desktop is unaffected.
+#
+# iOS Simulator (safe: affects the simulator only)
 xcrun simctl ui <UDID> appearance dark
 xcrun simctl ui <UDID> appearance light
 ```
+
+For **Mac Catalyst**, changing system appearance affects the user's entire macOS desktop. Only do
+that with explicit user approval; otherwise prefer app-level theme controls and verify via
+`maui devflow ui property` / WebView inspection.
 
 ### Verify dark mode via inspection
 Use `maui devflow` to verify colors without relying on screenshots:

--- a/.claude/skills/maui-ai-debugging/references/linux.md
+++ b/.claude/skills/maui-ai-debugging/references/linux.md
@@ -81,14 +81,17 @@ directly to `http://localhost:<port>`. No port forwarding (unlike Android) or en
 
 ## Key Simulation
 
-The `LinuxAppDriver` uses `xdotool` for key simulation. Install it if needed:
+The `LinuxAppDriver` may use `xdotool` as a backend for **driver-mediated** key simulation.
+This is an implementation detail for Linux automation support, **not** a recommendation for an
+AI agent to invoke `xdotool` directly from the shell. Install it if the driver needs it:
 
 ```bash
 sudo apt install xdotool
 ```
 
-For Wayland-only environments, `ydotool` may be needed instead. Key simulation is used
-by the CLI for alert dismissal and keyboard input.
+For Wayland-only environments, `ydotool` may be needed instead. Prefer `maui devflow ui fill`,
+`maui devflow ui tap`, and `maui devflow batch` for normal interaction; only the driver backend
+should reach for `xdotool`.
 
 ## Platform Differences
 
@@ -101,7 +104,7 @@ by the CLI for alert dismissal and keyboard input.
 | Network | Varies by platform | Direct localhost |
 | Screenshots | `VisualDiagnostics` | GTK `WidgetPaintable` → `Texture.SaveToPng()` |
 | Native tap | Platform gesture system | `Gtk.Widget.Activate()` |
-| Key simulation | Platform-specific | `xdotool` |
+| Key simulation | Driver-mediated backend | `xdotool` |
 | Blazor WebView | WKWebView / WebView2 / Chrome | WebKitGTK 6.0 |
 
 ## Troubleshooting
@@ -115,7 +118,9 @@ by the CLI for alert dismissal and keyboard input.
 ### xdotool Not Working
 
 - On Wayland, `xdotool` may not work. Try `ydotool` instead
-- Ensure the app window has focus for key events
+- Prefer DevFlow commands over direct key injection wherever possible
+- If driver-mediated key input still fails, ensure the app window has focus manually (or with
+  explicit user approval for a disruptive workaround)
 
 ### WebKitGTK CDP Issues
 


### PR DESCRIPTION
## Why

The `maui-ai-debugging` skill had a few mixed signals around host-level automation. In particular, some reference sections mentioned `osascript` or `xdotool` in ways that could be read as recommended troubleshooting steps even though the core guidance says not to disrupt the user's desktop.

## What changed

- clarified that the default workflow is `maui devflow` plus simulator-scoped commands
- explicitly framed `osascript`, direct `xdotool`, and host appearance/window manipulation as approval-gated or manual-only edge cases
- updated the iOS/Mac and Linux references so the troubleshooting guidance matches the non-disruptive safety section
- added a clearer routing boundary so the skill is not used for generic desktop automation

## Notes

Docs-only change. No runtime or product behavior changes are intended.