### PR TITLE
Add Wayland support for Linux key simulation and screen recording

### DIFF
--- a/.claude/skills/maui-ai-debugging/references/linux.md
+++ b/.claude/skills/maui-ai-debugging/references/linux.md
@@ -155,7 +155,7 @@ Key simulation is used by the CLI for alert dismissal and keyboard input.
 
 - Wayland screen recording uses `ffmpeg -f pipewire` instead of `x11grab`
 - Requires PipeWire to be installed and running (standard on modern Wayland desktops)
-- Check ffmpeg PipeWire support: `ffmpeg -formats | grep pipewire`
+- Check ffmpeg PipeWire support: `ffmpeg -devices | grep pipewire`
 - If PipeWire is not available, you can force X11 with `GDK_BACKEND=x11` and use `x11grab`
 - The first recording on Wayland may trigger a system permission dialog for screen sharing
 

--- a/.claude/skills/maui-ai-debugging/references/linux.md
+++ b/.claude/skills/maui-ai-debugging/references/linux.md
@@ -81,14 +81,43 @@ directly to `http://localhost:<port>`. No port forwarding (unlike Android) or en
 
 ## Key Simulation
 
-The `LinuxAppDriver` uses `xdotool` for key simulation. Install it if needed:
+The `LinuxAppDriver` automatically detects the display server and uses the appropriate tool:
+
+- **X11 sessions**: Uses `xdotool` (human-readable key names, no daemon needed)
+- **Wayland sessions**: Uses `ydotool` (Linux input event keycodes, requires `ydotoold` daemon)
+
+Detection uses `XDG_SESSION_TYPE` and `WAYLAND_DISPLAY` environment variables. If the
+preferred tool isn't installed, it falls back to whichever is available.
+
+### Installing xdotool (X11)
 
 ```bash
-sudo apt install xdotool
+sudo apt install xdotool       # Debian/Ubuntu
+sudo dnf install xdotool       # Fedora
 ```
 
-For Wayland-only environments, `ydotool` may be needed instead. Key simulation is used
-by the CLI for alert dismissal and keyboard input.
+### Installing ydotool (Wayland)
+
+```bash
+sudo apt install ydotool       # Debian/Ubuntu
+sudo dnf install ydotool       # Fedora
+```
+
+**Required setup for ydotool** (to run without root):
+
+```bash
+# Add your user to the input group for /dev/uinput access
+sudo usermod -aG input $USER
+
+# Create udev rule for persistent permissions
+echo 'KERNEL=="uinput", GROUP="input", MODE="0660"' | sudo tee /etc/udev/rules.d/99-uinput.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+
+# Log out and back in, then start the daemon
+ydotoold &
+```
+
+Key simulation is used by the CLI for alert dismissal and keyboard input.
 
 ## Platform Differences
 
@@ -101,7 +130,8 @@ by the CLI for alert dismissal and keyboard input.
 | Network | Varies by platform | Direct localhost |
 | Screenshots | `VisualDiagnostics` | GTK `WidgetPaintable` → `Texture.SaveToPng()` |
 | Native tap | Platform gesture system | `Gtk.Widget.Activate()` |
-| Key simulation | Platform-specific | `xdotool` |
+| Key simulation | Platform-specific | `xdotool` (X11) / `ydotool` (Wayland) |
+| Screen recording | Platform-specific | `ffmpeg` with `x11grab` (X11) / `pipewire` (Wayland) |
 | Blazor WebView | WKWebView / WebView2 / Chrome | WebKitGTK 6.0 |
 
 ## Troubleshooting
@@ -112,10 +142,22 @@ by the CLI for alert dismissal and keyboard input.
 2. Check that `Application.Current` is available when `StartDevFlowAgent()` runs
 3. Verify the port isn't in use: `lsof -i :<port>` or `ss -tlnp | grep <port>`
 
-### xdotool Not Working
+### xdotool / ydotool Not Working
 
