### PR TITLE
Fix duplicate Android emulator listing while AVD is booting

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -288,4 +288,121 @@ public class DeviceManagerTests
 		Assert.Equal("Pixel_6_API_35", devices[0].EmulatorId);
 		Assert.True(devices[0].IsRunning);
 	}
+
+	[Fact]
+	public async Task GetAllDevicesAsync_MergesOfflineEmulatorWithLockedAvd()
+	{
+		// Regression: while an emulator is booting, adb reports it as "Offline"
+		// with no AVD name populated. Previously this produced two entries
+		// (an unnamed offline serial plus a "Shutdown" AVD). The AVD's lock
+		// file lets us pair them into a single booting device.
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device
+				{
+					Id = "emulator-5554",
+					Name = "emulator-5554",
+					Platforms = new[] { "android" },
+					Type = DeviceType.Emulator,
+					State = DeviceState.Offline,
+					IsEmulator = true,
+					IsRunning = false,
+					Details = new JsonObject()
+				}
+			},
+			Avds = new List<AvdInfo>
+			{
+				new AvdInfo { Name = "Pixel_6_API_35", Target = "android-35", DeviceProfile = "pixel_6", IsLocked = true }
+			}
+		};
+
+		var manager = new DeviceManager(fakeAndroid);
+
+		var devices = await manager.GetAllDevicesAsync();
+
+		Assert.Single(devices);
+		Assert.Equal("emulator-5554", devices[0].Id);
+		Assert.Equal("Pixel_6_API_35", devices[0].EmulatorId);
+		Assert.Equal("Pixel_6_API_35", devices[0].Name);
+		Assert.Equal(DeviceState.Booting, devices[0].State);
+		Assert.NotNull(devices[0].Details);
+		Assert.Equal("Pixel_6_API_35", devices[0].Details!["avd"]?.ToString());
+	}
+
+	[Fact]
+	public async Task GetAllDevicesAsync_UnlockedAvdDoesNotMergeWithOfflineEmulator()
+	{
+		// If the AVD has no lock file we cannot safely pair it with an unnamed
+		// offline serial (it could belong to a different AVD). Leave both
+		// entries separate.
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device
+				{
+					Id = "emulator-5554",
+					Name = "emulator-5554",
+					Platforms = new[] { "android" },
+					Type = DeviceType.Emulator,
+					State = DeviceState.Offline,
+					IsEmulator = true,
+					IsRunning = false,
+					Details = new JsonObject()
+				}
+			},
+			Avds = new List<AvdInfo>
+			{
+				new AvdInfo { Name = "Pixel_6_API_35", Target = "android-35", IsLocked = false }
+			}
+		};
+
+		var manager = new DeviceManager(fakeAndroid);
+
+		var devices = await manager.GetAllDevicesAsync();
+
+		Assert.Equal(2, devices.Count);
+	}
+
+	[Fact]
+	public async Task GetAllDevicesAsync_LockedAvdDoesNotHijackAlreadyNamedEmulator()
+	{
+		// A named running emulator must not be "stolen" by a locked AVD with a
+		// different name. Each locked AVD only pairs with unnamed offline serials.
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device
+				{
+					Id = "emulator-5554",
+					Name = "Pixel_6_API_35",
+					Platforms = new[] { "android" },
+					Type = DeviceType.Emulator,
+					State = DeviceState.Booted,
+					IsEmulator = true,
+					IsRunning = true,
+					EmulatorId = "Pixel_6_API_35",
+					Details = new JsonObject { ["avd"] = "Pixel_6_API_35" }
+				}
+			},
+			Avds = new List<AvdInfo>
+			{
+				new AvdInfo { Name = "Pixel_6_API_35", Target = "android-35", IsLocked = true },
+				new AvdInfo { Name = "Other_AVD", Target = "android-34", IsLocked = true }
+			}
+		};
+
+		var manager = new DeviceManager(fakeAndroid);
+
+		var devices = await manager.GetAllDevicesAsync();
+
+		// Pixel_6_API_35 merged into running, Other_AVD added as separate Shutdown entry
+		// (the Other_AVD "lock" has no matching offline serial to pair with).
+		Assert.Equal(2, devices.Count);
+		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.IsRunning);
+		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && !d.IsRunning);
+	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -399,10 +399,74 @@ public class DeviceManagerTests
 
 		var devices = await manager.GetAllDevicesAsync();
 
