### PR TITLE
Prompt interactively when Android SDK licenses not accepted

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
@@ -3,7 +3,9 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using Microsoft.Maui.Cli;
 using Microsoft.Maui.Cli.Commands;
+using Microsoft.Maui.Cli.UnitTests.Fakes;
 using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
@@ -200,5 +202,94 @@ public class AndroidCommandsTests
 		Assert.Contains(androidCommand.Subcommands, c => c.Name == "jdk");
 		Assert.Contains(androidCommand.Subcommands, c => c.Name == "sdk");
 		Assert.Contains(androidCommand.Subcommands, c => c.Name == "emulator");
+	}
+
+	// --- Handler-level tests for the JSON/non-Spectre 'android install' license preflight. ---
+	// These exercise the behavior added in PR #106: fail fast when the SDK is already
+	// installed and licenses aren't accepted, but don't block on a fresh machine where
+	// InstallAsync will bootstrap tools non-interactively.
+
+	static async Task<(int ExitCode, FakeAndroidProvider Android)> InvokeAndroidInstallJsonAsync(
+		Action<FakeAndroidProvider> configure,
+		params string[] extraArgs)
+	{
+		var fakeAndroid = new FakeAndroidProvider();
+		configure(fakeAndroid);
+
+		var testProvider = ServiceConfiguration.CreateTestServiceProvider(androidProvider: fakeAndroid);
+		var originalServices = Program.Services;
+		try
+		{
+			Program.Services = testProvider;
+
+			var rootCommand = Program.BuildRootCommand();
+			var args = new List<string> { "android", "install", "--json" };
+			args.AddRange(extraArgs);
+			var parseResult = rootCommand.Parse(args.ToArray());
+			var exitCode = await parseResult.InvokeAsync();
+			return (exitCode, fakeAndroid);
+		}
+		finally
+		{
+			Program.ResetServices();
+		}
+	}
+
+	[Fact]
+	public async Task InstallCommand_Json_FailsFast_WhenSdkInstalledAndLicensesNotAccepted()
+	{
+		var (exitCode, fake) = await InvokeAndroidInstallJsonAsync(f =>
+		{
+			f.IsSdkInstalled = true;
+			f.SdkPath = Path.Combine(Path.GetTempPath(), "sdk-test");
+			f.LicensesAccepted = false;
+		});
+
+		Assert.Equal(1, exitCode);
+		Assert.Empty(fake.InstallCalls);
+	}
+
+	[Fact]
+	public async Task InstallCommand_Json_ProceedsOnFreshMachine_WhenSdkNotInstalled()
+	{
+		// Regression: on a fresh machine the preflight should NOT block; InstallAsync
+		// is responsible for bootstrapping the SDK and (with --accept-licenses) accepting
+		// licenses non-interactively.
+		var (exitCode, fake) = await InvokeAndroidInstallJsonAsync(f =>
+		{
+			f.IsSdkInstalled = false;
+			f.LicensesAccepted = false;
+		});
+
+		Assert.Equal(0, exitCode);
+		Assert.Single(fake.InstallCalls);
+	}
+
+	[Fact]
+	public async Task InstallCommand_Json_Proceeds_WhenLicensesAlreadyAccepted()
+	{
+		var (exitCode, fake) = await InvokeAndroidInstallJsonAsync(f =>
+		{
+			f.IsSdkInstalled = true;
+			f.SdkPath = Path.Combine(Path.GetTempPath(), "sdk-test");
+			f.LicensesAccepted = true;
+		});
+
+		Assert.Equal(0, exitCode);
+		Assert.Single(fake.InstallCalls);
+	}
+
+	[Fact]
+	public async Task InstallCommand_Json_Proceeds_WhenAcceptLicensesFlagPassed()
+	{
+		var (exitCode, fake) = await InvokeAndroidInstallJsonAsync(f =>
+		{
+			f.IsSdkInstalled = true;
+			f.SdkPath = Path.Combine(Path.GetTempPath(), "sdk-test");
+			f.LicensesAccepted = false;
+		}, "--accept-licenses");
+
+		Assert.Equal(0, exitCode);
+		Assert.Single(fake.InstallCalls);
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -175,7 +175,7 @@ public static partial class AndroidCommands
 							onProgress: (pkg, idx, total) =>
 							{
 								var pct = (double)idx / total * 100;
-								pkgTask.Update(pct, $"Installing {pkg} ({idx + 1}/{total})");
+								pkgTask.Update(pct, $"Installing {pkg} ({idx}/{total})");
 							},
 							cancellationToken);
 						pkgTask.Complete($"{pkgList.Count} packages installed");