-- On Wayland, `xdotool` may not work. Try `ydotool` instead
+- On Wayland, `xdotool` does not work — install `ydotool` and start `ydotoold`
+- On X11, `xdotool` is preferred over `ydotool` (simpler, no daemon)
+- If `ydotool` fails silently, check that `ydotoold` daemon is running: `pgrep -x ydotoold`
+- If `ydotool` gives permission errors, ensure your user is in the `input` group and `/dev/uinput` is group-writable
 - Ensure the app window has focus for key events
+- Check `XDG_SESSION_TYPE` to verify which display server is active: `echo $XDG_SESSION_TYPE`
+
+### Screen Recording on Wayland
+
+- Wayland screen recording uses `ffmpeg -f pipewire` instead of `x11grab`
+- Requires PipeWire to be installed and running (standard on modern Wayland desktops)
+- Check ffmpeg PipeWire support: `ffmpeg -formats | grep pipewire`
+- If PipeWire is not available, you can force X11 with `GDK_BACKEND=x11` and use `x11grab`
+- The first recording on Wayland may trigger a system permission dialog for screen sharing
 
 ### WebKitGTK CDP Issues
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
@@ -93,9 +93,10 @@ public class LinuxAppDriver : AppDriverBase
         if (!fullPath.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase))
             fullPath = Path.ChangeExtension(fullPath, ".mp4");
 
-        var display = Environment.GetEnvironmentVariable("DISPLAY") ?? ":0";
+        var captureFormat = LinuxDisplayServer.GetFfmpegCaptureFormat();
+        var captureInput = LinuxDisplayServer.GetFfmpegCaptureInput();
         var psi = new ProcessStartInfo("ffmpeg",
-            $"-f x11grab -framerate 30 -t {timeoutSeconds} -i {display} -y \"{fullPath}\"")
+            $"-f {captureFormat} -framerate 30 -t {timeoutSeconds} -i {captureInput} -y \"{fullPath}\"")
         {
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
@@ -168,6 +169,38 @@ public class LinuxAppDriver : AppDriverBase
                 "ffmpeg is required for screen recording on Linux but was not found on PATH. " +
                 "Install it via your package manager (e.g., 'apt install ffmpeg' or 'dnf install ffmpeg').");
         }
+
+        // Warn if on Wayland and PipeWire may not be available in ffmpeg
+        if (LinuxDisplayServer.IsWayland)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo("ffmpeg", "-formats")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                };
+                using var proc = Process.Start(psi);
+                var output = proc?.StandardOutput.ReadToEnd() ?? "";
+                proc?.WaitForExit(5000);
+                if (!output.Contains("pipewire", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        "Screen recording on Wayland requires ffmpeg with PipeWire support, but your ffmpeg build " +
+                        "does not include the 'pipewire' format. Install a PipeWire-enabled ffmpeg build, or run " +
+                        "under X11 (GDK_BACKEND=x11) to use x11grab instead.");
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                throw;
+            }
+            catch
+            {
+                // Could not verify PipeWire support — proceed and let ffmpeg fail if needed
+            }
+        }
     }
 
     public override Task BackAsync()
