### PR TITLE
Default Android JDK to 21

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
@@ -65,6 +65,39 @@ public class AndroidCommandsTests
 	}
 
 	[Fact]
+	public void InstallCommand_JdkVersionDefaultsToDefaultJdkVersion()
+	{
+		// Arrange
+		var androidCommand = AndroidCommands.Create();
+		var installCommand = androidCommand.Subcommands.First(c => c.Name == "install");
+		var jdkVersionOption = (Option<int>)installCommand.Options.First(o => o.Name == "--jdk-version");
+
+		// Act — no --jdk-version supplied, so the default value factory should resolve.
+		var parseResult = installCommand.Parse("install");
+
+		// Assert
+		Assert.Empty(parseResult.Errors);
+		Assert.Equal(Microsoft.Maui.Cli.Providers.Android.JdkManager.DefaultJdkVersion, parseResult.GetValue(jdkVersionOption));
+	}
+
+	[Fact]
+	public void JdkInstallCommand_VersionDefaultsToDefaultJdkVersion()
+	{
+		// Arrange
+		var androidCommand = AndroidCommands.Create();
+		var jdkCommand = androidCommand.Subcommands.First(c => c.Name == "jdk");
+		var jdkInstallCommand = jdkCommand.Subcommands.First(c => c.Name == "install");
+		var versionOption = (Option<int>)jdkInstallCommand.Options.First(o => o.Name == "--version");
+
+		// Act — no --version supplied, so the default value factory should resolve.
+		var parseResult = jdkInstallCommand.Parse("install");
+
+		// Assert
+		Assert.Empty(parseResult.Errors);
+		Assert.Equal(Microsoft.Maui.Cli.Providers.Android.JdkManager.DefaultJdkVersion, parseResult.GetValue(versionOption));
+	}
+
+	[Fact]
 	public void EmulatorCreateCommand_PackageIsOptional()
 	{
 		// Arrange

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -122,13 +122,13 @@ public class AndroidProviderTests
 				Message = "JDK 17"
 			});
 
-		public Task InstallAsync(int version = 17, string? installPath = null, CancellationToken cancellationToken = default) =>
+		public Task InstallAsync(int? version = null, string? installPath = null, CancellationToken cancellationToken = default) =>
 			Task.CompletedTask;
 
-		public Task InstallAsync(int version, string? installPath, Action<double, string>? onProgress, CancellationToken cancellationToken = default) =>
+		public Task InstallAsync(int? version, string? installPath, Action<double, string>? onProgress, CancellationToken cancellationToken = default) =>
 			Task.CompletedTask;
 
-		public IEnumerable<int> GetAvailableVersions() => [17, 21];
+		public IEnumerable<int> GetAvailableVersions() => JdkManager.SupportedInstallVersions;
 	}
 
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
@@ -47,7 +47,7 @@ public class FakeAndroidProvider : IAndroidProvider
 	/// Optional delegate invoked by <see cref="InstallAsync"/> so tests can simulate
 	/// progress reporting.
 	/// </summary>
-	public Action<string?, string?, int, IEnumerable<string>?, IProgress<string>?, CancellationToken>? InstallCallback { get; set; }
+	public Action<string?, string?, int?, IEnumerable<string>?, IProgress<string>?, CancellationToken>? InstallCallback { get; set; }
 
 	// --- Call tracking ---
 
@@ -58,9 +58,9 @@ public class FakeAndroidProvider : IAndroidProvider
 	public List<string> StoppedEmulators { get; } = new();
 	public List<List<string>> UninstalledPackageSets { get; } = new();
 	public int AcceptLicensesCalled { get; private set; }
-	public List<(string? SdkPath, string? JdkPath, int JdkVersion, List<string>? AdditionalPackages)> InstallCalls { get; } = new();
+	public List<(string? SdkPath, string? JdkPath, int? JdkVersion, List<string>? AdditionalPackages)> InstallCalls { get; } = new();
 	public List<string> InstallSdkToolsCalls { get; } = new();
-	public List<int> InstallJdkCalls { get; } = new();
+	public List<int?> InstallJdkCalls { get; } = new();
 	public bool Disposed { get; private set; }
 
 	// --- IAndroidProvider implementation ---
@@ -159,13 +159,13 @@ public class FakeAndroidProvider : IAndroidProvider
 	public (string Command, string Arguments)? GetLicenseAcceptanceCommand()
 		=> LicenseAcceptanceCommand;
 