-		// Pixel_6_API_35 merged into running, Other_AVD added as separate Shutdown entry
-		// (the Other_AVD "lock" has no matching offline serial to pair with).
+		// Pixel_6_API_35 merged into the running entry. Other_AVD has a lock
+		// file but no offline serial to pair with, so it surfaces as its own
+		// booting entry (not Shutdown).
 		Assert.Equal(2, devices.Count);
-		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.IsRunning);
-		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && !d.IsRunning);
+		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.IsRunning && d.State == DeviceState.Booted);
+		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && d.State == DeviceState.Booting && d.IsRunning);
+	}
+
+	[Fact]
+	public async Task GetAllDevicesAsync_LockedAvdWithoutMatchingSerialReportsBooting()
+	{
+		// Stale lock or early boot window: a locked AVD exists but adb has not
+		// listed any serial for it yet. The entry should surface as Booting so
+		// users don't see a misleading "Shutdown" state.
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			Devices = new List<Device>(),
+			Avds = new List<AvdInfo>
+			{
+				new AvdInfo { Name = "Pixel_6_API_35", Target = "android-35", IsLocked = true }
+			}
+		};
+
+		var manager = new DeviceManager(fakeAndroid);
+
+		var devices = await manager.GetAllDevicesAsync();
+
+		Assert.Single(devices);
+		Assert.Equal(DeviceState.Booting, devices[0].State);
+		Assert.True(devices[0].IsRunning);
+	}
+
+	[Fact]
+	public async Task GetAllDevicesAsync_LockedAvdDoesNotHijackNonOfflineEmulator()
+	{
+		// A Booted/Connected emulator that momentarily lacks an AVD name (e.g.
+		// transient adb gap) must not be paired with a locked AVD. Only Offline
+		// serials are eligible for lock-based fallback pairing.
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			Devices = new List<Device>
+			{
+				new Device
+				{
+					Id = "emulator-5554",
+					Name = "emulator-5554",
+					Platforms = new[] { "android" },
+					Type = DeviceType.Emulator,
+					State = DeviceState.Booted,
+					IsEmulator = true,
+					IsRunning = true,
+					Details = new JsonObject()
+				}
+			},
+			Avds = new List<AvdInfo>
+			{
+				new AvdInfo { Name = "Pixel_6_API_35", Target = "android-35", IsLocked = true }
+			}
+		};
+
+		var manager = new DeviceManager(fakeAndroid);
+
+		var devices = await manager.GetAllDevicesAsync();
+
+		// Two separate entries: the booted serial (untouched) and the locked AVD
+		// surfaced as its own Booting entry.
+		Assert.Equal(2, devices.Count);
+		Assert.Contains(devices, d => d.Id == "emulator-5554" && d.State == DeviceState.Booted && string.IsNullOrEmpty(d.EmulatorId));
+		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.State == DeviceState.Booting);
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -401,23 +401,22 @@ public class DeviceManagerTests
 
 		// Pixel_6_API_35 merged into the running entry. Other_AVD has a lock
 		// file but no offline serial to pair with, so it surfaces as its own
-		// Booted entry (lock files prove the qemu process is alive but we
-		// have no adb evidence of an in-progress boot).
+		// Booting entry (we can't confirm boot completion without adb; the
+		// merge path will flip it to Booted on the next refresh once adb
+		// registers the serial).
 		Assert.Equal(2, devices.Count);
 		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.IsRunning && d.State == DeviceState.Booted);
-		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && d.State == DeviceState.Booted && d.IsRunning);
+		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && d.State == DeviceState.Booting && d.IsRunning);
 	}
 
 	[Fact]
