### PR TITLE
feat: Add file management support to DevFlow agent

### DIFF
--- a/docs/DevFlow/spec/README.md
+++ b/docs/DevFlow/spec/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the canonical DevFlow protocol contract used by the MAUI implementation in this repository.
 
-- `openapi.yaml` defines the versioned HTTP surface under `/api/v1/*`
+- `openapi.yaml` defines the versioned HTTP surface under `/api/v1/*`, including logical storage root discovery and sandboxed file management. The current shared implementation advertises only the `appData` root.
 - `asyncapi.yaml` defines the streaming channels under `/ws/v1/*`
 - `schemas/` contains the shared payload models
 - `examples/` contains representative request and response payloads

--- a/docs/DevFlow/spec/openapi.json
+++ b/docs/DevFlow/spec/openapi.json
@@ -56,7 +56,7 @@
     },
     {
       "name": "storage",
-      "description": "Preferences and secure storage"
+      "description": "Preferences, secure storage, and sandboxed app files"
     },
     {
       "name": "extensions",
@@ -2401,6 +2401,234 @@
         }
       }
     },
+    "/api/v1/storage/roots": {
+      "get": {
+        "operationId": "listStorageRoots",
+        "tags": [
+          "storage"
+        ],
+        "summary": "List file storage roots",
+        "description": "Lists logical file storage roots advertised by the agent. The current shared implementation advertises only `appData`; platform agents may advertise additional roots in the future. Absolute on-device paths are not returned.\n",
+        "responses": {
+          "200": {
+            "description": "Storage roots.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StorageRootsResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/storage/files": {
+      "get": {
+        "operationId": "listFiles",
+        "tags": [
+          "storage"
+        ],
+        "summary": "List storage files",
+        "description": "Lists files and directories under an advertised storage root. The optional path is always relative to the selected root; rooted paths, `..` traversal segments, and symlink/reparse-point traversal are rejected. Absolute on-device paths are not returned. Omit `root` to use the default `appData` root.\n",
+        "parameters": [
+          {
+            "name": "root",
+            "in": "query",
+            "description": "Storage root id. Defaults to `appData`. Use `/api/v1/storage/roots` to discover supported roots.",
+            "schema": {
+              "type": "string",
+              "default": "appData"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Relative subdirectory path. Omit or pass an empty string for the selected root.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Directory listing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidPath"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/v1/storage/files/{path}": {
+      "get": {
+        "operationId": "downloadFile",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Download a storage file",
+        "description": "Downloads a file under an advertised storage root and returns base64-encoded content. The path parameter is a single URI-encoded relative path; path separators inside it must be percent-encoded. Omit `root` to use the default `appData` root.\n",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "description": "URI-encoded relative file path under the selected storage root.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "root",
+            "in": "query",
+            "description": "Storage root id. Defaults to `appData`. Use `/api/v1/storage/roots` to discover supported roots.",
+            "schema": {
+              "type": "string",
+              "default": "appData"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File content and metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDownloadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidPath"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "put": {
+        "operationId": "uploadFile",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Upload a storage file",
+        "description": "Creates or overwrites a file under an advertised storage root. Parent directories are created automatically after path sandbox validation. Omit `root` to use the default `appData` root.\n",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "description": "URI-encoded relative file path under the selected storage root.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "root",
+            "in": "query",
+            "description": "Storage root id. Defaults to `appData`. Use `/api/v1/storage/roots` to discover supported roots.",
+            "schema": {
+              "type": "string",
+              "default": "appData"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileUploadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Uploaded file metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidPath"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteFile",
+        "tags": [
+          "storage"
+        ],
+        "summary": "Delete a storage file",
+        "description": "Deletes a file under an advertised storage root. Omit `root` to use the default `appData` root.",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "description": "URI-encoded relative file path under the selected storage root.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "root",
+            "in": "query",
+            "description": "Storage root id. Defaults to `appData`. Use `/api/v1/storage/roots` to discover supported roots.",
+            "schema": {
+              "type": "string",
+              "default": "appData"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted file metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidPath"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/api/v1/storage/secure": {
       "delete": {
         "operationId": "clearSecureStorage",
@@ -2613,6 +2841,22 @@
               "title": "Invalid selector",
               "status": 400,
               "errorCode": "invalid-selector"
+            }
+          }
+        }
+      },
+      "InvalidPath": {
+        "description": "Invalid or unsafe storage path or unavailable storage root.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "example": {
+              "type": "urn:devflow:error:invalid-path",
+              "title": "Invalid storage path",
+              "status": 400,
+              "errorCode": "invalid-path"
             }
           }
         }
@@ -3005,6 +3249,16 @@
                   "features": [
                     "get",
                     "set",
+                    "delete"
+                  ]
+                },
+                "storage.files": {
+                  "version": 1,
+                  "features": [
+                    "roots",
+                    "list",
+                    "download",
+                    "upload",
                     "delete"
                   ]
                 }
@@ -5108,6 +5362,256 @@
           "value": {
             "type": "string",
             "description": "The string value to store securely."
+          }
+        }
+      },
+      "StorageRoot": {
+        "type": "object",
+        "description": "A logical app storage root advertised by the agent. Absolute device paths are intentionally not exposed.",
+        "required": [
+          "id",
+          "displayName",
+          "kind",
+          "isWritable",
+          "isReadOnly",
+          "isPersistent",
+          "isBackedUp",
+          "mayBeClearedBySystem",
+          "isUserVisible",
+          "supportedOperations"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable root id to pass as the root query parameter. The current shared implementation advertises appData."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Human-readable root name."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Portable root kind, such as appData. Future platform roots may use additional kinds."
+          },
+          "isWritable": {
+            "type": "boolean",
+            "description": "Whether files can be uploaded or deleted in this root."
+          },
+          "isReadOnly": {
+            "type": "boolean",
+            "description": "Whether this root is read-only."
+          },
+          "isPersistent": {
+            "type": "boolean",
+            "description": "Whether data is expected to persist across app restarts."
+          },
+          "isBackedUp": {
+            "type": "boolean",
+            "description": "Whether the platform typically backs up this root."
+          },
+          "mayBeClearedBySystem": {
+            "type": "boolean",
+            "description": "Whether the operating system may purge files in this root."
+          },
+          "isUserVisible": {
+            "type": "boolean",
+            "description": "Whether the root is normally visible to users outside the app."
+          },
+          "supportedOperations": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "list",
+                "download",
+                "upload",
+                "delete"
+              ]
+            },
+            "description": "File operations supported by this root."
+          }
+        }
+      },
+      "StorageRootsResponse": {
+        "type": "object",
+        "description": "Logical file storage roots advertised by the agent. The current shared implementation returns only appData.",
+        "required": [
+          "roots"
+        ],
+        "properties": {
+          "roots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StorageRoot"
+            }
+          }
+        }
+      },
+      "FileEntry": {
+        "type": "object",
+        "description": "A file or directory under a storage root.",
+        "required": [
+          "name",
+          "type",
+          "lastModified"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Entry name, not including parent directories."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "file",
+              "directory"
+            ],
+            "description": "Entry kind."
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "File size in bytes. Present only for file entries."
+          },
+          "lastModified": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp when the entry was last modified."
+          }
+        }
+      },
+      "FileListResponse": {
+        "type": "object",
+        "description": "Directory listing under a logical storage root. Absolute device paths are never returned.",
+        "required": [
+          "root",
+          "path",
+          "entries"
+        ],
+        "properties": {
+          "root": {
+            "type": "string",
+            "description": "Logical storage root id used for the listing."
+          },
+          "path": {
+            "type": "string",
+            "description": "Normalized relative directory path. Empty string represents the selected storage root."
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileEntry"
+            }
+          }
+        }
+      },
+      "FileDownloadResponse": {
+        "type": "object",
+        "description": "Downloaded file content and metadata.",
+        "required": [
+          "root",
+          "path",
+          "size",
+          "lastModified",
+          "contentBase64"
+        ],
+        "properties": {
+          "root": {
+            "type": "string",
+            "description": "Logical storage root id used for the download."
+          },
+          "path": {
+            "type": "string",
+            "description": "Normalized relative file path."
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "File size in bytes."
+          },
+          "lastModified": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp when the file was last modified."
+          },
+          "contentBase64": {
+            "type": "string",
+            "contentEncoding": "base64",
+            "description": "File content encoded as base64."
+          }
+        }
+      },
+      "FileUploadRequest": {
+        "type": "object",
+        "description": "Request to upload file content under a storage root.",
+        "required": [
+          "contentBase64"
+        ],
+        "properties": {
+          "contentBase64": {
+            "type": "string",
+            "contentEncoding": "base64",
+            "description": "File content encoded as base64."
+          }
+        }
+      },
+      "FileUploadResponse": {
+        "type": "object",
+        "description": "Uploaded file metadata.",
+        "required": [
+          "success",
+          "root",
+          "path",
+          "size",
+          "lastModified"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "root": {
+            "type": "string",
+            "description": "Logical storage root id used for the upload."
+          },
+          "path": {
+            "type": "string",
+            "description": "Normalized relative file path."
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "File size in bytes."
+          },
+          "lastModified": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp when the file was last modified."
+          }
+        }
+      },
+      "FileDeleteResponse": {
+        "type": "object",
+        "description": "Deleted file metadata.",
+        "required": [
+          "success",
+          "root",
+          "path"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "root": {
+            "type": "string",
+            "description": "Logical storage root id used for the delete."
+          },
+          "path": {
+            "type": "string",
+            "description": "Normalized relative file path."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable delete confirmation."
           }
         }
       }

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -35,7 +35,7 @@ tags:
   - name: device
     description: Device info, sensors, permissions, geolocation
   - name: storage
-    description: Preferences and secure storage
+    description: Preferences, secure storage, and sandboxed app files
   - name: extensions
     description: Third-party extension routes
 
@@ -1607,6 +1607,169 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/v1/storage/roots:
+    get:
+      operationId: listStorageRoots
+      tags: [storage]
+      summary: List file storage roots
+      description: >
+        Lists logical file storage roots advertised by the agent. The current
+        shared implementation advertises only `appData`; platform agents may
+        advertise additional roots in the future. Absolute on-device paths are
+        not returned.
+      responses:
+        "200":
+          description: Storage roots.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/storage.json#/$defs/StorageRootsResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/storage/files:
+    get:
+      operationId: listFiles
+      tags: [storage]
+      summary: List storage files
+      description: >
+        Lists files and directories under an advertised storage root. The
+        optional path is always relative to the selected root; rooted paths, `..`
+        traversal segments, and symlink/reparse-point traversal are rejected.
+        Absolute on-device paths are not returned. Omit `root` to use the
+        default `appData` root.
+      parameters:
+        - name: root
+          in: query
+          description: Storage root id. Defaults to `appData`. Use `/api/v1/storage/roots` to discover supported roots.
+          schema:
+            type: string
+            default: appData
+        - name: path
+          in: query
+          description: Relative subdirectory path. Omit or pass an empty string for the selected root.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Directory listing.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/storage.json#/$defs/FileListResponse"
+        "400":
+          $ref: "#/components/responses/InvalidPath"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/storage/files/{path}:
+    get:
+      operationId: downloadFile
+      tags: [storage]
+      summary: Download a storage file
+      description: >
+        Downloads a file under an advertised storage root and returns base64-encoded
+        content. The path parameter is a single URI-encoded relative path; path
+        separators inside it must be percent-encoded. Omit `root` to use the
+        default `appData` root.
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: URI-encoded relative file path under the selected storage root.
+          schema:
+            type: string
+        - name: root
+          in: query
+          description: Storage root id. Defaults to `appData`. Use `/api/v1/storage/roots` to discover supported roots.
+          schema:
+            type: string
+            default: appData
+      responses:
+        "200":
+          description: File content and metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/storage.json#/$defs/FileDownloadResponse"
+        "400":
+          $ref: "#/components/responses/InvalidPath"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    put:
+      operationId: uploadFile
+      tags: [storage]
+      summary: Upload a storage file
+      description: >
+        Creates or overwrites a file under an advertised storage root. Parent
+        directories are created automatically after path sandbox validation.
+        Omit `root` to use the default `appData` root.
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: URI-encoded relative file path under the selected storage root.
+          schema:
+            type: string
+        - name: root
+          in: query
+          description: Storage root id. Defaults to `appData`. Use `/api/v1/storage/roots` to discover supported roots.
+          schema:
+            type: string
+            default: appData
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/storage.json#/$defs/FileUploadRequest"
+      responses:
+        "200":
+          description: Uploaded file metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/storage.json#/$defs/FileUploadResponse"
+        "400":
+          $ref: "#/components/responses/InvalidPath"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: deleteFile
+      tags: [storage]
+      summary: Delete a storage file
+      description: Deletes a file under an advertised storage root. Omit `root` to use the default `appData` root.
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: URI-encoded relative file path under the selected storage root.
+          schema:
+            type: string
+        - name: root
+          in: query
+          description: Storage root id. Defaults to `appData`. Use `/api/v1/storage/roots` to discover supported roots.
+          schema:
+            type: string
+            default: appData
+      responses:
+        "200":
+          description: Deleted file metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/storage.json#/$defs/FileDeleteResponse"
+        "400":
+          $ref: "#/components/responses/InvalidPath"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /api/v1/storage/secure:
     delete:
       operationId: clearSecureStorage
