### PR TITLE
ci: add stub workflow for review.agent discovery

### DIFF
--- a/.github/workflows/review.agent.lock.yml
+++ b/.github/workflows/review.agent.lock.yml
@@ -1,0 +1,29 @@
+# Stub workflow — enables discovery of review.agent.lock.yml so that
+# `gh workflow run review.agent.lock.yml --ref <branch>` works.
+# The real workflow lives on the feature branch; --ref executes THAT version.
+# This stub is safe to leave on main — it does nothing on its own.
+#
+# Once PR #118 (feat/expert-review-workflow) merges, this stub is replaced
+# by the real compiled workflow and can be removed.
+
+name: "Expert Code Review"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+
+permissions: {}
+
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "This is a stub workflow for discovery only."
+          echo "Use --ref <branch> to run the real workflow from a feature branch."
+          echo "See PR #118 for the full implementation."
+          exit 1

--- a/.github/workflows/review.agent.lock.yml
+++ b/.github/workflows/review.agent.lock.yml
@@ -20,10 +20,7 @@ permissions: {}
 
 jobs:
   stub:
+    if: false
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "This is a stub workflow for discovery only."
-          echo "Use --ref <branch> to run the real workflow from a feature branch."
-          echo "See PR #118 for the full implementation."
-          exit 1
+      - run: echo "Stub for discovery only. Use --ref <branch> to run the real workflow."


### PR DESCRIPTION
## Summary

Adds a minimal stub `review.agent.lock.yml` to main so that GitHub Actions can discover the `workflow_dispatch` trigger. This enables testing the real review workflow from the feature branch (`feat/expert-review-workflow`, PR #118) using:

```bash
gh workflow run review.agent.lock.yml --ref feat/expert-review-workflow -f pr_number=115
```

### Why this is needed

GitHub requires `workflow_dispatch` workflows to exist on the default branch before they can be triggered via API/CLI/UI. The real workflow only exists on `feat/expert-review-workflow` (PR #118).

### What it does

- The stub does nothing — it exits with failure if run directly
- It only serves as a discovery placeholder so `--ref` can dispatch the real workflow
- Once PR #118 merges, this stub is replaced by the real compiled workflow

### Safe to merge

- `permissions: {}` — no permissions granted
- The stub job just prints a message and exits 1
- No secrets, no checkout, no tools