### PR TITLE
Fix internal CI signing for Linux GTK4 packages

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -124,44 +124,76 @@ extends:
                 $(_OfficialBuildArgs)
               displayName: Build and Test Cli
 
-          # TODO: Re-enable when dotnet-buildtools-prereqs image with GTK4 deps is available
-          # - job: LinuxGtk4
-          #   displayName: Linux GTK4 - Ubuntu
-          #   container: ubuntu2404
-          #   pool:
-          #     name: NetCore1ESPool-Internal
-          #     image: build.azurelinux.3.amd64
-          #     os: linux
-          #   strategy:
-          #     matrix:
-          #       Release:
-          #         _BuildConfig: Release
-          #         _OfficialBuildArgs: /p:DotNetSignType=$(_SignType)
-          #           /p:TeamName=$(_TeamName)
-          #           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          #   steps:
-          #   - task: UseDotNet@2
-          #     displayName: Install .NET SDK
-          #     inputs:
-          #       useGlobalJson: true
-          #   - script: |
-          #       sudo apt-get update
-          #       sudo apt-get install -y \
-          #         libgtk-4-dev \
-          #         libwebkitgtk-6.0-dev \
-          #         gobject-introspection \
-          #         libgirepository1.0-dev \
-          #         gir1.2-gtk-4.0 \
-          #         gir1.2-webkit-6.0 \
-          #         pkg-config
-          #     displayName: Install GTK4 dependencies
-          #   - script: |
-          #       ./eng/common/cibuild.sh \
-          #         --configuration $(_BuildConfig) \
-          #         --prepareMachine \
-          #         --projects $(Build.SourcesDirectory)/platforms/Linux.Gtk4/Linux.Gtk4.slnx \
-          #         $(_OfficialBuildArgs)
-          #     displayName: Build and Pack Linux GTK4
+          # The Linux GTK4 NuGet packages are pure managed (net10.0) assemblies
+          # using GirCore for GTK/WebKit bindings, so they build and pack on Windows.
+          # Running on Windows is required so MicroBuild/ESRP can sign the DLLs —
+          # signing does not execute on Linux agents.
+          - job: LinuxGtk4
+            displayName: Linux GTK4 - Windows
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+                  _OfficialBuildArgs: /p:DotNetSignType=$(_SignType)
+                    /p:TeamName=$(_TeamName)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            steps:
+            - task: UseDotNet@2
+              displayName: Install .NET SDK
+              inputs:
+                useGlobalJson: true
+            - script: eng\common\cibuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                -projects $(Build.SourcesDirectory)\platforms\Linux.Gtk4\Linux.Gtk4.slnx
+                $(_OfficialBuildArgs)
+              displayName: Build and Pack Linux GTK4
+
+          # Verification-only build on real Linux to catch any platform-specific
+          # build breaks. This job does NOT pack or publish artifacts — the
+          # shipping NuGet packages come from the Windows LinuxGtk4 job above
+          # so that MicroBuild/ESRP can sign the DLLs.
+          - job: LinuxGtk4_LinuxVerify
+            displayName: Linux GTK4 - Ubuntu (verify)
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals build.ubuntu.2204.amd64
+              os: linux
+            templateContext:
+              outputs: []
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+            steps:
+            - task: UseDotNet@2
+              displayName: Install .NET SDK
+              inputs:
+                useGlobalJson: true
+            - script: |
+                sudo apt-get update
+                sudo apt-get install -y \
+                  libgtk-4-dev \
+                  libwebkitgtk-6.0-dev \
+                  gobject-introspection \
+                  libgirepository1.0-dev \
+                  gir1.2-gtk-4.0 \
+                  gir1.2-webkit-6.0 \
+                  pkg-config
+              displayName: Install GTK4 dependencies
+            - script: |
+                ./eng/common/build.sh \
+                  --configuration $(_BuildConfig) \
+                  --restore \
+                  --build \
+                  --prepareMachine \
+                  --ci \
+                  --projects $(Build.SourcesDirectory)/platforms/Linux.Gtk4/Linux.Gtk4.slnx \
+                  /p:OfficialBuild=false
+              displayName: Build Linux GTK4 (no pack)
        
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/Linux.Gtk4.BlazorWebView.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/Linux.Gtk4.BlazorWebView.csproj
@@ -9,6 +9,7 @@
     <Description>Blazor Hybrid support for Microsoft.Maui.Platforms.Linux.Gtk4 — host Blazor components in a native GTK4 window using WebKitGTK.</Description>
     <PackageTags>maui;linux;blazor;webview;gtk;gtk4;webkit;webkitgtk;hybrid</PackageTags>
     <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Linux.Gtk4.Essentials.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Linux.Gtk4.Essentials.csproj