@@ -1757,6 +1920,18 @@ components:
             title: Invalid selector
             status: 400
             errorCode: invalid-selector
+
+    InvalidPath:
+      description: Invalid or unsafe storage path or unavailable storage root.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:invalid-path"
+            title: Invalid storage path
+            status: 400
+            errorCode: invalid-path
 
     Timeout:
       description: Operation timed out.

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -150,6 +150,16 @@
               "set",
               "delete"
             ]
+          },
+          "storage.files": {
+            "version": 1,
+            "features": [
+              "roots",
+              "list",
+              "download",
+              "upload",
+              "delete"
+            ]
           }
         }
       ]

--- a/docs/DevFlow/spec/schemas/storage.json
+++ b/docs/DevFlow/spec/schemas/storage.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "storage.json",
   "title": "Storage Models",
-  "description": "Storage models for application preferences and secure storage operations.",
+  "description": "Storage models for application preferences, secure storage, and sandboxed file storage operations.",
   "$defs": {
     "PreferenceValueType": {
       "type": "string",
@@ -75,6 +75,256 @@
         "value": {
           "type": "string",
           "description": "The string value to store securely."
+        }
+      }
+    },
+    "StorageRoot": {
+      "type": "object",
+      "description": "A logical app storage root advertised by the agent. Absolute device paths are intentionally not exposed.",
+      "required": [
+        "id",
+        "displayName",
+        "kind",
+        "isWritable",
+        "isReadOnly",
+        "isPersistent",
+        "isBackedUp",
+        "mayBeClearedBySystem",
+        "isUserVisible",
+        "supportedOperations"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable root id to pass as the root query parameter. The current shared implementation advertises appData."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable root name."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Portable root kind, such as appData. Future platform roots may use additional kinds."
+        },
+        "isWritable": {
+          "type": "boolean",
+          "description": "Whether files can be uploaded or deleted in this root."
+        },
+        "isReadOnly": {
+          "type": "boolean",
+          "description": "Whether this root is read-only."
+        },
+        "isPersistent": {
+          "type": "boolean",
+          "description": "Whether data is expected to persist across app restarts."
+        },
+        "isBackedUp": {
+          "type": "boolean",
+          "description": "Whether the platform typically backs up this root."
+        },
+        "mayBeClearedBySystem": {
+          "type": "boolean",
+          "description": "Whether the operating system may purge files in this root."
+        },
+        "isUserVisible": {
+          "type": "boolean",
+          "description": "Whether the root is normally visible to users outside the app."
+        },
+        "supportedOperations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "list",
+              "download",
+              "upload",
+              "delete"
+            ]
+          },
+          "description": "File operations supported by this root."
+        }
+      }
+    },
+    "StorageRootsResponse": {
+      "type": "object",
+      "description": "Logical file storage roots advertised by the agent. The current shared implementation returns only appData.",
+      "required": [
+        "roots"
+      ],
+      "properties": {
+        "roots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StorageRoot"
+          }
+        }
+      }
+    },
+    "FileEntry": {
+      "type": "object",
+      "description": "A file or directory under a storage root.",
+      "required": [
+        "name",
+        "type",
+        "lastModified"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Entry name, not including parent directories."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "file",
+            "directory"
+          ],
+          "description": "Entry kind."
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "File size in bytes. Present only for file entries."
+        },
+        "lastModified": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC timestamp when the entry was last modified."
+        }
+      }
+    },
+    "FileListResponse": {
+      "type": "object",
+      "description": "Directory listing under a logical storage root. Absolute device paths are never returned.",
+      "required": [
+        "root",
+        "path",
+        "entries"
+      ],
+      "properties": {
+        "root": {
+          "type": "string",
+          "description": "Logical storage root id used for the listing."
+        },
+        "path": {
+          "type": "string",
+          "description": "Normalized relative directory path. Empty string represents the selected storage root."
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FileEntry"
+          }
+        }
+      }
+    },
+    "FileDownloadResponse": {
+      "type": "object",
+      "description": "Downloaded file content and metadata.",
+      "required": [
+        "root",
+        "path",
+        "size",
+        "lastModified",
+        "contentBase64"
+      ],
+      "properties": {
+        "root": {
+          "type": "string",
+          "description": "Logical storage root id used for the download."
+        },
+        "path": {
+          "type": "string",
+          "description": "Normalized relative file path."
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "File size in bytes."
+        },
+        "lastModified": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC timestamp when the file was last modified."
+        },
+        "contentBase64": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "File content encoded as base64."
+        }
+      }
+    },
+    "FileUploadRequest": {
+      "type": "object",
+      "description": "Request to upload file content under a storage root.",
+      "required": [
+        "contentBase64"
+      ],
+      "properties": {
+        "contentBase64": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "File content encoded as base64."
+        }
+      }
+    },
+    "FileUploadResponse": {
+      "type": "object",
+      "description": "Uploaded file metadata.",
+      "required": [
+        "success",
+        "root",
+        "path",
+        "size",
+        "lastModified"
+      ],
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "root": {
+          "type": "string",
+          "description": "Logical storage root id used for the upload."
+        },
+        "path": {
+          "type": "string",
+          "description": "Normalized relative file path."
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "File size in bytes."
+        },
+        "lastModified": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC timestamp when the file was last modified."
+        }
+      }
+    },
+    "FileDeleteResponse": {
+      "type": "object",
+      "description": "Deleted file metadata.",
+      "required": [
+        "success",
+        "root",
+        "path"
+      ],
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "root": {
+          "type": "string",
+          "description": "Logical storage root id used for the delete."
+        },
+        "path": {
+          "type": "string",
+          "description": "Normalized relative file path."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable delete confirmation."
         }
       }
     }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -236,6 +236,60 @@ public class DevFlowCliIntegrationTests
     }
 
     [Fact]
