### PR TITLE
Add 5 critical MCP tools: capabilities, back, key, gesture, batch

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -36,7 +36,8 @@ public static class McpServerHost
 			.WithTools<RecordingTools>()
 			.WithTools<PreferencesTools>()
 			.WithTools<PlatformTools>()
-			.WithTools<SensorTools>();
+			.WithTools<SensorTools>()
+			.WithTools<BatchTools>();
 
 		await builder.Build().RunAsync();
 	}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
@@ -95,6 +95,8 @@ public sealed class AgentTools
     {
         var agent = await session.GetAgentClientAsync(agentPort);
         var capabilities = await agent.GetCapabilitiesAsync();
+        if (capabilities.ValueKind == System.Text.Json.JsonValueKind.Undefined)
+            return "Agent not responding. Is the app running?";
         return CliJson.SerializeUntyped(capabilities, indented: false);
     }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
@@ -88,6 +88,16 @@ public sealed class AgentTools
         return $"Timeout after {timeout}s — no agent connected" + (app != null ? $" matching '{app}'" : "") + ".";
     }
 
+    [McpServerTool(Name = "maui_capabilities"), Description("Get the capabilities supported by the connected agent. Returns a JSON object describing available features (e.g., profiler, sensors, webview). Use this to check what the agent supports before calling other tools.")]
+    public static async Task<string> Capabilities(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        var agent = await session.GetAgentClientAsync(agentPort);
+        var capabilities = await agent.GetCapabilitiesAsync();
+        return CliJson.SerializeUntyped(capabilities, indented: false);
+    }
+
     [McpServerTool(Name = "maui_select_agent"), Description("Set the default agent for this MCP session. Subsequent tool calls will use this agent automatically without needing agentPort.")]
     public static string SelectAgent(
         McpAgentSession session,

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
@@ -10,9 +10,10 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 public sealed class BatchTools
 {
 	[McpServerTool(Name = "maui_batch"), Description("""
-		Execute multiple UI actions atomically in a single request. Actions run sequentially.
+		Execute multiple UI actions in a single request. Actions run sequentially and are not transactional.
+		Earlier actions are applied even if a later action fails.
 		The 'actionsJson' parameter must be a JSON array of action objects.
-		Each action object must have an "action" field specifying the operation.
+		Each action object must have an "action" (or "type") field specifying the operation.
 
 		Supported actions and their fields:
 		- {"action":"tap", "elementId":"<id>"}
@@ -25,21 +26,25 @@ public sealed class BatchTools
 		- {"action":"navigate", "route":"//page"}
 		- {"action":"back"}
 
+		Note: The backend accepts both "action" and "type" fields. For gesture actions,
+		use "action":"gesture" with a separate "type" field for the gesture kind.
+
 		Example: [{"action":"fill","elementId":"entry1","text":"hello"},{"action":"tap","elementId":"btn1"}]
 		""")]
 	public static async Task<string> Batch(
 		McpAgentSession session,
-		[Description("JSON array of action objects (see tool description for schema)")] string actionsJson,
+		[Description("JSON array of action objects. Each must have an 'action' or 'type' field (see tool description for schema)")] string actionsJson,
 		[Description("If true, continue executing remaining actions after a failure (default: false)")] bool continueOnError = false,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
-		JsonArray? parsed;
+		JsonArray parsed;
 		try
 		{
 			var node = JsonNode.Parse(actionsJson);
-			parsed = node?.AsArray();
-			if (parsed == null)
+			if (node is not JsonArray array)
 				return "Invalid input: 'actionsJson' must be a JSON array, not " + (node?.GetValueKind().ToString() ?? "null") + ".";
+
+			parsed = array;
 		}
 		catch (JsonException ex)
 		{

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
@@ -61,7 +61,7 @@ public sealed class BatchTools
 				return $"Invalid action at index {i}: expected a JSON object, got {parsed[i]?.GetValueKind().ToString() ?? "null"}.";
 
 			if (obj["action"] == null && obj["type"] == null)
-				return $"Invalid action at index {i}: must have an 'action' field (e.g., 'tap', 'fill', 'navigate').";
+				return $"Invalid action at index {i}: must have an 'action' or 'type' field (e.g., 'tap', 'fill', 'navigate').";
 
 			actions.Add(obj);
 		}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
@@ -1,0 +1,68 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Server;
+using Microsoft.Maui.Cli.DevFlow.Mcp;
+
+namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class BatchTools
+{
+	[McpServerTool(Name = "maui_batch"), Description("""
+		Execute multiple UI actions atomically in a single request. Actions run sequentially.
+		The 'actionsJson' parameter must be a JSON array of action objects.
+		Each action object must have an "action" field specifying the operation.
+
+		Supported actions and their fields:
+		- {"action":"tap", "elementId":"<id>"}
+		- {"action":"fill", "elementId":"<id>", "text":"<value>"}
+		- {"action":"clear", "elementId":"<id>"}
+		- {"action":"key", "key":"enter", "elementId":"<id>"}
+		- {"action":"focus", "elementId":"<id>"}
+		- {"action":"scroll", "elementId":"<id>", "deltaX":0, "deltaY":200}
+		- {"action":"gesture", "type":"swipe", "elementId":"<id>", "direction":"up"}
+		- {"action":"navigate", "route":"//page"}
+		- {"action":"back"}
+
+		Example: [{"action":"fill","elementId":"entry1","text":"hello"},{"action":"tap","elementId":"btn1"}]
+		""")]
+	public static async Task<string> Batch(
+		McpAgentSession session,
+		[Description("JSON array of action objects (see tool description for schema)")] string actionsJson,
+		[Description("If true, continue executing remaining actions after a failure (default: false)")] bool continueOnError = false,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		JsonArray? parsed;
+		try
+		{
+			var node = JsonNode.Parse(actionsJson);
+			parsed = node?.AsArray();
+			if (parsed == null)
+				return "Invalid input: 'actionsJson' must be a JSON array, not " + (node?.GetValueKind().ToString() ?? "null") + ".";
+		}
+		catch (JsonException ex)
+		{
+			return $"Invalid JSON in 'actionsJson': {ex.Message}";
+		}
+
+		if (parsed.Count == 0)
+			return "Empty actions array — nothing to execute.";
+
+		var actions = new List<JsonObject>();
+		for (int i = 0; i < parsed.Count; i++)
+		{
+			if (parsed[i] is not JsonObject obj)
+				return $"Invalid action at index {i}: expected a JSON object, got {parsed[i]?.GetValueKind().ToString() ?? "null"}.";
+
+			if (obj["action"] == null && obj["type"] == null)
+				return $"Invalid action at index {i}: must have an 'action' field (e.g., 'tap', 'fill', 'navigate').";
+
+			actions.Add(obj);
+		}
+
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.BatchAsync(actions, continueOnError);
+		return CliJson.SerializeUntyped(result, indented: false);
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
@@ -47,43 +47,59 @@ public sealed class InteractionTools
 			: $"Failed to clear element '{elementId}'.";
 	}
 
-	[McpServerTool(Name = "maui_key"), Description("Send a key press to an element or the app. Supported keys for Entry/Editor/SearchBar: 'enter' (submit or newline), 'backspace' (delete last character). Use 'text' parameter to type characters. Other keys may have no effect depending on the element type.")]
+	[McpServerTool(Name = "maui_key"), Description("Send a key press to an element. Supported keys for Entry/Editor/SearchBar: 'enter' (submit or newline), 'backspace' (delete last character). Use 'text' parameter to type characters. For reliable behavior, provide an element ID; omitting it may have no effect depending on the agent/platform implementation.")]
 	public static async Task<string> Key(
 		McpAgentSession session,
 		[Description("Key to press: 'enter', 'return', 'backspace', 'delete'")] string key,
-		[Description("Target element ID (optional — uses focused element if omitted)")] string? elementId = null,
+		[Description("Target element ID. Optional, but omitting it may result in no action; provide an element ID for reliable behavior.")] string? elementId = null,
 		[Description("Text to type character by character into the element")] string? text = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
 		var success = await agent.KeyAsync(key, elementId, text);
 		return success
-			? elementId is not null ? $"Sent key '{key}' to element '{elementId}'." : $"Sent key '{key}'."
-			: $"Failed to send key '{key}'. Element may not support keyboard input.";
+			? elementId is not null
+				? $"Sent key '{key}' to element '{elementId}'."
+				: $"Sent key '{key}' without a target element; it may have had no effect."
+			: $"Failed to send key '{key}'. The target element may not support keyboard input, or no target element was provided.";
 	}
 
-	[McpServerTool(Name = "maui_gesture"), Description("Perform a touch gesture on the app. Supported gesture types: 'swipe' (requires direction), 'tap', 'longpress'. Use maui_tap for simple taps — this tool is for advanced gestures like swiping.")]
+	[McpServerTool(Name = "maui_gesture"), Description("Perform a touch gesture on the app. Supported gesture types: 'swipe' (requires direction), 'tap', 'longpress', and 'long-press'. Use maui_tap for simple taps — this tool is for advanced gestures like swiping.")]
 	public static async Task<string> Gesture(
 		McpAgentSession session,
-		[Description("Gesture type: 'swipe', 'tap', or 'longpress'")] string type,
+		[Description("Gesture type: 'swipe', 'tap', 'longpress', or 'long-press'")] string type,
 		[Description("Target element ID (optional)")] string? elementId = null,
-		[Description("Swipe direction: 'up', 'down', 'left', 'right' (required for swipe)")] string? direction = null,
+		[Description("Swipe direction: 'up', 'down', 'left', or 'right' (required for swipe)")] string? direction = null,
 		[Description("Swipe distance in pixels (optional, uses default if omitted)")] double? distance = null,
 		[Description("Gesture duration in milliseconds (optional)")] int? durationMs = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
-		var validTypes = new[] { "swipe", "tap", "longpress" };
-		if (!validTypes.Contains(type, StringComparer.OrdinalIgnoreCase))
-			return $"Unsupported gesture type '{type}'. Supported types: {string.Join(", ", validTypes)}.";
+		var normalizedType = (type ?? string.Empty).Trim().ToLowerInvariant();
+		if (normalizedType == "long-press")
+			normalizedType = "longpress";
 
-		if (type.Equals("swipe", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(direction))
-			return "Swipe gesture requires a 'direction' parameter ('up', 'down', 'left', 'right').";
+		var validTypes = new[] { "swipe", "tap", "longpress" };
+		if (Array.IndexOf(validTypes, normalizedType) < 0)
+			return $"Unsupported gesture type '{type}'. Supported types: swipe, tap, longpress, long-press.";
+
+		string? normalizedDirection = null;
+		if (normalizedType == "swipe")
+		{
+			normalizedDirection = direction?.Trim().ToLowerInvariant();
+			var validDirections = new[] { "up", "down", "left", "right" };
+
+			if (string.IsNullOrEmpty(normalizedDirection))
+				return "Swipe gesture requires a 'direction' parameter ('up', 'down', 'left', 'right').";
+
+			if (Array.IndexOf(validDirections, normalizedDirection) < 0)
+				return $"Unsupported swipe direction '{direction}'. Supported directions: up, down, left, right.";
+		}
 
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var success = await agent.GestureAsync(type, elementId, direction, distance, durationMs);
+		var success = await agent.GestureAsync(normalizedType, elementId, normalizedDirection, distance, durationMs);
 		return success
-			? elementId is not null ? $"Performed {type} gesture on element '{elementId}'." : $"Performed {type} gesture."
-			: $"Failed to perform {type} gesture.";
+			? elementId is not null ? $"Performed {normalizedType} gesture on element '{elementId}'." : $"Performed {normalizedType} gesture."
+			: $"Failed to perform {normalizedType} gesture.";
 	}
 
 	[McpServerTool(Name = "maui_scroll"), Description("Scroll a ScrollView, CollectionView, or ListView. Supports delta-based scrolling, scrolling to an item index, or scrolling an element into view.")]

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
@@ -47,6 +47,45 @@ public sealed class InteractionTools
 			: $"Failed to clear element '{elementId}'.";
 	}
 
+	[McpServerTool(Name = "maui_key"), Description("Send a key press to an element or the app. Supported keys for Entry/Editor/SearchBar: 'enter' (submit or newline), 'backspace' (delete last character). Use 'text' parameter to type characters. Other keys may have no effect depending on the element type.")]
+	public static async Task<string> Key(
+		McpAgentSession session,
+		[Description("Key to press: 'enter', 'return', 'backspace', 'delete'")] string key,
+		[Description("Target element ID (optional — uses focused element if omitted)")] string? elementId = null,
+		[Description("Text to type character by character into the element")] string? text = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.KeyAsync(key, elementId, text);
+		return success
+			? elementId is not null ? $"Sent key '{key}' to element '{elementId}'." : $"Sent key '{key}'."
+			: $"Failed to send key '{key}'. Element may not support keyboard input.";
+	}
+
+	[McpServerTool(Name = "maui_gesture"), Description("Perform a touch gesture on the app. Supported gesture types: 'swipe' (requires direction), 'tap', 'longpress'. Use maui_tap for simple taps — this tool is for advanced gestures like swiping.")]
+	public static async Task<string> Gesture(
+		McpAgentSession session,
+		[Description("Gesture type: 'swipe', 'tap', or 'longpress'")] string type,
+		[Description("Target element ID (optional)")] string? elementId = null,
+		[Description("Swipe direction: 'up', 'down', 'left', 'right' (required for swipe)")] string? direction = null,
+		[Description("Swipe distance in pixels (optional, uses default if omitted)")] double? distance = null,
+		[Description("Gesture duration in milliseconds (optional)")] int? durationMs = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var validTypes = new[] { "swipe", "tap", "longpress" };
+		if (!validTypes.Contains(type, StringComparer.OrdinalIgnoreCase))
+			return $"Unsupported gesture type '{type}'. Supported types: {string.Join(", ", validTypes)}.";
+
+		if (type.Equals("swipe", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(direction))
+			return "Swipe gesture requires a 'direction' parameter ('up', 'down', 'left', 'right').";
+
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.GestureAsync(type, elementId, direction, distance, durationMs);
+		return success
+			? elementId is not null ? $"Performed {type} gesture on element '{elementId}'." : $"Performed {type} gesture."
+			: $"Failed to perform {type} gesture.";
+	}
+
 	[McpServerTool(Name = "maui_scroll"), Description("Scroll a ScrollView, CollectionView, or ListView. Supports delta-based scrolling, scrolling to an item index, or scrolling an element into view.")]
 	public static async Task<string> Scroll(
 		McpAgentSession session,

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NavigationTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NavigationTools.cs
@@ -20,6 +20,18 @@ public sealed class NavigationTools
 			: $"Failed to navigate to '{route}'. Route may not exist in the Shell.";
 	}
 
+	[McpServerTool(Name = "maui_back"), Description("Go back in the app navigation stack. Equivalent to pressing the system back button.")]
+	public static async Task<string> Back(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.BackAsync();
+		return success
+			? "Navigated back successfully."
+			: "Failed to navigate back. Navigation stack may be empty.";
+	}
+
 	[McpServerTool(Name = "maui_focus"), Description("Set focus to a UI element.")]
 	public static async Task<string> Focus(
 		McpAgentSession session,


### PR DESCRIPTION
## Summary

Closes the critical gap between DevFlow's AgentClient API and the MCP tool surface. After the v1 spec alignment (2c05e684), several new AgentClient methods had no MCP tools.

## New MCP Tools

| Tool | File | AgentClient Method | Description |
|---|---|---|---|
| `maui_capabilities` | AgentTools.cs | `GetCapabilitiesAsync` | Discover agent-supported features before using other tools |
| `maui_back` | NavigationTools.cs | `BackAsync` | System back navigation |
| `maui_key` | InteractionTools.cs | `KeyAsync` | Keyboard input (enter, backspace, text typing) |
| `maui_gesture` | InteractionTools.cs | `GestureAsync` | Touch gestures (swipe, tap, longpress) with validation |
| `maui_batch` | BatchTools.cs (new) | `BatchAsync` | Atomic multi-action sequences with JSON validation |

## Design Decisions

- **`maui_gesture`** validates types to the supported backend set (`swipe`, `tap`, `longpress`) and requires `direction` for swipes — fails fast instead of silently succeeding
- **`maui_key`** documents actual backend behavior (enter/backspace work on Entry/Editor/SearchBar; other keys may be no-ops)
- **`maui_batch`** accepts a JSON string with strict validation (array check, object check, action field check) with descriptive error messages
- **`maui_capabilities`** placed in AgentTools since it's agent metadata, not UI interaction

## Remaining Gaps (tracked in issues)

- **Profiler tools** (6 methods): #112
- **WebView interaction tools** (4+ methods): #113

## Testing

- ✅ Build passes (`dotnet build src/Cli/Microsoft.Maui.Cli/`)
- ✅ Existing 260 unit tests unaffected (12 pre-existing failures unchanged)
- Manual testing: use `maui devflow mcp` with a running MAUI app, or the equivalent CLI commands