-	public Task InstallJdkAsync(int version = 17, string? installPath = null, IProgress<string>? progress = null, CancellationToken cancellationToken = default)
+	public Task InstallJdkAsync(int? version = null, string? installPath = null, IProgress<string>? progress = null, CancellationToken cancellationToken = default)
 	{
 		InstallJdkCalls.Add(version);
 		return Task.CompletedTask;
 	}
 
-	public Task InstallAsync(string? sdkPath = null, string? jdkPath = null, int jdkVersion = 17, IEnumerable<string>? additionalPackages = null, bool acceptLicenses = false, IProgress<string>? progress = null, CancellationToken cancellationToken = default)
+	public Task InstallAsync(string? sdkPath = null, string? jdkPath = null, int? jdkVersion = null, IEnumerable<string>? additionalPackages = null, bool acceptLicenses = false, IProgress<string>? progress = null, CancellationToken cancellationToken = default)
 	{
 		InstallCalls.Add((sdkPath, jdkPath, jdkVersion, additionalPackages?.ToList()));
 		InstallCallback?.Invoke(sdkPath, jdkPath, jdkVersion, additionalPackages, progress, cancellationToken);

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeJdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeJdkManager.cs
@@ -24,11 +24,11 @@ public class FakeJdkManager : IJdkManager
 			Message = IsInstalled ? null : "JDK not found"
 		});
 
-	public Task InstallAsync(int version = 17, string? installPath = null, CancellationToken cancellationToken = default)
+	public Task InstallAsync(int? version = null, string? installPath = null, CancellationToken cancellationToken = default)
 		=> Task.CompletedTask;
 
-	public Task InstallAsync(int version, string? installPath, Action<double, string>? onProgress, CancellationToken cancellationToken = default)
+	public Task InstallAsync(int? version, string? installPath, Action<double, string>? onProgress, CancellationToken cancellationToken = default)
 		=> Task.CompletedTask;
 
-	public IEnumerable<int> GetAvailableVersions() => new[] { 17, 21 };
+	public IEnumerable<int> GetAvailableVersions() => JdkManager.SupportedInstallVersions;
 }

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -25,7 +25,7 @@ public static partial class AndroidCommands
 		{
 			new Option<string>("--sdk-path") { Description = "Custom SDK installation path" },
 			new Option<string>("--jdk-path") { Description = "Custom JDK installation path" },
-			new Option<int>("--jdk-version") { Description = "JDK version to install (17 or 21)", DefaultValueFactory = _ => 17 },
+			new Option<int>("--jdk-version") { Description = "JDK version to install (17 or 21)", DefaultValueFactory = _ => JdkManager.DefaultJdkVersion },
 			new Option<bool>("--accept-licenses") { Description = "Non-interactively accept all SDK licenses" },
 			packagesOption
 		};

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Jdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Jdk.cs
@@ -46,7 +46,7 @@ public static partial class AndroidCommands
 		// jdk install
 		var installCommand = new Command("install", "Install OpenJDK")
 		{
-			new Option<int>("--version") { Description = "JDK version (17 or 21)", DefaultValueFactory = _ => 17 },
+			new Option<int>("--version") { Description = "JDK version (17 or 21)", DefaultValueFactory = _ => JdkManager.DefaultJdkVersion },
 			new Option<string>("--path") { Description = "Installation path" }
 		};
 		installCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -353,23 +353,26 @@ public class AndroidProvider : IAndroidProvider
 		return (sdkManagerPath, "--licenses");
 	}
 
