### PR TITLE
Fix AndroidProvider health check test environment isolation

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -105,6 +105,7 @@ public class SdkManagerTests : IDisposable
 	}
 }
 
+[Collection("AndroidEnvironment")]
 public class AndroidProviderTests
 {
 	sealed class StubJdkManager : IJdkManager
@@ -139,11 +140,15 @@ public class AndroidProviderTests
 
 		var originalAndroidHome = Environment.GetEnvironmentVariable("ANDROID_HOME");
 		var originalAndroidSdkRoot = Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT");
+		var originalPath = Environment.GetEnvironmentVariable("PATH");
 
 		try
 		{
 			Environment.SetEnvironmentVariable("ANDROID_HOME", tempSdk);
 			Environment.SetEnvironmentVariable("ANDROID_SDK_ROOT", null);
+			// Clear PATH so the fallback SdkManager discovery doesn't find a
+			// system-wide sdkmanager (e.g. from a CI runner's Android SDK).
+			Environment.SetEnvironmentVariable("PATH", "");
 
 			using var provider = new AndroidProvider(new StubJdkManager());
 			var checks = await provider.CheckHealthAsync();
@@ -158,6 +163,7 @@ public class AndroidProviderTests
 		{
 			Environment.SetEnvironmentVariable("ANDROID_HOME", originalAndroidHome);
 			Environment.SetEnvironmentVariable("ANDROID_SDK_ROOT", originalAndroidSdkRoot);
+			Environment.SetEnvironmentVariable("PATH", originalPath);
 
 			if (Directory.Exists(tempSdk))
 				Directory.Delete(tempSdk, recursive: true);

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/AndroidEnvironmentCollection.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/AndroidEnvironmentCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests.Fixtures;
+
+[CollectionDefinition("AndroidEnvironment", DisableParallelization = true)]
+public sealed class AndroidEnvironmentCollection
+{
+}


### PR DESCRIPTION
Fixes the `CheckHealthAsync_ReturnsSdkManagerError_WhenSdkDirectoryExistsButManagerIsMissing` test that fails on Windows CI runners.

## Problem
The test sets `ANDROID_HOME` to an empty temp directory expecting `sdkmanager` to not be found, but the `SdkManager` has a fallback that searches `PATH`. On CI runners with a pre-installed Android SDK, the fallback finds a system-wide `sdkmanager`, making the health check return `Status=Ok` instead of the expected `Status=Error`.

## Fix
Clear `PATH` during the test so the fallback discovery doesn't find a system-wide `sdkmanager`. Restore it in the `finally` block.

## Failing CI run
https://github.com/dotnet/maui-labs/actions/runs/24885433284

## Validation
`dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/ --filter CheckHealthAsync_ReturnsSdkManagerError`