@@ -178,10 +211,24 @@ public class LinuxAppDriver : AppDriverBase
 
     public override Task PressKeyAsync(string key)
     {
-        // Use xdotool for key simulation on Linux
         if (!OperatingSystem.IsLinux())
             return Task.CompletedTask;
 
+        var tool = LinuxDisplayServer.GetPreferredInputTool();
+        switch (tool)
+        {
+            case InputTool.Xdotool:
+                return PressKeyWithXdotool(key);
+            case InputTool.Ydotool:
+                return PressKeyWithYdotool(key);
+            default:
+                // No input tool available — silent no-op (matches previous behavior)
+                return Task.CompletedTask;
+        }
+    }
+
+    private static Task PressKeyWithXdotool(string key)
+    {
         var xdotoolKey = MapToXdotoolKey(key);
         if (xdotoolKey == null) return Task.CompletedTask;
 
@@ -199,6 +246,31 @@ public class LinuxAppDriver : AppDriverBase
         catch
         {
             // xdotool may not be installed
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static Task PressKeyWithYdotool(string key)
+    {
+        var keyCode = MapToYdotoolKeyCode(key);
+        if (keyCode == null) return Task.CompletedTask;
+
+        try
+        {
+            // ydotool key syntax: <keycode>:1 <keycode>:0 (press then release)
+            var psi = new ProcessStartInfo("ydotool", $"key {keyCode}:1 {keyCode}:0")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            using var proc = Process.Start(psi);
+            proc?.WaitForExit(5000);
+        }
+        catch
+        {
+            // ydotool may not be installed or ydotoold not running
         }
 
         return Task.CompletedTask;
@@ -301,6 +373,24 @@ public class LinuxAppDriver : AppDriverBase
         "right" => "Right",
         "home" => "Home",
         "end" => "End",
+        _ => null
+    };
+
+    // Linux input event codes from linux/input-event-codes.h
+    private static string? MapToYdotoolKeyCode(string key) => key.ToLowerInvariant() switch
+    {
+        "enter" or "return" => "28",
+        "escape" or "back" => "1",
+        "tab" => "15",
+        "space" => "57",
+        "backspace" => "14",
+        "delete" => "111",
+        "up" => "103",
+        "down" => "108",
+        "left" => "105",
+        "right" => "106",
+        "home" => "102",
+        "end" => "107",
         _ => null
     };
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
@@ -175,20 +175,22 @@ public class LinuxAppDriver : AppDriverBase
         {
             try
             {
-                var psi = new ProcessStartInfo("ffmpeg", "-formats")
+                var psi = new ProcessStartInfo("ffmpeg", "-devices")
                 {
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false
                 };
                 using var proc = Process.Start(psi);
-                var output = proc?.StandardOutput.ReadToEnd() ?? "";
+                var stdout = proc?.StandardOutput.ReadToEnd() ?? "";
+                var stderr = proc?.StandardError.ReadToEnd() ?? "";
                 proc?.WaitForExit(5000);
-                if (!output.Contains("pipewire", StringComparison.OrdinalIgnoreCase))
+                if (!stdout.Contains("pipewire", StringComparison.OrdinalIgnoreCase) &&
+                    !stderr.Contains("pipewire", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new InvalidOperationException(
                         "Screen recording on Wayland requires ffmpeg with PipeWire support, but your ffmpeg build " +
-                        "does not include the 'pipewire' format. Install a PipeWire-enabled ffmpeg build, or run " +
+                        "does not include the 'pipewire' device. Install a PipeWire-enabled ffmpeg build, or run " +
                         "under X11 (GDK_BACKEND=x11) to use x11grab instead.");
                 }
             }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
@@ -94,7 +94,7 @@ public class LinuxAppDriver : AppDriverBase
             fullPath = Path.ChangeExtension(fullPath, ".mp4");
 
         var captureFormat = LinuxDisplayServer.GetFfmpegCaptureFormat();
-        var captureInput = LinuxDisplayServer.GetFfmpegCaptureInput();
+        var captureInput = LinuxDisplayServer.GetDefaultCaptureDisplay();
         var psi = new ProcessStartInfo("ffmpeg",
             $"-f {captureFormat} -framerate 30 -t {timeoutSeconds} -i {captureInput} -y \"{fullPath}\"")
         {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
@@ -243,7 +243,10 @@ public class LinuxAppDriver : AppDriverBase
                 UseShellExecute = false
             };
             using var proc = Process.Start(psi);
-            proc?.WaitForExit(5000);
+            if (proc != null && !proc.WaitForExit(5000))
+            {
+                try { proc.Kill(); } catch { }
+            }
         }
         catch
         {
@@ -268,7 +271,10 @@ public class LinuxAppDriver : AppDriverBase
                 UseShellExecute = false
             };
             using var proc = Process.Start(psi);
-            proc?.WaitForExit(5000);
+            if (proc != null && !proc.WaitForExit(5000))
+            {
+                try { proc.Kill(); } catch { }
+            }
         }
         catch
         {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxDisplayServer.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxDisplayServer.cs
@@ -55,20 +55,7 @@ internal static class LinuxDisplayServer
     {
         try
         {
-            var psi = new ProcessStartInfo("pgrep", "-x ydotoold")
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-            using var proc = Process.Start(psi);
-            if (proc == null) return false;
-            if (!proc.WaitForExit(3000))
-            {
-                try { proc.Kill(); } catch { }
-                return false;
-            }
-            return proc.ExitCode == 0;
+            return Process.GetProcessesByName("ydotoold").Length > 0;
         }
         catch
         {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxDisplayServer.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxDisplayServer.cs
@@ -34,8 +34,13 @@ internal static class LinuxDisplayServer
                 UseShellExecute = false
             };
             using var proc = Process.Start(psi);
-            proc?.WaitForExit(3000);
-            return proc?.ExitCode == 0;
+            if (proc == null) return false;
+            if (!proc.WaitForExit(3000))
+            {
+                try { proc.Kill(); } catch { }
+                return false;
+            }
+            return proc.ExitCode == 0;
         }
         catch
         {
@@ -57,8 +62,13 @@ internal static class LinuxDisplayServer
                 UseShellExecute = false
             };
             using var proc = Process.Start(psi);
-            proc?.WaitForExit(3000);
-            return proc?.ExitCode == 0;
+            if (proc == null) return false;
+            if (!proc.WaitForExit(3000))
+            {
+                try { proc.Kill(); } catch { }
+                return false;
+            }
+            return proc.ExitCode == 0;
         }
         catch
         {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxDisplayServer.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxDisplayServer.cs
@@ -104,9 +104,10 @@ internal static class LinuxDisplayServer
     public static string GetFfmpegCaptureFormat() => IsWayland ? "pipewire" : "x11grab";
 
     /// <summary>
-    /// Returns the ffmpeg input source for screen capture.
+    /// Returns the default capture display identifier for the current session.
+    /// For X11, returns the DISPLAY value (e.g. ":0"). For Wayland/PipeWire, returns "0".
     /// </summary>
-    public static string GetFfmpegCaptureInput()
+    public static string GetDefaultCaptureDisplay()
     {
         if (IsWayland)
             return "0"; // PipeWire default screen source

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxDisplayServer.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxDisplayServer.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics;
+
+namespace Microsoft.Maui.DevFlow.Driver;
+
+/// <summary>
+/// Detects the Linux display server (X11 vs Wayland) and available input automation tools.
+/// </summary>
+internal static class LinuxDisplayServer
+{
+    /// <summary>
+    /// Returns true if the current session is running on Wayland.
+    /// </summary>
+    public static bool IsWayland =>
+        string.Equals(Environment.GetEnvironmentVariable("XDG_SESSION_TYPE"), "wayland", StringComparison.OrdinalIgnoreCase)
+        || Environment.GetEnvironmentVariable("WAYLAND_DISPLAY") != null;
+
+    /// <summary>
+    /// Returns true if the current session is running on X11.
+    /// Falls back to true if the session type cannot be determined (legacy default).
+    /// </summary>
+    public static bool IsX11 => !IsWayland;
+
+    /// <summary>
+    /// Checks whether a command-line tool is available on PATH.
+    /// </summary>
+    public static bool IsToolAvailable(string toolName)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("which", toolName)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            using var proc = Process.Start(psi);
+            proc?.WaitForExit(3000);
+            return proc?.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if the ydotoold daemon is running (required for ydotool).
+    /// </summary>
+    public static bool IsYdotooldRunning()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("pgrep", "-x ydotoold")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            using var proc = Process.Start(psi);
+            proc?.WaitForExit(3000);
+            return proc?.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns the recommended input tool for the current session.
+    /// Prefers xdotool on X11, ydotool on Wayland. Falls back to whichever is available.
+    /// </summary>
+    public static InputTool GetPreferredInputTool()
+    {
+        var hasXdotool = IsToolAvailable("xdotool");
+        var hasYdotool = IsToolAvailable("ydotool");
+
+        if (IsWayland)
+        {
+            if (hasYdotool) return InputTool.Ydotool;
+            if (hasXdotool) return InputTool.Xdotool; // XWayland fallback
+            return InputTool.None;
+        }
+
+        // X11
+        if (hasXdotool) return InputTool.Xdotool;
+        if (hasYdotool) return InputTool.Ydotool;
+        return InputTool.None;
+    }
+
+    /// <summary>
+    /// Returns the recommended ffmpeg capture format for the current display server.
+    /// </summary>
+    public static string GetFfmpegCaptureFormat() => IsWayland ? "pipewire" : "x11grab";
+
+    /// <summary>
+    /// Returns the ffmpeg input source for screen capture.
+    /// </summary>
+    public static string GetFfmpegCaptureInput()
+    {
+        if (IsWayland)
+            return "0"; // PipeWire default screen source
+
+        var display = Environment.GetEnvironmentVariable("DISPLAY") ?? ":0";
+        return display;
+    }
+}
+
+internal enum InputTool
+{
+    None,
+    Xdotool,
+    Ydotool
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/LinuxDisplayServerTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/LinuxDisplayServerTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class LinuxDisplayServerTests : IDisposable
+{
+    private readonly string? _origSessionType;
+    private readonly string? _origWaylandDisplay;
+    private readonly string? _origDisplay;
+
+    public LinuxDisplayServerTests()
+    {
+        _origSessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+        _origWaylandDisplay = Environment.GetEnvironmentVariable("WAYLAND_DISPLAY");
+        _origDisplay = Environment.GetEnvironmentVariable("DISPLAY");
+    }
+
+    public void Dispose()
+    {
+        SetEnv("XDG_SESSION_TYPE", _origSessionType);
+        SetEnv("WAYLAND_DISPLAY", _origWaylandDisplay);
+        SetEnv("DISPLAY", _origDisplay);
+    }
+
+    private static void SetEnv(string name, string? value)
+    {
+        if (value == null)
+            Environment.SetEnvironmentVariable(name, null);
+        else
+            Environment.SetEnvironmentVariable(name, value);
+    }
+
+    // ── IsWayland / IsX11 detection ──
+
+    [Fact]
+    public void IsWayland_WhenXdgSessionTypeIsWayland_ReturnsTrue()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", "wayland");
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+
+        Assert.True(LinuxDisplayServer.IsWayland);
+        Assert.False(LinuxDisplayServer.IsX11);
+    }
+
+    [Fact]
+    public void IsWayland_WhenXdgSessionTypeIsWayland_CaseInsensitive()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", "Wayland");
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+
+        Assert.True(LinuxDisplayServer.IsWayland);
+    }
+
+    [Fact]
+    public void IsWayland_WhenWaylandDisplayIsSet_ReturnsTrue()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", null);
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", "wayland-0");
+
+        Assert.True(LinuxDisplayServer.IsWayland);
+        Assert.False(LinuxDisplayServer.IsX11);
+    }
+
+    [Fact]
+    public void IsX11_WhenSessionTypeIsX11_ReturnsTrue()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", "x11");
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+
+        Assert.True(LinuxDisplayServer.IsX11);
+        Assert.False(LinuxDisplayServer.IsWayland);
+    }
+
+    [Fact]
+    public void IsX11_WhenNoSessionVarsSet_DefaultsToX11()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", null);
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+
+        Assert.True(LinuxDisplayServer.IsX11);
+        Assert.False(LinuxDisplayServer.IsWayland);
+    }
+
+    // ── Ffmpeg capture format ──
+
+    [Fact]
+    public void GetFfmpegCaptureFormat_OnWayland_ReturnsPipewire()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", "wayland");
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+
+        Assert.Equal("pipewire", LinuxDisplayServer.GetFfmpegCaptureFormat());
+    }
+
+    [Fact]
+    public void GetFfmpegCaptureFormat_OnX11_ReturnsX11grab()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", "x11");
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+
+        Assert.Equal("x11grab", LinuxDisplayServer.GetFfmpegCaptureFormat());
+    }
+
+    // ── Default capture display ──
+
+    [Fact]
+    public void GetDefaultCaptureDisplay_OnWayland_ReturnsZero()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", "wayland");
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+
+        Assert.Equal("0", LinuxDisplayServer.GetDefaultCaptureDisplay());
+    }
+
+    [Fact]
+    public void GetDefaultCaptureDisplay_OnX11_ReturnsDisplayEnvVar()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", "x11");
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+        Environment.SetEnvironmentVariable("DISPLAY", ":1");
+
+        Assert.Equal(":1", LinuxDisplayServer.GetDefaultCaptureDisplay());
+    }
+
+    [Fact]
+    public void GetDefaultCaptureDisplay_OnX11_DefaultsToColonZero()
+    {
+        Environment.SetEnvironmentVariable("XDG_SESSION_TYPE", "x11");
+        Environment.SetEnvironmentVariable("WAYLAND_DISPLAY", null);
+        Environment.SetEnvironmentVariable("DISPLAY", null);
+
+        Assert.Equal(":0", LinuxDisplayServer.GetDefaultCaptureDisplay());
+    }
+
+    // ── IsYdotooldRunning ──
+
+    [Fact]
+    public void IsYdotooldRunning_DoesNotThrow()
+    {
+        // This should return a boolean without throwing, regardless of
+        // whether ydotoold is actually running on the test machine.
+        var result = LinuxDisplayServer.IsYdotooldRunning();
+        Assert.IsType<bool>(result);
+    }
+}


