### PR TITLE
Rework debug identity isolation to metadata-only session identity

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/AgentRegistration.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/AgentRegistration.cs
@@ -31,6 +31,9 @@ public record AgentRegistration
     [JsonPropertyName("version")]
     public string? Version { get; init; }
 
+    [JsonPropertyName("sessionId")]
+    public string? SessionId { get; init; }
+
     [JsonPropertyName("connectedAt")]
     public DateTime ConnectedAt { get; init; } = DateTime.UtcNow;
 
@@ -82,4 +85,7 @@ internal record RegistrationMessage
 
     [JsonPropertyName("version")]
     public string? Version { get; init; }
+
+    [JsonPropertyName("sessionId")]
+    public string? SessionId { get; init; }
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerServer.cs
@@ -195,6 +195,7 @@ public class BrokerServer : IDisposable
                 AppName = registration.AppName,
                 Port = assignedPort,
                 Version = registration.Version,
+                SessionId = registration.SessionId,
                 ConnectedAt = DateTime.UtcNow
             };
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BrokerRegistration.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BrokerRegistration.cs
@@ -51,7 +51,15 @@ public class BrokerRegistration : IDisposable
     /// </summary>
     public static void SetLogger(ILogger logger) => _staticLogger = logger;
 
-    public BrokerRegistration(string project, string tfm, string platform, string appName, string? sessionId = null, int brokerPort = DefaultBrokerPort, ILogger? logger = null)
+    /// <summary>
+    /// Backward-compatible constructor preserving the old signature for external consumers.
+    /// </summary>
+    public BrokerRegistration(string project, string tfm, string platform, string appName, int brokerPort = DefaultBrokerPort, ILogger? logger = null)
+        : this(project, tfm, platform, appName, sessionId: null, brokerPort, logger)
+    {
+    }
+
+    public BrokerRegistration(string project, string tfm, string platform, string appName, string? sessionId, int brokerPort = DefaultBrokerPort, ILogger? logger = null)
     {
         _project = project;
         _tfm = tfm;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BrokerRegistration.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BrokerRegistration.cs
@@ -24,6 +24,7 @@ public class BrokerRegistration : IDisposable
     private readonly string _tfm;
     private readonly string _platform;
     private readonly string _appName;
+    private readonly string? _sessionId;
     private int _brokerPort;
     private int? _assignedPort;
     private ILogger? _logger;
@@ -50,12 +51,13 @@ public class BrokerRegistration : IDisposable
     /// </summary>
     public static void SetLogger(ILogger logger) => _staticLogger = logger;
 
-    public BrokerRegistration(string project, string tfm, string platform, string appName, int brokerPort = DefaultBrokerPort, ILogger? logger = null)
+    public BrokerRegistration(string project, string tfm, string platform, string appName, string? sessionId = null, int brokerPort = DefaultBrokerPort, ILogger? logger = null)
     {
         _project = project;
         _tfm = tfm;
         _platform = platform;
         _appName = appName;
+        _sessionId = sessionId;
         _brokerPort = brokerPort;
         _logger = logger;
     }
@@ -229,7 +231,8 @@ public class BrokerRegistration : IDisposable
         appName = _appName,
         currentPort = CurrentPort,
         version = typeof(BrokerRegistration).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+        sessionId = _sessionId
     });
 
     private record RegistrationResponse

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -29,6 +29,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
     private readonly VisualTreeWalker _treeWalker;
     private FileLogProvider? _logProvider;
     private BrokerRegistration? _brokerRegistration;
+    private string? _sessionId;
     protected Application? _app;
     protected IDispatcher? _dispatcher;
     private bool _disposed;
@@ -331,6 +332,13 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         => _brokerRegistration = registration;
 
     /// <summary>
+    /// Sets the DevFlow session identity for this agent, derived from the build environment.
+    /// Included in status responses so clients can identify which environment built the running app.
+    /// </summary>
+    public void SetSessionId(string? sessionId)
+        => _sessionId = sessionId;
+
+    /// <summary>
     /// Writes a log entry originating from the WebView/Blazor console.
     /// Called by the Blazor package via reflection to route JS console output through ILogger.
     /// </summary>
@@ -533,6 +541,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                         .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
                     framework = ".NET MAUI",
                     frameworkVersion = Environment.Version.ToString(),