-	public async Task GetAllDevicesAsync_LockedAvdWithoutMatchingSerialReportsBooted()
+	public async Task GetAllDevicesAsync_LockedAvdWithoutMatchingSerialReportsBooting()
 	{
-		// Stale lock file or adb-blind fully-booted emulator: a locked AVD
-		// exists but adb has not listed any serial for it. Lock files tell us
-		// the qemu process is alive; they cannot tell us boot state. Since the
-		// merge path already surfaces Booting when adb sees the serial as
-		// Offline (the live evidence of an in-progress boot), the else branch
-		// defaulting to Booted matches the far more common cause of this state
-		// (adb blind to a running emulator).
+		// Early boot window: a locked AVD exists but adb has not yet listed
+		// any serial for it. Lock files prove the qemu process is alive but
+		// can't confirm boot completion. Report Booting (the common case
+		// during startup); the merge path will surface Booted once adb
+		// registers the emulator on a later refresh.
 		var fakeAndroid = new FakeAndroidProvider
 		{
 			Devices = new List<Device>(),
@@ -432,7 +431,7 @@ public class DeviceManagerTests
 		var devices = await manager.GetAllDevicesAsync();
 
 		Assert.Single(devices);
-		Assert.Equal(DeviceState.Booted, devices[0].State);
+		Assert.Equal(DeviceState.Booting, devices[0].State);
 		Assert.True(devices[0].IsRunning);
 	}
 
@@ -469,11 +468,10 @@ public class DeviceManagerTests
 		var devices = await manager.GetAllDevicesAsync();
 
 		// Two separate entries: the booted serial (untouched) and the locked AVD
-		// surfaced as its own Booted entry (lock files indicate a live qemu
-		// process; the else branch defaults to Booted since adb has no
-		// evidence of an in-progress boot).
+		// surfaced as its own Booting entry (the else branch defaults to
+		// Booting when adb has no serial to pair with).
 		Assert.Equal(2, devices.Count);
 		Assert.Contains(devices, d => d.Id == "emulator-5554" && d.State == DeviceState.Booted && string.IsNullOrEmpty(d.EmulatorId));
-		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.State == DeviceState.Booted);
+		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.State == DeviceState.Booting);
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -407,7 +407,7 @@ public class DeviceManagerTests
 		// registers the serial).
 		Assert.Equal(2, devices.Count);
 		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.IsRunning && d.State == DeviceState.Booted);
-		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && d.State == DeviceState.Booting && d.IsRunning);
+		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && d.State == DeviceState.Booting && !d.IsRunning);
 	}
 
 	[Fact]
@@ -433,7 +433,10 @@ public class DeviceManagerTests
 
 		Assert.Single(devices);
 		Assert.Equal(DeviceState.Booting, devices[0].State);
-		Assert.True(devices[0].IsRunning);
+		// IsRunning stays false: we have no adb serial, so the entry is not
+		// addressable via `adb -s <id>`. Display shows Booting for UX, but
+		// running-device consumers must not auto-select this target.
+		Assert.False(devices[0].IsRunning);
 	}
 
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -327,6 +327,7 @@ public class DeviceManagerTests
 		Assert.Equal("Pixel_6_API_35", devices[0].EmulatorId);
 		Assert.Equal("Pixel_6_API_35", devices[0].Name);
 		Assert.Equal(DeviceState.Booting, devices[0].State);
+		Assert.True(devices[0].IsRunning, "Booting emulator must report IsRunning=true (qemu is alive)");
 		Assert.NotNull(devices[0].Details);
 		Assert.Equal("Pixel_6_API_35", devices[0].Details!["avd"]?.ToString());
 	}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -401,18 +401,23 @@ public class DeviceManagerTests
 
 		// Pixel_6_API_35 merged into the running entry. Other_AVD has a lock
 		// file but no offline serial to pair with, so it surfaces as its own
-		// booting entry (not Shutdown).
+		// Booted entry (lock files prove the qemu process is alive but we
+		// have no adb evidence of an in-progress boot).
 		Assert.Equal(2, devices.Count);
 		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.IsRunning && d.State == DeviceState.Booted);
-		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && d.State == DeviceState.Booting && d.IsRunning);
+		Assert.Contains(devices, d => d.EmulatorId == "Other_AVD" && d.State == DeviceState.Booted && d.IsRunning);
 	}
 
 	[Fact]