+    public async Task StorageFilesDownload_WithNestedDevicePathAndOutputDirectory_UsesRemoteFileName()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-download-");
+
+        try
+        {
+            var result = await cli.InvokeAsync("devflow", "storage", "files", "download", "logs/app.log", "--output", tempDir.FullName, "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            var outputFile = Path.Combine(tempDir.FullName, "app.log");
+            Assert.Equal("hello", await File.ReadAllTextAsync(outputFile));
+            var json = result.ParseJsonOutput();
+            Assert.Equal(outputFile, json.GetProperty("localPath").GetString());
+
+            var request = Assert.Single(server.RecordedRequests, r => r.Path.StartsWith("/api/v1/storage/files/", StringComparison.Ordinal));
+            Assert.Equal("GET", request.Method);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StorageFilesDownload_WithTrailingDirectorySeparator_CreatesDirectoryAndUsesRemoteFileName()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-download-");
+
+        try
+        {
+            var outputDirectory = Path.Combine(tempDir.FullName, "created-downloads") + Path.DirectorySeparatorChar;
+
+            var result = await cli.InvokeAsync("devflow", "storage", "files", "download", "logs/app.log", "--output", outputDirectory, "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            var outputFile = Path.Combine(outputDirectory, "app.log");
+            Assert.Equal("hello", await File.ReadAllTextAsync(outputFile));
+            var json = result.ParseJsonOutput();
+            Assert.Equal(outputFile, json.GetProperty("localPath").GetString());
+
+            var request = Assert.Single(server.RecordedRequests, r => r.Path.StartsWith("/api/v1/storage/files/", StringComparison.Ordinal));
+            Assert.Equal("GET", request.Method);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task StorageFilesUpload_UsesPutV1FilesRoute()
     {
         var (server, cli) = await CreateFixturesAsync();
@@ -275,6 +329,36 @@ public class DevFlowCliIntegrationTests
         }
         finally
         {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StorageFilesUpload_WithRelativeLocalFile_ReadsFromCurrentDirectory()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-upload-");
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+
+        try
+        {
+            var localFile = Path.Combine(tempDir.FullName, "payload.txt");
+            await File.WriteAllTextAsync(localFile, "relative content");
+            Directory.SetCurrentDirectory(tempDir.FullName);
+
+            var result = await cli.InvokeAsync("devflow", "storage", "files", "upload", "app.log", "--file", "payload.txt", "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            var expectedBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("relative content"));
+
+            var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+            Assert.Equal("PUT", request.Method);
+            Assert.Contains($"\"contentBase64\":\"{expectedBase64}\"", request.Body);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
             tempDir.Delete(recursive: true);
         }
     }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using Microsoft.Maui.Cli.UnitTests.Fixtures;
 using Xunit;
@@ -180,6 +181,61 @@ public class DevFlowCliIntegrationTests
     }
 
     [Fact]
+    public async Task StorageFilesDownload_WithOutputDirectory_WritesRemoteFileName()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-download-");
+
+        try
+        {
+            var result = await cli.InvokeAsync("devflow", "storage", "files", "download", "app.log", "--output", tempDir.FullName, "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            var outputFile = Path.Combine(tempDir.FullName, "app.log");
+            Assert.Equal("hello", await File.ReadAllTextAsync(outputFile));
+            var json = result.ParseJsonOutput();
+            Assert.True(json.GetProperty("success").GetBoolean());
+            Assert.Equal(outputFile, json.GetProperty("localPath").GetString());
+            Assert.False(json.TryGetProperty("contentBase64", out _));
+
+            var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+            Assert.Equal("GET", request.Method);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StorageFilesDownload_WithOutputFile_WritesExplicitPath()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-download-");
+
+        try
+        {
+            var outputFile = Path.Combine(tempDir.FullName, "renamed.txt");
+
+            var result = await cli.InvokeAsync("devflow", "storage", "files", "download", "app.log", "--output", outputFile, "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("hello", await File.ReadAllTextAsync(outputFile));
+            var json = result.ParseJsonOutput();
+            Assert.Equal(outputFile, json.GetProperty("localPath").GetString());
+
+            var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+            Assert.Equal("GET", request.Method);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task StorageFilesUpload_UsesPutV1FilesRoute()
     {
         var (server, cli) = await CreateFixturesAsync();
@@ -194,6 +250,70 @@ public class DevFlowCliIntegrationTests
         var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
         Assert.Equal("PUT", request.Method);
         Assert.Contains("\"contentBase64\":\"aGVsbG8=\"", request.Body);
+    }
+
+    [Fact]
+    public async Task StorageFilesUpload_WithLocalFile_ReadsFileContent()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-upload-");
+
+        try
+        {
+            var localFile = Path.Combine(tempDir.FullName, "payload.txt");
+            await File.WriteAllTextAsync(localFile, "from disk");
+
+            var result = await cli.InvokeAsync("devflow", "storage", "files", "upload", "app.log", "--file", localFile, "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            var expectedBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("from disk"));
+
+            var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+            Assert.Equal("PUT", request.Method);
+            Assert.Contains($"\"contentBase64\":\"{expectedBase64}\"", request.Body);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StorageFilesUpload_WithContentAndLocalFile_ReturnsError()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-upload-");
+
+        try
+        {
+            var localFile = Path.Combine(tempDir.FullName, "payload.txt");
+            await File.WriteAllTextAsync(localFile, "from disk");
+
+            var result = await cli.InvokeAsync("devflow", "storage", "files", "upload", "app.log", "aGVsbG8=", "--file", localFile, "--json");
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains("Provide exactly one of contentBase64 or --file.", result.StdErr);
+            Assert.DoesNotContain(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StorageFilesUpload_WithoutContentOrLocalFile_ReturnsError()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "upload", "app.log", "--json");
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Provide exactly one of contentBase64 or --file.", result.StdErr);
+        Assert.DoesNotContain(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
     }
 
     [Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -252,7 +252,7 @@ public class DevFlowCliIntegrationTests
             var json = result.ParseJsonOutput();
             Assert.Equal(outputFile, json.GetProperty("localPath").GetString());
 
-            var request = Assert.Single(server.RecordedRequests, r => r.Path.StartsWith("/api/v1/storage/files/", StringComparison.Ordinal));
+            var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/logs%2Fapp.log");
             Assert.Equal("GET", request.Method);
         }
         finally
@@ -280,7 +280,7 @@ public class DevFlowCliIntegrationTests
             var json = result.ParseJsonOutput();
             Assert.Equal(outputFile, json.GetProperty("localPath").GetString());
 
-            var request = Assert.Single(server.RecordedRequests, r => r.Path.StartsWith("/api/v1/storage/files/", StringComparison.Ordinal));
+            var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/logs%2Fapp.log");
             Assert.Equal("GET", request.Method);
         }
         finally

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -96,6 +96,154 @@ public class DevFlowCliIntegrationTests
     }
 
     [Fact]
+    public async Task StorageRoots_UsesV1StorageRootsRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "roots", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal("appData", json.GetProperty("roots")[0].GetProperty("id").GetString());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/roots");
+        Assert.Equal("GET", request.Method);
+    }
+
+    [Fact]
+    public async Task StorageFilesList_UsesV1FilesRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "list", "logs", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal("logs", json.GetProperty("path").GetString());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files");
+        Assert.Equal("GET", request.Method);
+        Assert.Contains("path=logs", request.QueryString);
+    }
+
+    [Fact]
+    public async Task StorageFilesList_WithRoot_UsesRootQuery()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "list", "logs", "--root", "appData", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal("appData", json.GetProperty("root").GetString());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files");
+        Assert.Equal("GET", request.Method);
+        Assert.Contains("path=logs", request.QueryString);
+        Assert.Contains("root=appData", request.QueryString);
+    }
+
+    [Fact]
+    public async Task StorageFilesDownload_UsesV1FilesRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "download", "app.log", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal("aGVsbG8=", json.GetProperty("contentBase64").GetString());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+        Assert.Equal("GET", request.Method);
+    }
+
+    [Fact]
+    public async Task StorageFilesDownload_WithRoot_UsesRootQuery()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "download", "app.log", "--root", "appData", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal("appData", json.GetProperty("root").GetString());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+        Assert.Equal("GET", request.Method);
+        Assert.Contains("root=appData", request.QueryString);
+    }
+
+    [Fact]
+    public async Task StorageFilesUpload_UsesPutV1FilesRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "upload", "app.log", "aGVsbG8=", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.True(json.GetProperty("success").GetBoolean());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+        Assert.Equal("PUT", request.Method);
+        Assert.Contains("\"contentBase64\":\"aGVsbG8=\"", request.Body);
+    }
+
+    [Fact]
+    public async Task StorageFilesUpload_WithRoot_UsesRootQuery()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "upload", "app.log", "aGVsbG8=", "--root", "appData", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal("appData", json.GetProperty("root").GetString());
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+        Assert.Equal("PUT", request.Method);
+        Assert.Contains("root=appData", request.QueryString);
+        Assert.Contains("\"contentBase64\":\"aGVsbG8=\"", request.Body);
+    }
+
+    [Fact]
+    public async Task StorageFilesDelete_UsesDeleteV1FilesRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "delete", "app.log", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+        Assert.Equal("DELETE", request.Method);
+    }
+
+    [Fact]
+    public async Task StorageFilesDelete_WithRoot_UsesRootQuery()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var serverHandle = server;
+
+        var result = await cli.InvokeAsync("devflow", "storage", "files", "delete", "app.log", "--root", "appData", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+
+        var request = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/storage/files/app.log");
+        Assert.Equal("DELETE", request.Method);
+        Assert.Contains("root=appData", request.QueryString);
+    }
+
+    [Fact]
     public async Task DeviceInfo_UsesV1DeviceEndpoint()
     {
         var (server, cli) = await CreateFixturesAsync();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
@@ -49,7 +49,7 @@ internal static class MockAgentResponses
           "network": { "supported": true, "features": ["list", "detail", "clear"] },
           "logs": { "supported": true, "features": ["list", "stream"] },
           "sensors": { "supported": true, "features": ["list", "start", "stop"] },
-          "storage": { "supported": true, "features": ["preferences", "secure-storage"] },
+          "storage": { "supported": true, "features": ["preferences", "secure-storage", "roots", "files"] },
           "profiler": { "supported": true, "features": ["capabilities", "sessions", "samples"] }
         }
         """;
@@ -138,6 +138,60 @@ internal static class MockAgentResponses
         {
           "key": "token",
           "value": "secret-value"
+        }
+        """;
+
+    public const string StorageRoots = """
+        {
+          "roots": [
+            {
+              "id": "appData",
+              "displayName": "App data",
+              "kind": "appData",
+              "isWritable": true,
+              "isReadOnly": false,
+              "isPersistent": true,
+              "isBackedUp": true,
+              "mayBeClearedBySystem": false,
+              "isUserVisible": false,
+              "supportedOperations": ["list", "download", "upload", "delete"]
+            }
+          ]
+        }
+        """;
+
+    public const string FilesList = """
+        {
+          "root": "appData",
+          "path": "logs",
+          "entries": [
+            {
+              "name": "app.log",
+              "type": "file",
+              "size": 5,
+              "lastModified": "2026-04-01T12:00:00Z"
+            }
+          ]
+        }
+        """;
+
+    public static string FileDownload(string path) => $$"""
+        {
+          "root": "appData",
+          "path": "{{path}}",
+          "size": 5,
+          "lastModified": "2026-04-01T12:00:00Z",
+          "contentBase64": "aGVsbG8="
+        }
+        """;
+
+    public static string FileUpload(string path) => $$"""
+        {
+          "success": true,
+          "root": "appData",
+          "path": "{{path}}",
+          "size": 5,
+          "lastModified": "2026-04-01T12:00:00Z"
         }
         """;
 

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
@@ -137,6 +137,12 @@ public sealed class MockAgentServer : IAsyncDisposable
         app.MapPut("/api/v1/storage/secure/{key}", () => Results.Content(MockAgentResponses.SecureStorageValue, "application/json"));
         app.MapDelete("/api/v1/storage/secure/{key}", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
         app.MapDelete("/api/v1/storage/secure", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+
+        app.MapGet("/api/v1/storage/roots", () => Results.Content(MockAgentResponses.StorageRoots, "application/json"));
+        app.MapGet("/api/v1/storage/files", () => Results.Content(MockAgentResponses.FilesList, "application/json"));
+        app.MapGet("/api/v1/storage/files/{path}", (string path) => Results.Content(MockAgentResponses.FileDownload(path), "application/json"));
+        app.MapPut("/api/v1/storage/files/{path}", (string path) => Results.Content(MockAgentResponses.FileUpload(path), "application/json"));
+        app.MapDelete("/api/v1/storage/files/{path}", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
     }
 
     private static void RegisterWebViewEndpoints(WebApplication app)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -834,7 +834,18 @@ public class DevFlowCommands
         devflowCommand.Add(networkCommand);
 
         // ===== storage subcommands =====
-        var storageCommand = new Command("storage", "Manage app preferences and secure storage");
+        var storageCommand = new Command("storage", "Manage app preferences, secure storage, and sandboxed app files");
+
+        var storageRootsCmd = new Command("roots", "List file storage roots advertised by the app");
+        storageRootsCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            await SimpleGetAsync(host, port, "/api/v1/storage/roots", output.ResolveJsonMode(json, noJson));
+        });
+        storageCommand.Add(storageRootsCmd);
 
         // ===== preferences subcommands =====
         var prefsCommand = new Command("preferences", "Manage app preferences (key-value store)");
@@ -997,6 +1008,78 @@ public class DevFlowCommands
         secureCommand.Add(secureClearCmd);
 
         storageCommand.Add(secureCommand);
+
+        // ===== app file subcommands =====
+        var filesCommand = new Command("files", "Manage files under an advertised app storage root");
+        var filesRootOption = new Option<string?>("--root") { Description = "Storage root id (default: appData; use 'storage roots' to discover supported roots)" };
+        filesRootOption.Recursive = true;
+        filesCommand.Add(filesRootOption);
+
+        var filesListPathArg = new Argument<string?>("path") { Description = "Relative subdirectory path to list", DefaultValueFactory = _ => null };
+        var filesListCmd = new Command("list", "List files and directories") { filesListPathArg };
+        filesListCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            var path = ctx.GetValue(filesListPathArg);
+            var root = ctx.GetValue(filesRootOption);
+            var isJson = output.ResolveJsonMode(json, noJson);
+            var qs = BuildStorageFilesQuery(path, root);
+            await SimpleGetAsync(host, port, $"/api/v1/storage/files{qs}", isJson);
+        });
+        filesCommand.Add(filesListCmd);
+
+        var filesDownloadPathArg = new Argument<string>("path") { Description = "Relative file path under the selected storage root" };
+        var filesDownloadCmd = new Command("download", "Download a file as base64 content") { filesDownloadPathArg };
+        filesDownloadCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            var path = ctx.GetValue(filesDownloadPathArg)!;
+            var root = ctx.GetValue(filesRootOption);
+            await SimpleGetAsync(host, port, $"/api/v1/storage/files/{Uri.EscapeDataString(path)}{BuildStorageFilesQuery(root: root)}", output.ResolveJsonMode(json, noJson));
+        });
+        filesCommand.Add(filesDownloadCmd);
+
+        var filesUploadPathArg = new Argument<string>("path") { Description = "Relative file path under the selected storage root" };
+        var filesUploadContentArg = new Argument<string>("contentBase64") { Description = "Base64-encoded file content" };
+        var filesUploadCmd = new Command("upload", "Upload base64 content to a file") { filesUploadPathArg, filesUploadContentArg };
+        filesUploadCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            var path = ctx.GetValue(filesUploadPathArg)!;
+            var contentBase64 = ctx.GetValue(filesUploadContentArg)!;
+            var root = ctx.GetValue(filesRootOption);
+            var isJson = output.ResolveJsonMode(json, noJson);
+            await SimplePutAsync(host, port, $"/api/v1/storage/files/{Uri.EscapeDataString(path)}{BuildStorageFilesQuery(root: root)}", new JsonObject
+            {
+                ["contentBase64"] = contentBase64
+            }, isJson);
+        });
+        filesCommand.Add(filesUploadCmd);
+
+        var filesDeletePathArg = new Argument<string>("path") { Description = "Relative file path under the selected storage root" };
+        var filesDeleteCmd = new Command("delete", "Delete a file") { filesDeletePathArg };
+        filesDeleteCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            var path = ctx.GetValue(filesDeletePathArg)!;
+            var root = ctx.GetValue(filesRootOption);
+            await SimpleDeleteAsync(host, port, $"/api/v1/storage/files/{Uri.EscapeDataString(path)}{BuildStorageFilesQuery(root: root)}", output.ResolveJsonMode(json, noJson));
+        });
+        filesCommand.Add(filesDeleteCmd);
+
+        storageCommand.Add(filesCommand);
         devflowCommand.Add(storageCommand);
 
         // ===== device subcommands (read-only) =====
@@ -1764,6 +1847,17 @@ public class DevFlowCommands
     private static string FormatJson(JsonElement element)
     {
         return CliJson.PrettyPrint(element);
+    }
+
+    private static string BuildStorageFilesQuery(string? path = null, string? root = null)
+    {
+        var query = new List<string>();
+        if (!string.IsNullOrEmpty(path))
+            query.Add($"path={Uri.EscapeDataString(path)}");
+        if (!string.IsNullOrEmpty(root))
+            query.Add($"root={Uri.EscapeDataString(root)}");
+
+        return query.Count == 0 ? string.Empty : "?" + string.Join("&", query);
     }
 
     // ===== Generic agent HTTP helpers (for preferences, platform, sensors, etc.) =====

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -1032,7 +1032,11 @@ public class DevFlowCommands
         filesCommand.Add(filesListCmd);
 
         var filesDownloadPathArg = new Argument<string>("path") { Description = "Relative file path under the selected storage root" };
-        var filesDownloadCmd = new Command("download", "Download a file as base64 content") { filesDownloadPathArg };
+        var filesDownloadOutputOption = new Option<string?>("--output", "-o")
+        {
+            Description = "Local file or directory path to write the downloaded file to. Relative paths are resolved from the current directory."
+        };
+        var filesDownloadCmd = new Command("download", "Download a file as base64 content or write it locally") { filesDownloadPathArg, filesDownloadOutputOption };
         filesDownloadCmd.SetAction(async (ctx, ct) =>
         {
             var host = ctx.GetValue(agentHostOption)!;
@@ -1041,13 +1045,27 @@ public class DevFlowCommands
             var noJson = ctx.GetValue(noJsonOption);
             var path = ctx.GetValue(filesDownloadPathArg)!;
             var root = ctx.GetValue(filesRootOption);
-            await SimpleGetAsync(host, port, $"/api/v1/storage/files/{Uri.EscapeDataString(path)}{BuildStorageFilesQuery(root: root)}", output.ResolveJsonMode(json, noJson));
+            var outputPath = ctx.GetValue(filesDownloadOutputOption);
+            var isJson = output.ResolveJsonMode(json, noJson);
+
+            if (string.IsNullOrWhiteSpace(outputPath))
+                await SimpleGetAsync(host, port, $"/api/v1/storage/files/{Uri.EscapeDataString(path)}{BuildStorageFilesQuery(root: root)}", isJson);
+            else
+                await DownloadFileToLocalPathAsync(host, port, path, root, outputPath, isJson);
         });
         filesCommand.Add(filesDownloadCmd);
 
         var filesUploadPathArg = new Argument<string>("path") { Description = "Relative file path under the selected storage root" };