@@ -190,7 +190,7 @@ public static partial class AndroidCommands
 					{
 						formatter.WriteError(new Exception(
 							"Android SDK licenses have not been accepted. " +
-							"Re-run with --accept-licenses, or run 'maui android sdk accept-licenses' interactively."));
+							"Re-run this install command with --accept-licenses to bootstrap SDK tools and accept licenses non-interactively."));
 						return 1;
 					}
 
@@ -263,7 +263,26 @@ public static partial class AndroidCommands
 
 		using var process = System.Diagnostics.Process.Start(psi)
 			?? throw new InvalidOperationException("Failed to start sdkmanager --licenses");
-		await process.WaitForExitAsync(cancellationToken);
-		return process.ExitCode;
+
+		try
+		{
+			await process.WaitForExitAsync(cancellationToken);
+			return process.ExitCode;
+		}
+		catch (OperationCanceledException)
+		{
+			// Kill the child process tree so Ctrl+C doesn't leave an orphaned sdkmanager
+			// blocked on stdin.
+			if (!process.HasExited)
+			{
+				try { process.Kill(entireProcessTree: true); }
+				catch { /* Best-effort: process may have already exited. */ }
+
+				try { await process.WaitForExitAsync(CancellationToken.None); }
+				catch { /* Ignore cleanup failures; preserve original cancellation. */ }
+			}
+
+			throw;
+		}
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -118,19 +118,57 @@ public static partial class AndroidCommands
 						{
 							sdkTask.Complete("SDK Tools already installed");
 						}
+					});
 