-	public async Task GetAllDevicesAsync_LockedAvdWithoutMatchingSerialReportsBooting()
+	public async Task GetAllDevicesAsync_LockedAvdWithoutMatchingSerialReportsBooted()
 	{
-		// Stale lock or early boot window: a locked AVD exists but adb has not
-		// listed any serial for it yet. The entry should surface as Booting so
-		// users don't see a misleading "Shutdown" state.
+		// Stale lock file or adb-blind fully-booted emulator: a locked AVD
+		// exists but adb has not listed any serial for it. Lock files tell us
+		// the qemu process is alive; they cannot tell us boot state. Since the
+		// merge path already surfaces Booting when adb sees the serial as
+		// Offline (the live evidence of an in-progress boot), the else branch
+		// defaulting to Booted matches the far more common cause of this state
+		// (adb blind to a running emulator).
 		var fakeAndroid = new FakeAndroidProvider
 		{
 			Devices = new List<Device>(),
@@ -427,7 +432,7 @@ public class DeviceManagerTests
 		var devices = await manager.GetAllDevicesAsync();
 
 		Assert.Single(devices);
-		Assert.Equal(DeviceState.Booting, devices[0].State);
+		Assert.Equal(DeviceState.Booted, devices[0].State);
 		Assert.True(devices[0].IsRunning);
 	}
 
@@ -464,9 +469,11 @@ public class DeviceManagerTests
 		var devices = await manager.GetAllDevicesAsync();
 
 		// Two separate entries: the booted serial (untouched) and the locked AVD
-		// surfaced as its own Booting entry.
+		// surfaced as its own Booted entry (lock files indicate a live qemu
+		// process; the else branch defaults to Booted since adb has no
+		// evidence of an in-progress boot).
 		Assert.Equal(2, devices.Count);
 		Assert.Contains(devices, d => d.Id == "emulator-5554" && d.State == DeviceState.Booted && string.IsNullOrEmpty(d.EmulatorId));
-		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.State == DeviceState.Booting);
+		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.State == DeviceState.Booted);
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Output/SpectreOutputFormatter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/SpectreOutputFormatter.cs
@@ -120,6 +120,7 @@ public class SpectreOutputFormatter : IOutputFormatter
 			{
 				DeviceState.Booted => "green",
 				DeviceState.Connected => "green",
+				DeviceState.Booting => "yellow",
 				DeviceState.Shutdown => "grey",
 				DeviceState.Offline => "red",
 				_ => "white"

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AvdManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AvdManager.cs
@@ -157,7 +157,38 @@ public class AvdManager
 			SystemImage = systemImage,
 			Target = target,
 			Path = avd.Path,
+			IsLocked = IsAvdLocked(avd.Path),
 		};
