### PR TITLE
Fix Linux GTK4 official build pool image

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -118,9 +118,12 @@ extends:
 
           - job: LinuxGtk4
             displayName: Linux GTK4 - Ubuntu
+            container:
+              image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals ubuntu.2404.amd64
+              image: build.azurelinux.3.amd64
+              os: linux
             strategy:
               matrix:
                 Release:


### PR DESCRIPTION
## Problem

The `LinuxGtk4` job in the official build pipeline fails with:

```
Image ubuntu.2404.amd64 doesn't exist in pool NetCore1ESPool-Internal
```

## Fix

Switch to the standard internal Linux pattern used by `dotnet/runtime`:

- **Host**: `build.azurelinux.3.amd64` (the only Linux image in `NetCore1ESPool-Internal`)
- **Container**: `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04`

This gives us an Ubuntu 24.04 environment with `apt-get` and the GTK4/WebKitGTK 6.0 dev packages, running on the approved internal pool.

### Reference

- [Arcade: ChoosingAMachinePool.md](https://github.com/dotnet/arcade/blob/main/Documentation/ChoosingAMachinePool.md) — documents `build.azurelinux.3.amd64` as the only internal Linux image
- [`dotnet/runtime` pipeline-with-resources.yml](https://github.com/dotnet/runtime/blob/main/eng/pipelines/common/templates/pipeline-with-resources.yml) — uses same `prereqs:ubuntu-24.04` container pattern