-						// Step 3: Accept licenses (only if --accept-licenses)
+					// Step 3: Ensure licenses are accepted.
+					// - If --accept-licenses was passed, bulk-accept non-interactively.
+					// - Otherwise, if running interactively, hand stdin/stdout to `sdkmanager --licenses`
+					//   so the user can review and accept each license. The Spectre live renderer
+					//   has exited above, so child-process prompts are visible.
+					// - In CI/non-interactive mode without --accept-licenses, fail fast rather than hang.
+					var licensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);
+					if (!licensesAccepted)
+					{
 						if (acceptLicenses)
 						{
-							var licenseTask = ctx.AddTask("Accepting licenses");
-							licenseTask.SetIndeterminate("Checking licenses...");
-							await androidProvider.AcceptLicensesAsync(
-								onProgress: msg => licenseTask.SetIndeterminate(msg),
-								cancellationToken);
-							licenseTask.Complete("Licenses accepted");
+							await spectre.LiveProgressAsync(async (ctx) =>
+							{
+								var licenseTask = ctx.AddTask("Accepting licenses");
+								licenseTask.SetIndeterminate("Checking licenses...");
+								await androidProvider.AcceptLicensesAsync(
+									onProgress: msg => licenseTask.SetIndeterminate(msg),
+									cancellationToken);
+								licenseTask.Complete("Licenses accepted");
+							});
+						}
+						else if (isCi || Console.IsInputRedirected)
+						{
+							formatter.WriteError(new Exception(
+								"Android SDK licenses have not been accepted. " +
+								"Re-run with --accept-licenses, or run 'maui android sdk accept-licenses' interactively."));
+							return 1;
+						}
+						else
+						{
+							formatter.WriteInfo("Android SDK licenses must be accepted to continue.");
+							formatter.WriteInfo("Review each license and type 'y' to accept.\n");
+							var exitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+							if (exitCode != 0)
+							{
+								formatter.WriteError(new Exception(
+									$"License acceptance exited with code {exitCode}. Aborting install."));
+								return 1;
+							}
+							formatter.WriteSuccess("Licenses accepted");
 						}
 
-						// Step 4: Install packages
+						// Prevent per-package re-prompting during Step 4.
+						acceptLicenses = true;
+					}
+
+					// Step 4: Install packages
+					await spectre.LiveProgressAsync(async (ctx) =>
+					{
 						var pkgTask = ctx.AddTask($"Installing packages (0/{pkgList.Count})");
 						pkgTask.Update(0, $"Installing packages (0/{pkgList.Count})...");
 						await androidProvider.InstallPackagesAsync(pkgList, acceptLicenses,
@@ -145,6 +183,17 @@ public static partial class AndroidCommands
 				}
 				else
 				{
+					// JSON / non-Spectre path: non-interactive by nature. If licenses aren't
+					// already accepted and the caller didn't pass --accept-licenses, fail fast
+					// rather than letting sdkmanager block on stdin.
+					if (!acceptLicenses && !await androidProvider.AreLicensesAcceptedAsync(cancellationToken))
+					{
+						formatter.WriteError(new Exception(
+							"Android SDK licenses have not been accepted. " +
+							"Re-run with --accept-licenses, or run 'maui android sdk accept-licenses' interactively."));
+						return 1;
+					}
+
 					var progress = new Progress<string>(message =>
 					{
 						formatter.WriteProgress(message);
@@ -184,5 +233,37 @@ public static partial class AndroidCommands
 		});
 
 		return command;
+	}
+
+	/// <summary>
+	/// Spawns <c>sdkmanager --licenses</c> with inherited stdio so the user can review and
+	/// accept each SDK license interactively. Returns the child process exit code.
+	/// </summary>
+	static async Task<int> RunInteractiveLicenseAcceptanceAsync(
+		IAndroidProvider androidProvider,
+		CancellationToken cancellationToken)
+	{
+		var licenseCommand = androidProvider.GetLicenseAcceptanceCommand()
+			?? throw new InvalidOperationException(
+				"Android SDK is not installed (sdkmanager not found). " +
+				"Install the command-line tools first.");
+
+		var psi = new System.Diagnostics.ProcessStartInfo
+		{
+			FileName = licenseCommand.Command,
+			Arguments = licenseCommand.Arguments,
+			UseShellExecute = false,
+			RedirectStandardInput = false,
+			RedirectStandardOutput = false,
+			RedirectStandardError = false
+		};
+
+		foreach (var kvp in AndroidEnvironment.BuildEnvironmentVariables(androidProvider.SdkPath, androidProvider.JdkPath))
+			psi.Environment[kvp.Key] = kvp.Value;
+
+		using var process = System.Diagnostics.Process.Start(psi)
+			?? throw new InvalidOperationException("Failed to start sdkmanager --licenses");
+		await process.WaitForExitAsync(cancellationToken);
+		return process.ExitCode;
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -141,7 +141,7 @@ public static partial class AndroidCommands
 								licenseTask.Complete("Licenses accepted");
 							});
 						}
-						else if (isCi || Console.IsInputRedirected)
+						else if (isCi || Console.IsInputRedirected || Console.IsOutputRedirected)
 						{
 							formatter.WriteError(new Exception(
 								"Android SDK licenses have not been accepted. " +
@@ -161,10 +161,14 @@ public static partial class AndroidCommands
 							}
 							formatter.WriteSuccess("Licenses accepted");
 						}
-
-						// Prevent per-package re-prompting during Step 4.
-						acceptLicenses = true;
 					}
