### PR TITLE
fix: remove premature Graphene.Point.Free() calls causing heap corruption

### DIFF
--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/GtkViewHandler.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Handlers/GtkViewHandler.cs
@@ -281,7 +281,6 @@ public abstract class GtkViewHandler<TVirtualView, TPlatformView> : ViewHandler<
 		var anchorPt = Graphene.Point.Alloc();
 		anchorPt.Init(anchorX, anchorY);
 		transform = transform!.Translate(anchorPt)!;
-		anchorPt.Free();
 
 		if (hasRotation)
 			transform = transform.Rotate((float)view.Rotation)!;
@@ -292,7 +291,6 @@ public abstract class GtkViewHandler<TVirtualView, TPlatformView> : ViewHandler<
 		var negPt = Graphene.Point.Alloc();
 		negPt.Init(-anchorX, -anchorY);
 		transform = transform.Translate(negPt)!;
-		negPt.Free();
 
 		layoutPanel.SetChildTransform(widget, transform);
 	}

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkLayoutPanel.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkLayoutPanel.cs
@@ -125,7 +125,6 @@ public class GtkLayoutPanel : Gtk.Fixed
 					var pt = Graphene.Point.Alloc();
 					pt.Init((float)bounds.X, (float)bounds.Y);
 					transform = Gsk.Transform.New().Translate(pt);
-					pt.Free();
 				}
 				else
 				{


### PR DESCRIPTION
## Summary

Remove premature `Graphene.Point.Free()` calls that cause native heap corruption (use-after-free) during GTK rendering.

## Problem

After `Graphene.Point.Alloc()` + `Init()`, the point is passed to `Gsk.Transform.Translate(pt)`. The transform retains a reference to the point's native memory. Calling `pt.Free()` immediately after `Translate()` frees memory that the transform still uses, causing heap corruption during the next GTK render cycle.

### Crash signature
```
malloc_consolidate(): unaligned fastbin chunk detected
double free or corruption (fasttop)
```

### Reproduction conditions
Any app that combines:
- A `BlazorWebView` (WebKit GTK widget)
- A sibling view with non-zero `ZIndex` (e.g. a splash overlay with `ZIndex = 1000`)
- Complex children in the overlay (e.g. `BoxView` + `Label`)

The crash occurs because `GtkLayoutPanel.LayoutAllocateCallback` calls `Gsk.Transform.New().Translate(pt)` then `pt.Free()` for every child with non-zero bounds during layout. WebKit's Vulkan/NGL renderer later accesses the freed memory, triggering the corruption.

## Fix

Remove all `Graphene.Point.Free()` calls after `Gsk.Transform.Translate()`:

| File | Removed call |
|------|-------------|
| `GtkLayoutPanel.cs` | `pt.Free()` in layout allocate (line 128) |
| `GtkViewHandler.cs` | `anchorPt.Free()` in `MapTransformProperty` (line 282) |
| `GtkViewHandler.cs` | `negPt.Free()` in `MapTransformProperty` (line 293) |

The original Maui.Gtk code did not call `Free()` on these objects and ran without issues.

## Testing

Verified with [MauiSherpa](https://github.com/redth/MAUI.Sherpa) (a real-world MAUI Blazor Hybrid app with splash overlay using ZIndex):
- **Before fix**: Crashes immediately on launch with heap corruption
- **After fix**: Runs successfully, no crashes

Also verified the `GtkLayoutPanel.cs` `pt.Free()` removal alone is sufficient to fix the immediate crash. The `GtkViewHandler.cs` removals address the same pattern in the transform property mapper (latent bug that triggers when rotation/scale/translation is used).