+                    sessionId = _sessionId,
                 },
                 device = new
                 {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
 /// </summary>
 public sealed class AndroidEmulatorFixture : AppFixtureBase
 {
+    const string PackageId = "com.companyname.mauitodo";
+
     Process? _emulatorProcess;
     CancellationTokenSource? _appMonitorCts;
     Task? _appMonitorTask;
@@ -18,14 +20,10 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
     string? _lastKnownPid;
     string? _diagnosticsDir;
     string? _serialNumber;
-    string? _packageId;
     int _apiLevel;
     string _sdkRoot = null!;
 
     public override string Platform => "android";
-
-    string PackageId => _packageId
-        ?? throw new InvalidOperationException("Android package id has not been resolved from the built manifest.");
 
     protected override async Task InitializePlatformAsync()
     {
@@ -51,8 +49,6 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
             var projectPath = GetSampleProjectPath();
             await BuildSampleAsync(projectPath, "net10.0-android",
                 $"-p:EmbedAssembliesIntoApk=true -p:MauiDevFlowPort={AgentPort}");
-
-            _packageId = ReadBuiltAndroidApplicationId(projectPath, "Debug", "net10.0-android");
 
             var apkPath = FindApk();
             await InstallApkAsync(apkPath);
@@ -99,11 +95,7 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
 
         if (_serialNumber != null)
         {
-            if (_packageId != null)
-            {
-                try { await AdbAsync($"shell am force-stop {_packageId}", timeoutSeconds: 5); } catch { }
-            }
-
+            try { await AdbAsync($"shell am force-stop {PackageId}", timeoutSeconds: 5); } catch { }
             try { await RunProcessAsync(AdbPath(), $"-s {_serialNumber} forward --remove tcp:{AgentPort}", timeoutSeconds: 5); } catch { }
         }
 
@@ -541,11 +533,8 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
 
     async Task LaunchAppAsync()
     {
-        var packageId = _packageId
-            ?? throw new InvalidOperationException("Android package ID was not resolved from the built manifest.");
-
         var output = await AdbCheckedAsync(
-            $"shell cmd package resolve-activity --brief -c android.intent.category.LAUNCHER {packageId}",
+            $"shell cmd package resolve-activity --brief -c android.intent.category.LAUNCHER {PackageId}",
             timeoutSeconds: 10);
 
         var activityLine = output
@@ -554,30 +543,30 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
 
         if (string.IsNullOrEmpty(activityLine))
             throw new InvalidOperationException(
-                $"Could not resolve launcher activity for {packageId}. Output: {output}");
+                $"Could not resolve launcher activity for {PackageId}. Output: {output}");
 
-        await AdbCheckedAsync($"shell am force-stop {packageId}", timeoutSeconds: 10);
+        await AdbCheckedAsync($"shell am force-stop {PackageId}", timeoutSeconds: 10);
         var launchOutput = await AdbCheckedAsync($"shell am start -W -n {activityLine}", timeoutSeconds: 30);
 
         if (launchOutput.Contains("Error:", StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException($"Failed to launch {packageId}: {launchOutput}");
+            throw new InvalidOperationException($"Failed to launch {PackageId}: {launchOutput}");
 
-        await WaitForAppProcessAsync(packageId, timeoutSeconds: 30);
+        await WaitForAppProcessAsync(timeoutSeconds: 30);
     }
 
-    async Task WaitForAppProcessAsync(string packageId, int timeoutSeconds)
+    async Task WaitForAppProcessAsync(int timeoutSeconds)
     {
         var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
 
         while (DateTime.UtcNow < deadline)
         {
-            var (output, _, exitCode) = await AdbAsync($"shell pidof {packageId}", timeoutSeconds: 5);
+            var (output, _, exitCode) = await AdbAsync($"shell pidof {PackageId}", timeoutSeconds: 5);
             if (exitCode == 0 && !string.IsNullOrWhiteSpace(output))
                 return;
 
             await Task.Delay(1000);
         }
 
-        throw new TimeoutException($"Android app process '{packageId}' did not appear within {timeoutSeconds}s.");
+        throw new TimeoutException($"Android app process '{PackageId}' did not appear within {timeoutSeconds}s.");
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureBase.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
-using System.Xml.Linq;
 using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
@@ -235,34 +234,6 @@ public abstract class AppFixtureBase : IAppFixture
 
         throw new InvalidOperationException(
             $"Could not locate DevFlow.Sample build output. Checked '{artifactsPath}' and '{projectBinPath}'.");
-    }
-
-    protected static string ReadBuiltAndroidApplicationId(string projectPath, string configuration, string targetFramework)
-    {
-        var projectDirectory = Path.GetDirectoryName(projectPath)
-            ?? throw new InvalidOperationException($"Could not determine project directory for '{projectPath}'.");
-        var projectName = Path.GetFileNameWithoutExtension(projectPath);
-        var repoRoot = FindRepoRoot();
-
-        var candidateManifestPaths = new[]
-        {
-            Path.Combine(repoRoot, "artifacts", "obj", projectName, configuration, targetFramework, "AndroidManifest.xml"),
-            Path.Combine(projectDirectory, "obj", configuration, targetFramework, "AndroidManifest.xml"),
-        };
-
-        foreach (var manifestPath in candidateManifestPaths)
-        {
-            if (!File.Exists(manifestPath))
-                continue;
-
-            var manifest = XDocument.Load(manifestPath);
-            var packageName = manifest.Root?.Attribute("package")?.Value?.Trim();
-            if (!string.IsNullOrWhiteSpace(packageName))
-                return packageName;
-        }
-
-        throw new InvalidOperationException(
-            $"Could not resolve the built Android application ID for '{projectPath}'. Checked: {string.Join(", ", candidateManifestPaths)}");
     }
 
     protected static int FindFreePort()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/AgentServiceExtensions.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/AgentServiceExtensions.cs
@@ -27,6 +27,7 @@ public static class AgentServiceExtensions
         // Read project identity from assembly metadata (injected by .targets)
         var project = ReadAssemblyMetadataProject() ?? "unknown";
         var tfm = ReadAssemblyMetadataTfm() ?? "unknown";
+        var sessionId = ReadAssemblyMetadataSessionId();
 
         // Always register with the broker for discoverability (must run on thread pool
         // to avoid deadlock with SynchronizationContext — AddMauiDevFlowAgent runs on
@@ -55,7 +56,7 @@ public static class AgentServiceExtensions
                     : "Unknown";
                 appName = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown";
             }
-            brokerReg = new BrokerRegistration(project, tfm, platform, appName);
+            brokerReg = new BrokerRegistration(project, tfm, platform, appName, sessionId);
             // If the user set a custom port, tell the broker upfront so it registers
             // with that port instead of assigning one from the pool.
             if (hasCustomPort)
@@ -86,6 +87,7 @@ public static class AgentServiceExtensions
         }
 
         var service = new PlatformAgentService(options);
+        service.SetSessionId(sessionId);
         if (brokerReg != null)
         {
             // Tell the broker registration what port we ended up on, so late
@@ -297,6 +299,7 @@ public static class AgentServiceExtensions
 
     internal static string? ReadAssemblyMetadataProject() => ReadAssemblyMetadata("Microsoft.Maui.DevFlowProject");
     internal static string? ReadAssemblyMetadataTfm() => ReadAssemblyMetadata("Microsoft.Maui.DevFlowTfm");
+    internal static string? ReadAssemblyMetadataSessionId() => ReadAssemblyMetadata("Microsoft.Maui.DevFlowSessionId");
 
     private static string? FindMetadataInAssembly(System.Reflection.Assembly assembly, string key)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
@@ -33,6 +33,8 @@
       <MauiDevFlowSessionId Condition="'$(MauiDevFlowSessionId)' == '' and '$(_MauiDevFlowSessionIdTail)' != ''">dw$(_MauiDevFlowSessionIdTail)</MauiDevFlowSessionId>
       <!-- Sanitize session ID for safe XML interpolation (manifest overlay, plist) -->
       <MauiDevFlowSessionId>$([System.Text.RegularExpressions.Regex]::Replace($([System.String]::Copy('$(MauiDevFlowSessionId)').ToLowerInvariant()), '[^a-z0-9]+', ''))</MauiDevFlowSessionId>
+      <!-- Pre-compute platform identifier for use in downstream target conditions -->
+      <_DevFlowTargetPlatform>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</_DevFlowTargetPlatform>
       <_MauiDevFlowMetadata></_MauiDevFlowMetadata>
       <_MauiDevFlowMetadata Condition="'$(MauiDevFlowPort)' != ''">$(_MauiDevFlowMetadata)[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowPort", "$(MauiDevFlowPort)")]
 </_MauiDevFlowMetadata>
@@ -58,7 +60,7 @@
   <Target Name="_InjectMauiDevFlowAndroidManifestMetadata"
           AfterTargets="_SetMauiDevFlowPort"
           BeforeTargets="_MergeManifest"
-          Condition="$(TargetFramework.Contains('android')) and '$(MauiDevFlowSessionId)' != ''">
+          Condition="'$(_DevFlowTargetPlatform)' == 'android' and '$(MauiDevFlowSessionId)' != ''">
     <PropertyGroup>
       <_DevFlowManifestOverlay>$(IntermediateOutputPath)DevFlowManifestOverlay.xml</_DevFlowManifestOverlay>
     </PropertyGroup>
@@ -78,7 +80,7 @@
   <Target Name="_InjectMauiDevFlowiOSPlistMetadata"
           AfterTargets="_SetMauiDevFlowPort"
           BeforeTargets="_DetectAppManifest"
-          Condition="($(TargetFramework.Contains('ios')) or $(TargetFramework.Contains('maccatalyst'))) and '$(MauiDevFlowSessionId)' != ''">
+          Condition="('$(_DevFlowTargetPlatform)' == 'ios' or '$(_DevFlowTargetPlatform)' == 'maccatalyst') and '$(MauiDevFlowSessionId)' != ''">
     <PropertyGroup>
       <_DevFlowPartialPlist>$(IntermediateOutputPath)DevFlowInfo.plist</_DevFlowPartialPlist>
     </PropertyGroup>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
@@ -4,11 +4,11 @@
     CLI override (-p:MauiDevFlowPort=9225) takes priority over the config file.
     If neither is set, the agent uses its default port (9223).
 
-    Also enables Debug-only app identity isolation by default so DevFlow-enabled builds
-    from separate worktrees can coexist on devices/simulators. Opt out with:
-      -p:MauiDevFlowEnableDebugAppIdentityIsolation=false
-    Or override the suffix with:
-      -p:MauiDevFlowDebugAppIdentitySuffix=yourSuffix
+    Computes a session identity (MauiDevFlowSessionId) derived from the project path
+    so DevFlow can distinguish builds from different environments (e.g. worktrees,
+    CI agents, dev machines). Override with:
+      -p:MauiDevFlowSessionId=yourId
+    The session identity is metadata-only — it never modifies ApplicationId.
   -->
   <Target Name="_ReadMauiDevFlowConfig" BeforeTargets="_SetMauiDevFlowPort"
           Condition="'$(MauiDevFlowPort)' == '' AND Exists('$(MSBuildProjectDirectory)/.mauidevflow')">
@@ -19,35 +19,26 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_SetMauiDevFlowPort" BeforeTargets="PrepareForBuild;CoreCompile">
+  <Target Name="_SetMauiDevFlowPort" BeforeTargets="CoreCompile">
     <PropertyGroup>
       <_MauiDevFlowPortFile>$(IntermediateOutputPath)Microsoft.Maui.DevFlowPort.g.cs</_MauiDevFlowPortFile>
-      <MauiDevFlowEnableDebugAppIdentityIsolation Condition="'$(MauiDevFlowEnableDebugAppIdentityIsolation)' == '' and '$(MAUI_DEVFLOW_ENABLE_DEBUG_APP_IDENTITY_ISOLATION)' != ''">$(MAUI_DEVFLOW_ENABLE_DEBUG_APP_IDENTITY_ISOLATION)</MauiDevFlowEnableDebugAppIdentityIsolation>
-      <MauiDevFlowEnableDebugAppIdentityIsolation Condition="'$(MauiDevFlowEnableDebugAppIdentityIsolation)' == '' and '$(Configuration)' == 'Debug'">true</MauiDevFlowEnableDebugAppIdentityIsolation>
-      <MauiDevFlowEnableDebugAppIdentityIsolation Condition="'$(MauiDevFlowEnableDebugAppIdentityIsolation)' == ''">false</MauiDevFlowEnableDebugAppIdentityIsolation>
-      <_MauiDevFlowIsolationEnabled>$([System.String]::Copy('$(MauiDevFlowEnableDebugAppIdentityIsolation)').ToLowerInvariant())</_MauiDevFlowIsolationEnabled>
-      <MauiDevFlowDebugAppIdentitySuffix Condition="'$(MauiDevFlowDebugAppIdentitySuffix)' == ''">$(MAUI_DEVFLOW_DEBUG_APP_IDENTITY_SUFFIX)</MauiDevFlowDebugAppIdentitySuffix>
-      <MauiDevFlowBaseApplicationId Condition="'$(MauiDevFlowBaseApplicationId)' == ''">$(ApplicationId)</MauiDevFlowBaseApplicationId>
-      <_MauiDevFlowRawIdentitySuffix>$(MauiDevFlowDebugAppIdentitySuffix)</_MauiDevFlowRawIdentitySuffix>
-      <_MauiDevFlowRawIdentitySuffix Condition="'$(_MauiDevFlowRawIdentitySuffix)' == '' and '$(_MauiDevFlowIsolationEnabled)' == 'true'">$(MSBuildProjectFullPath)</_MauiDevFlowRawIdentitySuffix>
-      <_MauiDevFlowSanitizedIdentitySuffix>$([System.Text.RegularExpressions.Regex]::Replace($([System.String]::Copy('$(_MauiDevFlowRawIdentitySuffix)').ToLowerInvariant()), '[^a-z0-9]+', ''))</_MauiDevFlowSanitizedIdentitySuffix>
-      <_MauiDevFlowIdentitySuffixTail Condition="'$(_MauiDevFlowSanitizedIdentitySuffix)' != '' and $([System.String]::Copy('$(_MauiDevFlowSanitizedIdentitySuffix)').Length) &gt; 24">$([System.String]::Copy('$(_MauiDevFlowSanitizedIdentitySuffix)').Substring($([MSBuild]::Subtract($([System.String]::Copy('$(_MauiDevFlowSanitizedIdentitySuffix)').Length), 24))))</_MauiDevFlowIdentitySuffixTail>
-      <_MauiDevFlowIdentitySuffixTail Condition="'$(_MauiDevFlowIdentitySuffixTail)' == ''">$(_MauiDevFlowSanitizedIdentitySuffix)</_MauiDevFlowIdentitySuffixTail>
-      <MauiDevFlowResolvedDebugAppIdentitySuffix Condition="'$(_MauiDevFlowIdentitySuffixTail)' != ''">dw$(_MauiDevFlowIdentitySuffixTail)</MauiDevFlowResolvedDebugAppIdentitySuffix>
-      <ApplicationId Condition="'$(_MauiDevFlowIsolationEnabled)' == 'true' and '$(MauiDevFlowBaseApplicationId)' != '' and '$(MauiDevFlowResolvedDebugAppIdentitySuffix)' != ''">$(MauiDevFlowBaseApplicationId).debug.$(MauiDevFlowResolvedDebugAppIdentitySuffix)</ApplicationId>
-      <MauiDevFlowResolvedApplicationId>$(ApplicationId)</MauiDevFlowResolvedApplicationId>
+      <!-- Session identity: allow explicit override via property or environment variable -->
+      <MauiDevFlowSessionId Condition="'$(MauiDevFlowSessionId)' == ''">$(MAUI_DEVFLOW_SESSION_ID)</MauiDevFlowSessionId>
+      <!-- Default: derive from project path — lowercase, alphanumeric only, last 24 chars, prefixed with 'dw' -->
+      <_MauiDevFlowRawSessionId Condition="'$(MauiDevFlowSessionId)' != ''">$(MauiDevFlowSessionId)</_MauiDevFlowRawSessionId>
+      <_MauiDevFlowRawSessionId Condition="'$(_MauiDevFlowRawSessionId)' == ''">$(MSBuildProjectFullPath)</_MauiDevFlowRawSessionId>
+      <_MauiDevFlowSanitizedSessionId>$([System.Text.RegularExpressions.Regex]::Replace($([System.String]::Copy('$(_MauiDevFlowRawSessionId)').ToLowerInvariant()), '[^a-z0-9]+', ''))</_MauiDevFlowSanitizedSessionId>
+      <_MauiDevFlowSessionIdTail Condition="'$(_MauiDevFlowSanitizedSessionId)' != '' and $([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Length) &gt; 24">$([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Substring($([MSBuild]::Subtract($([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Length), 24))))</_MauiDevFlowSessionIdTail>
+      <_MauiDevFlowSessionIdTail Condition="'$(_MauiDevFlowSessionIdTail)' == ''">$(_MauiDevFlowSanitizedSessionId)</_MauiDevFlowSessionIdTail>
+      <MauiDevFlowSessionId Condition="'$(MauiDevFlowSessionId)' == '' and '$(_MauiDevFlowSessionIdTail)' != ''">dw$(_MauiDevFlowSessionIdTail)</MauiDevFlowSessionId>
       <_MauiDevFlowMetadata></_MauiDevFlowMetadata>
       <_MauiDevFlowMetadata Condition="'$(MauiDevFlowPort)' != ''">$(_MauiDevFlowMetadata)[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowPort", "$(MauiDevFlowPort)")]
 </_MauiDevFlowMetadata>
       <_MauiDevFlowProjectPath>$([MSBuild]::ValueOrDefault('$(MSBuildProjectFullPath)','').Replace('\','\\'))</_MauiDevFlowProjectPath>
       <_MauiDevFlowMetadata>$(_MauiDevFlowMetadata)[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowProject", "$(_MauiDevFlowProjectPath)")]
 [assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowTfm", "$(TargetFramework)")]</_MauiDevFlowMetadata>
-      <_MauiDevFlowMetadata Condition="'$(MauiDevFlowBaseApplicationId)' != ''">$(_MauiDevFlowMetadata)
-[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowBaseApplicationId", "$(MauiDevFlowBaseApplicationId)")]</_MauiDevFlowMetadata>
-      <_MauiDevFlowMetadata Condition="'$(MauiDevFlowResolvedApplicationId)' != ''">$(_MauiDevFlowMetadata)
-[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowApplicationId", "$(MauiDevFlowResolvedApplicationId)")]</_MauiDevFlowMetadata>
-      <_MauiDevFlowMetadata Condition="'$(MauiDevFlowResolvedDebugAppIdentitySuffix)' != ''">$(_MauiDevFlowMetadata)
-[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowDebugAppIdentitySuffix", "$(MauiDevFlowResolvedDebugAppIdentitySuffix)")]</_MauiDevFlowMetadata>
+      <_MauiDevFlowMetadata Condition="'$(MauiDevFlowSessionId)' != ''">$(_MauiDevFlowMetadata)
+[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowSessionId", "$(MauiDevFlowSessionId)")]</_MauiDevFlowMetadata>
     </PropertyGroup>
     <WriteLinesToFile File="$(_MauiDevFlowPortFile)"
                      Lines="$(_MauiDevFlowMetadata)"
@@ -55,6 +46,53 @@
                      WriteOnlyWhenDifferent="true" />
     <ItemGroup>
       <Compile Include="$(_MauiDevFlowPortFile)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Android: Inject session identity as <meta-data> in AndroidManifest.xml.
+    Queryable via: adb shell dumpsys package <pkg> | grep devflow.sessionId
+  -->
+  <Target Name="_InjectMauiDevFlowAndroidManifestMetadata"
+          AfterTargets="_SetMauiDevFlowPort"
+          BeforeTargets="_MergeManifest"
+          Condition="$(TargetFramework.Contains('android')) and '$(MauiDevFlowSessionId)' != ''">
+    <PropertyGroup>
+      <_DevFlowManifestOverlay>$(IntermediateOutputPath)DevFlowManifestOverlay.xml</_DevFlowManifestOverlay>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_DevFlowManifestOverlay)"
+                     Lines='&lt;manifest xmlns:android="http://schemas.android.com/apk/res/android"&gt;&lt;application&gt;&lt;meta-data android:name="com.microsoft.maui.devflow.sessionId" android:value="$(MauiDevFlowSessionId)" /&gt;&lt;/application&gt;&lt;/manifest&gt;'
+                     Overwrite="true"
+                     WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <AndroidManifestOverlay Include="$(_DevFlowManifestOverlay)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    iOS / Mac Catalyst: Inject session identity into Info.plist.
+    Queryable via: xcrun simctl get_app_container <udid> <bundle_id> app, then plutil -p <path>/Info.plist
+  -->
+  <Target Name="_InjectMauiDevFlowiOSPlistMetadata"
+          AfterTargets="_SetMauiDevFlowPort"
+          BeforeTargets="_DetectAppManifest"
+          Condition="($(TargetFramework.Contains('ios')) or $(TargetFramework.Contains('maccatalyst'))) and '$(MauiDevFlowSessionId)' != ''">
+    <PropertyGroup>
+      <_DevFlowPartialPlist>$(IntermediateOutputPath)DevFlowInfo.plist</_DevFlowPartialPlist>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_DevFlowPartialPlist)"
+                     Lines='&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
+&lt;plist version="1.0"&gt;
+&lt;dict&gt;
+  &lt;key&gt;MauiDevFlowSessionId&lt;/key&gt;
+  &lt;string&gt;$(MauiDevFlowSessionId)&lt;/string&gt;
+&lt;/dict&gt;
+&lt;/plist&gt;'
+                     Overwrite="true"
+                     WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <PartialAppManifest Include="$(_DevFlowPartialPlist)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/build/Microsoft.Maui.DevFlow.Agent.targets
@@ -19,7 +19,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_SetMauiDevFlowPort" BeforeTargets="CoreCompile">
+  <Target Name="_SetMauiDevFlowPort" BeforeTargets="PrepareForBuild;CoreCompile">
     <PropertyGroup>
       <_MauiDevFlowPortFile>$(IntermediateOutputPath)Microsoft.Maui.DevFlowPort.g.cs</_MauiDevFlowPortFile>
       <!-- Session identity: allow explicit override via property or environment variable -->
@@ -31,6 +31,8 @@
       <_MauiDevFlowSessionIdTail Condition="'$(_MauiDevFlowSanitizedSessionId)' != '' and $([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Length) &gt; 24">$([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Substring($([MSBuild]::Subtract($([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Length), 24))))</_MauiDevFlowSessionIdTail>
       <_MauiDevFlowSessionIdTail Condition="'$(_MauiDevFlowSessionIdTail)' == ''">$(_MauiDevFlowSanitizedSessionId)</_MauiDevFlowSessionIdTail>
       <MauiDevFlowSessionId Condition="'$(MauiDevFlowSessionId)' == '' and '$(_MauiDevFlowSessionIdTail)' != ''">dw$(_MauiDevFlowSessionIdTail)</MauiDevFlowSessionId>
+      <!-- Sanitize session ID for safe XML interpolation (manifest overlay, plist) -->
+      <MauiDevFlowSessionId>$([System.Text.RegularExpressions.Regex]::Replace($([System.String]::Copy('$(MauiDevFlowSessionId)').ToLowerInvariant()), '[^a-z0-9]+', ''))</MauiDevFlowSessionId>
       <_MauiDevFlowMetadata></_MauiDevFlowMetadata>
       <_MauiDevFlowMetadata Condition="'$(MauiDevFlowPort)' != ''">$(_MauiDevFlowMetadata)[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowPort", "$(MauiDevFlowPort)")]
 </_MauiDevFlowMetadata>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
@@ -33,6 +33,8 @@
       <MauiDevFlowSessionId Condition="'$(MauiDevFlowSessionId)' == '' and '$(_MauiDevFlowSessionIdTail)' != ''">dw$(_MauiDevFlowSessionIdTail)</MauiDevFlowSessionId>
       <!-- Sanitize session ID for safe XML interpolation (manifest overlay, plist) -->
       <MauiDevFlowSessionId>$([System.Text.RegularExpressions.Regex]::Replace($([System.String]::Copy('$(MauiDevFlowSessionId)').ToLowerInvariant()), '[^a-z0-9]+', ''))</MauiDevFlowSessionId>
+      <!-- Pre-compute platform identifier for use in downstream target conditions -->
+      <_DevFlowTargetPlatform>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</_DevFlowTargetPlatform>
       <_MauiDevFlowMetadata></_MauiDevFlowMetadata>
       <_MauiDevFlowMetadata Condition="'$(MauiDevFlowPort)' != ''">$(_MauiDevFlowMetadata)[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowPort", "$(MauiDevFlowPort)")]
 </_MauiDevFlowMetadata>
@@ -58,7 +60,7 @@
   <Target Name="_InjectMauiDevFlowAndroidManifestMetadata"
           AfterTargets="_SetMauiDevFlowPort"
           BeforeTargets="_MergeManifest"
-          Condition="$(TargetFramework.Contains('android')) and '$(MauiDevFlowSessionId)' != ''">
+          Condition="'$(_DevFlowTargetPlatform)' == 'android' and '$(MauiDevFlowSessionId)' != ''">
     <PropertyGroup>
       <_DevFlowManifestOverlay>$(IntermediateOutputPath)DevFlowManifestOverlay.xml</_DevFlowManifestOverlay>
     </PropertyGroup>
@@ -78,7 +80,7 @@
   <Target Name="_InjectMauiDevFlowiOSPlistMetadata"
           AfterTargets="_SetMauiDevFlowPort"
           BeforeTargets="_DetectAppManifest"
-          Condition="($(TargetFramework.Contains('ios')) or $(TargetFramework.Contains('maccatalyst'))) and '$(MauiDevFlowSessionId)' != ''">
+          Condition="('$(_DevFlowTargetPlatform)' == 'ios' or '$(_DevFlowTargetPlatform)' == 'maccatalyst') and '$(MauiDevFlowSessionId)' != ''">
     <PropertyGroup>
       <_DevFlowPartialPlist>$(IntermediateOutputPath)DevFlowInfo.plist</_DevFlowPartialPlist>
     </PropertyGroup>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
@@ -4,11 +4,11 @@
     CLI override (-p:MauiDevFlowPort=9225) takes priority over the config file.
     If neither is set, the agent uses its default port (9223).
 
-    Also enables Debug-only app identity isolation by default so DevFlow-enabled builds
-    from separate worktrees can coexist on devices/simulators. Opt out with:
-      -p:MauiDevFlowEnableDebugAppIdentityIsolation=false
-    Or override the suffix with:
-      -p:MauiDevFlowDebugAppIdentitySuffix=yourSuffix
+    Computes a session identity (MauiDevFlowSessionId) derived from the project path
+    so DevFlow can distinguish builds from different environments (e.g. worktrees,
+    CI agents, dev machines). Override with:
+      -p:MauiDevFlowSessionId=yourId
+    The session identity is metadata-only — it never modifies ApplicationId.
   -->
   <Target Name="_ReadMauiDevFlowConfig" BeforeTargets="_SetMauiDevFlowPort"
           Condition="'$(MauiDevFlowPort)' == '' AND Exists('$(MSBuildProjectDirectory)/.mauidevflow')">
@@ -19,35 +19,26 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_SetMauiDevFlowPort" BeforeTargets="PrepareForBuild;CoreCompile">
+  <Target Name="_SetMauiDevFlowPort" BeforeTargets="CoreCompile">
     <PropertyGroup>
       <_MauiDevFlowPortFile>$(IntermediateOutputPath)Microsoft.Maui.DevFlowPort.g.cs</_MauiDevFlowPortFile>
-      <MauiDevFlowEnableDebugAppIdentityIsolation Condition="'$(MauiDevFlowEnableDebugAppIdentityIsolation)' == '' and '$(MAUI_DEVFLOW_ENABLE_DEBUG_APP_IDENTITY_ISOLATION)' != ''">$(MAUI_DEVFLOW_ENABLE_DEBUG_APP_IDENTITY_ISOLATION)</MauiDevFlowEnableDebugAppIdentityIsolation>
-      <MauiDevFlowEnableDebugAppIdentityIsolation Condition="'$(MauiDevFlowEnableDebugAppIdentityIsolation)' == '' and '$(Configuration)' == 'Debug'">true</MauiDevFlowEnableDebugAppIdentityIsolation>
-      <MauiDevFlowEnableDebugAppIdentityIsolation Condition="'$(MauiDevFlowEnableDebugAppIdentityIsolation)' == ''">false</MauiDevFlowEnableDebugAppIdentityIsolation>
-      <_MauiDevFlowIsolationEnabled>$([System.String]::Copy('$(MauiDevFlowEnableDebugAppIdentityIsolation)').ToLowerInvariant())</_MauiDevFlowIsolationEnabled>
-      <MauiDevFlowDebugAppIdentitySuffix Condition="'$(MauiDevFlowDebugAppIdentitySuffix)' == ''">$(MAUI_DEVFLOW_DEBUG_APP_IDENTITY_SUFFIX)</MauiDevFlowDebugAppIdentitySuffix>
-      <MauiDevFlowBaseApplicationId Condition="'$(MauiDevFlowBaseApplicationId)' == ''">$(ApplicationId)</MauiDevFlowBaseApplicationId>
-      <_MauiDevFlowRawIdentitySuffix>$(MauiDevFlowDebugAppIdentitySuffix)</_MauiDevFlowRawIdentitySuffix>
-      <_MauiDevFlowRawIdentitySuffix Condition="'$(_MauiDevFlowRawIdentitySuffix)' == '' and '$(_MauiDevFlowIsolationEnabled)' == 'true'">$(MSBuildProjectFullPath)</_MauiDevFlowRawIdentitySuffix>
-      <_MauiDevFlowSanitizedIdentitySuffix>$([System.Text.RegularExpressions.Regex]::Replace($([System.String]::Copy('$(_MauiDevFlowRawIdentitySuffix)').ToLowerInvariant()), '[^a-z0-9]+', ''))</_MauiDevFlowSanitizedIdentitySuffix>
-      <_MauiDevFlowIdentitySuffixTail Condition="'$(_MauiDevFlowSanitizedIdentitySuffix)' != '' and $([System.String]::Copy('$(_MauiDevFlowSanitizedIdentitySuffix)').Length) &gt; 24">$([System.String]::Copy('$(_MauiDevFlowSanitizedIdentitySuffix)').Substring($([MSBuild]::Subtract($([System.String]::Copy('$(_MauiDevFlowSanitizedIdentitySuffix)').Length), 24))))</_MauiDevFlowIdentitySuffixTail>
-      <_MauiDevFlowIdentitySuffixTail Condition="'$(_MauiDevFlowIdentitySuffixTail)' == ''">$(_MauiDevFlowSanitizedIdentitySuffix)</_MauiDevFlowIdentitySuffixTail>
-      <MauiDevFlowResolvedDebugAppIdentitySuffix Condition="'$(_MauiDevFlowIdentitySuffixTail)' != ''">dw$(_MauiDevFlowIdentitySuffixTail)</MauiDevFlowResolvedDebugAppIdentitySuffix>
-      <ApplicationId Condition="'$(_MauiDevFlowIsolationEnabled)' == 'true' and '$(MauiDevFlowBaseApplicationId)' != '' and '$(MauiDevFlowResolvedDebugAppIdentitySuffix)' != ''">$(MauiDevFlowBaseApplicationId).debug.$(MauiDevFlowResolvedDebugAppIdentitySuffix)</ApplicationId>
-      <MauiDevFlowResolvedApplicationId>$(ApplicationId)</MauiDevFlowResolvedApplicationId>
+      <!-- Session identity: allow explicit override via property or environment variable -->
+      <MauiDevFlowSessionId Condition="'$(MauiDevFlowSessionId)' == ''">$(MAUI_DEVFLOW_SESSION_ID)</MauiDevFlowSessionId>
+      <!-- Default: derive from project path — lowercase, alphanumeric only, last 24 chars, prefixed with 'dw' -->
+      <_MauiDevFlowRawSessionId Condition="'$(MauiDevFlowSessionId)' != ''">$(MauiDevFlowSessionId)</_MauiDevFlowRawSessionId>
+      <_MauiDevFlowRawSessionId Condition="'$(_MauiDevFlowRawSessionId)' == ''">$(MSBuildProjectFullPath)</_MauiDevFlowRawSessionId>
+      <_MauiDevFlowSanitizedSessionId>$([System.Text.RegularExpressions.Regex]::Replace($([System.String]::Copy('$(_MauiDevFlowRawSessionId)').ToLowerInvariant()), '[^a-z0-9]+', ''))</_MauiDevFlowSanitizedSessionId>
+      <_MauiDevFlowSessionIdTail Condition="'$(_MauiDevFlowSanitizedSessionId)' != '' and $([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Length) &gt; 24">$([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Substring($([MSBuild]::Subtract($([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Length), 24))))</_MauiDevFlowSessionIdTail>
+      <_MauiDevFlowSessionIdTail Condition="'$(_MauiDevFlowSessionIdTail)' == ''">$(_MauiDevFlowSanitizedSessionId)</_MauiDevFlowSessionIdTail>
+      <MauiDevFlowSessionId Condition="'$(MauiDevFlowSessionId)' == '' and '$(_MauiDevFlowSessionIdTail)' != ''">dw$(_MauiDevFlowSessionIdTail)</MauiDevFlowSessionId>
       <_MauiDevFlowMetadata></_MauiDevFlowMetadata>
       <_MauiDevFlowMetadata Condition="'$(MauiDevFlowPort)' != ''">$(_MauiDevFlowMetadata)[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowPort", "$(MauiDevFlowPort)")]
 </_MauiDevFlowMetadata>
       <_MauiDevFlowProjectPath>$([MSBuild]::ValueOrDefault('$(MSBuildProjectFullPath)','').Replace('\','\\'))</_MauiDevFlowProjectPath>
       <_MauiDevFlowMetadata>$(_MauiDevFlowMetadata)[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowProject", "$(_MauiDevFlowProjectPath)")]
 [assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowTfm", "$(TargetFramework)")]</_MauiDevFlowMetadata>
-      <_MauiDevFlowMetadata Condition="'$(MauiDevFlowBaseApplicationId)' != ''">$(_MauiDevFlowMetadata)
-[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowBaseApplicationId", "$(MauiDevFlowBaseApplicationId)")]</_MauiDevFlowMetadata>
-      <_MauiDevFlowMetadata Condition="'$(MauiDevFlowResolvedApplicationId)' != ''">$(_MauiDevFlowMetadata)
-[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowApplicationId", "$(MauiDevFlowResolvedApplicationId)")]</_MauiDevFlowMetadata>
-      <_MauiDevFlowMetadata Condition="'$(MauiDevFlowResolvedDebugAppIdentitySuffix)' != ''">$(_MauiDevFlowMetadata)
-[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowDebugAppIdentitySuffix", "$(MauiDevFlowResolvedDebugAppIdentitySuffix)")]</_MauiDevFlowMetadata>
+      <_MauiDevFlowMetadata Condition="'$(MauiDevFlowSessionId)' != ''">$(_MauiDevFlowMetadata)
+[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowSessionId", "$(MauiDevFlowSessionId)")]</_MauiDevFlowMetadata>
     </PropertyGroup>
     <WriteLinesToFile File="$(_MauiDevFlowPortFile)"
                      Lines="$(_MauiDevFlowMetadata)"
@@ -55,6 +46,53 @@
                      WriteOnlyWhenDifferent="true" />
     <ItemGroup>
       <Compile Include="$(_MauiDevFlowPortFile)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Android: Inject session identity as <meta-data> in AndroidManifest.xml.
+    Queryable via: adb shell dumpsys package <pkg> | grep devflow.sessionId
+  -->
+  <Target Name="_InjectMauiDevFlowAndroidManifestMetadata"
+          AfterTargets="_SetMauiDevFlowPort"
+          BeforeTargets="_MergeManifest"
+          Condition="$(TargetFramework.Contains('android')) and '$(MauiDevFlowSessionId)' != ''">
+    <PropertyGroup>
+      <_DevFlowManifestOverlay>$(IntermediateOutputPath)DevFlowManifestOverlay.xml</_DevFlowManifestOverlay>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_DevFlowManifestOverlay)"
+                     Lines='&lt;manifest xmlns:android="http://schemas.android.com/apk/res/android"&gt;&lt;application&gt;&lt;meta-data android:name="com.microsoft.maui.devflow.sessionId" android:value="$(MauiDevFlowSessionId)" /&gt;&lt;/application&gt;&lt;/manifest&gt;'
+                     Overwrite="true"
+                     WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <AndroidManifestOverlay Include="$(_DevFlowManifestOverlay)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    iOS / Mac Catalyst: Inject session identity into Info.plist.
+    Queryable via: xcrun simctl get_app_container <udid> <bundle_id> app, then plutil -p <path>/Info.plist
+  -->
+  <Target Name="_InjectMauiDevFlowiOSPlistMetadata"
+          AfterTargets="_SetMauiDevFlowPort"
+          BeforeTargets="_DetectAppManifest"
+          Condition="($(TargetFramework.Contains('ios')) or $(TargetFramework.Contains('maccatalyst'))) and '$(MauiDevFlowSessionId)' != ''">
+    <PropertyGroup>
+      <_DevFlowPartialPlist>$(IntermediateOutputPath)DevFlowInfo.plist</_DevFlowPartialPlist>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_DevFlowPartialPlist)"
+                     Lines='&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
+&lt;plist version="1.0"&gt;
+&lt;dict&gt;
+  &lt;key&gt;MauiDevFlowSessionId&lt;/key&gt;
+  &lt;string&gt;$(MauiDevFlowSessionId)&lt;/string&gt;
+&lt;/dict&gt;
+&lt;/plist&gt;'
+                     Overwrite="true"
+                     WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <PartialAppManifest Include="$(_DevFlowPartialPlist)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/buildTransitive/Microsoft.Maui.DevFlow.Agent.targets
@@ -19,7 +19,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_SetMauiDevFlowPort" BeforeTargets="CoreCompile">
+  <Target Name="_SetMauiDevFlowPort" BeforeTargets="PrepareForBuild;CoreCompile">
     <PropertyGroup>
       <_MauiDevFlowPortFile>$(IntermediateOutputPath)Microsoft.Maui.DevFlowPort.g.cs</_MauiDevFlowPortFile>
       <!-- Session identity: allow explicit override via property or environment variable -->
@@ -31,6 +31,8 @@
       <_MauiDevFlowSessionIdTail Condition="'$(_MauiDevFlowSanitizedSessionId)' != '' and $([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Length) &gt; 24">$([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Substring($([MSBuild]::Subtract($([System.String]::Copy('$(_MauiDevFlowSanitizedSessionId)').Length), 24))))</_MauiDevFlowSessionIdTail>
       <_MauiDevFlowSessionIdTail Condition="'$(_MauiDevFlowSessionIdTail)' == ''">$(_MauiDevFlowSanitizedSessionId)</_MauiDevFlowSessionIdTail>
       <MauiDevFlowSessionId Condition="'$(MauiDevFlowSessionId)' == '' and '$(_MauiDevFlowSessionIdTail)' != ''">dw$(_MauiDevFlowSessionIdTail)</MauiDevFlowSessionId>
+      <!-- Sanitize session ID for safe XML interpolation (manifest overlay, plist) -->
+      <MauiDevFlowSessionId>$([System.Text.RegularExpressions.Regex]::Replace($([System.String]::Copy('$(MauiDevFlowSessionId)').ToLowerInvariant()), '[^a-z0-9]+', ''))</MauiDevFlowSessionId>
       <_MauiDevFlowMetadata></_MauiDevFlowMetadata>
       <_MauiDevFlowMetadata Condition="'$(MauiDevFlowPort)' != ''">$(_MauiDevFlowMetadata)[assembly: System.Reflection.AssemblyMetadataAttribute("Microsoft.Maui.DevFlowPort", "$(MauiDevFlowPort)")]
 </_MauiDevFlowMetadata>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
@@ -115,7 +115,8 @@ public sealed class MauiDevFlowAgentTargetsTests : IDisposable
         RunSetMauiDevFlowPortTarget("/p:MauiDevFlowSessionId=my-custom-session");
 
         var contents = File.ReadAllText(GeneratedFilePath);
-        Assert.Contains("\"Microsoft.Maui.DevFlowSessionId\", \"my-custom-session\"", contents);
+        // Explicit values are sanitized (lowercase, alphanumeric only) for XML safety
+        Assert.Contains("\"Microsoft.Maui.DevFlowSessionId\", \"mycustomsession\"", contents);
     }
 
     [Theory]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MauiDevFlowAgentTargetsTests.cs
@@ -91,7 +91,51 @@ public sealed class MauiDevFlowAgentTargetsTests : IDisposable
     [Theory]
     [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
     [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
-    public void SetMauiDevFlowPort_RewritesDebugApplicationId_ByDefault(string relativeTargetPath)
+    public void SetMauiDevFlowPort_EmitsSessionId_DerivedFromProjectPath(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath);
+
+        RunSetMauiDevFlowPortTarget();
+
+        var contents = File.ReadAllText(GeneratedFilePath);
+        var expectedSessionId = ComputeExpectedSessionId(ProjectFilePath);
+        Assert.Contains($"\"Microsoft.Maui.DevFlowSessionId\", \"{expectedSessionId}\"", contents);
+        Assert.DoesNotContain("Microsoft.Maui.DevFlowBaseApplicationId", contents);
+        Assert.DoesNotContain("Microsoft.Maui.DevFlowApplicationId", contents);
+        Assert.DoesNotContain("Microsoft.Maui.DevFlowDebugAppIdentitySuffix", contents);
+    }
+
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void SetMauiDevFlowPort_UsesExplicitSessionId_WhenProvided(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath);
+
+        RunSetMauiDevFlowPortTarget("/p:MauiDevFlowSessionId=my-custom-session");
+
+        var contents = File.ReadAllText(GeneratedFilePath);
+        Assert.Contains("\"Microsoft.Maui.DevFlowSessionId\", \"my-custom-session\"", contents);
+    }
+
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void SetMauiDevFlowPort_EmitsSessionId_ForReleaseBuilds(string relativeTargetPath)
+    {
+        CreateTestProject(relativeTargetPath);
+
+        RunSetMauiDevFlowPortTarget("/p:Configuration=Release");
+
+        var contents = File.ReadAllText(GetGeneratedFilePath("Release"));
+        var expectedSessionId = ComputeExpectedSessionId(ProjectFilePath);
+        Assert.Contains($"\"Microsoft.Maui.DevFlowSessionId\", \"{expectedSessionId}\"", contents);
+    }
+
+    [Theory]
+    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
+    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
+    public void SetMauiDevFlowPort_DoesNotRewriteApplicationId(string relativeTargetPath)
     {
         CreateTestProject(relativeTargetPath, """
             <ApplicationId>com.example.myapp</ApplicationId>
@@ -100,58 +144,11 @@ public sealed class MauiDevFlowAgentTargetsTests : IDisposable
         RunSetMauiDevFlowPortTarget();
 
         var contents = File.ReadAllText(GeneratedFilePath);
-        var expectedSuffix = ComputeExpectedDebugIdentitySuffix(ProjectFilePath);
-        Assert.Contains("\"Microsoft.Maui.DevFlowBaseApplicationId\", \"com.example.myapp\"", contents);
-        Assert.Contains($"\"Microsoft.Maui.DevFlowDebugAppIdentitySuffix\", \"{expectedSuffix}\"", contents);
-        Assert.Contains($"\"Microsoft.Maui.DevFlowApplicationId\", \"com.example.myapp.debug.{expectedSuffix}\"", contents);
-    }
-
-    [Theory]
-    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
-    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
-    public void SetMauiDevFlowPort_UsesExplicitDebugIdentitySuffix_WhenProvided(string relativeTargetPath)
-    {
-        CreateTestProject(relativeTargetPath, """
-            <ApplicationId>com.example.myapp</ApplicationId>
-            """);
-
-        RunSetMauiDevFlowPortTarget("/p:MauiDevFlowDebugAppIdentitySuffix=Agent-42");
-
-        var contents = File.ReadAllText(GeneratedFilePath);
-        Assert.Contains("\"Microsoft.Maui.DevFlowDebugAppIdentitySuffix\", \"dwagent42\"", contents);
-        Assert.Contains("\"Microsoft.Maui.DevFlowApplicationId\", \"com.example.myapp.debug.dwagent42\"", contents);
-    }
-
-    [Theory]
-    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
-    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
-    public void SetMauiDevFlowPort_DoesNotRewriteApplicationId_WhenIsolationDisabled(string relativeTargetPath)
-    {
-        CreateTestProject(relativeTargetPath, """
-            <ApplicationId>com.example.myapp</ApplicationId>
-            """);
-
-        RunSetMauiDevFlowPortTarget("/p:MauiDevFlowEnableDebugAppIdentityIsolation=false");
-
-        var contents = File.ReadAllText(GeneratedFilePath);
-        Assert.Contains("\"Microsoft.Maui.DevFlowApplicationId\", \"com.example.myapp\"", contents);
-        Assert.DoesNotContain("Microsoft.Maui.DevFlowDebugAppIdentitySuffix", contents);
-    }
-
-    [Theory]
-    [InlineData("build/Microsoft.Maui.DevFlow.Agent.targets")]
-    [InlineData("buildTransitive/Microsoft.Maui.DevFlow.Agent.targets")]
-    public void SetMauiDevFlowPort_DoesNotRewriteApplicationId_ForReleaseBuilds(string relativeTargetPath)
-    {
-        CreateTestProject(relativeTargetPath, """
-            <ApplicationId>com.example.myapp</ApplicationId>
-            """);
-
-        RunSetMauiDevFlowPortTarget("/p:Configuration=Release");
-
-        var contents = File.ReadAllText(GetGeneratedFilePath("Release"));
-        Assert.Contains("\"Microsoft.Maui.DevFlowApplicationId\", \"com.example.myapp\"", contents);
-        Assert.DoesNotContain("Microsoft.Maui.DevFlowDebugAppIdentitySuffix", contents);
+        // Session ID should be present
+        Assert.Contains("Microsoft.Maui.DevFlowSessionId", contents);
+        // ApplicationId must NOT be rewritten — no identity isolation metadata
+        Assert.DoesNotContain("Microsoft.Maui.DevFlowBaseApplicationId", contents);
+        Assert.DoesNotContain("Microsoft.Maui.DevFlowApplicationId", contents);
     }
 
     private string ProjectFilePath => Path.Combine(_projectDirectory, "Test.csproj");
@@ -187,7 +184,7 @@ public sealed class MauiDevFlowAgentTargetsTests : IDisposable
             """);
     }
 
-    private static string ComputeExpectedDebugIdentitySuffix(string projectFilePath)
+    private static string ComputeExpectedSessionId(string projectFilePath)
     {
         var sanitized = new string(
             projectFilePath

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -82,8 +82,11 @@ You can override the automatically derived identity:
 
 ```bash
 # Set a specific session identity
-dotnet build -p:MauiDevFlowSessionId=my-session
+dotnet build -p:MauiDevFlowSessionId=mysession
 ```
+
+> **Note:** Session IDs are sanitized to lowercase alphanumeric characters only.
+> For example, `My-Session` would become `mysession`.
 
 The same value can also be supplied via the `MAUI_DEVFLOW_SESSION_ID` environment variable.
 

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -66,26 +66,26 @@ maui devflow ui tap --automationid "MyButton"
 maui devflow mcp
 ```
 
-### Debug app identity isolation
+### Session identity
 
-When `Microsoft.Maui.DevFlow.Agent` is referenced, **Debug** builds automatically rewrite
-the app `ApplicationId` to include a DevFlow-specific suffix derived from the project path.
-That lets separate worktrees or agent sessions install distinct debug copies of the same
-app on a device or simulator instead of competing for one installed identity.
+When `Microsoft.Maui.DevFlow.Agent` is referenced, builds are tagged with a **session identity**
+derived from the project path. This metadata-only identifier helps DevFlow distinguish builds
+from different environments (e.g. worktrees, CI agents, dev machines) without modifying
+the app's `ApplicationId` or bundle identifier.
 
-You can override or disable the behavior when needed:
+The session identity is included in:
+- Assembly metadata (`Microsoft.Maui.DevFlowSessionId`)
+- Broker registration (visible via `maui devflow list`)
+- Agent status endpoint (`/api/v1/agent/status`)
+
+You can override the automatically derived identity:
 
 ```bash
-# Disable Debug identity isolation
-dotnet build -p:MauiDevFlowEnableDebugAppIdentityIsolation=false
-
-# Force a specific Debug identity suffix
-dotnet build -p:MauiDevFlowDebugAppIdentitySuffix=agent42
+# Set a specific session identity
+dotnet build -p:MauiDevFlowSessionId=my-session
 ```
 
-The same values can also be supplied via environment variables:
-`MAUI_DEVFLOW_ENABLE_DEBUG_APP_IDENTITY_ISOLATION` and
-`MAUI_DEVFLOW_DEBUG_APP_IDENTITY_SUFFIX`.
+The same value can also be supplied via the `MAUI_DEVFLOW_SESSION_ID` environment variable.
 
 ## Features
 


### PR DESCRIPTION
## Motivation

PR #142 added debug app identity isolation by rewriting `ApplicationId` at build time to `<base>.debug.<suffix>`. While the goal of distinguishing builds from different worktrees/environments is sound, changing the bundle identifier or package ID has unintended consequences -- third-party SDKs, provisioning profiles, Info.plist/AndroidManifest declarations, and other artifacts that depend on a stable application ID can break in subtle ways.

This PR reworks the approach to be **metadata-only**: the session identity is propagated through assembly metadata, broker registration, and platform-native metadata without ever touching `ApplicationId`.

## Approach

**MSBuild targets** compute a `MauiDevFlowSessionId` derived from the project path (lowercase, alphanumeric, last 24 chars, prefixed `dw`). This is emitted as:

- **Assembly metadata** (`Microsoft.Maui.DevFlowSessionId`) -- read at runtime by the agent
- **Android manifest overlay** (`<meta-data android:name="com.microsoft.maui.devflow.sessionId">`) -- queryable via `adb shell dumpsys package`
- **iOS/Mac Catalyst partial plist** (`MauiDevFlowSessionId` key) -- queryable via `plutil`

The session ID flows through the **broker registration protocol** and is included in the agent's **HTTP status response**, so the CLI/MCP layer can distinguish agents from different environments.

Override via `-p:MauiDevFlowSessionId=custom` or `MAUI_DEVFLOW_SESSION_ID` env var.

## Key changes

- Remove `ApplicationId` rewriting from both `build/` and `buildTransitive/` targets
- Add `MauiDevFlowSessionId` computation and assembly metadata emission
- Add `_InjectMauiDevFlowAndroidManifestMetadata` target (manifest overlay)
- Add `_InjectMauiDevFlowiOSPlistMetadata` target (partial plist)
- Add `sessionId` to `AgentRegistration`, `RegistrationMessage`, `BrokerRegistration`, and `BrokerServer`
- Add `SetSessionId()` and status response inclusion in `DevFlowAgentService`
- Replace 4 identity isolation tests with 4 session ID tests
- Revert integration test fixtures to hardcoded package IDs
- Update README documentation

## Notes

- Platform metadata targets use `WriteOnlyWhenDifferent` to avoid downstream build churn -- since the session ID is derived from the project path (static), file timestamps stay stable between builds.
- The `BrokerRegistration` constructor adds a new `sessionId` parameter before `brokerPort`. Existing callers use named parameters for `brokerPort` so this is non-breaking.
- All 147 tests pass.