### PR TITLE
Add MSBuild info message for DevFlow debug identity isolation

### DIFF
--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
@@ -56,5 +56,8 @@
     <ItemGroup>
       <Compile Include="$(_MauiDevFlowPortFile)" />
     </ItemGroup>
+    <Message Condition="'$(_MauiDevFlowIsolationEnabled)' == 'true' and '$(MauiDevFlowBaseApplicationId)' != '$(ApplicationId)'"
+             Importance="normal"
+             Text="DevFlow: ApplicationId rewritten from '$(MauiDevFlowBaseApplicationId)' to '$(ApplicationId)' for debug identity isolation. Opt out with -p:MauiDevFlowEnableDebugAppIdentityIsolation=false" />
   </Target>
 </Project>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
@@ -56,5 +56,8 @@
     <ItemGroup>
       <Compile Include="$(_MauiDevFlowPortFile)" />
     </ItemGroup>
+    <Message Condition="'$(_MauiDevFlowIsolationEnabled)' == 'true' and '$(MauiDevFlowBaseApplicationId)' != '$(ApplicationId)'"
+             Importance="normal"
+             Text="DevFlow: ApplicationId rewritten from '$(MauiDevFlowBaseApplicationId)' to '$(ApplicationId)' for debug identity isolation. Opt out with -p:MauiDevFlowEnableDebugAppIdentityIsolation=false" />
   </Target>
 </Project>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
@@ -154,6 +154,49 @@ public sealed class MauiDevFlowAgentTargetsTests : IDisposable
         Assert.DoesNotContain("Microsoft.Maui.DevFlowDebugAppIdentitySuffix", contents);
     }
 
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void SetMauiDevFlowPort_EmitsMessageWhenApplicationIdRewritten(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath, """
+            <ApplicationId>com.example.myapp</ApplicationId>
+            """);
+
+        var output = RunSetMauiDevFlowPortTarget("/v:normal");
+
+        Assert.Contains("DevFlow: ApplicationId rewritten from 'com.example.myapp' to 'com.example.myapp.debug.", output);
+        Assert.Contains("Opt out with -p:MauiDevFlowEnableDebugAppIdentityIsolation=false", output);
+    }
+
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void SetMauiDevFlowPort_DoesNotEmitMessage_WhenIsolationDisabled(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath, """
+            <ApplicationId>com.example.myapp</ApplicationId>
+            """);
+
+        var output = RunSetMauiDevFlowPortTarget("/v:normal", "/p:MauiDevFlowEnableDebugAppIdentityIsolation=false");
+
+        Assert.DoesNotContain("DevFlow: ApplicationId rewritten", output);
+    }
+
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void SetMauiDevFlowPort_DoesNotEmitMessage_ForReleaseBuilds(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath, """
+            <ApplicationId>com.example.myapp</ApplicationId>
+            """);
+
+        var output = RunSetMauiDevFlowPortTarget("/v:normal", "/p:Configuration=Release");
+
+        Assert.DoesNotContain("DevFlow: ApplicationId rewritten", output);
+    }
+
     private string ProjectFilePath => Path.Combine(_projectDirectory, "Test.csproj");
 
     private string ConfigFilePath => Path.Combine(_projectDirectory, ".mauidevflow");
@@ -201,7 +244,7 @@ public sealed class MauiDevFlowAgentTargetsTests : IDisposable
         return $"dw{sanitized}";
     }
 
-    private void RunSetMauiDevFlowPortTarget(params string[] properties)
+    private string RunSetMauiDevFlowPortTarget(params string[] properties)
     {
         var startInfo = new ProcessStartInfo("dotnet")
         {
@@ -231,6 +274,8 @@ public sealed class MauiDevFlowAgentTargetsTests : IDisposable
         Assert.True(
             process.ExitCode == 0,
             $"dotnet msbuild failed with exit code {process.ExitCode}.{Environment.NewLine}{output}{error}");
+
+        return output;
     }
 
     private static string FindRepoRoot()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
@@ -258,7 +258,10 @@ public sealed class MauiDevFlowAgentTargetsTests : IDisposable
         startInfo.ArgumentList.Add(ProjectFilePath);
         startInfo.ArgumentList.Add("/t:_SetMauiDevFlowPort");
         startInfo.ArgumentList.Add("/nologo");
-        startInfo.ArgumentList.Add("/v:minimal");
+
+        // Only default to minimal verbosity when the caller hasn't specified one
+        if (!properties.Any(p => p.StartsWith("/v:", StringComparison.OrdinalIgnoreCase)))
+            startInfo.ArgumentList.Add("/v:minimal");
 
         foreach (var property in properties)
             startInfo.ArgumentList.Add(property);


### PR DESCRIPTION
Follow-up to #142.

Emits a normal-importance MSBuild message when debug identity isolation rewrites the ApplicationId, so developers see the change in build output and know how to opt out.

Example output:
```
DevFlow: ApplicationId rewritten from 'com.example.myapp' to 'com.example.myapp.debug.dw...' for debug identity isolation. Opt out with -p:MauiDevFlowEnableDebugAppIdentityIsolation=false
```

## Changes
- Added `<Message>` task to both `build/` and `buildTransitive/` targets
- Added test verifying the message appears in Debug builds
- Added test verifying the message does NOT appear when isolation is disabled or in Release

## Validation
`dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/ --filter MauiDevFlowAgentTargetsTests`