-        var filesUploadContentArg = new Argument<string>("contentBase64") { Description = "Base64-encoded file content" };
-        var filesUploadCmd = new Command("upload", "Upload base64 content to a file") { filesUploadPathArg, filesUploadContentArg };
+        var filesUploadContentArg = new Argument<string?>("contentBase64")
+        {
+            Description = "Base64-encoded file content. Omit when using --file.",
+            DefaultValueFactory = _ => null
+        };
+        var filesUploadFileOption = new Option<string?>("--file", "-f")
+        {
+            Description = "Local file to upload. Relative paths are resolved from the current directory."
+        };
+        var filesUploadCmd = new Command("upload", "Upload base64 content or a local file") { filesUploadPathArg, filesUploadContentArg, filesUploadFileOption };
         filesUploadCmd.SetAction(async (ctx, ct) =>
         {
             var host = ctx.GetValue(agentHostOption)!;
@@ -1055,9 +1073,15 @@ public class DevFlowCommands
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
             var path = ctx.GetValue(filesUploadPathArg)!;
-            var contentBase64 = ctx.GetValue(filesUploadContentArg)!;
+            var contentBase64Argument = ctx.GetValue(filesUploadContentArg);
+            var localFilePath = ctx.GetValue(filesUploadFileOption);
             var root = ctx.GetValue(filesRootOption);
             var isJson = output.ResolveJsonMode(json, noJson);
+
+            var contentBase64 = await GetUploadContentBase64Async(contentBase64Argument, localFilePath, isJson);
+            if (contentBase64 is null)
+                return;
+
             await SimplePutAsync(host, port, $"/api/v1/storage/files/{Uri.EscapeDataString(path)}{BuildStorageFilesQuery(root: root)}", new JsonObject
             {
                 ["contentBase64"] = contentBase64
@@ -1858,6 +1882,130 @@ public class DevFlowCommands
             query.Add($"root={Uri.EscapeDataString(root)}");
 
         return query.Count == 0 ? string.Empty : "?" + string.Join("&", query);
+    }
+
+    private static async Task<string?> GetUploadContentBase64Async(string? contentBase64Argument, string? localFilePath, bool json)
+    {
+        var hasContentArgument = contentBase64Argument is not null;
+        var hasLocalFile = !string.IsNullOrWhiteSpace(localFilePath);
+
+        if (hasContentArgument == hasLocalFile)
+        {
+            Output.WriteError("Provide exactly one of contentBase64 or --file.", json, "InvocationError");
+            _errorOccurred = true;
+            return null;
+        }
+
+        if (hasContentArgument)
+            return contentBase64Argument!;
+
+        try
+        {
+            var fullPath = Path.GetFullPath(localFilePath!);
+            if (!File.Exists(fullPath))
+            {
+                Output.WriteError($"Local file not found: {fullPath}", json, "InvocationError");
+                _errorOccurred = true;
+                return null;
+            }
+
+            var bytes = await File.ReadAllBytesAsync(fullPath);
+            return Convert.ToBase64String(bytes);
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException)
+        {
+            Output.WriteError($"Failed to read local file: {ex.Message}", json);
+            _errorOccurred = true;
+            return null;
+        }
+    }
+
+    private static async Task DownloadFileToLocalPathAsync(string host, int port, string devicePath, string? root, string destinationPath, bool json)
+    {
+        try
+        {
+            using var http = new HttpClient();
+            http.Timeout = TimeSpan.FromSeconds(30);
+            var response = await http.GetAsync($"http://{host}:{port}/api/v1/storage/files/{Uri.EscapeDataString(devicePath)}{BuildStorageFilesQuery(root: root)}");
+            var body = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.WriteLine(body);
+                _errorOccurred = true;
+                return;
+            }
+
+            var responseObject = CliJson.ParseNode(body) as JsonObject;
+            if (responseObject is null ||
+                !responseObject.TryGetPropertyValue("contentBase64", out var contentNode) ||
+                contentNode is null ||
+                contentNode.GetValueKind() != JsonValueKind.String)
+            {
+                Output.WriteError("Download response did not include contentBase64.", json);
+                _errorOccurred = true;
+                return;
+            }
+
+            var contentBase64 = contentNode.GetValue<string>();
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(contentBase64);
+            }
+            catch (FormatException ex)
+            {
+                Output.WriteError($"Download response contained invalid base64 content: {ex.Message}", json);
+                _errorOccurred = true;
+                return;
+            }
+
+            var localPath = ResolveDownloadDestinationPath(destinationPath, devicePath);
+            var parentDirectory = Path.GetDirectoryName(localPath);
+            if (!string.IsNullOrEmpty(parentDirectory))
+                Directory.CreateDirectory(parentDirectory);
+
+            await File.WriteAllBytesAsync(localPath, bytes);
+
+            if (json)
+            {
+                responseObject.Remove("contentBase64");
+                responseObject["success"] = true;
+                responseObject["localPath"] = localPath;
+                Console.WriteLine(CliJson.SerializeUntyped(responseObject));
+            }
+            else
+            {
+                Console.WriteLine($"Downloaded {devicePath} to {localPath}");
+            }
+        }
+        catch (Exception ex) when (ex is ArgumentException or HttpRequestException or IOException or JsonException or NotSupportedException or TaskCanceledException or UnauthorizedAccessException)
+        {
+            Output.WriteError(ex.Message, json);
+            _errorOccurred = true;
+        }
+    }
+
+    private static string ResolveDownloadDestinationPath(string destinationPath, string devicePath)
+    {
+        var fullDestinationPath = Path.GetFullPath(destinationPath);
+        if (Directory.Exists(fullDestinationPath) || EndsWithDirectorySeparator(destinationPath))
+            return Path.Combine(fullDestinationPath, GetDeviceFileName(devicePath));
+
+        return fullDestinationPath;
+    }
+
+    private static bool EndsWithDirectorySeparator(string path)
+        => path.Length > 0 && (path[^1] == Path.DirectorySeparatorChar || path[^1] == Path.AltDirectorySeparatorChar);
+
+    private static string GetDeviceFileName(string devicePath)
+    {
+        var normalizedPath = devicePath.Replace('\\', '/').TrimEnd('/');
+        var fileName = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+        if (string.IsNullOrEmpty(fileName))
+            throw new ArgumentException("The device path must include a file name.", nameof(devicePath));
+
+        return fileName;
     }
 
     // ===== Generic agent HTTP helpers (for preferences, platform, sensors, etc.) =====

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -37,6 +37,7 @@ public static class McpServerHost
 			.WithTools<PreferencesTools>()
 			.WithTools<PlatformTools>()
 			.WithTools<SensorTools>()
+			.WithTools<FileTools>()
 			.WithTools<BatchTools>();
 
 		await builder.Build().RunAsync();

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/FileTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/FileTools.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Microsoft.Maui.Cli.DevFlow.Mcp;
+
+namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class FileTools
+{
+	[McpServerTool(Name = "maui_files_list"), Description("List files and directories in the app's data directory. Optionally specify a subdirectory path.")]
+	public static async Task<string> ListFiles(
+		McpAgentSession session,
+		[Description("Subdirectory path relative to the app data root (optional, lists root if omitted)")] string? path = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.ListFilesAsync(path);
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to list files." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_files_download"), Description("Download a file from the app's data directory. Returns the file content as base64.")]
+	public static async Task<string> DownloadFile(
+		McpAgentSession session,
+		[Description("File path relative to the app data root")] string path,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.DownloadFileAsync(path);
+		return result.ValueKind == JsonValueKind.Undefined ? $"Failed to download file '{path}'." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_files_upload"), Description("Upload a file to the app's data directory. Content must be base64-encoded. Parent directories are created automatically.")]
+	public static async Task<string> UploadFile(
+		McpAgentSession session,
+		[Description("File path relative to the app data root")] string path,
+		[Description("File content encoded as base64")] string contentBase64,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.UploadFileAsync(path, contentBase64);
+		return result.ValueKind == JsonValueKind.Undefined ? $"Failed to upload file '{path}'." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_files_delete"), Description("Delete a file from the app's data directory.")]
+	public static async Task<string> DeleteFile(
+		McpAgentSession session,
+		[Description("File path relative to the app data root")] string path,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.DeleteFileAsync(path);
+		return success ? $"File '{path}' deleted." : $"Failed to delete file '{path}'.";
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/FileTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/FileTools.cs
@@ -8,48 +8,62 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class FileTools
 {
-	[McpServerTool(Name = "maui_files_list"), Description("List files and directories in the app's data directory. Optionally specify a subdirectory path.")]
-	public static async Task<string> ListFiles(
+	[McpServerTool(Name = "maui_storage_roots"), Description("List file storage roots advertised by the app. Use this before specifying a non-default root.")]
+	public static async Task<string> ListStorageRoots(
 		McpAgentSession session,
-		[Description("Subdirectory path relative to the app data root (optional, lists root if omitted)")] string? path = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var result = await agent.ListFilesAsync(path);
+		var result = await agent.ListStorageRootsAsync();
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to list storage roots." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_files_list"), Description("List files and directories under an advertised app storage root. Optionally specify a subdirectory path.")]
+	public static async Task<string> ListFiles(
+		McpAgentSession session,
+		[Description("Subdirectory path relative to the selected storage root (optional, lists root if omitted)")] string? path = null,
+		[Description("Storage root id (default: appData; call maui_storage_roots to discover supported roots)")] string? root = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.ListFilesAsync(path, root);
 		return result.ValueKind == JsonValueKind.Undefined ? "Failed to list files." : result.ToString();
 	}
 
-	[McpServerTool(Name = "maui_files_download"), Description("Download a file from the app's data directory. Returns the file content as base64.")]
+	[McpServerTool(Name = "maui_files_download"), Description("Download a file from an advertised app storage root. Returns the file content as base64.")]
 	public static async Task<string> DownloadFile(
 		McpAgentSession session,
-		[Description("File path relative to the app data root")] string path,
+		[Description("File path relative to the selected storage root")] string path,
+		[Description("Storage root id (default: appData; call maui_storage_roots to discover supported roots)")] string? root = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var result = await agent.DownloadFileAsync(path);
+		var result = await agent.DownloadFileAsync(path, root);
 		return result.ValueKind == JsonValueKind.Undefined ? $"Failed to download file '{path}'." : result.ToString();
 	}
 
-	[McpServerTool(Name = "maui_files_upload"), Description("Upload a file to the app's data directory. Content must be base64-encoded. Parent directories are created automatically.")]
+	[McpServerTool(Name = "maui_files_upload"), Description("Upload a file to an advertised app storage root. Content must be base64-encoded. Parent directories are created automatically.")]
 	public static async Task<string> UploadFile(
 		McpAgentSession session,
-		[Description("File path relative to the app data root")] string path,
+		[Description("File path relative to the selected storage root")] string path,
 		[Description("File content encoded as base64")] string contentBase64,
+		[Description("Storage root id (default: appData; call maui_storage_roots to discover supported roots)")] string? root = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var result = await agent.UploadFileAsync(path, contentBase64);
+		var result = await agent.UploadFileAsync(path, contentBase64, root);
 		return result.ValueKind == JsonValueKind.Undefined ? $"Failed to upload file '{path}'." : result.ToString();
 	}
 
-	[McpServerTool(Name = "maui_files_delete"), Description("Delete a file from the app's data directory.")]
+	[McpServerTool(Name = "maui_files_delete"), Description("Delete a file from an advertised app storage root.")]
 	public static async Task<string> DeleteFile(
 		McpAgentSession session,
-		[Description("File path relative to the app data root")] string path,
+		[Description("File path relative to the selected storage root")] string path,
+		[Description("Storage root id (default: appData; call maui_storage_roots to discover supported roots)")] string? root = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var success = await agent.DeleteFileAsync(path);
+		var success = await agent.DeleteFileAsync(path, root);
 		return success ? $"File '{path}' deleted." : $"Failed to delete file '{path}'.";
 	}
 }

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -98,7 +98,7 @@ maui apple simulator delete "iPhone 16 Pro"
 | `maui devflow webview` | Blazor WebView automation via Chrome DevTools Protocol |
 | `maui devflow logs` | Fetch and stream application logs |
 | `maui devflow network` | Monitor HTTP network requests |
-| `maui devflow storage` | Access app preferences and secure storage |
+| `maui devflow storage` | Access app preferences, secure storage, discover file storage roots, and manage sandboxed app files |
 | `maui devflow agent` | Discover and inspect connected DevFlow agents |
 | `maui devflow broker` | Manage the DevFlow agent broker (start, stop, status, log) |
 | `maui devflow batch` | Execute commands from stdin for scripting |

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -109,6 +109,19 @@ maui apple simulator delete "iPhone 16 Pro"
 
 Run `maui <command> --help` for detailed options on any command.
 
+DevFlow file commands can use local files directly:
+
+```bash
+# Upload local bytes into the selected app storage root
+maui devflow storage files upload logs/app.log --file ./app.log
+
+# Download to a directory, preserving the device file name
+maui devflow storage files download logs/app.log --output ./downloads/
+
+# Download to an explicit local file name
+maui devflow storage files download logs/app.log --output ./downloads/app-copy.log
+```
+
 ## Global Options
 
 | Option | Description |

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -498,6 +498,11 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         _server.MapPut("/api/v1/storage/secure/{key}", HandleSecureStorageSet);
         _server.MapDelete("/api/v1/storage/secure/{key}", HandleSecureStorageDelete);
         _server.MapDelete("/api/v1/storage/secure", HandleSecureStorageClear);
+
+        _server.MapGet("/api/v1/storage/files", HandleFilesList);
+        _server.MapGet("/api/v1/storage/files/{path}", HandleFileDownload);
+        _server.MapPut("/api/v1/storage/files/{path}", HandleFileUpload);
+        _server.MapDelete("/api/v1/storage/files/{path}", HandleFileDelete);
     }
 
     private async Task<HttpResponse> HandleStatus(HttpRequest request)
@@ -623,7 +628,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             storage = new
             {
                 supported = true,
-                features = new[] { "preferences", "secure-storage" }
+                features = new[] { "preferences", "secure-storage", "files" }
             },
             profiler = new
             {
@@ -5354,6 +5359,187 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         }
     }
 
+    // ── File storage endpoints ──
+
+    private static string GetAppDataBasePath()
+        => FileSystem.AppDataDirectory;
+
+    private static string ResolveFilePath(string relativePath)
+    {
+        // Normalize separators and prevent directory traversal
+        var normalized = relativePath.Replace('\\', '/');
+        if (normalized.Contains(".."))
+            throw new InvalidOperationException("Directory traversal is not allowed");
+
+        return Path.Combine(GetAppDataBasePath(), normalized);
+    }
+
+    private Task<HttpResponse> HandleFilesList(HttpRequest request)
+    {
+        try
+        {
+            var basePath = GetAppDataBasePath();
+            var subdir = request.QueryParams.GetValueOrDefault("path", "");
+
+            var targetDir = string.IsNullOrEmpty(subdir)
+                ? basePath
+                : ResolveFilePath(subdir);
+
+            if (!Directory.Exists(targetDir))
+                return Task.FromResult(HttpResponse.Json(new
+                {
+                    basePath,
+                    path = subdir,
+                    entries = Array.Empty<object>()
+                }));
+
+            var entries = new List<object>();
+            foreach (var dir in Directory.GetDirectories(targetDir))
+            {
+                var info = new DirectoryInfo(dir);
+                entries.Add(new
+                {
+                    name = info.Name,
+                    type = "directory",
+                    lastModified = info.LastWriteTimeUtc.ToString("O")
+                });
+            }
+            foreach (var file in Directory.GetFiles(targetDir))
+            {
+                var info = new FileInfo(file);
+                entries.Add(new
+                {
+                    name = info.Name,
+                    type = "file",
+                    size = info.Length,
+                    lastModified = info.LastWriteTimeUtc.ToString("O")
+                });
+            }
+
+            return Task.FromResult(HttpResponse.Json(new
+            {
+                basePath,
+                path = subdir,
+                entries
+            }));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(HttpResponse.Error($"Failed to list files: {ex.Message}"));
+        }
+    }
+
+    private async Task<HttpResponse> HandleFileDownload(HttpRequest request)
+    {
+        try
+        {
+            if (!request.RouteParams.TryGetValue("path", out var relativePath) || string.IsNullOrWhiteSpace(relativePath))
+                return HttpResponse.Error("file path is required");
+
+            relativePath = Uri.UnescapeDataString(relativePath);
+            var fullPath = ResolveFilePath(relativePath);
+
+            if (!File.Exists(fullPath))
+                return HttpResponse.NotFound($"File not found: {relativePath}");
+
+            var bytes = await File.ReadAllBytesAsync(fullPath);
+            var contentBase64 = Convert.ToBase64String(bytes);
+            var info = new FileInfo(fullPath);
+
+            return HttpResponse.Json(new
+            {
+                path = relativePath,
+                size = info.Length,
+                lastModified = info.LastWriteTimeUtc.ToString("O"),
+                contentBase64
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return HttpResponse.Error(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return HttpResponse.Error($"Failed to download file: {ex.Message}");
+        }
+    }
+
+    private async Task<HttpResponse> HandleFileUpload(HttpRequest request)
+    {
+        try
+        {
+            if (!request.RouteParams.TryGetValue("path", out var relativePath) || string.IsNullOrWhiteSpace(relativePath))
+                return HttpResponse.Error("file path is required");
+
+            relativePath = Uri.UnescapeDataString(relativePath);
+            var fullPath = ResolveFilePath(relativePath);
+
+            var body = request.BodyAs<FileUploadRequest>();
+            if (body == null || string.IsNullOrEmpty(body.ContentBase64))
+                return HttpResponse.Error("Request body must include 'contentBase64'");
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(body.ContentBase64);
+            }
+            catch (FormatException)
+            {
+                return HttpResponse.Error("Invalid base64 content");
+            }
+
+            // Ensure parent directory exists
+            var dir = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            await File.WriteAllBytesAsync(fullPath, bytes);
+            var info = new FileInfo(fullPath);
+
+            return HttpResponse.Json(new
+            {
+                success = true,
+                path = relativePath,
+                size = info.Length,
+                lastModified = info.LastWriteTimeUtc.ToString("O")
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return HttpResponse.Error(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return HttpResponse.Error($"Failed to upload file: {ex.Message}");
+        }
+    }
+
+    private Task<HttpResponse> HandleFileDelete(HttpRequest request)
+    {
+        try
+        {
+            if (!request.RouteParams.TryGetValue("path", out var relativePath) || string.IsNullOrWhiteSpace(relativePath))
+                return Task.FromResult(HttpResponse.Error("file path is required"));
+
+            relativePath = Uri.UnescapeDataString(relativePath);
+            var fullPath = ResolveFilePath(relativePath);
+
+            if (!File.Exists(fullPath))
+                return Task.FromResult(HttpResponse.NotFound($"File not found: {relativePath}"));
+
+            File.Delete(fullPath);
+            return Task.FromResult(HttpResponse.Ok($"File deleted: {relativePath}"));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Task.FromResult(HttpResponse.Error(ex.Message));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(HttpResponse.Error($"Failed to delete file: {ex.Message}"));
+        }
+    }
+
     // ── Platform info endpoints ──
 
     private const string PlatformErrorReasonMissingPermission = "missing_permission";
@@ -5937,4 +6123,9 @@ public class PreferenceSetRequest
 public class SecureStorageSetRequest
 {
     public string? Value { get; set; }
+}
+
+public class FileUploadRequest
+{
+    public string? ContentBase64 { get; set; }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -507,6 +507,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         _server.MapDelete("/api/v1/storage/secure/{key}", HandleSecureStorageDelete);
         _server.MapDelete("/api/v1/storage/secure", HandleSecureStorageClear);
 
+        _server.MapGet("/api/v1/storage/roots", HandleStorageRoots);
         _server.MapGet("/api/v1/storage/files", HandleFilesList);
         _server.MapGet("/api/v1/storage/files/{path}", HandleFileDownload);
         _server.MapPut("/api/v1/storage/files/{path}", HandleFileUpload);
@@ -637,7 +638,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             storage = new
             {
                 supported = true,
-                features = new[] { "preferences", "secure-storage", "files" }
+                features = new[] { "preferences", "secure-storage", "roots", "files" }
             },
             profiler = new
             {
@@ -5370,40 +5371,152 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     // ── File storage endpoints ──
 
-    private static string GetAppDataBasePath()
+    private const string DefaultFileStorageRootId = "appData";
+    private const string FileStorageOperationList = "list";
+    private const string FileStorageOperationDownload = "download";
+    private const string FileStorageOperationUpload = "upload";
+    private const string FileStorageOperationDelete = "delete";
+
+    protected sealed class FileStorageRoot
+    {
+        public FileStorageRoot(
+            string id,
+            string displayName,
+            string kind,
+            string basePath,
+            bool isWritable,
+            bool isPersistent,
+            bool isBackedUp,
+            bool mayBeClearedBySystem,
+            bool isUserVisible,
+            params string[] supportedOperations)
+        {
+            Id = id;
+            DisplayName = displayName;
+            Kind = kind;
+            BasePath = basePath;
+            IsWritable = isWritable;
+            IsPersistent = isPersistent;
+            IsBackedUp = isBackedUp;
+            MayBeClearedBySystem = mayBeClearedBySystem;
+            IsUserVisible = isUserVisible;
+            SupportedOperations = supportedOperations;
+        }
+
+        public string Id { get; }
+        public string DisplayName { get; }
+        public string Kind { get; }
+        public string BasePath { get; }
+        public bool IsWritable { get; }
+        public bool IsReadOnly => !IsWritable;
+        public bool IsPersistent { get; }
+        public bool IsBackedUp { get; }
+        public bool MayBeClearedBySystem { get; }
+        public bool IsUserVisible { get; }
+        public IReadOnlyList<string> SupportedOperations { get; }
+
+        public bool SupportsOperation(string operation)
+            => SupportedOperations.Contains(operation, StringComparer.Ordinal);
+    }
+
+    protected virtual string GetAppDataBasePath()
         => FileSystem.AppDataDirectory;
 
-    private static string ResolveFilePath(string relativePath)
+    protected virtual IReadOnlyList<FileStorageRoot> GetFileStorageRoots()
     {
-        // Normalize separators and prevent directory traversal
-        var normalized = relativePath.Replace('\\', '/');
-        if (normalized.Contains(".."))
-            throw new InvalidOperationException("Directory traversal is not allowed");
+        var appDataPath = GetAppDataBasePath();
+        if (string.IsNullOrWhiteSpace(appDataPath))
+            return Array.Empty<FileStorageRoot>();
 
-        return Path.Combine(GetAppDataBasePath(), normalized);
+        return new[]
+        {
+            new FileStorageRoot(
+                DefaultFileStorageRootId,
+                "App data",
+                "appData",
+                appDataPath,
+                isWritable: true,
+                isPersistent: true,
+                isBackedUp: true,
+                mayBeClearedBySystem: false,
+                isUserVisible: false,
+                FileStorageOperationList,
+                FileStorageOperationDownload,
+                FileStorageOperationUpload,
+                FileStorageOperationDelete)
+        };
+    }
+
+    private Task<HttpResponse> HandleStorageRoots(HttpRequest request)
+    {
+        try
+        {
+            return Task.FromResult(HttpResponse.Json(new
+            {
+                roots = GetFileStorageRoots().Select(ToFileStorageRootDescriptor).ToArray()
+            }));
+        }
+        catch (Exception)
+        {
+            return Task.FromResult(HttpResponse.Error("Failed to list storage roots"));
+        }
+    }
+
+    private static object ToFileStorageRootDescriptor(FileStorageRoot root)
+        => new
+        {
+            id = root.Id,
+            displayName = root.DisplayName,
+            kind = root.Kind,
+            isWritable = root.IsWritable,
+            isReadOnly = root.IsReadOnly,
+            isPersistent = root.IsPersistent,
+            isBackedUp = root.IsBackedUp,
+            mayBeClearedBySystem = root.MayBeClearedBySystem,
+            isUserVisible = root.IsUserVisible,
+            supportedOperations = root.SupportedOperations.ToArray()
+        };
+
+    private FileStorageRoot ResolveFileStorageRoot(HttpRequest request, string operation)
+    {
+        var rootId = request.QueryParams.GetValueOrDefault("root");
+        if (string.IsNullOrWhiteSpace(rootId))
+            rootId = DefaultFileStorageRootId;
+
+        var root = GetFileStorageRoots().FirstOrDefault(
+            r => string.Equals(r.Id, rootId, StringComparison.Ordinal));
+
+        if (root == null)
+            throw new InvalidOperationException($"Storage root '{rootId}' is not available. Use /api/v1/storage/roots to list supported roots.");
+
+        if (!root.SupportsOperation(operation))
+            throw new InvalidOperationException($"Storage root '{root.Id}' does not support '{operation}'.");
+
+        if (string.IsNullOrWhiteSpace(root.BasePath))
+            throw new InvalidOperationException($"Storage root '{root.Id}' is not available.");
+
+        return root;
     }
 
     private Task<HttpResponse> HandleFilesList(HttpRequest request)
     {
         try
         {
-            var basePath = GetAppDataBasePath();
+            var root = ResolveFileStorageRoot(request, FileStorageOperationList);
             var subdir = request.QueryParams.GetValueOrDefault("path", "");
+            var resolved = FileStoragePathResolver.Resolve(root.BasePath, subdir, allowRoot: true);
+            FileStoragePathResolver.EnsureNoReparsePointTraversal(resolved.BasePath, resolved.FullPath, includeTarget: true);
 
-            var targetDir = string.IsNullOrEmpty(subdir)
-                ? basePath
-                : ResolveFilePath(subdir);
-
-            if (!Directory.Exists(targetDir))
+            if (!Directory.Exists(resolved.FullPath))
                 return Task.FromResult(HttpResponse.Json(new
                 {
-                    basePath,
-                    path = subdir,
+                    root = root.Id,
+                    path = resolved.RelativePath,
                     entries = Array.Empty<object>()
                 }));
 
             var entries = new List<object>();
-            foreach (var dir in Directory.GetDirectories(targetDir))
+            foreach (var dir in Directory.GetDirectories(resolved.FullPath))
             {
                 var info = new DirectoryInfo(dir);
                 entries.Add(new
@@ -5413,7 +5526,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                     lastModified = info.LastWriteTimeUtc.ToString("O")
                 });
             }
-            foreach (var file in Directory.GetFiles(targetDir))
+            foreach (var file in Directory.GetFiles(resolved.FullPath))
             {
                 var info = new FileInfo(file);
                 entries.Add(new
@@ -5427,14 +5540,16 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
 
             return Task.FromResult(HttpResponse.Json(new
             {
-                basePath,
-                path = subdir,
+                root = root.Id,
+                path = resolved.RelativePath,
                 entries
             }));
         }
         catch (Exception ex)
         {
-            return Task.FromResult(HttpResponse.Error($"Failed to list files: {ex.Message}"));
+            return Task.FromResult(ex is InvalidOperationException
+                ? HttpResponse.Error(ex.Message)
+                : HttpResponse.Error("Failed to list files"));
         }
     }
 
@@ -5445,19 +5560,22 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             if (!request.RouteParams.TryGetValue("path", out var relativePath) || string.IsNullOrWhiteSpace(relativePath))
                 return HttpResponse.Error("file path is required");
 
+            var root = ResolveFileStorageRoot(request, FileStorageOperationDownload);
             relativePath = Uri.UnescapeDataString(relativePath);
-            var fullPath = ResolveFilePath(relativePath);
+            var resolved = FileStoragePathResolver.Resolve(root.BasePath, relativePath);
+            FileStoragePathResolver.EnsureNoReparsePointTraversal(resolved.BasePath, resolved.FullPath, includeTarget: true);
 
-            if (!File.Exists(fullPath))
+            if (!File.Exists(resolved.FullPath))
                 return HttpResponse.NotFound($"File not found: {relativePath}");
 
-            var bytes = await File.ReadAllBytesAsync(fullPath);
+            var bytes = await File.ReadAllBytesAsync(resolved.FullPath);
             var contentBase64 = Convert.ToBase64String(bytes);
-            var info = new FileInfo(fullPath);
+            var info = new FileInfo(resolved.FullPath);
 
             return HttpResponse.Json(new
             {
-                path = relativePath,
+                root = root.Id,
+                path = resolved.RelativePath,
                 size = info.Length,
                 lastModified = info.LastWriteTimeUtc.ToString("O"),
                 contentBase64
@@ -5467,9 +5585,9 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         {
             return HttpResponse.Error(ex.Message);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            return HttpResponse.Error($"Failed to download file: {ex.Message}");
+            return HttpResponse.Error("Failed to download file");
         }
     }
 
@@ -5480,8 +5598,10 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             if (!request.RouteParams.TryGetValue("path", out var relativePath) || string.IsNullOrWhiteSpace(relativePath))
                 return HttpResponse.Error("file path is required");
 
+            var root = ResolveFileStorageRoot(request, FileStorageOperationUpload);
             relativePath = Uri.UnescapeDataString(relativePath);
-            var fullPath = ResolveFilePath(relativePath);
+            var resolved = FileStoragePathResolver.Resolve(root.BasePath, relativePath);
+            FileStoragePathResolver.EnsureNoReparsePointTraversal(resolved.BasePath, resolved.FullPath, includeTarget: true);
 
             var body = request.BodyAs<FileUploadRequest>();
             if (body == null || string.IsNullOrEmpty(body.ContentBase64))
@@ -5497,18 +5617,18 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                 return HttpResponse.Error("Invalid base64 content");
             }
 
-            // Ensure parent directory exists
-            var dir = Path.GetDirectoryName(fullPath);
+            var dir = Path.GetDirectoryName(resolved.FullPath);
             if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                 Directory.CreateDirectory(dir);
 
-            await File.WriteAllBytesAsync(fullPath, bytes);
-            var info = new FileInfo(fullPath);
+            await File.WriteAllBytesAsync(resolved.FullPath, bytes);
+            var info = new FileInfo(resolved.FullPath);
 
             return HttpResponse.Json(new
             {
                 success = true,
-                path = relativePath,
+                root = root.Id,
+                path = resolved.RelativePath,
                 size = info.Length,
                 lastModified = info.LastWriteTimeUtc.ToString("O")
             });
@@ -5517,9 +5637,9 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         {
             return HttpResponse.Error(ex.Message);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            return HttpResponse.Error($"Failed to upload file: {ex.Message}");
+            return HttpResponse.Error("Failed to upload file");
         }
     }
 
@@ -5530,22 +5650,30 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             if (!request.RouteParams.TryGetValue("path", out var relativePath) || string.IsNullOrWhiteSpace(relativePath))
                 return Task.FromResult(HttpResponse.Error("file path is required"));
 
+            var root = ResolveFileStorageRoot(request, FileStorageOperationDelete);
             relativePath = Uri.UnescapeDataString(relativePath);
-            var fullPath = ResolveFilePath(relativePath);
+            var resolved = FileStoragePathResolver.Resolve(root.BasePath, relativePath);
+            FileStoragePathResolver.EnsureNoReparsePointTraversal(resolved.BasePath, resolved.FullPath, includeTarget: true);
 
-            if (!File.Exists(fullPath))
+            if (!File.Exists(resolved.FullPath))
                 return Task.FromResult(HttpResponse.NotFound($"File not found: {relativePath}"));
 
-            File.Delete(fullPath);
-            return Task.FromResult(HttpResponse.Ok($"File deleted: {relativePath}"));
+            File.Delete(resolved.FullPath);
+            return Task.FromResult(HttpResponse.Json(new
+            {
+                success = true,
+                root = root.Id,
+                path = resolved.RelativePath,
+                message = $"File deleted: {resolved.RelativePath}"
+            }));
         }
         catch (InvalidOperationException ex)
         {
             return Task.FromResult(HttpResponse.Error(ex.Message));
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            return Task.FromResult(HttpResponse.Error($"Failed to delete file: {ex.Message}"));
+            return Task.FromResult(HttpResponse.Error("Failed to delete file"));
         }
     }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -5621,6 +5621,8 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                 Directory.CreateDirectory(dir);
 
+            FileStoragePathResolver.EnsureNoReparsePointTraversal(resolved.BasePath, resolved.FullPath, includeTarget: true);
+
             await File.WriteAllBytesAsync(resolved.FullPath, bytes);
             var info = new FileInfo(resolved.FullPath);
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/FileStoragePathResolver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/FileStoragePathResolver.cs
@@ -1,0 +1,99 @@
+namespace Microsoft.Maui.DevFlow.Agent.Core;
+
+internal readonly record struct ResolvedFileStoragePath(
+    string BasePath,
+    string FullPath,
+    string RelativePath);
+
+internal static class FileStoragePathResolver
+{
+    public static ResolvedFileStoragePath Resolve(string basePath, string? relativePath, bool allowRoot = false)
+    {
+        if (string.IsNullOrWhiteSpace(basePath))
+            throw new InvalidOperationException("App data directory is unavailable");
+
+        var fullBasePath = Path.GetFullPath(basePath);
+        var requestedPath = relativePath ?? string.Empty;
+
+        if (requestedPath.IndexOf('\0') >= 0)
+            throw new InvalidOperationException("Invalid file path");
+
+        if (string.IsNullOrWhiteSpace(requestedPath))
+        {
+            if (!allowRoot)
+                throw new InvalidOperationException("file path is required");
+
+            return new ResolvedFileStoragePath(fullBasePath, fullBasePath, string.Empty);
+        }
+
+        if (IsRootedOrDriveQualified(requestedPath))
+            throw new InvalidOperationException("Rooted or absolute paths are not allowed");
+
+        var normalizedForSegments = requestedPath.Replace('\\', '/');
+        var segments = normalizedForSegments.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Any(segment => segment == ".."))
+            throw new InvalidOperationException("Directory traversal is not allowed");
+
+        var normalizedPath = string.Join(Path.DirectorySeparatorChar.ToString(), segments);
+        var fullPath = Path.GetFullPath(Path.Combine(fullBasePath, normalizedPath));
+
+        EnsureContained(fullBasePath, fullPath);
+
+        var relative = Path.GetRelativePath(fullBasePath, fullPath);
+        if (relative == ".")
+            relative = string.Empty;
+
+        relative = relative.Replace(Path.DirectorySeparatorChar, '/');
+        if (Path.AltDirectorySeparatorChar != Path.DirectorySeparatorChar)
+            relative = relative.Replace(Path.AltDirectorySeparatorChar, '/');
+
+        return new ResolvedFileStoragePath(fullBasePath, fullPath, relative);
+    }
+
+    public static void EnsureNoReparsePointTraversal(string basePath, string targetPath, bool includeTarget)
+    {
+        var relative = Path.GetRelativePath(basePath, targetPath);
+        if (relative == ".")
+            return;
+
+        var parts = relative.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+
+        var path = Path.GetFullPath(basePath);
+        var count = includeTarget ? parts.Length : Math.Max(0, parts.Length - 1);
+        for (var i = 0; i < count; i++)
+        {
+            path = Path.Combine(path, parts[i]);
+            if (!File.Exists(path) && !Directory.Exists(path))
+                continue;
+
+            if ((File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0)
+                throw new InvalidOperationException("Symbolic links are not allowed in file storage paths");
+        }
+    }
+
+    private static bool IsRootedOrDriveQualified(string path)
+        => Path.IsPathRooted(path)
+            || path.StartsWith('/')
+            || path.StartsWith('\\')
+            || (path.Length >= 2 && char.IsLetter(path[0]) && path[1] == ':');
+
+    private static void EnsureContained(string basePath, string fullPath)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        var baseWithSeparator = basePath.EndsWith(Path.DirectorySeparatorChar)
+            || basePath.EndsWith(Path.AltDirectorySeparatorChar)
+            ? basePath
+            : basePath + Path.DirectorySeparatorChar;
+
+        if (!string.Equals(fullPath, basePath, comparison)
+            && !fullPath.StartsWith(baseWithSeparator, comparison))
+        {
+            throw new InvalidOperationException("Directory traversal is not allowed");
+        }
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/Properties/InternalsVisibleTo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Maui.DevFlow.Tests")]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/FileStorageTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/FileStorageTests.cs
@@ -1,0 +1,141 @@
+using System.Text;
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "Files")]
+public class FileStorageTests : IntegrationTestBase
+{
+    const string TestPathPrefix = "integration-tests/files";
+
+    public FileStorageTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Fact]
+    public async Task ListStorageRoots_ReturnsAppDataRootOnly()
+    {
+        var roots = await Client.ListStorageRootsAsync();
+
+        var root = Assert.Single(roots.GetProperty("roots").EnumerateArray());
+        Assert.Equal("appData", root.GetProperty("id").GetString());
+        Assert.Equal("appData", root.GetProperty("kind").GetString());
+        Assert.True(root.GetProperty("isWritable").GetBoolean());
+        Assert.Contains("upload", root.GetProperty("supportedOperations").EnumerateArray().Select(value => value.GetString()));
+        Assert.DoesNotContain("basePath", roots.ToString());
+    }
+
+    [Fact]
+    public async Task UploadDownloadListAndDelete_RoundTripsSubdirectoryFile()
+    {
+        var path = TestPath("roundtrip.txt");
+        var contentBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello from file integration test"));
+
+        var upload = await Client.UploadFileAsync(path, contentBase64);
+        Assert.True(upload.GetProperty("success").GetBoolean());
+        Assert.Equal("appData", upload.GetProperty("root").GetString());
+        Assert.Equal(path, upload.GetProperty("path").GetString());
+
+        var list = await Client.ListFilesAsync(TestPathPrefix);
+        Assert.Equal("appData", list.GetProperty("root").GetString());
+        Assert.DoesNotContain("basePath", list.ToString());
+        Assert.Contains("roundtrip.txt", list.ToString());
+
+        var download = await Client.DownloadFileAsync(path);
+        Assert.Equal("appData", download.GetProperty("root").GetString());
+        Assert.Equal(path, download.GetProperty("path").GetString());
+        Assert.Equal(contentBase64, download.GetProperty("contentBase64").GetString());
+
+        var deleted = await Client.DeleteFileAsync(path);
+        Assert.True(deleted);
+
+        Assert.False(await Client.DeleteFileAsync(path));
+    }
+
+    [Fact]
+    public async Task ExplicitAppDataRoot_RoundTripsFile()
+    {
+        var path = TestPath("explicit-root.txt");
+        var contentBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello from explicit appData root"));
+
+        try
+        {
+            var upload = await Client.UploadFileAsync(path, contentBase64, "appData");
+            Assert.True(upload.GetProperty("success").GetBoolean());
+            Assert.Equal("appData", upload.GetProperty("root").GetString());
+
+            var download = await Client.DownloadFileAsync(path, "appData");
+            Assert.Equal("appData", download.GetProperty("root").GetString());
+            Assert.Equal(contentBase64, download.GetProperty("contentBase64").GetString());
+        }
+        finally
+        {
+            await Client.DeleteFileAsync(path, "appData");
+        }
+    }
+
+    [Fact]
+    public async Task UnsupportedRoot_ReturnsClearError()
+    {
+        var result = await Client.UploadFileAsync(TestPath("unsupported-root.txt"), "aGVsbG8=", "cache");
+
+        Assert.False(result.GetProperty("success").GetBoolean());
+        Assert.Contains("Storage root 'cache' is not available", result.GetProperty("error").GetString());
+    }
+
+    [Theory]
+    [InlineData("../outside.txt")]
+    [InlineData("integration-tests/../outside.txt")]
+    [InlineData("integration-tests/%2e%2e/outside.txt")]
+    public async Task Upload_RejectsTraversalPaths(string rawPath)
+    {
+        var path = Uri.UnescapeDataString(rawPath);
+        var result = await Client.UploadFileAsync(path, Convert.ToBase64String(new byte[] { 1, 2, 3 }));
+
+        Assert.False(result.GetProperty("success").GetBoolean());
+        Assert.Contains("Directory traversal is not allowed", result.GetProperty("error").GetString());
+    }
+
+    [Theory]
+    [InlineData("/tmp/outside.txt")]
+    [InlineData("\\Windows\\win.ini")]
+    [InlineData("C:\\Windows\\win.ini")]
+    public async Task Download_RejectsRootedOrAbsolutePaths(string path)
+    {
+        var result = await Client.DownloadFileAsync(path);
+
+        Assert.False(result.GetProperty("success").GetBoolean());
+        Assert.Contains("Rooted or absolute paths are not allowed", result.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task Upload_AllowsFileNamesContainingDotDot()
+    {
+        var path = TestPath("my..log");
+        var contentBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("legitimate dot dot file name"));
+
+        try
+        {
+            var upload = await Client.UploadFileAsync(path, contentBase64);
+
+            Assert.True(upload.GetProperty("success").GetBoolean());
+            Assert.Equal(path, upload.GetProperty("path").GetString());
+        }
+        finally
+        {
+            await Client.DeleteFileAsync(path);
+        }
+    }
+
+    [Fact]
+    public async Task Upload_RejectsInvalidBase64()
+    {
+        var result = await Client.UploadFileAsync(TestPath("invalid-base64.txt"), "not base64!");
+
+        Assert.False(result.GetProperty("success").GetBoolean());
+        Assert.Contains("Invalid base64 content", result.GetProperty("error").GetString());
+    }
+
+    private static string TestPath(string fileName) => $"{TestPathPrefix}/{Guid.NewGuid():N}-{fileName}";
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -685,6 +685,41 @@ public class AgentClient : IDisposable
         return await PostActionAsync($"{DeviceApi}/sensors/{Uri.EscapeDataString(sensor)}/stop", new JsonObject());
     }
 
+    // ── Files ──
+
+    public async Task<JsonElement> ListFilesAsync(string? path = null)
+    {
+        var url = $"{StorageApi}/files";
+        if (!string.IsNullOrEmpty(path))
+            url += $"?path={Uri.EscapeDataString(path)}";
+        return await GetJsonAsync(url);
+    }
+
+    public async Task<JsonElement> DownloadFileAsync(string path)
+    {
+        return await GetJsonAsync($"{StorageApi}/files/{Uri.EscapeDataString(path)}");
+    }
+
+    public async Task<JsonElement> UploadFileAsync(string path, string contentBase64)
+    {
+        try
+        {
+            var body = new JsonObject { ["contentBase64"] = contentBase64 };
+            using var content = DriverJson.CreateJsonContent(body);
+            var response = await _http.PutAsync($"{_baseUrl}{StorageApi}/files/{Uri.EscapeDataString(path)}", content);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(responseBody))
+                return default;
+            return DriverJson.ParseElement(responseBody);
+        }
+        catch { return default; }
+    }
+
+    public async Task<bool> DeleteFileAsync(string path)
+    {
+        return await DeleteActionAsync($"{StorageApi}/files/{Uri.EscapeDataString(path)}");
+    }
+
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -687,38 +687,56 @@ public class AgentClient : IDisposable
 
     // ── Files ──
 
-    public async Task<JsonElement> ListFilesAsync(string? path = null)
+    public async Task<JsonElement> ListStorageRootsAsync()
+    {
+        return await GetJsonAsync($"{StorageApi}/roots");
+    }
+
+    public async Task<JsonElement> ListFilesAsync(string? path = null, string? root = null)
     {
         var url = $"{StorageApi}/files";
-        if (!string.IsNullOrEmpty(path))
-            url += $"?path={Uri.EscapeDataString(path)}";
+        var query = BuildStorageFilesQuery(path, root);
+        if (!string.IsNullOrEmpty(query))
+            url += query;
+
         return await GetJsonAsync(url);
     }
 
-    public async Task<JsonElement> DownloadFileAsync(string path)
+    public async Task<JsonElement> DownloadFileAsync(string path, string? root = null)
     {
-        return await GetJsonAsync($"{StorageApi}/files/{Uri.EscapeDataString(path)}");
+        return await GetJsonAsync($"{StorageApi}/files/{Uri.EscapeDataString(path)}{BuildRootQuery(root)}");
     }
 
-    public async Task<JsonElement> UploadFileAsync(string path, string contentBase64)
+    public async Task<JsonElement> UploadFileAsync(string path, string contentBase64, string? root = null)
     {
-        try
-        {
-            var body = new JsonObject { ["contentBase64"] = contentBase64 };
-            using var content = DriverJson.CreateJsonContent(body);
-            var response = await _http.PutAsync($"{_baseUrl}{StorageApi}/files/{Uri.EscapeDataString(path)}", content);
-            var responseBody = await response.Content.ReadAsStringAsync();
-            if (string.IsNullOrWhiteSpace(responseBody))
-                return default;
-            return DriverJson.ParseElement(responseBody);
-        }
-        catch { return default; }
+        var body = new JsonObject { ["contentBase64"] = contentBase64 };
+        using var content = DriverJson.CreateJsonContent(body);
+        using var response = await _http.PutAsync($"{_baseUrl}{StorageApi}/files/{Uri.EscapeDataString(path)}{BuildRootQuery(root)}", content);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        if (string.IsNullOrWhiteSpace(responseBody))
+            return default;
+
+        return DriverJson.ParseElement(responseBody);
     }
 
-    public async Task<bool> DeleteFileAsync(string path)
+    public async Task<bool> DeleteFileAsync(string path, string? root = null)
     {
-        return await DeleteActionAsync($"{StorageApi}/files/{Uri.EscapeDataString(path)}");
+        return await DeleteActionAsync($"{StorageApi}/files/{Uri.EscapeDataString(path)}{BuildRootQuery(root)}");
     }
+
+    private static string BuildStorageFilesQuery(string? path, string? root)
+    {
+        var query = new List<string>();
+        if (!string.IsNullOrEmpty(path))
+            query.Add($"path={Uri.EscapeDataString(path)}");
+        if (!string.IsNullOrEmpty(root))
+            query.Add($"root={Uri.EscapeDataString(root)}");
+
+        return query.Count == 0 ? string.Empty : "?" + string.Join("&", query);
+    }
+
+    private static string BuildRootQuery(string? root)
+        => string.IsNullOrEmpty(root) ? string.Empty : $"?root={Uri.EscapeDataString(root)}";
 
     public void Dispose()
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
@@ -474,5 +474,188 @@ public class AgentHttpServerTests : IDisposable
         listener.Stop();
     }
 
+    [Fact]
+    public async Task ListStorageRootsAsync_UsesV1StorageRootsRoute()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("GET /api/v1/storage/roots", request);
+
+            var body = """{"roots":[{"id":"appData","displayName":"App data","kind":"appData","isWritable":true,"isReadOnly":false,"isPersistent":true,"isBackedUp":true,"mayBeClearedBySystem":false,"isUserVisible":false,"supportedOperations":["list","download","upload","delete"]}]}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.ListStorageRootsAsync();
+
+        Assert.Equal("appData", result.GetProperty("roots")[0].GetProperty("id").GetString());
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task ListFilesAsync_UsesV1StorageFilesRouteAndEscapesPath()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("GET /api/v1/storage/files?path=logs%2Ftoday", request);
+
+            var body = """{"path":"logs/today","entries":[{"name":"app.log","type":"file","size":4,"lastModified":"2026-04-01T12:00:00Z"}]}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.ListFilesAsync("logs/today");
+
+        Assert.Equal("logs/today", result.GetProperty("path").GetString());
+        Assert.Equal("app.log", result.GetProperty("entries")[0].GetProperty("name").GetString());
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task ListFilesAsync_WithRoot_AppendsRootQuery()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("GET /api/v1/storage/files?path=logs%2Ftoday&root=appData", request);
+
+            var body = """{"root":"appData","path":"logs/today","entries":[]}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.ListFilesAsync("logs/today", "appData");
+
+        Assert.Equal("appData", result.GetProperty("root").GetString());
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_SendsPutWithBase64Payload()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("PUT /api/v1/storage/files/logs%2Fapp.txt", request);
+            Assert.Contains("\"contentBase64\":\"aGVsbG8=\"", request);
+
+            var body = """{"success":true,"path":"logs/app.txt","size":5,"lastModified":"2026-04-01T12:00:00Z"}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.UploadFileAsync("logs/app.txt", "aGVsbG8=");
+
+        Assert.True(result.GetProperty("success").GetBoolean());
+        Assert.Equal("logs/app.txt", result.GetProperty("path").GetString());
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_WithRoot_AppendsRootQuery()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("GET /api/v1/storage/files/logs%2Fapp.txt?root=appData", request);
+
+            var body = """{"root":"appData","path":"logs/app.txt","size":5,"lastModified":"2026-04-01T12:00:00Z","contentBase64":"aGVsbG8="}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.DownloadFileAsync("logs/app.txt", "appData");
+
+        Assert.Equal("appData", result.GetProperty("root").GetString());
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task DeleteFileAsync_ReturnsFalseOnNotFound()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("DELETE /api/v1/storage/files/missing.txt", request);
+
+            var body = """{"success":false,"error":"File not found: missing.txt"}""";
+            var response = $"HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.DeleteFileAsync("missing.txt");
+
+        Assert.False(result);
+
+        await acceptTask;
+        listener.Stop();
+    }
+
     public void Dispose() { }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/FileStoragePathResolverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/FileStoragePathResolverTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.Maui.DevFlow.Agent.Core;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class FileStoragePathResolverTests
+{
+    [Fact]
+    public void Resolve_AllowsFileNamesContainingDotDot()
+    {
+        var basePath = CreateTempDirectory();
+
+        var resolved = FileStoragePathResolver.Resolve(basePath, "logs/my..log");
+
+        Assert.Equal("logs/my..log", resolved.RelativePath);
+        Assert.True(
+            resolved.FullPath.StartsWith(Path.GetFullPath(basePath), StringComparison.Ordinal),
+            resolved.FullPath);
+    }
+
+    [Theory]
+    [InlineData("../outside.txt")]
+    [InlineData("logs/../outside.txt")]
+    [InlineData("logs/%2e%2e/outside.txt")]
+    public void Resolve_RejectsTraversalSegments(string path)
+    {
+        var basePath = CreateTempDirectory();
+        var decodedPath = Uri.UnescapeDataString(path);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FileStoragePathResolver.Resolve(basePath, decodedPath));
+
+        Assert.Equal("Directory traversal is not allowed", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("/etc/passwd")]
+    [InlineData("\\Windows\\win.ini")]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("C:Windows\\win.ini")]
+    public void Resolve_RejectsRootedOrAbsolutePaths(string path)
+    {
+        var basePath = CreateTempDirectory();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FileStoragePathResolver.Resolve(basePath, path));
+
+        Assert.Equal("Rooted or absolute paths are not allowed", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_AllowsRootWhenRequested()
+    {
+        var basePath = CreateTempDirectory();
+
+        var resolved = FileStoragePathResolver.Resolve(basePath, null, allowRoot: true);
+
+        Assert.Equal(string.Empty, resolved.RelativePath);
+        Assert.Equal(Path.GetFullPath(basePath), resolved.FullPath);
+    }
+
+    [Fact]
+    public void Resolve_RejectsEmptyFilePathByDefault()
+    {
+        var basePath = CreateTempDirectory();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FileStoragePathResolver.Resolve(basePath, ""));
+
+        Assert.Equal("file path is required", ex.Message);
+    }
+
+    [Fact]
+    public void EnsureNoReparsePointTraversal_RejectsSymlinkedDirectory()
+    {
+        var basePath = CreateTempDirectory();
+        var outsidePath = CreateTempDirectory();
+        var linkPath = Path.Combine(basePath, "linked");
+
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, outsidePath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        var targetPath = Path.Combine(linkPath, "outside.txt");
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            FileStoragePathResolver.EnsureNoReparsePointTraversal(basePath, targetPath, includeTarget: true));
+
+        Assert.Equal("Symbolic links are not allowed in file storage paths", error.Message);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "mauidevflow-files-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/FileStorageRootTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/FileStorageRootTests.cs
@@ -112,6 +112,36 @@ public class FileStorageRootTests
         Assert.False(File.Exists(Path.Combine(appDataPath, path)));
     }
 
+    [Fact]
+    public async Task FileUpload_RejectsSymlinkedTargetFile()
+    {
+        var appDataPath = CreateTempDirectory();
+        var outsidePath = CreateTempDirectory();
+        var outsideFile = Path.Combine(outsidePath, "outside.txt");
+        await File.WriteAllTextAsync(outsideFile, "outside");
+        var linkPath = Path.Combine(appDataPath, "linked.txt");
+
+        try
+        {
+            File.CreateSymbolicLink(linkPath, outsideFile);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        using var service = CreateService(("appData", appDataPath));
+        using var client = new AgentClient("localhost", service.ServicePort);
+
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        var result = await WaitForJsonAsync(() => client.UploadFileAsync("linked.txt", "aGVsbG8="));
+
+        Assert.False(result.GetProperty("success").GetBoolean());
+        Assert.Contains("Symbolic links are not allowed", result.GetProperty("error").GetString(), StringComparison.Ordinal);
+        Assert.Equal("outside", await File.ReadAllTextAsync(outsideFile));
+    }
+
     private static RootedDevFlowAgentService CreateService(params (string Id, string BasePath)[] roots)
         => CreateService(roots.Select(root => new TestStorageRoot(root.Id, root.BasePath)).ToArray());
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/FileStorageRootTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/FileStorageRootTests.cs
@@ -1,0 +1,236 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Maui.DevFlow.Agent.Core;
+using Microsoft.Maui.DevFlow.Driver;
+using Microsoft.Maui.Dispatching;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class FileStorageRootTests
+{
+    [Fact]
+    public async Task StorageRoots_ReturnsContributedRootsWithoutPhysicalPath()
+    {
+        var appDataPath = CreateTempDirectory();
+        var customPath = CreateTempDirectory();
+        using var service = CreateService(("appData", appDataPath), ("custom", customPath));
+        using var client = new AgentClient("localhost", service.ServicePort);
+
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        var result = await WaitForJsonAsync(client.ListStorageRootsAsync);
+
+        Assert.Equal(JsonValueKind.Array, result.GetProperty("roots").ValueKind);
+        Assert.Equal("appData", result.GetProperty("roots")[0].GetProperty("id").GetString());
+        Assert.Equal("custom", result.GetProperty("roots")[1].GetProperty("id").GetString());
+        Assert.DoesNotContain("basePath", result.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(appDataPath, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(customPath, result.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FileEndpoints_ExplicitAppDataRoot_RoundTrips()
+    {
+        var appDataPath = CreateTempDirectory();
+        using var service = CreateService(("appData", appDataPath));
+        using var client = new AgentClient("localhost", service.ServicePort);
+
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        var path = $"root-tests/{Guid.NewGuid():N}.txt";
+        var contentBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello app data"));
+
+        var upload = await WaitForJsonAsync(() => client.UploadFileAsync(path, contentBase64, "appData"));
+        Assert.True(upload.GetProperty("success").GetBoolean());
+        Assert.Equal("appData", upload.GetProperty("root").GetString());
+        Assert.Equal(path, upload.GetProperty("path").GetString());
+
+        var list = await client.ListFilesAsync("root-tests", "appData");
+        Assert.Equal("appData", list.GetProperty("root").GetString());
+        Assert.Contains(Path.GetFileName(path), list.ToString(), StringComparison.Ordinal);
+
+        var download = await client.DownloadFileAsync(path, "appData");
+        Assert.Equal("appData", download.GetProperty("root").GetString());
+        Assert.Equal(contentBase64, download.GetProperty("contentBase64").GetString());
+
+        Assert.True(await client.DeleteFileAsync(path, "appData"));
+    }
+
+    [Fact]
+    public async Task FileEndpoints_UnadvertisedRoot_ReturnsClearError()
+    {
+        var appDataPath = CreateTempDirectory();
+        using var service = CreateService(("appData", appDataPath));
+        using var client = new AgentClient("localhost", service.ServicePort);
+
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        var result = await WaitForJsonAsync(() => client.UploadFileAsync("cache.txt", "aGVsbG8=", "cache"));
+
+        Assert.False(result.GetProperty("success").GetBoolean());
+        Assert.Contains("Storage root 'cache' is not available", result.GetProperty("error").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FileEndpoints_RejectsOperationNotSupportedByContributedRoot()
+    {
+        var appDataPath = CreateTempDirectory();
+        var readOnlyPath = CreateTempDirectory();
+        using var service = CreateService(
+            new TestStorageRoot("appData", appDataPath),
+            new TestStorageRoot("readonly", readOnlyPath, false, "list", "download"));
+        using var client = new AgentClient("localhost", service.ServicePort);
+
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        var result = await WaitForJsonAsync(() => client.UploadFileAsync("blocked.txt", "aGVsbG8=", "readonly"));
+
+        Assert.False(result.GetProperty("success").GetBoolean());
+        Assert.Contains("Storage root 'readonly' does not support 'upload'", result.GetProperty("error").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FileEndpoints_UsesContributedCustomRoot()
+    {
+        var appDataPath = CreateTempDirectory();
+        var customPath = CreateTempDirectory();
+        using var service = CreateService(("appData", appDataPath), ("custom", customPath));
+        using var client = new AgentClient("localhost", service.ServicePort);
+
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        var path = $"custom-root/{Guid.NewGuid():N}.txt";
+        var contentBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("custom root content"));
+
+        var upload = await WaitForJsonAsync(() => client.UploadFileAsync(path, contentBase64, "custom"));
+
+        Assert.True(upload.GetProperty("success").GetBoolean());
+        Assert.Equal("custom", upload.GetProperty("root").GetString());
+        Assert.True(File.Exists(Path.Combine(customPath, path)));
+        Assert.False(File.Exists(Path.Combine(appDataPath, path)));
+    }
+
+    private static RootedDevFlowAgentService CreateService(params (string Id, string BasePath)[] roots)
+        => CreateService(roots.Select(root => new TestStorageRoot(root.Id, root.BasePath)).ToArray());
+
+    private static RootedDevFlowAgentService CreateService(params TestStorageRoot[] roots)
+    {
+        var port = GetFreePort();
+        return new RootedDevFlowAgentService(port, roots);
+    }
+
+    private static async Task<JsonElement> WaitForJsonAsync(Func<Task<JsonElement>> action)
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            var result = await action();
+            if (result.ValueKind != JsonValueKind.Undefined)
+                return result;
+
+            await Task.Delay(100);
+        }
+
+        throw new InvalidOperationException("Agent endpoint did not return JSON before timeout.");
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "mauidevflow-roots-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    private sealed class RootedDevFlowAgentService : DevFlowAgentService
+    {
+        private readonly IReadOnlyList<FileStorageRoot> _roots;
+
+        public RootedDevFlowAgentService(int port, IReadOnlyList<TestStorageRoot> roots)
+            : base(new AgentOptions { Port = port })
+        {
+            ServicePort = port;
+            _roots = roots.Select(root => new FileStorageRoot(
+                root.Id,
+                root.Id == "appData" ? "App data" : root.Id,
+                root.Id,
+                root.BasePath,
+                root.IsWritable,
+                isPersistent: true,
+                isBackedUp: root.Id == "appData",
+                mayBeClearedBySystem: false,
+                isUserVisible: false,
+                root.SupportedOperations.ToArray())).ToArray();
+        }
+
+        public int ServicePort { get; }
+
+        protected override IReadOnlyList<FileStorageRoot> GetFileStorageRoots() => _roots;
+    }
+
+    private sealed class TestStorageRoot
+    {
+        private static readonly string[] s_defaultOperations = ["list", "download", "upload", "delete"];
+
+        public TestStorageRoot(string id, string basePath, bool isWritable = true, params string[] supportedOperations)
+        {
+            Id = id;
+            BasePath = basePath;
+            IsWritable = isWritable;
+            SupportedOperations = supportedOperations.Length == 0 ? s_defaultOperations : supportedOperations;
+        }
+
+        public string Id { get; }
+        public string BasePath { get; }
+        public bool IsWritable { get; }
+        public IReadOnlyList<string> SupportedOperations { get; }
+    }
+
+    private sealed class ImmediateDispatcher : IDispatcher
+    {
+        public bool IsDispatchRequired => false;
+
+        public bool Dispatch(Action action)
+        {
+            action();
+            return true;
+        }
+
+        public bool DispatchDelayed(TimeSpan delay, Action action)
+        {
+            action();
+            return true;
+        }
+
+        public IDispatcherTimer CreateTimer() => new ImmediateDispatcherTimer();
+    }
+
+    private sealed class ImmediateDispatcherTimer : IDispatcherTimer
+    {
+        public bool IsRepeating { get; set; }
+        public TimeSpan Interval { get; set; }
+        public bool IsRunning { get; private set; }
+        public event EventHandler? Tick
+        {
+            add { }
+            remove { }
+        }
+
+        public void Start()
+        {
+            IsRunning = true;
+        }
+
+        public void Stop()
+        {
+            IsRunning = false;
+        }
+    }
+}

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -102,7 +102,7 @@ The same value can also be supplied via the `MAUI_DEVFLOW_SESSION_ID` environmen
 - **MCP Server** — 50+ structured tools for AI agent integration (Claude, etc.)
 - **Logging** — buffered JSONL file logging with WebView JS console capture
 - **Real-time Streaming** — WebSocket channels for logs, network, sensors, profiler, and UI events
-- **Storage Access** — read/write app preferences and secure storage remotely
+- **Storage Access** — read/write app preferences, secure storage, discover file storage roots, and manage sandboxed app files remotely
 - **Device Introspection** — battery, connectivity, geolocation, display, permissions, and sensor data
 - **Dialog Handling** — detect and dismiss alerts/action sheets programmatically
 - **Batch Operations** — execute command sequences from stdin for scripting
@@ -119,7 +119,7 @@ All DevFlow commands are available under `maui devflow`. Run `maui devflow <comm
 | `webview` | Blazor WebView automation — DOM, JS eval, navigation, input, screenshots |
 | `logs` | Fetch and stream application logs |
 | `network` | Monitor and inspect HTTP requests |
-| `storage` | Read/write app preferences and secure storage |
+| `storage` | Read/write app preferences, secure storage, discover file storage roots, and manage sandboxed app files |
 | `agent` | Discover and inspect connected agents (status, list, wait, diagnose) |
 | `broker` | Manage the agent broker (start, stop, status, log) |
 | `batch` | Execute command sequences from stdin |


### PR DESCRIPTION
This pull request adds comprehensive file management capabilities to the DevFlow agent and CLI, allowing users to list, download, upload, and delete files in the app's data directory. The changes span both the agent's HTTP API and the CLI tooling, and include backend implementations, new endpoints, and updates to the agent capabilities.

**File management feature additions:**

* Added a new `FileTools` class to the CLI, providing commands to list, download, upload (with base64 encoding), and delete files in the app's data directory. These commands interact with the agent and support optional agent port selection.
* Registered the new `FileTools` in the CLI's tool builder, enabling these commands in the CLI.

**Agent HTTP API and backend support:**

* Introduced new HTTP endpoints in the agent for file listing, download, upload, and delete operations under `/api/v1/storage/files`, with secure path handling to prevent directory traversal. [[1]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR501-R505) [[2]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR5362-R5542)
* Implemented backend logic for each file operation, including directory creation on upload and base64 encoding for file transfer.
* Added a `FileUploadRequest` class to represent the payload for file uploads.

**API client and capabilities:**

* Extended the agent client with methods to call the new file management endpoints, handling JSON responses and base64 encoding/decoding as needed.
* Updated the agent's reported capabilities to include the new "files" feature in the storage section.Introduce file storage endpoints and client/tools to list, download, upload, and delete files in the app data directory. Adds a new MCP server tool FileTools (list/download/upload/delete) and registers it in McpServerHost. Implements HTTP routes in DevFlowAgentService (/api/v1/storage/files...) with path resolution to FileSystem.AppDataDirectory, directory-traversal protection, base64 file upload/download handling, parent-directory creation on upload, and JSON responses. Adds FileUploadRequest DTO and exposes new methods on AgentClient (ListFilesAsync, DownloadFileAsync, UploadFileAsync, DeleteFileAsync). Also advertises the new "files" feature in the agent capabilities.