### PR TITLE
fix: delegate ShouldInterceptRequest in DevFlowWebViewClient

### DIFF
--- a/src/DevFlow/Microsoft.Maui.DevFlow.Blazor/BlazorWebViewDebugService.Android.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Blazor/BlazorWebViewDebugService.Android.cs
@@ -137,6 +137,11 @@ internal class DevFlowWebViewClient : WebViewClient
         }
     }
 
+    public override WebResourceResponse? ShouldInterceptRequest(AWebView? view, IWebResourceRequest? request)
+    {
+        return _innerClient?.ShouldInterceptRequest(view, request) ?? base.ShouldInterceptRequest(view, request);
+    }
+
     public override bool ShouldOverrideUrlLoading(AWebView? view, IWebResourceRequest? request)
     {
         return _innerClient?.ShouldOverrideUrlLoading(view, request) ?? base.ShouldOverrideUrlLoading(view, request);


### PR DESCRIPTION
## Problem

`DevFlowWebViewClient` (added in 2c05e684) replaces MAUI's `WebKitWebViewClient` on Android to detect page navigation and re-inject chobitsu. However, it only delegates `OnPageFinished` and `ShouldOverrideUrlLoading` — it does **not** delegate `ShouldInterceptRequest`.

MAUI's `WebKitWebViewClient.ShouldInterceptRequest()` is the mechanism that serves local `wwwroot/` assets (CSS, JS, images) via the `https://0.0.0.1/` custom scheme. Without delegation, the base `WebViewClient` returns `null` ("don't intercept"), so all asset requests fail — the WebView tries to fetch from `0.0.0.1` over the network, which doesn't exist.

### Symptoms
- `index.html` loads (served separately as `HostPage`) but all CSS/JS fail
- `document.styleSheets.length === 0`, `typeof Blazor === "undefined"`
- App stuck on splash/loading screen
- Affects any MAUI Blazor Hybrid app using `AddMauiBlazorDevFlowTools()` on Android

### Affected versions
- **Working:** `0.1.0-preview.4.26202.3`
- **Broken:** `0.1.0-preview.5.26217.12`

## Fix

Add `ShouldInterceptRequest` override that delegates to the inner client, matching the existing pattern used for `ShouldOverrideUrlLoading`.

Fixes #101