+	}
+
+	/// <summary>
+	/// Returns <c>true</c> when the AVD directory contains a runtime lock file,
+	/// which the Android emulator creates when an instance is starting, booting
+	/// or already running for this AVD. On Windows these are directories
+	/// (e.g. <c>hardware-qemu.ini.lock\</c>); on macOS/Linux they are regular
+	/// files — checking existence works in both cases.
+	/// </summary>
+	static bool IsAvdLocked(string? avdPath)
+	{
+		if (string.IsNullOrEmpty(avdPath))
+			return false;
+
+		try
+		{
+			// The emulator writes several lock markers; hardware-qemu.ini.lock is
+			// the most reliable one — present for the entire lifetime of a running
+			// instance. multiinstance.lock is also checked as a fallback.
+			return Directory.Exists(avdPath) && (
+				File.Exists(System.IO.Path.Combine(avdPath, "hardware-qemu.ini.lock")) ||
+				Directory.Exists(System.IO.Path.Combine(avdPath, "hardware-qemu.ini.lock")) ||
+				File.Exists(System.IO.Path.Combine(avdPath, "multiinstance.lock")) ||
+				Directory.Exists(System.IO.Path.Combine(avdPath, "multiinstance.lock")));
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Trace.WriteLine($"AVD lock check failed for '{avdPath}': {ex.Message}");
+			return false;
+		}
 	}
 
 	public async Task<AvdInfo> CreateAvdAsync(string name, string deviceProfile, string systemImage,

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AvdManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AvdManager.cs
@@ -164,9 +164,9 @@ public class AvdManager
 	/// <summary>
 	/// Returns <c>true</c> when the AVD directory contains a runtime lock file,
 	/// which the Android emulator creates when an instance is starting, booting
-	/// or already running for this AVD. On Windows these are directories
-	/// (e.g. <c>hardware-qemu.ini.lock\</c>); on macOS/Linux they are regular
-	/// files — checking existence works in both cases.
+	/// or already running for this AVD. On Windows the lock is a directory
+	/// (e.g. <c>hardware-qemu.ini.lock\</c>); on macOS/Linux it is a regular
+	/// file — checking existence works in both cases.
 	/// </summary>
 	static bool IsAvdLocked(string? avdPath)
 	{
@@ -175,14 +175,18 @@ public class AvdManager
 
 		try
 		{
-			// The emulator writes several lock markers; hardware-qemu.ini.lock is
-			// the most reliable one — present for the entire lifetime of a running
-			// instance. multiinstance.lock is also checked as a fallback.
-			return Directory.Exists(avdPath) && (
-				File.Exists(System.IO.Path.Combine(avdPath, "hardware-qemu.ini.lock")) ||
-				Directory.Exists(System.IO.Path.Combine(avdPath, "hardware-qemu.ini.lock")) ||
-				File.Exists(System.IO.Path.Combine(avdPath, "multiinstance.lock")) ||
-				Directory.Exists(System.IO.Path.Combine(avdPath, "multiinstance.lock")));
+			// Only hardware-qemu.ini.lock is a reliable aliveness marker —
+			// the emulator holds it for the entire lifetime of a running
+			// instance and the OS releases it when the process exits
+			// (on Windows it's a directory locked via a sentinel file;
+			// on macOS/Linux it's an fcntl-held file that disappears on
+			// clean shutdown). multiinstance.lock is NOT reliable — it is
+			// a plain empty file that Android's emulator frequently leaves
+			// behind after a crash or ungraceful shutdown, producing
+			// false positives for shutdown AVDs.
+			var qemuLock = System.IO.Path.Combine(avdPath, "hardware-qemu.ini.lock");
+			return Directory.Exists(avdPath) &&
+				(File.Exists(qemuLock) || Directory.Exists(qemuLock));
 		}
 		catch (Exception ex)
 		{

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AvdManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AvdManager.cs
@@ -175,15 +175,17 @@ public class AvdManager
 
 		try
 		{
-			// Only hardware-qemu.ini.lock is a reliable aliveness marker —
-			// the emulator holds it for the entire lifetime of a running
-			// instance and the OS releases it when the process exits
-			// (on Windows it's a directory locked via a sentinel file;
-			// on macOS/Linux it's an fcntl-held file that disappears on
-			// clean shutdown). multiinstance.lock is NOT reliable — it is
-			// a plain empty file that Android's emulator frequently leaves
-			// behind after a crash or ungraceful shutdown, producing
-			// false positives for shutdown AVDs.
+			// Best-effort heuristic, NOT a guarantee. The emulator creates
+			// hardware-qemu.ini.lock when a qemu instance starts and removes
+			// it during clean shutdown via its own atexit handler. The OS
+			// does NOT remove this file/directory on process exit, so a
+			// SIGKILL/taskkill/power-loss leaves a stale marker on disk
+			// until the AVD is launched again (the emulator cleans stale
+			// markers on startup). multiinstance.lock is worse — it has no
+			// cleanup mechanism at all and is widely known to linger after
+			// any ungraceful shutdown, so we do not use it.
+			// Known follow-up: Android Studio's authoritative signal is
+			// $HOME/.android/avd/running/pid_NNNN.ini + a live ProcessHandle.
 			var qemuLock = System.IO.Path.Combine(avdPath, "hardware-qemu.ini.lock");
 			return Directory.Exists(avdPath) &&
 				(File.Exists(qemuLock) || Directory.Exists(qemuLock));

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
@@ -151,6 +151,14 @@ public record AvdInfo
 	public string? SystemImage { get; init; }
 	public string? Target { get; init; }
 	public string? Path { get; init; }
+
+	/// <summary>
+	/// True when the AVD directory contains a runtime lock file
+	/// (e.g. <c>hardware-qemu.ini.lock</c>), indicating that an
+	/// emulator instance is currently starting, booting, or running
+	/// for this AVD.
+	/// </summary>
+	public bool IsLocked { get; init; }
 }
 
 /// <summary>

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -162,6 +162,13 @@ public class DeviceManager : IDeviceManager
 					// broken adb server (blind to a fully booted device).
 					// That is a user-environment issue (restart adb) rather
 					// than something we can reliably detect from lock files.
+					// IsRunning stays false in this branch even when the AVD
+					// is locked: we have no adb serial, so the entry is NOT
+					// addressable via `adb -s <id>`. Consumers like the
+					// profile command filter on IsRunning and then pass
+					// device.Id to adb — marking this IsRunning=true would
+					// let `maui profile --device <avd_name>` auto-select an
+					// un-addressable target and fail downstream.
 					devices.Add(new Device
 					{
 						Id = avd.Name,
@@ -170,7 +177,7 @@ public class DeviceManager : IDeviceManager
 						Type = DeviceType.Emulator,
 						State = avd.IsLocked ? DeviceState.Booting : DeviceState.Shutdown,
 						IsEmulator = true,
-						IsRunning = avd.IsLocked,
+						IsRunning = false,
 						ConnectionType = Models.ConnectionType.Local,
 						EmulatorId = avd.Name,
 						Model = avd.DeviceProfile,

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -136,13 +136,27 @@ public class DeviceManager : IDeviceManager
 					var resolvedAbi = abi ?? (PlatformDetector.IsArm64 ? "arm64-v8a" : "x86_64");
 					var versionName = AndroidEnvironment.MapApiLevelToVersion(apiLevel);
 					var subModel = AndroidEnvironment.MapTagIdToSubModel(tagId, playStoreEnabled);
+
+					// Lock files signal that the emulator qemu process is alive,
+					// but they do not distinguish "still booting" from "fully
+					// booted". The merge path above already surfaces Booting
+					// when adb sees the serial as Offline — the live evidence
+					// of an in-progress boot. When we reach this else branch
+					// adb did not list any serial for this AVD, which in
+					// practice means either the emulator is fully booted but
+					// adb is blind to it (server restart, port conflict,
+					// stale lock file), or we are in the very short <1s
+					// window before adb first registers the serial. Reporting
+					// Booted here matches the far more common case and the
+					// next refresh will naturally correct short-lived early-
+					// boot misreads via the merge path.
 					devices.Add(new Device
 					{
 						Id = avd.Name,
 						Name = avd.Name,
 						Platforms = new[] { "android" },
 						Type = DeviceType.Emulator,
-						State = avd.IsLocked ? DeviceState.Booting : DeviceState.Shutdown,
+						State = avd.IsLocked ? DeviceState.Booted : DeviceState.Shutdown,
 						IsEmulator = true,
 						IsRunning = avd.IsLocked,
 						ConnectionType = Models.ConnectionType.Local,

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -36,10 +36,16 @@ public class DeviceManager : IDeviceManager
 
 			// Also get AVDs (virtual devices that may not be running)
 			var avds = await _androidProvider.GetAvdsAsync(cancellationToken);
+
+			// Track which running emulator entries we've already merged with an
+			// AVD, so we can pair "offline" emulator-NNNN serials (whose AVD name
+			// has not yet been resolved by adb) with locked AVDs as a fallback.
+			var mergedIndices = new HashSet<int>();
+
 			foreach (var avd in avds)
 			{
-				// Check if this AVD is already in the running devices list
-				// Match by AVD name in details dict or by EmulatorId
+				// First pass: match by AVD name (requires adb to have resolved it,
+				// which only happens once the device is fully online).
 				var runningIndex = devices.FindIndex(d =>
 					d.Platforms.Contains("android") &&
 					d.IsEmulator &&
@@ -51,6 +57,34 @@ public class DeviceManager : IDeviceManager
 						string.Equals(d.EmulatorId, avd.Name, StringComparison.OrdinalIgnoreCase)
 					));
 
+				// Second pass: if this AVD has an active lock file it is currently
+				// starting / booting. Pair it with the first unmerged offline
+				// emulator-* serial that has no resolved AVD name — that is the
+				// device produced by this AVD's qemu instance.
+				if (runningIndex < 0 && avd.IsLocked)
+				{
+					for (var i = 0; i < devices.Count; i++)
+					{
+						if (mergedIndices.Contains(i))
+							continue;
+
+						var d = devices[i];
+						if (!d.Platforms.Contains("android") || !d.IsEmulator)
+							continue;
+
+						var hasAvdName =
+							(d.Details != null &&
+							 d.Details.TryGetPropertyValue("avd", out var existingAvd) &&
+							 !string.IsNullOrEmpty(existingAvd?.ToString())) ||
+							!string.IsNullOrEmpty(d.EmulatorId);
+						if (hasAvdName)
+							continue;
+
+						runningIndex = i;
+						break;
+					}
+				}
+
 				// Extract metadata from system image path (e.g., "system-images;android-35;google_apis_playstore;arm64-v8a")
 				var (apiLevel, tagId, abi) = ParseSystemImage(avd.SystemImage);
 				var playStoreEnabled = tagId?.Contains("playstore", StringComparison.OrdinalIgnoreCase) ?? false;
@@ -61,15 +95,28 @@ public class DeviceManager : IDeviceManager
 					var running = devices[runningIndex];
 					var subModel = AndroidEnvironment.MapTagIdToSubModel(tagId, playStoreEnabled);
 					var details = running.Details?.DeepClone() as JsonObject ?? new JsonObject();
+					details["avd"] = avd.Name;
 					details["tag_id"] = tagId ?? "default";
 					details["target"] = avd.Target ?? "unknown";
 
+					// If the running device didn't have an AVD-resolved name yet
+					// (e.g. still offline/booting), prefer the AVD name as the
+					// display name while keeping the adb serial as the Id so
+					// subsequent adb commands still work.
+					var displayName = string.IsNullOrEmpty(running.EmulatorId) ? avd.Name : running.Name;
+					var state = running.State == DeviceState.Offline && avd.IsLocked
+						? DeviceState.Booting
+						: running.State;
+
 					devices[runningIndex] = running with
 					{
+						Name = displayName,
 						EmulatorId = avd.Name,
 						SubModel = subModel,
+						State = state,
 						Details = details
 					};
+					mergedIndices.Add(runningIndex);
 				}
 				else
 				{

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -137,26 +137,28 @@ public class DeviceManager : IDeviceManager
 					var versionName = AndroidEnvironment.MapApiLevelToVersion(apiLevel);
 					var subModel = AndroidEnvironment.MapTagIdToSubModel(tagId, playStoreEnabled);
 
-					// Lock files signal that the emulator qemu process is alive,
-					// but they do not distinguish "still booting" from "fully
-					// booted". The merge path above already surfaces Booting
-					// when adb sees the serial as Offline — the live evidence
-					// of an in-progress boot. When we reach this else branch
-					// adb did not list any serial for this AVD, which in
-					// practice means either the emulator is fully booted but
-					// adb is blind to it (server restart, port conflict,
-					// stale lock file), or we are in the very short <1s
-					// window before adb first registers the serial. Reporting
-					// Booted here matches the far more common case and the
-					// next refresh will naturally correct short-lived early-
-					// boot misreads via the merge path.
+					// Lock files signal that the emulator qemu process is alive.
+					// They cannot distinguish "still booting" from "fully
+					// booted"; only adb can, via the Offline -> Online
+					// transition surfaced by the merge path above. When we
+					// reach this else branch adb listed no serial for this
+					// AVD - almost always because the emulator is in the
+					// early boot window before adb has registered it.
+					// Report Booting so users know it's not yet ready; on
+					// the next refresh the merge path will take over and
+					// surface Booted once adb is online.
+					//
+					// The less common cause is a healthy emulator with a
+					// broken adb server (blind to a fully booted device).
+					// That is a user-environment issue (restart adb) rather
+					// than something we can reliably detect from lock files.
 					devices.Add(new Device
 					{
 						Id = avd.Name,
 						Name = avd.Name,
 						Platforms = new[] { "android" },
 						Type = DeviceType.Emulator,
-						State = avd.IsLocked ? DeviceState.Booted : DeviceState.Shutdown,
+						State = avd.IsLocked ? DeviceState.Booting : DeviceState.Shutdown,
 						IsEmulator = true,
 						IsRunning = avd.IsLocked,
 						ConnectionType = Models.ConnectionType.Local,

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -120,12 +120,22 @@ public class DeviceManager : IDeviceManager
 						? DeviceState.Booting
 						: running.State;
 
+					// A locked AVD paired with an adb-visible serial means qemu
+					// is alive. Keep IsRunning in sync with the promoted State
+					// so we never surface "Booting + IsRunning=false", which is
+					// internally inconsistent and confuses consumers.
+					var isRunning = running.IsRunning
+						|| state == DeviceState.Booting
+						|| state == DeviceState.Booted
+						|| state == DeviceState.Connected;
+
 					devices[runningIndex] = running with
 					{
 						Name = displayName,
 						EmulatorId = avd.Name,
 						SubModel = subModel,
 						State = state,
+						IsRunning = isRunning,
 						Details = details
 					};
 					mergedIndices.Add(runningIndex);

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -61,6 +61,12 @@ public class DeviceManager : IDeviceManager
 				// starting / booting. Pair it with the first unmerged offline
 				// emulator-* serial that has no resolved AVD name — that is the
 				// device produced by this AVD's qemu instance.
+				//
+				// Known limitation: when multiple AVDs are booted at exactly the
+				// same moment, pairing happens by iteration order and names can
+				// be swapped across the resulting entries. We accept this rather
+				// than leaving duplicates, and a future improvement could read
+				// the emulator console port from the lock files to disambiguate.
 				if (runningIndex < 0 && avd.IsLocked)
 				{
 					for (var i = 0; i < devices.Count; i++)
@@ -70,6 +76,12 @@ public class DeviceManager : IDeviceManager
 
 						var d = devices[i];
 						if (!d.Platforms.Contains("android") || !d.IsEmulator)
+							continue;
+
+						// Only pair with serials adb currently reports as Offline —
+						// an online/Booted/Connected emulator with a transient empty
+						// AVD name must not be hijacked by a locked AVD.
+						if (d.State != DeviceState.Offline)
 							continue;
 
 						var hasAvdName =
@@ -130,9 +142,9 @@ public class DeviceManager : IDeviceManager
 						Name = avd.Name,
 						Platforms = new[] { "android" },
 						Type = DeviceType.Emulator,
-						State = DeviceState.Shutdown,
+						State = avd.IsLocked ? DeviceState.Booting : DeviceState.Shutdown,
 						IsEmulator = true,
-						IsRunning = false,
+						IsRunning = avd.IsLocked,
 						ConnectionType = Models.ConnectionType.Local,
 						EmulatorId = avd.Name,
 						Model = avd.DeviceProfile,


### PR DESCRIPTION
Fixes #141

## Symptom

`maui device list --json --platform android` returns **2 entries** for a single emulator while it is booting:

```json
[
  { "name": "emulator-5554", "state": "Offline" },
  { "name": "MAUI_Emulator_API_36.1", "state": "Shutdown" }
]
```

## Cause

While the emulator is booting, `adb` reports the serial as `offline` and cannot yet resolve the AVD name (`getprop` / `adb emu avd name` both require the device to be online). The existing merge step in `DeviceManager.GetAllDevicesAsync` keys off AVD name, so it cannot pair the offline adb entry with the matching AVD from the AVD scan, producing two listings for a single physical emulator.

## Fix

Detect running/booting AVDs via the `hardware-qemu.ini.lock` marker that the Android emulator writes into `$HOME/.android/avd/<name>.avd/` for the lifetime of a running instance. Pair any locked AVD with an unnamed offline `emulator-*` serial during the merge pass.

- Cross-platform: the marker is checked as file *and* directory (on Windows `hardware-qemu.ini.lock` is a directory).
- We intentionally do **not** rely on `multiinstance.lock` ΓÇö Chromium documents that it has no cleanup mechanism and is often stale.
- Merged entry reports `state=Booting` and uses the AVD name; adb serial is preserved as the Id so subsequent commands still target it.
- Named/online emulators are never re-paired ΓÇö only unnamed **offline** serials are eligible (state guard enforced).
- Unpaired locked AVDs (no matching adb serial yet) surface as their own `Booting` entry but with `IsRunning=false` ΓÇö they are not `adb -s <id>` addressable by AVD name, so downstream commands that auto-select running targets (`maui profile --device`) correctly skip them until adb registers the serial.

See issue #135 for the planned deterministic pairing using `$HOME/.android/avd/running/pid_NNNN.ini` (Android Studio's authoritative approach).

## After

```json
[
  { "name": "MAUI_Emulator_API_36.1", "identifier": "emulator-5554", "state": "Booting" }
]
```

## Tests

Added/updated in `DeviceManagerTests` (15 tests total pass):

- `OfflineEmulatorWithLockedAvdReportsBooting` ΓÇö offline serial + locked AVD merges to single `Booting` entry.
- `OfflineEmulatorWithUnlockedAvdStaysSeparate` ΓÇö unlocked AVD does not hijack an offline serial.
- `LockedAvdDoesNotHijackAlreadyNamedEmulator` ΓÇö a second locked AVD does not steal an emulator that already has an AvdName.
- `LockedAvdWithoutMatchingSerialReportsBooting` ΓÇö unpaired locked AVD surfaces as Booting + IsRunning=false.
- `LockedAvdDoesNotHijackNonOfflineEmulator` ΓÇö only Offline serials are eligible for fallback pairing.

Verified end-to-end against a booting AVD on Windows: single merged `Booting` entry during boot, flips to `Booted` once adb registers the serial.

## Follow-up issues

- #135 Authoritative emulator liveness via `running/pid_NNNN.ini` + `ProcessHandle` (deterministic pairing).
- #136 Stale-offline ghost serial hijacking mitigation.
- #137 Dual-boot pairing order + `HasAvdName` provider-contract tests.

