### PR TITLE
Harden MCP tools: batch exceptions, gesture null params, capabilities message

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
@@ -96,7 +96,7 @@ public sealed class AgentTools
         var agent = await session.GetAgentClientAsync(agentPort);
         var capabilities = await agent.GetCapabilitiesAsync();
         if (capabilities.ValueKind == System.Text.Json.JsonValueKind.Undefined)
-            return "Agent not responding. Is the app running?";
+            return "Unable to retrieve capabilities. The agent may not support this feature or may be running an older version.";
         return CliJson.SerializeUntyped(capabilities, indented: false);
     }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
@@ -96,7 +96,7 @@ public sealed class AgentTools
         var agent = await session.GetAgentClientAsync(agentPort);
         var capabilities = await agent.GetCapabilitiesAsync();
         if (capabilities.ValueKind == System.Text.Json.JsonValueKind.Undefined)
-            return "Unable to retrieve capabilities. The agent may not support this feature or may be running an older version.";
+            return "Unable to retrieve capabilities. The agent may not be running, or may not support this feature (older version).";
         return CliJson.SerializeUntyped(capabilities, indented: false);
     }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
@@ -72,9 +72,9 @@ public sealed class BatchTools
 			var result = await agent.BatchAsync(actions, continueOnError);
 			return CliJson.SerializeUntyped(result, indented: false);
 		}
-		catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or System.Text.Json.JsonException)
+		catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or System.Text.Json.JsonException)
 		{
-			return $"Batch request failed: {ex.Message}. Is the app running?";
+			return $"Batch request failed: {ex.Message}. Verify the app is running and the agent supports the batch endpoint.";
 		}
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
@@ -66,8 +66,15 @@ public sealed class BatchTools
 			actions.Add(obj);
 		}
 
-		var agent = await session.GetAgentClientAsync(agentPort);
-		var result = await agent.BatchAsync(actions, continueOnError);
-		return CliJson.SerializeUntyped(result, indented: false);
+		try
+		{
+			var agent = await session.GetAgentClientAsync(agentPort);
+			var result = await agent.BatchAsync(actions, continueOnError);
+			return CliJson.SerializeUntyped(result, indented: false);
+		}
+		catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or System.Text.Json.JsonException)
+		{
+			return $"Batch request failed: {ex.Message}. Is the app running?";
+		}
 	}
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -169,14 +169,17 @@ public class AgentClient : IDisposable
 
     public async Task<bool> GestureAsync(string type, string? elementId = null, string? direction = null, double? distance = null, int? durationMs = null)
     {
-        return await PostActionAsync($"{UiApi}/actions/gesture", new JsonObject
+        var payload = new JsonObject
         {
-            ["elementId"] = elementId,
-            ["type"] = type,
-            ["direction"] = direction,
-            ["distance"] = distance,
-            ["durationMs"] = durationMs
-        });
+            ["type"] = type
+        };
+
+        if (elementId is not null) payload["elementId"] = elementId;
+        if (direction is not null) payload["direction"] = direction;
+        if (distance.HasValue) payload["distance"] = distance.Value;
+        if (durationMs.HasValue) payload["durationMs"] = durationMs.Value;
+
+        return await PostActionAsync($"{UiApi}/actions/gesture", payload);
     }
 
     public async Task<JsonElement> BatchAsync(IEnumerable<JsonObject> actions, bool continueOnError = false)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -207,16 +207,20 @@ public class AgentClient : IDisposable
     {
         var url = $"{UiApi}/actions/scroll";
         if (window != null) url += $"?window={window}";
-        return await PostActionAsync(url, new JsonObject
+
+        var payload = new JsonObject
         {
-            ["elementId"] = elementId,
             ["deltaX"] = deltaX,
             ["deltaY"] = deltaY,
-            ["animated"] = animated,
-            ["itemIndex"] = itemIndex,
-            ["groupIndex"] = groupIndex,
-            ["scrollToPosition"] = scrollToPosition
-        });
+            ["animated"] = animated
+        };
+
+        if (elementId is not null) payload["elementId"] = elementId;
+        if (itemIndex.HasValue) payload["itemIndex"] = itemIndex.Value;
+        if (groupIndex.HasValue) payload["groupIndex"] = groupIndex.Value;
+        if (scrollToPosition is not null) payload["scrollToPosition"] = scrollToPosition;
+
+        return await PostActionAsync(url, payload);
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #115.

Three hardening fixes identified during the review of the MCP tools PR:

### 1. Batch exception handling
`agent.BatchAsync()` could throw `HttpRequestException`, `TaskCanceledException`, or `JsonException` when the agent is unreachable or crashes mid-request. Other tools handle this via `PostActionAsync` (which catches internally), but batch uses raw `BatchAsync`. Now wrapped with a try/catch that returns a friendly error.

### 2. Gesture nullable parameter serialization
`GestureAsync` was including null `distance`/`durationMs` in the JSON payload, which would fail on the agent non-nullable DTO (`double Distance = 120`, `int DurationMs = 200`). Now omits null values from the JsonObject so the agent uses its defaults.

### 3. Capabilities error message
Changed from "Agent not responding" (misleading for older agents) to a message that distinguishes connectivity issues from feature support.

## Validation
`dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/` - 341 passed (5 pre-existing locale-dependent failures in OutputFormatterTests unrelated to this change)