@@ -9,6 +9,7 @@
     <Description>MAUI Essentials implementations for Linux — clipboard, preferences, device info, connectivity, and more using GTK4, DBus, and freedesktop.org APIs.</Description>
     <PackageTags>maui;linux;essentials;gtk;gtk4;dbus;freedesktop;clipboard;preferences</PackageTags>
     <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj
@@ -9,6 +9,7 @@
     <Description>A .NET MAUI backend for Linux using GTK4. Run your MAUI apps natively on Linux desktops with real GTK4 widgets via GirCore bindings.</Description>
     <PackageTags>maui;linux;gtk;gtk4;desktop;dotnet;cross-platform;gircore</PackageTags>
     <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

The internal official build was failing in the **Signing Validation** stage with:

```
[File] Microsoft.Maui.Platforms.Linux.Gtk4.dll
  Signed: False [Error] HRESULT: 800b0100 (No signature was present in the subject)
[File] Microsoft.Maui.Platforms.Linux.Gtk4.Essentials.dll
  Signed: False [Error] HRESULT: 800b0100
```

(see [build 2953745](https://dev.azure.com/dnceng/internal/_build/results?buildId=2953745))

The two GTK4 DLLs were being packed into NuGet packages **completely unsigned** while every other first-party assembly was signed correctly.

## Root cause

The `LinuxGtk4` job in `eng/pipelines/devflow-official.yml` ran on an Ubuntu agent with `enableMicrobuild: true`. Per the [Arcade signing docs](https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Signing.md), MicroBuild/ESRP signing only executes on **Windows** agents — on Linux the Sign target effectively no-ops, so the DLLs landed in the `.nupkg` unsigned. The post-build Signing Validation stage then (correctly) failed.

## Fix

Move the shipping Linux GTK4 build to a Windows agent. The Linux GTK4 NuGet packages are pure managed (net10.0) assemblies using GirCore for GTK/WebKit bindings, so they build and pack on Windows without needing any native GTK/WebKit headers — those are only required at runtime on the end-user Linux machine.

### Pipeline changes

- **`LinuxGtk4` (Windows)** — runs `cibuild.cmd` against `Linux.Gtk4.slnx` on the same image as DevFlow/Cli. This produces the signed shipping nupkgs.
- **`LinuxGtk4_LinuxVerify` (Ubuntu 22.04)** — keeps a real-Linux smoke build to catch any platform-specific build breaks. Runs `build.sh --restore --build` only (no pack/publish), with `templateContext.outputs: []` so it produces no artifacts that could collide with the Windows job's signed nupkgs.

### Project changes

- Add `<IsShipping>true</IsShipping>` to `Linux.Gtk4`, `Linux.Gtk4.Essentials`, and `Linux.Gtk4.BlazorWebView` so signing/publishing infra includes them.

## Notes

- The arcade SDK update from earlier iterations was reverted (the changes under `eng/common/` are no longer part of this PR), so previous review comments on `eng/common/template-guidance.md` and `eng/common/core-templates/post-build/post-build.yml` no longer apply.
- Branch was rebased onto `main` and the fix-up commits squashed into a single change for clarity.