-	public async Task InstallJdkAsync(int version = 17, string? installPath = null,
+	public async Task InstallJdkAsync(int? version = null, string? installPath = null,
 		IProgress<string>? progress = null, CancellationToken cancellationToken = default)
 	{
-		progress?.Report($"Installing OpenJDK {version}...");
-		await _jdkManager.InstallAsync(version, installPath, cancellationToken);
+		var resolvedVersion = version ?? JdkManager.DefaultJdkVersion;
+		progress?.Report($"Installing OpenJDK {resolvedVersion}...");
+		await _jdkManager.InstallAsync(resolvedVersion, installPath, cancellationToken);
 		_jdkPath = installPath ?? PlatformDetector.Paths.DefaultJdkPath;
-		progress?.Report($"OpenJDK {version} installed to {_jdkPath}");
+		progress?.Report($"OpenJDK {resolvedVersion} installed to {_jdkPath}");
 	}
 
-	public async Task InstallAsync(string? sdkPath = null, string? jdkPath = null, int jdkVersion = 17,
+	public async Task InstallAsync(string? sdkPath = null, string? jdkPath = null, int? jdkVersion = null,
 		IEnumerable<string>? additionalPackages = null, bool acceptLicenses = false, IProgress<string>? progress = null, CancellationToken cancellationToken = default)
 	{
+		var resolvedJdkVersion = jdkVersion ?? JdkManager.DefaultJdkVersion;
+
 		// Step 1: Install JDK if not present
 		if (!IsJdkInstalled)
 		{
 			progress?.Report("Step 1/4: Installing JDK...");
-			await InstallJdkAsync(jdkVersion, jdkPath, progress, cancellationToken);
+			await InstallJdkAsync(resolvedJdkVersion, jdkPath, progress, cancellationToken);
 		}
 		else
 		{

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
@@ -123,14 +123,16 @@ public interface IAndroidProvider : IDisposable
 	(string Command, string Arguments)? GetLicenseAcceptanceCommand();
 
 	/// <summary>
-	/// Installs JDK if not present.
+	/// Installs JDK if not present. When <paramref name="version"/> is null,
+	/// <see cref="JdkManager.DefaultJdkVersion"/> is used.
 	/// </summary>
-	Task InstallJdkAsync(int version = 17, string? installPath = null, IProgress<string>? progress = null, CancellationToken cancellationToken = default);
+	Task InstallJdkAsync(int? version = null, string? installPath = null, IProgress<string>? progress = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Installs the Android development environment.
+	/// Installs the Android development environment. When <paramref name="jdkVersion"/> is null,
+	/// <see cref="JdkManager.DefaultJdkVersion"/> is used.
 	/// </summary>
-	Task InstallAsync(string? sdkPath = null, string? jdkPath = null, int jdkVersion = 17, IEnumerable<string>? additionalPackages = null, bool acceptLicenses = false, IProgress<string>? progress = null, CancellationToken cancellationToken = default);
+	Task InstallAsync(string? sdkPath = null, string? jdkPath = null, int? jdkVersion = null, IEnumerable<string>? additionalPackages = null, bool acceptLicenses = false, IProgress<string>? progress = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Installs Android SDK command-line tools with structured progress reporting.

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/IJdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/IJdkManager.cs
@@ -31,14 +31,15 @@ public interface IJdkManager
 	Task<HealthCheck> CheckHealthAsync(CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Installs JDK.
+	/// Installs JDK. When <paramref name="version"/> is null, <see cref="JdkManager.DefaultJdkVersion"/> is used.
 	/// </summary>
-	Task InstallAsync(int version = 17, string? installPath = null, CancellationToken cancellationToken = default);
+	Task InstallAsync(int? version = null, string? installPath = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Installs JDK with structured progress reporting.
+	/// Installs JDK with structured progress reporting. When <paramref name="version"/> is null,
+	/// <see cref="JdkManager.DefaultJdkVersion"/> is used.
 	/// </summary>
-	Task InstallAsync(int version, string? installPath, Action<double, string>? onProgress, CancellationToken cancellationToken = default);
+	Task InstallAsync(int? version, string? installPath, Action<double, string>? onProgress, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Gets available JDK versions for installation.

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/JdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/JdkManager.cs
@@ -13,9 +13,25 @@ namespace Microsoft.Maui.Cli.Providers.Android;
 /// </summary>
 public class JdkManager : IJdkManager
 {
-	const int DefaultJdkVersion = 17;
+	/// <summary>
+	/// The default JDK version installed by <c>maui android</c> commands when none is specified.
+	/// This is the single source of truth; all callers (CLI options, interfaces, fakes) should
+	/// reference this constant rather than hard-coding a version number.
+	/// </summary>
+	public const int DefaultJdkVersion = 21;
+
+	/// <summary>
+	/// JDK versions supported for automatic download and installation. Order matters:
+	/// the first entry is the default. Used by <see cref="GetAvailableVersions"/> and
+	/// <see cref="InstallAsync(int?, string?, CancellationToken)"/> validation.
+	/// </summary>
+	public static readonly IReadOnlyList<int> SupportedInstallVersions = new[] { DefaultJdkVersion, 17 };
+
+	/// <summary>
+	/// Minimum JDK major version accepted by health checks and fallback detection.
+	/// Versions older than this are considered unsupported for .NET MAUI Android builds.
+	/// </summary>
 	const int MinJdkVersion = 11;
-	const int MaxJdkVersion = 21;
 	const int DownloadBufferSize = 81920;
 
 	static readonly HttpClient s_httpClient = new() { Timeout = TimeSpan.FromMinutes(10) };
@@ -44,8 +60,12 @@ public class JdkManager : IJdkManager
 		// Searches Program Files, registry, known vendor paths, etc.
 		try
 		{
+			// Detection accepts any JDK >= MinJdkVersion. We deliberately don't cap the
+			// upper bound here: CheckHealthAsync only rejects versions below MinJdkVersion,
+			// so a user who has JDK 22/23/etc. installed should be found and used rather
+			// than ignored. Installation is separately gated by SupportedInstallVersions.
 			var knownJdk = Xamarin.Android.Tools.JdkInfo.GetKnownSystemJdkInfos(logger: (_, _) => { })
-				.Where(j => j.Version != null && j.Version.Major >= MinJdkVersion && j.Version.Major <= MaxJdkVersion)
+				.Where(j => j.Version != null && j.Version.Major >= MinJdkVersion)
 				.OrderByDescending(j => j.Version)
 				.FirstOrDefault();
 
@@ -100,7 +120,7 @@ public class JdkManager : IJdkManager
 				Fix = new FixInfo
 				{
 					IssueId = ErrorCodes.JdkNotFound,
-					Description = "Install OpenJDK 17",
+					Description = $"Install OpenJDK {DefaultJdkVersion}",
 					AutoFixable = true,
 					Command = "maui android jdk install"
 				}
@@ -159,7 +179,7 @@ public class JdkManager : IJdkManager
 		};
 	}
 
-	public async Task InstallAsync(int version = DefaultJdkVersion, string? installPath = null,
+	public async Task InstallAsync(int? version = null, string? installPath = null,
 		CancellationToken cancellationToken = default)
 	{
 		await InstallAsync(version, installPath, onProgress: null, cancellationToken);
@@ -168,21 +188,24 @@ public class JdkManager : IJdkManager
 	/// <summary>
 	/// Installs JDK with structured progress reporting for rich UI rendering.
 	/// </summary>
-	public async Task InstallAsync(int version, string? installPath,
+	public async Task InstallAsync(int? version, string? installPath,
 		Action<double, string>? onProgress, CancellationToken cancellationToken = default)
 	{
-		if (version < MinJdkVersion || version > MaxJdkVersion)
+		var resolvedVersion = version ?? DefaultJdkVersion;
+
+		if (!SupportedInstallVersions.Contains(resolvedVersion))
 		{
 			throw new MauiToolException(
 				ErrorCodes.JdkVersionUnsupported,
-				$"JDK version {version} is not supported. Supported versions: {MinJdkVersion}-{MaxJdkVersion}");
+				$"JDK version {resolvedVersion} is not available for installation. " +
+				$"Supported versions: {string.Join(", ", SupportedInstallVersions)}");
 		}
 
 		var targetPath = installPath ?? PlatformDetector.Paths.DefaultJdkPath;
 		Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
 
-		var downloadUrl = GetDownloadUrl(version);
-		var tempArchivePath = Path.Combine(Path.GetTempPath(), $"openjdk-{version}.tar.gz");
+		var downloadUrl = GetDownloadUrl(resolvedVersion);
+		var tempArchivePath = Path.Combine(Path.GetTempPath(), $"openjdk-{resolvedVersion}.tar.gz");
 
 		try
 		{
@@ -219,7 +242,7 @@ public class JdkManager : IJdkManager
 
 			// Update detected path
 			DetectedJdkPath = targetPath;
-			DetectedJdkVersion = version;
+			DetectedJdkVersion = resolvedVersion;
 		}
 		catch (Exception ex) when (ex is not MauiToolException)
 		{
@@ -332,9 +355,5 @@ public class JdkManager : IJdkManager
 		}
 	}
 
-	public IEnumerable<int> GetAvailableVersions()
-	{
-		yield return 17;
-		yield return 21;
-	}
+	public IEnumerable<int> GetAvailableVersions() => SupportedInstallVersions;
 }


### PR DESCRIPTION
Bumps the default JDK installed/used by the `maui android` CLI from OpenJDK 17 to OpenJDK 21.

### Changes
- `JdkManager.DefaultJdkVersion` 17 → 21
- `maui android install --jdk-version` default → 21
- `maui android jdk install --version` default → 21
- `IJdkManager.InstallAsync` / `IAndroidProvider.InstallJdkAsync` / `InstallAsync` default parameter → 21
- `GetAvailableVersions()` now lists 21 first, then 17
- Health-check fix description updated to reference the default version constant
- Test fakes and stubs updated to match the new signatures

### Compat
- Users who need 17 can still pass `--jdk-version 17` / `--version 17`.
- Existing JDK installs are unaffected; detection still supports OpenJDK 11+.

### Validation
- `dotnet build src/Cli/Cli.slnf` — succeeds
- `dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests` — 268/268 passing