### PR DESCRIPTION
## Motivation

`LinuxAppDriver` hard-codes `xdotool` for key simulation and `ffmpeg -f x11grab` for screen recording -- both X11-only. GTK4 defaults to Wayland on modern distros, and GTK5 plans to drop X11 entirely, so these fail silently for most MAUI.Gtk users today.

## Approach

Detect the display server at runtime and use the appropriate tool automatically:

- **New `LinuxDisplayServer` helper** -- checks `XDG_SESSION_TYPE` and `WAYLAND_DISPLAY` env vars to detect X11 vs Wayland, probes tool availability (`xdotool`, `ydotool`, `ydotoold`), and selects the ffmpeg capture format
- **Dual-path key simulation** -- uses `xdotool` on X11 (human-readable key names) and `ydotool` on Wayland (Linux input event keycodes with press/release syntax). Falls back to whichever tool is available if the preferred one is missing
- **Dual-path screen recording** -- uses `ffmpeg -f x11grab` on X11 and `ffmpeg -f pipewire` on Wayland. Validates PipeWire support in the ffmpeg build before attempting capture on Wayland
- **Updated skill docs** -- expanded `linux.md` with Wayland setup instructions (ydotool permissions, PipeWire requirements), updated platform differences table, and new troubleshooting guidance

## Key design decisions

- **ydotool over wtype**: ydotool works on all Wayland compositors (GNOME, KDE, Sway, Hyprland) while wtype only works on wlroots-based compositors
- **Fallback strategy**: if running on Wayland but only xdotool is installed (XWayland scenario), we fall back to xdotool rather than doing nothing
- **ydotool keycodes**: uses Linux `input-event-codes.h` constants with explicit `:1`/`:0` press/release syntax (e.g., `key 28:1 28:0` for Enter)
- **Silent no-op preserved**: if neither tool is available, `PressKeyAsync()` silently returns, matching the previous behavior

## Things to note

- ydotool requires the `ydotoold` daemon and `/dev/uinput` permissions (documented in linux.md)
- PipeWire screen recording may trigger a system permission dialog on first use
- The `LinuxDisplayServer.IsYdotooldRunning()` check is available but not called in the hot path to avoid per-keystroke process spawning -- it's exposed for diagnostic use