+
+					// By this point licenses are accepted (either already, bulk-accepted, or
+					// interactively accepted). Force acceptLicenses=true into Step 4 so that
+					// if a newly-requested package introduces an as-yet-unaccepted license,
+					// sdkmanager bulk-accepts it rather than blocking on stdin behind the
+					// live progress renderer.
+					acceptLicenses = true;
 
 					// Step 4: Install packages
 					await spectre.LiveProgressAsync(async (ctx) =>
@@ -183,10 +187,14 @@ public static partial class AndroidCommands
 				}
 				else
 				{
-					// JSON / non-Spectre path: non-interactive by nature. If licenses aren't
-					// already accepted and the caller didn't pass --accept-licenses, fail fast
-					// rather than letting sdkmanager block on stdin.
-					if (!acceptLicenses && !await androidProvider.AreLicensesAcceptedAsync(cancellationToken))
+					// JSON / non-Spectre path: non-interactive by nature. If the SDK is already
+					// installed and licenses aren't yet accepted, fail fast rather than letting
+					// sdkmanager block on stdin. If the SDK isn't installed yet, there's nothing
+					// to hang on — InstallAsync will bootstrap tools and (when acceptLicenses
+					// is true) accept licenses non-interactively.
+					if (!acceptLicenses
+						&& androidProvider.IsSdkInstalled
+						&& !await androidProvider.AreLicensesAcceptedAsync(cancellationToken))
 					{
 						formatter.WriteError(new Exception(
 							"Android SDK licenses have not been accepted. " +

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -458,11 +458,11 @@ public static partial class AndroidCommands
 					if (exitCode == 0)
 					{
 						formatter.WriteSuccess("License acceptance completed");
+						return 0;
 					}
-					else
-					{
-						formatter.WriteWarning($"License acceptance exited with code {exitCode}");
-					}
+
+					formatter.WriteWarning($"License acceptance exited with code {exitCode}");
+					return exitCode;
 				}
 				return 0;
 			}

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -454,34 +454,14 @@ public static partial class AndroidCommands
 					formatter.WriteInfo("Starting interactive license acceptance...");
 					formatter.WriteInfo("Review each license and type 'y' to accept.\n");
 
-					// Run sdkmanager --licenses interactively (inherits stdin/stdout)
-					var processInfo = new System.Diagnostics.ProcessStartInfo
+					var exitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+					if (exitCode == 0)
 					{
-						FileName = licenseCommand.Value.Command,
-						Arguments = licenseCommand.Value.Arguments,
-						UseShellExecute = false,
-						RedirectStandardInput = false,
-						RedirectStandardOutput = false,
-						RedirectStandardError = false
-					};
-
-					// Set environment variables for JDK/SDK
-					foreach (var kvp in AndroidEnvironment.BuildEnvironmentVariables(androidProvider.SdkPath, androidProvider.JdkPath))
-						processInfo.Environment[kvp.Key] = kvp.Value;
-
-					using var process = System.Diagnostics.Process.Start(processInfo);
-					if (process != null)
+						formatter.WriteSuccess("License acceptance completed");
+					}
+					else
 					{
-						await process.WaitForExitAsync(cancellationToken);
-
-						if (process.ExitCode == 0)
-						{
-							formatter.WriteSuccess("License acceptance completed");
-						}
-						else
-						{
-							formatter.WriteWarning($"License acceptance exited with code {process.ExitCode}");
-						}
+						formatter.WriteWarning($"License acceptance exited with code {exitCode}");
 					}
 				}
 				return 0;


### PR DESCRIPTION
## Problem

Running `maui android install` without `--accept-licenses` appeared to hang at `Installing platform-tools`:

```
Installing platform-tools (2/5) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  20% 20/100 bytes ⣷
```

Root cause: `sdkmanager` prompts on stdin for each SDK license (`'y'` to accept), but the Spectre live progress renderer owned the console surface — the prompt was invisible and input was swallowed. The process deadlocked.

## Fix

Restructure the Spectre branch of `maui android install` to:

1. Run **Step 1 (JDK)** and **Step 2 (SDK Tools)** inside a first `LiveProgressAsync` block.
2. **Exit the live renderer** and check `AreLicensesAcceptedAsync`.
3. If licenses aren't yet accepted:
   - `--accept-licenses` → bulk-accept non-interactively (as before).
   - **Interactive terminal** → spawn `sdkmanager --licenses` with inherited stdio so the user sees each license and types `y` natively. Same pattern used by `maui android sdk accept-licenses`.
   - **CI / non-interactive stdin** → fail fast with an actionable message instead of hanging.
4. Re-enter a second `LiveProgressAsync` block for **Step 4 (packages)**. Because licenses are now accepted, per-package prompts won't occur.

The JSON / non-Spectre path also gets a pre-flight license check so IDE integrations fail fast rather than hang.

## Test

- `dotnet build src/Cli/Cli.slnf` — clean.
- `dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests` — **268/268 passing**.
