### PR TITLE
feat: BLE Monitoring (Win/iOS/Android/Mac)

### DIFF
--- a/docs/DevFlow/spec/asyncapi.yaml
+++ b/docs/DevFlow/spec/asyncapi.yaml
@@ -461,6 +461,133 @@ channels:
                   type: string
                   description: Name of the sensor to unsubscribe from.
 
+  # ── BLE Event Stream ─────────────────────────────────────────────────────
+  ble:
+    address: /ws/v1/ble
+    description: |
+      Live Bluetooth Low Energy event stream. Connect with query parameters to
+      optionally replay buffered events, filter by event type, and start native
+      scanning for the lifetime of the connection when supported. Streamed
+      events remain in the bounded BLE buffer until evicted or explicitly
+      cleared through the REST API.
+    servers:
+      - $ref: '#/servers/agent'
+    bindings:
+      ws:
+        query:
+          type: object
+          description: Connection query-string parameters for BLE streaming.
+          properties:
+            scan:
+              type: boolean
+              default: false
+              description: Start BLE scanning while this WebSocket connection is active.
+            replay:
+              type: integer
+              default: 100
+              minimum: 0
+              description: Number of buffered BLE events to replay on connect. Use 0 for live-only streaming.
+            type:
+              $ref: './schemas/device.json#/$defs/BleEventType'
+              description: Optional event type filter applied to replayed and live events.
+    messages:
+      bleSubscribed:
+        name: bleSubscribed
+        title: BLE Subscribed
+        summary: Confirmation that the BLE event stream is active.
+        contentType: application/json
+        payload:
+          type: object
+          description: BLE stream subscription confirmation.
+          required: [type, timestamp, scanning, replay]
+          properties:
+            type:
+              type: string
+              const: subscribed
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            scanning:
+              type: boolean
+              description: Whether native BLE scanning is currently active.
+            replay:
+              type: integer
+              minimum: 0
+              description: Number of buffered events requested for replay.
+            eventType:
+              $ref: './schemas/device.json#/$defs/BleEventType'
+              description: Event type filter for this stream, if any.
+
+      bleReplay:
+        name: bleReplay
+        title: BLE Event Replay
+        summary: Initial replay of buffered BLE events on connect.
+        contentType: application/json
+        payload:
+          type: object
+          description: Replay of buffered BLE events.
+          required: [type, timestamp, count, events]
+          properties:
+            type:
+              type: string
+              const: replay
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            count:
+              type: integer
+              minimum: 0
+              description: Number of events included in this replay message.
+            events:
+              type: array
+              items:
+                $ref: './schemas/device.json#/$defs/BleEvent'
+              description: Buffered BLE events matching the stream filter.
+
+      bleEvent:
+        name: bleEvent
+        title: BLE Event
+        summary: New BLE event recorded by the monitor.
+        contentType: application/json
+        payload:
+          type: object
+          description: Live BLE event.
+          required: [type, timestamp, event]
+          properties:
+            type:
+              type: string
+              const: ble_event
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            event:
+              $ref: './schemas/device.json#/$defs/BleEvent'
+              description: The BLE event.
+
+      bleError:
+        name: bleError
+        title: BLE Stream Error
+        summary: Error encountered while opening the BLE stream.
+        contentType: application/json
+        payload:
+          type: object
+          description: BLE stream error message.
+          required: [type, timestamp, error]
+          properties:
+            type:
+              type: string
+              const: error
+              description: Message type identifier.
+            timestamp:
+              $ref: './schemas/common.json#/$defs/Timestamp'
+              description: UTC timestamp when this message was produced.
+            error:
+              type: string
+              description: Human-readable error message.
+
   # ── Profiler Data Stream ────────────────────────────────────────────────
   profiler:
     address: /ws/v1/profiler

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -1570,10 +1570,12 @@ paths:
       summary: Stream BLE events
       description: >
         Opens a WebSocket stream for BLE events. The server first sends a
-        `subscribed` message containing the current scanning state, then sends
-        `ble_event` messages as events are recorded. Set `scan=true` to start a
-        native BLE scan for the lifetime of this WebSocket connection when
-        scanning is supported.
+        `subscribed` message containing the current scanning state and replay
+        settings, optionally sends a `replay` message with buffered events, then
+        sends `ble_event` messages as events are recorded. Streamed events remain
+        in the bounded BLE event buffer until evicted by retention or cleared via
+        the REST API. Set `scan=true` to start a native BLE scan for the lifetime
+        of this WebSocket connection when scanning is supported.
       parameters:
         - name: scan
           in: query
@@ -1581,6 +1583,18 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: replay
+          in: query
+          description: Number of buffered BLE events to replay after subscription. Use 0 for live-only streaming.
+          schema:
+            type: integer
+            minimum: 0
+            default: 100
+        - name: type
+          in: query
+          description: Optional event type filter applied to replayed and live events.
+          schema:
+            $ref: "./schemas/device.json#/$defs/BleEventType"
       responses:
         "101":
           description: WebSocket connection established.

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -33,7 +33,7 @@ tags:
   - name: logs
     description: Application logs
   - name: device
-    description: Device info, sensors, jobs, permissions, geolocation
+    description: Device info, sensors, BLE, jobs, permissions, geolocation
   - name: storage
     description: Preferences, secure storage, and sandboxed app files
   - name: extensions
@@ -1446,6 +1446,120 @@ paths:
                 $ref: "./schemas/device.json#/$defs/JobRunResponse"
         "501":
           $ref: "#/components/responses/UnsupportedCapability"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/ble:
+    get:
+      operationId: getBleStatus
+      tags: [device]
+      summary: Get BLE monitor status
+      description: >
+        Returns Bluetooth Low Energy monitor status, including whether scanning
+        is active, the buffered event count, subscriber count, and whether native
+        scanning is supported by this agent.
+      responses:
+        "200":
+          description: BLE monitor status.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/BleStatus"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/ble/events:
+    get:
+      operationId: getBleEvents
+      tags: [device]
+      summary: List BLE events
+      description: >
+        Returns recent BLE events recorded by the agent, optionally filtered by
+        event type. Events include scan results, connection changes,
+        characteristic reads/writes, notifications, service discoveries,
+        descriptor writes, MTU changes, bond state changes, and scan failures.
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of events to return. Use 0 to return no events.
+          schema:
+            type: integer
+            minimum: 0
+            default: 100
+        - name: type
+          in: query
+          description: Optional event type filter.
+          schema:
+            $ref: "./schemas/device.json#/$defs/BleEventType"
+      responses:
+        "200":
+          description: Buffered BLE events.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/BleEventsResponse"
+        "400":
+          description: Invalid BLE event query.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/common.json#/$defs/ProblemDetails"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: clearBleEvents
+      tags: [device]
+      summary: Clear BLE events
+      description: Clears all buffered BLE events.
+      responses:
+        "200":
+          description: BLE events cleared.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/actions.json#/$defs/ActionResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/ble/scan/start:
+    post:
+      operationId: startBleScan
+      tags: [device]
+      summary: Start BLE scan
+      description: >
+        Starts native BLE scanning when supported by the current platform.
+        Discovered advertisements are buffered as BLE events and streamed to BLE
+        WebSocket subscribers.
+      responses:
+        "200":
+          description: BLE scan started.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/actions.json#/$defs/ActionResponse"
+        "400":
+          description: BLE scanning is unavailable or cannot be started.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/common.json#/$defs/ProblemDetails"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/device/ble/scan/stop:
+    post:
+      operationId: stopBleScan
+      tags: [device]
+      summary: Stop BLE scan
+      description: Stops an active BLE scan.
+      responses:
+        "200":
+          description: BLE scan stopped.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/actions.json#/$defs/ActionResponse"
         "500":
           $ref: "#/components/responses/InternalError"
 

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -1563,6 +1563,36 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /ws/v1/ble:
+    get:
+      operationId: streamBleEvents
+      tags: [device]
+      summary: Stream BLE events
+      description: >
+        Opens a WebSocket stream for BLE events. The server first sends a
+        `subscribed` message containing the current scanning state, then sends
+        `ble_event` messages as events are recorded. Set `scan=true` to start a
+        native BLE scan for the lifetime of this WebSocket connection when
+        scanning is supported.
+      parameters:
+        - name: scan
+          in: query
+          description: Start BLE scanning automatically while this WebSocket connection is active.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "101":
+          description: WebSocket connection established.
+        "400":
+          description: WebSocket upgrade failed or BLE scanning cannot be started.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/common.json#/$defs/ProblemDetails"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /api/v1/device/permissions:
     get:
       operationId: listPermissions

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -143,6 +143,16 @@
             ],
             "supported": true
           },
+          "device.ble": {
+            "version": 1,
+            "features": [
+              "status",
+              "events",
+              "scan",
+              "stream"
+            ],
+            "supported": true
+          },
           "storage.preferences": {
             "version": 1,
             "features": [

--- a/docs/DevFlow/spec/schemas/device.json
+++ b/docs/DevFlow/spec/schemas/device.json
@@ -394,8 +394,8 @@
     },
     "BleEventType": {
       "type": "string",
-      "description": "BLE event type recorded by the monitor.",
-      "enum": [
+      "description": "BLE event type recorded by the monitor. The monitor accepts custom app-defined event types; examples list the built-in event types.",
+      "examples": [
         "scan_result",
         "connected",
         "disconnected",

--- a/docs/DevFlow/spec/schemas/device.json
+++ b/docs/DevFlow/spec/schemas/device.json
@@ -392,6 +392,134 @@
       },
       "additionalProperties": true
     },
+    "BleEventType": {
+      "type": "string",
+      "description": "BLE event type recorded by the monitor.",
+      "enum": [
+        "scan_result",
+        "connected",
+        "disconnected",
+        "connection_state_changed",
+        "connection_failed",
+        "characteristic_read",
+        "characteristic_write",
+        "characteristic_write_no_response",
+        "notification",
+        "service_discovered",
+        "descriptor_write",
+        "mtu_changed",
+        "bond_state_changed",
+        "adapter_state_changed",
+        "scan_failed"
+      ]
+    },
+    "BleStatus": {
+      "type": "object",
+      "description": "Bluetooth Low Energy monitor status.",
+      "required": [
+        "scanning",
+        "eventCount",
+        "subscribers",
+        "supportsScanning"
+      ],
+      "properties": {
+        "scanning": {
+          "type": "boolean",
+          "description": "Whether a native BLE scan is currently active."
+        },
+        "eventCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of BLE events currently buffered."
+        },
+        "subscribers": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of active BLE event stream subscribers."
+        },
+        "supportsScanning": {
+          "type": "boolean",
+          "description": "Whether this agent implementation supports native BLE scanning."
+        }
+      }
+    },
+    "BleEvent": {
+      "type": "object",
+      "description": "A Bluetooth Low Energy event recorded by the monitor.",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/BleEventType",
+          "description": "Event type."
+        },
+        "timestamp": {
+          "$ref": "common.json#/$defs/Timestamp",
+          "description": "UTC timestamp when the event was recorded."
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "Platform device identifier, such as a Bluetooth address or UUID."
+        },
+        "deviceName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Device display name, if available."
+        },
+        "rssi": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Received signal strength in dBm for scan results."
+        },
+        "serviceUuid": {
+          "type": "string",
+          "description": "GATT service UUID associated with the event."
+        },
+        "characteristicUuid": {
+          "type": "string",
+          "description": "GATT characteristic UUID associated with the event."
+        },
+        "descriptorUuid": {
+          "type": "string",
+          "description": "GATT descriptor UUID associated with the event."
+        },
+        "data": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Event-specific payload, such as advertisement data, state, error text, or a hex value."
+        }
+      },
+      "additionalProperties": true
+    },
+    "BleEventsResponse": {
+      "type": "object",
+      "description": "Response returned when listing buffered BLE events.",
+      "required": [
+        "count",
+        "events"
+      ],
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of events returned."
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/BleEvent"
+          },
+          "description": "Buffered BLE events."
+        }
+      }
+    },
     "GeolocationResult": {
       "type": "object",
       "description": "A geolocation reading.",

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -46,6 +46,7 @@ public static class McpServerHost
 			.WithTools<SensorTools>()
 			.WithTools<JobTools>()
 			.WithTools<FileTools>()
+			.WithTools<BleTools>()
 			.WithTools<BatchTools>();
 
 		await builder.Build().RunAsync();

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BleTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BleTools.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Microsoft.Maui.Cli.DevFlow.Mcp;
+
+namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class BleTools
+{
+	[McpServerTool(Name = "maui_ble_status"), Description("Get BLE monitor status including whether scanning is active, event count, and subscriber count.")]
+	public static async Task<string> GetBleStatus(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetBleStatusAsync();
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get BLE status." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_ble_events"), Description("Get recent BLE events (scan results, connections, disconnections, reads, writes, notifications). Optionally filter by event type.")]
+	public static async Task<string> GetBleEvents(
+		McpAgentSession session,
+		[Description("Max events to return (default 100)")] int? limit = null,
+		[Description("Filter by event type: scan_result, connected, disconnected, characteristic_read, characteristic_write, notification, service_discovered, mtu_changed, descriptor_write, bond_state_changed")] string? type = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetBleEventsAsync(limit ?? 100, type);
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get BLE events." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_ble_scan_start"), Description("Start a BLE scan to discover nearby Bluetooth Low Energy devices. Scan results appear as BLE events.")]
+	public static async Task<string> StartBleScan(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.StartBleScanAsync();
+		return success ? "BLE scan started." : "Failed to start BLE scan.";
+	}
+
+	[McpServerTool(Name = "maui_ble_scan_stop"), Description("Stop an active BLE scan.")]
+	public static async Task<string> StopBleScan(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.StopBleScanAsync();
+		return success ? "BLE scan stopped." : "Failed to stop BLE scan.";
+	}
+
+	[McpServerTool(Name = "maui_ble_events_clear"), Description("Clear all recorded BLE events.")]
+	public static async Task<string> ClearBleEvents(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var success = await agent.ClearBleEventsAsync();
+		return success ? "BLE events cleared." : "Failed to clear BLE events.";
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BleTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BleTools.cs
@@ -30,6 +30,18 @@ public sealed class BleTools
 		return result.ValueKind == JsonValueKind.Undefined ? "Failed to get BLE events." : result.ToString();
 	}
 
+	[McpServerTool(Name = "maui_ble_stream_url"), Description("Get the WebSocket URL for streaming live BLE events. The stream can replay buffered events on connect without consuming them.")]
+	public static async Task<string> GetBleStreamUrl(
+		McpAgentSession session,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+		[Description("Start BLE scanning automatically for the lifetime of this stream when supported (default false)")] bool scan = false,
+		[Description("Number of buffered events to replay when the stream opens. Use 0 for live-only streaming. Default is 100.")] int replay = 100,
+		[Description("Optional event type filter, such as scan_result, connected, disconnected, notification, or a custom app-defined event type.")] string? type = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		return agent.GetBleWebSocketUrl(scan, replay, type);
+	}
+
 	[McpServerTool(Name = "maui_ble_scan_start"), Description("Start a BLE scan to discover nearby Bluetooth Low Energy devices. Scan results appear as BLE events.")]
 	public static async Task<string> StartBleScan(
 		McpAgentSession session,

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs
@@ -32,13 +32,20 @@ public class BleMonitor : IDisposable
 
     public BleMonitor(int maxEvents = 2000)
     {
-        _maxEvents = maxEvents;
+        _maxEvents = Math.Max(0, maxEvents);
     }
 
     public bool IsScanning
     {
         get { lock (_gate) return _scanning; }
     }
+
+    public virtual bool SupportsScanning => false;
+
+    public virtual IReadOnlyList<string> SupportedFeatures
+        => SupportsScanning
+            ? ["status", "events", "scan", "stream"]
+            : ["status", "events", "stream"];
 
     public object GetStatus()
     {
@@ -48,13 +55,17 @@ public class BleMonitor : IDisposable
             {
                 scanning = _scanning,
                 eventCount = _eventCount,
-                subscribers = _subscribers.Count
+                subscribers = _subscribers.Count,
+                supportsScanning = SupportsScanning
             };
         }
     }
 
     public List<BleEvent> GetEvents(int limit = 100, string? type = null)
     {
+        if (limit <= 0)
+            return [];
+
         var all = _events.ToArray();
         IEnumerable<BleEvent> filtered = all;
         if (!string.IsNullOrEmpty(type))
@@ -80,7 +91,12 @@ public class BleMonitor : IDisposable
 
         // Trim ring buffer
         while (_events.Count > _maxEvents)
-            _events.TryDequeue(out _);
+        {
+            if (!_events.TryDequeue(out _))
+                break;
+
+            Interlocked.Decrement(ref _eventCount);
+        }
 
         // Broadcast to WebSocket subscribers
         var json = JsonSerializer.Serialize(new
@@ -235,8 +251,17 @@ public class BleMonitor : IDisposable
         if (_disposed) return;
         _disposed = true;
         StopScanning();
+        DisposePlatform();
         if (Instance == this)
             Instance = null;
+    }
+
+    /// <summary>
+    /// Allows platform-specific subclasses to release native resources that are not
+    /// tied strictly to an active scan, such as watchers, receivers, or callbacks.
+    /// </summary>
+    protected virtual void DisposePlatform()
+    {
     }
 }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs
@@ -1,0 +1,271 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.DevFlow.Agent.Core;
+
+/// <summary>
+/// Platform-agnostic BLE event monitor with ring buffer and WebSocket subscriber support.
+/// Platform-specific agents override StartScanning/StopScanning and push events via RecordEvent.
+/// Apps and BLE libraries can also push events directly via the static <see cref="Instance"/> singleton.
+/// </summary>
+public class BleMonitor : IDisposable
+{
+    /// <summary>
+    /// Global singleton so that app code / BLE libraries can push events without a reference to the agent.
+    /// </summary>
+    public static BleMonitor? Instance { get; internal set; }
+
+    private readonly ConcurrentQueue<BleEvent> _events = new();
+    private readonly List<ConcurrentQueue<string>> _subscribers = new();
+    private readonly object _gate = new();
+    private readonly int _maxEvents;
+    private int _eventCount;
+    private bool _scanning;
+    private bool _disposed;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public BleMonitor(int maxEvents = 2000)
+    {
+        _maxEvents = maxEvents;
+    }
+
+    public bool IsScanning
+    {
+        get { lock (_gate) return _scanning; }
+    }
+
+    public object GetStatus()
+    {
+        lock (_gate)
+        {
+            return new
+            {
+                scanning = _scanning,
+                eventCount = _eventCount,
+                subscribers = _subscribers.Count
+            };
+        }
+    }
+
+    public List<BleEvent> GetEvents(int limit = 100, string? type = null)
+    {
+        var all = _events.ToArray();
+        IEnumerable<BleEvent> filtered = all;
+        if (!string.IsNullOrEmpty(type))
+            filtered = filtered.Where(e => e.Type.Equals(type, StringComparison.OrdinalIgnoreCase));
+        return filtered.TakeLast(limit).ToList();
+    }
+
+    public void ClearEvents()
+    {
+        while (_events.TryDequeue(out _)) { }
+        Interlocked.Exchange(ref _eventCount, 0);
+    }
+
+    /// <summary>
+    /// Record a BLE event. Called by platform-specific code or app BLE libraries.
+    /// </summary>
+    public void RecordEvent(BleEvent evt)
+    {
+        evt.Timestamp ??= DateTimeOffset.UtcNow.ToString("O");
+
+        _events.Enqueue(evt);
+        Interlocked.Increment(ref _eventCount);
+
+        // Trim ring buffer
+        while (_events.Count > _maxEvents)
+            _events.TryDequeue(out _);
+
+        // Broadcast to WebSocket subscribers
+        var json = JsonSerializer.Serialize(new
+        {
+            type = "ble_event",
+            timestamp = evt.Timestamp,
+            @event = evt
+        }, JsonOpts);
+
+        List<ConcurrentQueue<string>> snapshot;
+        lock (_gate) { snapshot = new List<ConcurrentQueue<string>>(_subscribers); }
+        foreach (var q in snapshot)
+            q.Enqueue(json);
+    }
+
+    // Convenience methods for common event types
+
+    public void RecordScanResult(string deviceId, string? deviceName, int? rssi, string? advertisementData = null)
+        => RecordEvent(new BleEvent
+        {
+            Type = "scan_result",
+            DeviceId = deviceId,
+            DeviceName = deviceName,
+            Rssi = rssi,
+            Data = advertisementData
+        });
+
+    public void RecordConnectionStateChanged(string deviceId, string? deviceName, string state)
+        => RecordEvent(new BleEvent
+        {
+            Type = state switch
+            {
+                "connected" => "connected",
+                "disconnected" => "disconnected",
+                _ => "connection_state_changed"
+            },
+            DeviceId = deviceId,
+            DeviceName = deviceName,
+            Data = state
+        });
+
+    public void RecordCharacteristicRead(string deviceId, string? deviceName, string serviceUuid, string characteristicUuid, string? valueHex)
+        => RecordEvent(new BleEvent
+        {
+            Type = "characteristic_read",
+            DeviceId = deviceId,
+            DeviceName = deviceName,
+            ServiceUuid = serviceUuid,
+            CharacteristicUuid = characteristicUuid,
+            Data = valueHex
+        });
+
+    public void RecordCharacteristicWrite(string deviceId, string? deviceName, string serviceUuid, string characteristicUuid, string? valueHex, bool withResponse = true)
+        => RecordEvent(new BleEvent
+        {
+            Type = withResponse ? "characteristic_write" : "characteristic_write_no_response",
+            DeviceId = deviceId,
+            DeviceName = deviceName,
+            ServiceUuid = serviceUuid,
+            CharacteristicUuid = characteristicUuid,
+            Data = valueHex
+        });
+
+    public void RecordNotification(string deviceId, string? deviceName, string serviceUuid, string characteristicUuid, string? valueHex)
+        => RecordEvent(new BleEvent
+        {
+            Type = "notification",
+            DeviceId = deviceId,
+            DeviceName = deviceName,
+            ServiceUuid = serviceUuid,
+            CharacteristicUuid = characteristicUuid,
+            Data = valueHex
+        });
+
+    public void RecordServiceDiscovered(string deviceId, string? deviceName, string serviceUuid)
+        => RecordEvent(new BleEvent
+        {
+            Type = "service_discovered",
+            DeviceId = deviceId,
+            DeviceName = deviceName,
+            ServiceUuid = serviceUuid
+        });
+
+    public void RecordDescriptorWrite(string deviceId, string? deviceName, string serviceUuid, string characteristicUuid, string descriptorUuid, string? valueHex)
+        => RecordEvent(new BleEvent
+        {
+            Type = "descriptor_write",
+            DeviceId = deviceId,
+            DeviceName = deviceName,
+            ServiceUuid = serviceUuid,
+            CharacteristicUuid = characteristicUuid,
+            DescriptorUuid = descriptorUuid,
+            Data = valueHex
+        });
+
+    public void RecordMtuChanged(string deviceId, string? deviceName, int mtu)
+        => RecordEvent(new BleEvent
+        {
+            Type = "mtu_changed",
+            DeviceId = deviceId,
+            DeviceName = deviceName,
+            Data = mtu.ToString()
+        });
+
+    // Scanning lifecycle — platform agents override StartPlatformScan/StopPlatformScan
+
+    public string? StartScanning()
+    {
+        lock (_gate)
+        {
+            if (_scanning) return null;
+            var error = StartPlatformScan();
+            if (error != null) return error;
+            _scanning = true;
+            return null;
+        }
+    }
+
+    public string? StopScanning()
+    {
+        lock (_gate)
+        {
+            if (!_scanning) return null;
+            StopPlatformScan();
+            _scanning = false;
+            return null;
+        }
+    }
+
+    /// <summary>Override in platform subclass to start native BLE scan.</summary>
+    protected virtual string? StartPlatformScan() => "BLE scanning not supported on this platform";
+
+    /// <summary>Override in platform subclass to stop native BLE scan.</summary>
+    protected virtual void StopPlatformScan() { }
+
+    // WebSocket subscriber management
+
+    public ConcurrentQueue<string> Subscribe()
+    {
+        var queue = new ConcurrentQueue<string>();
+        lock (_gate) { _subscribers.Add(queue); }
+        return queue;
+    }
+
+    public void Unsubscribe(ConcurrentQueue<string> queue)
+    {
+        lock (_gate) { _subscribers.Remove(queue); }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        StopScanning();
+        if (Instance == this)
+            Instance = null;
+    }
+}
+
+public class BleEvent
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "";
+
+    [JsonPropertyName("timestamp")]
+    public string? Timestamp { get; set; }
+
+    [JsonPropertyName("deviceId")]
+    public string? DeviceId { get; set; }
+
+    [JsonPropertyName("deviceName")]
+    public string? DeviceName { get; set; }
+
+    [JsonPropertyName("rssi")]
+    public int? Rssi { get; set; }
+
+    [JsonPropertyName("serviceUuid")]
+    public string? ServiceUuid { get; set; }
+
+    [JsonPropertyName("characteristicUuid")]
+    public string? CharacteristicUuid { get; set; }
+
+    [JsonPropertyName("descriptorUuid")]
+    public string? DescriptorUuid { get; set; }
+
+    [JsonPropertyName("data")]
+    public string? Data { get; set; }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs
@@ -17,7 +17,7 @@ public class BleMonitor : IDisposable
     public static BleMonitor? Instance { get; internal set; }
 
     private readonly ConcurrentQueue<BleEvent> _events = new();
-    private readonly List<ConcurrentQueue<string>> _subscribers = new();
+    private readonly List<BleSubscriber> _subscribers = new();
     private readonly object _gate = new();
     private readonly int _maxEvents;
     private int _eventCount;
@@ -109,10 +109,15 @@ public class BleMonitor : IDisposable
             @event = evt
         }, JsonOpts);
 
-        List<ConcurrentQueue<string>> snapshot;
-        lock (_gate) { snapshot = new List<ConcurrentQueue<string>>(_subscribers); }
-        foreach (var q in snapshot)
-            q.Enqueue(json);
+        List<BleSubscriber> snapshot;
+        lock (_gate) { snapshot = new List<BleSubscriber>(_subscribers); }
+        foreach (var subscriber in snapshot)
+        {
+            if (subscriber.Type != null && !evt.Type.Equals(subscriber.Type, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            subscriber.Queue.Enqueue(json);
+        }
     }
 
     // Convenience methods for common event types
@@ -208,14 +213,32 @@ public class BleMonitor : IDisposable
 
     public string? StartScanning()
     {
+        TryStartScanning(out var error);
+        return error;
+    }
+
+    public bool TryStartScanning(out string? error)
+    {
         lock (_gate)
         {
-            if (_disposed) return "BLE monitor disposed";
-            if (_scanning) return null;
-            var error = StartPlatformScan();
-            if (error != null) return error;
+            if (_disposed)
+            {
+                error = "BLE monitor disposed";
+                return false;
+            }
+
+            if (_scanning)
+            {
+                error = null;
+                return false;
+            }
+
+            error = StartPlatformScan();
+            if (error != null)
+                return false;
+
             _scanning = true;
-            return null;
+            return true;
         }
     }
 
@@ -238,16 +261,16 @@ public class BleMonitor : IDisposable
 
     // WebSocket subscriber management
 
-    public ConcurrentQueue<string> Subscribe()
+    public ConcurrentQueue<string> Subscribe(string? type = null)
     {
         var queue = new ConcurrentQueue<string>();
-        lock (_gate) { _subscribers.Add(queue); }
+        lock (_gate) { _subscribers.Add(new BleSubscriber(queue, type)); }
         return queue;
     }
 
     public void Unsubscribe(ConcurrentQueue<string> queue)
     {
-        lock (_gate) { _subscribers.Remove(queue); }
+        lock (_gate) { _subscribers.RemoveAll(subscriber => ReferenceEquals(subscriber.Queue, queue)); }
     }
 
     public void Dispose()
@@ -266,6 +289,12 @@ public class BleMonitor : IDisposable
     /// </summary>
     protected virtual void DisposePlatform()
     {
+    }
+
+    private sealed class BleSubscriber(ConcurrentQueue<string> queue, string? type)
+    {
+        public ConcurrentQueue<string> Queue { get; } = queue;
+        public string? Type { get; } = string.IsNullOrWhiteSpace(type) ? null : type;
     }
 }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs
@@ -84,6 +84,9 @@ public class BleMonitor : IDisposable
     /// </summary>
     public void RecordEvent(BleEvent evt)
     {
+        if (_disposed)
+            return;
+
         evt.Timestamp ??= DateTimeOffset.UtcNow.ToString("O");
 
         _events.Enqueue(evt);
@@ -207,6 +210,7 @@ public class BleMonitor : IDisposable
     {
         lock (_gate)
         {
+            if (_disposed) return "BLE monitor disposed";
             if (_scanning) return null;
             var error = StartPlatformScan();
             if (error != null) return error;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -679,8 +679,8 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             },
             ble = new
             {
-                supported = true,
-                features = new[] { "status", "events", "scan", "stream" }
+                supported = Ble.SupportedFeatures.Count > 0,
+                features = Ble.SupportedFeatures
             },
             storage = new
             {
@@ -6287,7 +6287,16 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
     {
         var limit = 100;
         if (request.QueryParams.TryGetValue("limit", out var limitStr))
-            int.TryParse(limitStr, out limit);
+        {
+            if (!int.TryParse(limitStr, out limit) || limit < 0)
+            {
+                return Task.FromResult(HttpResponse.Error(
+                    "BLE event limit must be a non-negative integer",
+                    400,
+                    "invalid_limit",
+                    new { limit = limitStr }));
+            }
+        }
 
         var type = request.QueryParams.GetValueOrDefault("type");
         var events = Ble.GetEvents(limit, type);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -6334,21 +6334,66 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         var autoScan = request.QueryParams.GetValueOrDefault("scan", "false")
             .Equals("true", StringComparison.OrdinalIgnoreCase);
 
-        if (autoScan)
-            Ble.StartScanning();
+        var replay = 100;
+        if (request.QueryParams.TryGetValue("replay", out var replayStr) &&
+            (!int.TryParse(replayStr, out replay) || replay < 0))
+        {
+            await AgentHttpServer.WebSocketSendTextAsync(stream,
+                JsonSerializer.Serialize(new
+                {
+                    type = "error",
+                    timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                    error = "BLE stream replay must be a non-negative integer"
+                }), ct);
+            return;
+        }
 
-        var queue = Ble.Subscribe();
+        var type = request.QueryParams.GetValueOrDefault("type");
+        List<BleEvent> replayEvents = replay > 0 ? Ble.GetEvents(replay, type) : [];
+        var queue = Ble.Subscribe(type);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var startedScan = false;
 
         try
         {
+            if (autoScan)
+            {
+                startedScan = Ble.TryStartScanning(out var error);
+                if (error != null)
+                {
+                    await AgentHttpServer.WebSocketSendTextAsync(stream,
+                        JsonSerializer.Serialize(new
+                        {
+                            type = "error",
+                            timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                            error
+                        }), ct);
+                    return;
+                }
+            }
+
             await AgentHttpServer.WebSocketSendTextAsync(stream,
                 JsonSerializer.Serialize(new
                 {
                     type = "subscribed",
                     timestamp = DateTimeOffset.UtcNow.ToString("O"),
-                    scanning = Ble.IsScanning
+                    scanning = Ble.IsScanning,
+                    replay,
+                    eventType = type
                 }), ct);
+
+            if (replay > 0)
+            {
+                await AgentHttpServer.WebSocketSendTextAsync(stream,
+                    JsonSerializer.Serialize(new
+                    {
+                        type = "replay",
+                        timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                        count = replayEvents.Count,
+                        events = replayEvents
+                    }), ct);
+            }
 
             var readTask = Task.Run(async () =>
             {
@@ -6390,7 +6435,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         finally
         {
             Ble.Unsubscribe(queue);
-            if (autoScan)
+            if (startedScan)
                 Ble.StopScanning();
         }
     }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -44,6 +44,11 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
     /// </summary>
     public SensorManager Sensors { get; }
 
+    /// <summary>
+    /// Monitors BLE scan results, connections, reads, writes, and notifications.
+    /// </summary>
+    public BleMonitor Ble { get; }
+
     private readonly IProfilerCollector _profilerCollector;
     private readonly ProfilerSessionStore _profilerSessions;
     private readonly SemaphoreSlim _profilerStateGate = new(1, 1);
@@ -249,6 +254,8 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         _treeWalker = CreateTreeWalker();
         NetworkStore = new NetworkRequestStore(_options.MaxNetworkBufferSize);
         Sensors = new SensorManager();
+        Ble = CreateBleMonitor();
+        BleMonitor.Instance = Ble;
         _profilerCollector = CreateProfilerCollector();
         _profilerSessions = new ProfilerSessionStore(
             Math.Max(1, _options.MaxProfilerSamples),
@@ -293,6 +300,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
     /// to provide native frame/CPU integrations.
     /// </summary>
     protected virtual IProfilerCollector CreateProfilerCollector() => new RuntimeProfilerCollector();
+
+    /// <summary>
+    /// Creates the BLE monitor. Override in platform-specific subclasses
+    /// to provide native scan and connection monitoring.
+    /// </summary>
+    protected virtual BleMonitor CreateBleMonitor() => new BleMonitor();
 
     /// <summary>Platform name for status reporting. Override for platforms without DeviceInfo.</summary>
     protected virtual string PlatformName => DeviceInfo.Current.Platform.ToString();
@@ -517,6 +530,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
 
         _server.MapGet("/api/v1/device/jobs", HandleJobsList);
         _server.MapPost("/api/v1/device/jobs/{identifier}/run", HandleJobRun);
+        _server.MapGet("/api/v1/device/ble", HandleBleStatus);
+        _server.MapGet("/api/v1/device/ble/events", HandleBleEvents);
+        _server.MapPost("/api/v1/device/ble/scan/start", HandleBleScanStart);
+        _server.MapPost("/api/v1/device/ble/scan/stop", HandleBleScanStop);
+        _server.MapDelete("/api/v1/device/ble/events", HandleBleClearEvents);
+        _server.MapWebSocket("/ws/v1/ble", HandleBleWebSocket);
 
         _server.MapGet("/api/v1/storage/preferences", HandlePreferencesList);
         _server.MapGet("/api/v1/storage/preferences/{key}", HandlePreferencesGet);
@@ -595,6 +614,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
                     network = true,
                     logs = true,
                     sensors = true,
+                    ble = true,
                     storage = true,
                     profiler = IsProfilerFeatureAvailable,
                     jobs = IsJobsSupported,
@@ -656,6 +676,11 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             {
                 supported = true,
                 features = new[] { "list", "start", "stop", "stream" }
+            },
+            ble = new
+            {
+                supported = true,
+                features = new[] { "status", "events", "scan", "stream" }
             },
             storage = new
             {
@@ -4000,6 +4025,7 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         NetworkStore.OnRequestCaptured -= HandleCapturedNetworkRequest;
         StopAutoUiHooks();
         Sensors.Dispose();
+        Ble.Dispose();
 
         var cts = _profilerLoopCts;
         var loopTask = _profilerLoopTask;
@@ -6248,6 +6274,116 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
             return HttpResponse.Error($"Running jobs is not supported on {PlatformName}", 501, "unsupported-capability");
 
         return HttpResponse.Json(result);
+    }
+
+    // ── BLE endpoints ──
+
+    private Task<HttpResponse> HandleBleStatus(HttpRequest request)
+    {
+        return Task.FromResult(HttpResponse.Json(Ble.GetStatus()));
+    }
+
+    private Task<HttpResponse> HandleBleEvents(HttpRequest request)
+    {
+        var limit = 100;
+        if (request.QueryParams.TryGetValue("limit", out var limitStr))
+            int.TryParse(limitStr, out limit);
+
+        var type = request.QueryParams.GetValueOrDefault("type");
+        var events = Ble.GetEvents(limit, type);
+        return Task.FromResult(HttpResponse.Json(new { count = events.Count, events }));
+    }
+
+    private Task<HttpResponse> HandleBleScanStart(HttpRequest request)
+    {
+        var error = Ble.StartScanning();
+        return Task.FromResult(error != null
+            ? HttpResponse.Error(error)
+            : HttpResponse.Ok("BLE scan started"));
+    }
+
+    private Task<HttpResponse> HandleBleScanStop(HttpRequest request)
+    {
+        var error = Ble.StopScanning();
+        return Task.FromResult(error != null
+            ? HttpResponse.Error(error)
+            : HttpResponse.Ok("BLE scan stopped"));
+    }
+
+    private Task<HttpResponse> HandleBleClearEvents(HttpRequest request)
+    {
+        Ble.ClearEvents();
+        return Task.FromResult(HttpResponse.Ok("BLE events cleared"));
+    }
+
+    private async Task HandleBleWebSocket(
+        System.Net.Sockets.TcpClient client,
+        System.Net.Sockets.NetworkStream stream,
+        HttpRequest request,
+        CancellationToken ct)
+    {
+        var autoScan = request.QueryParams.GetValueOrDefault("scan", "false")
+            .Equals("true", StringComparison.OrdinalIgnoreCase);
+
+        if (autoScan)
+            Ble.StartScanning();
+
+        var queue = Ble.Subscribe();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        try
+        {
+            await AgentHttpServer.WebSocketSendTextAsync(stream,
+                JsonSerializer.Serialize(new
+                {
+                    type = "subscribed",
+                    timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                    scanning = Ble.IsScanning
+                }), ct);
+
+            var readTask = Task.Run(async () =>
+            {
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    var msg = await AgentHttpServer.WebSocketReadTextAsync(stream, cts.Token);
+                    if (msg == null) { await cts.CancelAsync(); break; }
+                }
+            }, cts.Token);
+
+            var lastPing = DateTime.UtcNow;
+            while (!cts.Token.IsCancellationRequested)
+            {
+                while (queue.TryDequeue(out var evt))
+                {
+                    try
+                    {
+                        await AgentHttpServer.WebSocketSendTextAsync(stream, evt, cts.Token);
+                    }
+                    catch { await cts.CancelAsync(); break; }
+                }
+
+                if ((DateTime.UtcNow - lastPing).TotalSeconds >= 15)
+                {
+                    try
+                    {
+                        await AgentHttpServer.WebSocketSendPingAsync(stream, cts.Token);
+                        lastPing = DateTime.UtcNow;
+                    }
+                    catch { await cts.CancelAsync(); break; }
+                }
+
+                try { await Task.Delay(20, cts.Token); }
+                catch { break; }
+            }
+
+            await readTask;
+        }
+        finally
+        {
+            Ble.Unsubscribe(queue);
+            if (autoScan)
+                Ble.StopScanning();
+        }
     }
 }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/AndroidBleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/AndroidBleMonitor.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Maui.DevFlow.Agent.Ble;
 
 internal sealed class AndroidBleMonitor : BleMonitor
 {
+    // Android's BluetoothProfile.GATT value is not exposed as a named ProfileType member.
+    private const global::Android.Bluetooth.ProfileType GattProfile = (global::Android.Bluetooth.ProfileType)7;
+
     private global::Android.Bluetooth.LE.BluetoothLeScanner? _scanner;
     private DevFlowScanCallback? _scanCallback;
     private DevFlowConnectionReceiver? _connectionReceiver;
@@ -16,6 +19,8 @@ internal sealed class AndroidBleMonitor : BleMonitor
         SnapshotConnectedDevices();
     }
 
+    public override bool SupportsScanning => true;
+
     private void SnapshotConnectedDevices()
     {
         try
@@ -24,8 +29,7 @@ internal sealed class AndroidBleMonitor : BleMonitor
                 global::Android.App.Application.Context.GetSystemService(global::Android.Content.Context.BluetoothService);
             if (manager == null) return;
 
-            // BluetoothProfile.Gatt = 7
-            var devices = manager.GetConnectedDevices((global::Android.Bluetooth.ProfileType)7);
+            var devices = manager.GetConnectedDevices(GattProfile);
             if (devices == null) return;
 
             foreach (var device in devices)
@@ -68,6 +72,25 @@ internal sealed class AndroidBleMonitor : BleMonitor
         }
         _scanCallback = null;
         _scanner = null;
+    }
+
+    protected override void DisposePlatform()
+    {
+        if (_receiverRegistered && _connectionReceiver != null)
+        {
+            try
+            {
+                global::Android.App.Application.Context.UnregisterReceiver(_connectionReceiver);
+            }
+            catch (global::Java.Lang.IllegalArgumentException)
+            {
+                // Receiver was already unregistered by Android.
+            }
+        }
+
+        _receiverRegistered = false;
+        _connectionReceiver?.Dispose();
+        _connectionReceiver = null;
     }
 
     private void RegisterConnectionReceiver()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/AndroidBleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/AndroidBleMonitor.cs
@@ -1,0 +1,184 @@
+#if ANDROID
+using Microsoft.Maui.DevFlow.Agent.Core;
+
+namespace Microsoft.Maui.DevFlow.Agent.Ble;
+
+internal sealed class AndroidBleMonitor : BleMonitor
+{
+    private global::Android.Bluetooth.LE.BluetoothLeScanner? _scanner;
+    private DevFlowScanCallback? _scanCallback;
+    private DevFlowConnectionReceiver? _connectionReceiver;
+    private bool _receiverRegistered;
+
+    public AndroidBleMonitor() : base()
+    {
+        RegisterConnectionReceiver();
+        SnapshotConnectedDevices();
+    }
+
+    private void SnapshotConnectedDevices()
+    {
+        try
+        {
+            var manager = (global::Android.Bluetooth.BluetoothManager?)
+                global::Android.App.Application.Context.GetSystemService(global::Android.Content.Context.BluetoothService);
+            if (manager == null) return;
+
+            // BluetoothProfile.Gatt = 7
+            var devices = manager.GetConnectedDevices((global::Android.Bluetooth.ProfileType)7);
+            if (devices == null) return;
+
+            foreach (var device in devices)
+            {
+                string? name = null;
+                try { name = device.Name; } catch { }
+                RecordConnectionStateChanged(device.Address ?? "", name, "connected");
+            }
+        }
+        catch { /* permissions may not be granted */ }
+    }
+
+    protected override string? StartPlatformScan()
+    {
+        var manager = (global::Android.Bluetooth.BluetoothManager?)
+            global::Android.App.Application.Context.GetSystemService(global::Android.Content.Context.BluetoothService);
+        var adapter = manager?.Adapter;
+        if (adapter == null || !adapter.IsEnabled)
+            return "Bluetooth is not enabled";
+
+        _scanner = adapter.BluetoothLeScanner;
+        if (_scanner == null)
+            return "BLE scanner not available";
+
+        _scanCallback = new DevFlowScanCallback(this);
+        var settings = new global::Android.Bluetooth.LE.ScanSettings.Builder()
+            .SetScanMode(global::Android.Bluetooth.LE.ScanMode.LowLatency)!
+            .Build();
+
+        _scanner.StartScan(null, settings, _scanCallback);
+        return null;
+    }
+
+    protected override void StopPlatformScan()
+    {
+        if (_scanner != null && _scanCallback != null)
+        {
+            try { _scanner.StopScan(_scanCallback); }
+            catch { /* scanner may already be stopped */ }
+        }
+        _scanCallback = null;
+        _scanner = null;
+    }
+
+    private void RegisterConnectionReceiver()
+    {
+        if (_receiverRegistered) return;
+        try
+        {
+            _connectionReceiver = new DevFlowConnectionReceiver(this);
+            var filter = new global::Android.Content.IntentFilter();
+            filter.AddAction(global::Android.Bluetooth.BluetoothDevice.ActionAclConnected);
+            filter.AddAction(global::Android.Bluetooth.BluetoothDevice.ActionAclDisconnected);
+            filter.AddAction(global::Android.Bluetooth.BluetoothDevice.ActionBondStateChanged);
+
+            var context = global::Android.App.Application.Context;
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.Tiramisu)
+            {
+#pragma warning disable CA1416
+                context.RegisterReceiver(
+                    _connectionReceiver, filter, global::Android.Content.ReceiverFlags.NotExported);
+#pragma warning restore CA1416
+            }
+            else
+            {
+#pragma warning disable CA1422
+                context.RegisterReceiver(_connectionReceiver, filter);
+#pragma warning restore CA1422
+            }
+            _receiverRegistered = true;
+        }
+        catch { /* permissions may not be granted */ }
+    }
+
+    private sealed class DevFlowScanCallback : global::Android.Bluetooth.LE.ScanCallback
+    {
+        private readonly AndroidBleMonitor _monitor;
+
+        public DevFlowScanCallback(AndroidBleMonitor monitor) => _monitor = monitor;
+
+        public override void OnScanResult(global::Android.Bluetooth.LE.ScanCallbackType callbackType, global::Android.Bluetooth.LE.ScanResult? result)
+        {
+            if (result?.Device == null) return;
+
+            string? name = null;
+            try { name = result.Device.Name; } catch { }
+
+            _monitor.RecordScanResult(
+                result.Device.Address ?? "",
+                name,
+                result.Rssi,
+                result.ScanRecord?.GetBytes() is byte[] bytes ? Convert.ToHexString(bytes) : null
+            );
+        }
+
+        public override void OnBatchScanResults(IList<global::Android.Bluetooth.LE.ScanResult>? results)
+        {
+            if (results == null) return;
+            foreach (var result in results)
+                OnScanResult(global::Android.Bluetooth.LE.ScanCallbackType.AllMatches, result);
+        }
+
+        public override void OnScanFailed(global::Android.Bluetooth.LE.ScanFailure errorCode)
+        {
+            _monitor.RecordEvent(new BleEvent
+            {
+                Type = "scan_failed",
+                Data = errorCode.ToString()
+            });
+        }
+    }
+
+    private sealed class DevFlowConnectionReceiver : global::Android.Content.BroadcastReceiver
+    {
+        private readonly AndroidBleMonitor _monitor;
+
+        public DevFlowConnectionReceiver(AndroidBleMonitor monitor) => _monitor = monitor;
+
+        public override void OnReceive(global::Android.Content.Context? context, global::Android.Content.Intent? intent)
+        {
+            if (intent == null) return;
+
+#pragma warning disable CA1422
+            var device = intent.GetParcelableExtra(global::Android.Bluetooth.BluetoothDevice.ExtraDevice) as global::Android.Bluetooth.BluetoothDevice;
+#pragma warning restore CA1422
+            if (device == null) return;
+
+            string? name = null;
+            try { name = device.Name; } catch { }
+
+            var action = intent.Action;
+            if (action == global::Android.Bluetooth.BluetoothDevice.ActionAclConnected)
+            {
+                _monitor.RecordConnectionStateChanged(device.Address ?? "", name, "connected");
+            }
+            else if (action == global::Android.Bluetooth.BluetoothDevice.ActionAclDisconnected)
+            {
+                _monitor.RecordConnectionStateChanged(device.Address ?? "", name, "disconnected");
+            }
+            else if (action == global::Android.Bluetooth.BluetoothDevice.ActionBondStateChanged)
+            {
+                var state = (global::Android.Bluetooth.Bond)intent.GetIntExtra(
+                    global::Android.Bluetooth.BluetoothDevice.ExtraBondState,
+                    (int)global::Android.Bluetooth.Bond.None);
+                _monitor.RecordEvent(new BleEvent
+                {
+                    Type = "bond_state_changed",
+                    DeviceId = device.Address ?? "",
+                    DeviceName = name,
+                    Data = state.ToString()
+                });
+            }
+        }
+    }
+}
+#endif

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/AppleBleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/AppleBleMonitor.cs
@@ -1,0 +1,173 @@
+#if IOS || MACCATALYST
+using CoreBluetooth;
+using Foundation;
+using Microsoft.Maui.DevFlow.Agent.Core;
+
+namespace Microsoft.Maui.DevFlow.Agent.Ble;
+
+internal sealed class AppleBleMonitor : BleMonitor
+{
+    private CBCentralManager? _centralManager;
+    private DevFlowCentralDelegate? _delegate;
+    private bool _snapshotTaken;
+
+    public AppleBleMonitor() : base()
+    {
+        // Create manager immediately so UpdatedState fires and we can snapshot connected devices
+        _delegate = new DevFlowCentralDelegate(this);
+        _centralManager = new CBCentralManager(_delegate, null);
+    }
+
+    protected override string? StartPlatformScan()
+    {
+        if (_centralManager == null)
+        {
+            _delegate = new DevFlowCentralDelegate(this);
+            _centralManager = new CBCentralManager(_delegate, null);
+        }
+
+        // If already powered on, start immediately; otherwise UpdatedState will start it
+        if (_centralManager.State == CBManagerState.PoweredOn)
+        {
+            _centralManager.ScanForPeripherals(
+                (CBUUID[]?)null,
+                new PeripheralScanningOptions { AllowDuplicatesKey = true }
+            );
+        }
+
+        return null;
+    }
+
+    protected override void StopPlatformScan()
+    {
+        if (_centralManager != null)
+        {
+            try { _centralManager.StopScan(); }
+            catch { /* may already be stopped */ }
+        }
+        // Don't dispose the manager — we still need it for connection events
+    }
+
+    internal void SnapshotConnectedDevices(CBCentralManager central)
+    {
+        if (_snapshotTaken) return;
+        _snapshotTaken = true;
+
+        try
+        {
+            // Retrieve peripherals connected to any known GATT service
+            // An empty array returns nothing, so we pass common service UUIDs
+            // However, RetrieveConnectedPeripherals with no filter isn't possible.
+            // Instead, we can check for any peripherals connected system-wide.
+            // The most reliable approach: use common standard BLE service UUIDs.
+            var commonServices = new[]
+            {
+                CBUUID.FromString("180A"), // Device Information
+                CBUUID.FromString("180F"), // Battery Service
+                CBUUID.FromString("1800"), // Generic Access
+                CBUUID.FromString("1801"), // Generic Attribute
+                CBUUID.FromString("180D"), // Heart Rate
+                CBUUID.FromString("1812"), // HID
+            };
+
+            var peripherals = central.RetrieveConnectedPeripherals(commonServices);
+            if (peripherals == null) return;
+
+            // Deduplicate by identifier
+            var seen = new HashSet<string>();
+            foreach (var peripheral in peripherals)
+            {
+                var id = peripheral.Identifier.ToString();
+                if (seen.Add(id))
+                    RecordConnectionStateChanged(id, peripheral.Name, "connected");
+            }
+        }
+        catch { /* permissions may not be granted */ }
+    }
+
+    private sealed class DevFlowCentralDelegate : CBCentralManagerDelegate
+    {
+        private readonly AppleBleMonitor _monitor;
+
+        public DevFlowCentralDelegate(AppleBleMonitor monitor) => _monitor = monitor;
+
+        public override void UpdatedState(CBCentralManager central)
+        {
+            if (central.State == CBManagerState.PoweredOn)
+            {
+                _monitor.SnapshotConnectedDevices(central);
+
+                if (_monitor.IsScanning)
+                {
+                    central.ScanForPeripherals(
+                        (CBUUID[]?)null,
+                        new PeripheralScanningOptions { AllowDuplicatesKey = true }
+                    );
+                }
+            }
+            else
+            {
+                _monitor.RecordEvent(new BleEvent
+                {
+                    Type = "adapter_state_changed",
+                    Data = central.State.ToString()
+                });
+            }
+        }
+
+        public override void DiscoveredPeripheral(CBCentralManager central, CBPeripheral peripheral, NSDictionary advertisementData, NSNumber rssi)
+        {
+            _monitor.RecordScanResult(
+                peripheral.Identifier.ToString(),
+                peripheral.Name,
+                rssi.Int32Value,
+                FormatAdvertisementData(advertisementData)
+            );
+        }
+
+        public override void ConnectedPeripheral(CBCentralManager central, CBPeripheral peripheral)
+        {
+            _monitor.RecordConnectionStateChanged(
+                peripheral.Identifier.ToString(),
+                peripheral.Name,
+                "connected"
+            );
+        }
+
+        public override void DisconnectedPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError? error)
+        {
+            _monitor.RecordConnectionStateChanged(
+                peripheral.Identifier.ToString(),
+                peripheral.Name,
+                "disconnected"
+            );
+        }
+
+        public override void FailedToConnectPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError? error)
+        {
+            _monitor.RecordEvent(new BleEvent
+            {
+                Type = "connection_failed",
+                DeviceId = peripheral.Identifier.ToString(),
+                DeviceName = peripheral.Name,
+                Data = error?.LocalizedDescription
+            });
+        }
+
+        private static string? FormatAdvertisementData(NSDictionary? data)
+        {
+            if (data == null || data.Count == 0) return null;
+            var parts = new List<string>();
+            foreach (var key in data.Keys)
+            {
+                var value = data[key];
+                if (value is NSData nsData)
+                    parts.Add($"{key}={Convert.ToHexString(nsData.ToArray())}");
+                else
+                    parts.Add($"{key}={value}");
+            }
+            return string.Join(";", parts);
+        }
+    }
+}
+#endif

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/AppleBleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/AppleBleMonitor.cs
@@ -18,6 +18,8 @@ internal sealed class AppleBleMonitor : BleMonitor
         _centralManager = new CBCentralManager(_delegate, null);
     }
 
+    public override bool SupportsScanning => true;
+
     protected override string? StartPlatformScan()
     {
         if (_centralManager == null)
@@ -46,6 +48,14 @@ internal sealed class AppleBleMonitor : BleMonitor
             catch { /* may already be stopped */ }
         }
         // Don't dispose the manager — we still need it for connection events
+    }
+
+    protected override void DisposePlatform()
+    {
+        _centralManager?.Dispose();
+        _centralManager = null;
+        _delegate?.Dispose();
+        _delegate = null;
     }
 
     internal void SnapshotConnectedDevices(CBCentralManager central)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/MacOsBleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/MacOsBleMonitor.cs
@@ -1,0 +1,164 @@
+#if MACOS
+using CoreBluetooth;
+using Foundation;
+using Microsoft.Maui.DevFlow.Agent.Core;
+
+namespace Microsoft.Maui.DevFlow.Agent.Ble;
+
+internal sealed class MacOsBleMonitor : BleMonitor
+{
+    private CBCentralManager? _centralManager;
+    private DevFlowCentralDelegate? _delegate;
+    private bool _snapshotTaken;
+
+    public MacOsBleMonitor() : base()
+    {
+        _delegate = new DevFlowCentralDelegate(this);
+        _centralManager = new CBCentralManager(_delegate, null);
+    }
+
+    protected override string? StartPlatformScan()
+    {
+        if (_centralManager == null)
+        {
+            _delegate = new DevFlowCentralDelegate(this);
+            _centralManager = new CBCentralManager(_delegate, null);
+        }
+
+        if (_centralManager.State == CBManagerState.PoweredOn)
+        {
+            _centralManager.ScanForPeripherals(
+                (CBUUID[]?)null,
+                new PeripheralScanningOptions { AllowDuplicatesKey = true }
+            );
+        }
+
+        return null;
+    }
+
+    protected override void StopPlatformScan()
+    {
+        if (_centralManager != null)
+        {
+            try { _centralManager.StopScan(); }
+            catch { }
+        }
+    }
+
+    internal void SnapshotConnectedDevices(CBCentralManager central)
+    {
+        if (_snapshotTaken) return;
+        _snapshotTaken = true;
+
+        try
+        {
+            var commonServices = new[]
+            {
+                CBUUID.FromString("180A"), // Device Information
+                CBUUID.FromString("180F"), // Battery Service
+                CBUUID.FromString("1800"), // Generic Access
+                CBUUID.FromString("1801"), // Generic Attribute
+                CBUUID.FromString("180D"), // Heart Rate
+                CBUUID.FromString("1812"), // HID
+            };
+
+            var peripherals = central.RetrieveConnectedPeripherals(commonServices);
+            if (peripherals == null) return;
+
+            var seen = new HashSet<string>();
+            foreach (var peripheral in peripherals)
+            {
+                var id = peripheral.Identifier.ToString();
+                if (seen.Add(id))
+                    RecordConnectionStateChanged(id, peripheral.Name, "connected");
+            }
+        }
+        catch { }
+    }
+
+    private sealed class DevFlowCentralDelegate : CBCentralManagerDelegate
+    {
+        private readonly MacOsBleMonitor _monitor;
+
+        public DevFlowCentralDelegate(MacOsBleMonitor monitor) => _monitor = monitor;
+
+        public override void UpdatedState(CBCentralManager central)
+        {
+            if (central.State == CBManagerState.PoweredOn)
+            {
+                _monitor.SnapshotConnectedDevices(central);
+
+                if (_monitor.IsScanning)
+                {
+                    central.ScanForPeripherals(
+                        (CBUUID[]?)null,
+                        new PeripheralScanningOptions { AllowDuplicatesKey = true }
+                    );
+                }
+            }
+            else
+            {
+                _monitor.RecordEvent(new BleEvent
+                {
+                    Type = "adapter_state_changed",
+                    Data = central.State.ToString()
+                });
+            }
+        }
+
+        public override void DiscoveredPeripheral(CBCentralManager central, CBPeripheral peripheral, NSDictionary advertisementData, NSNumber rssi)
+        {
+            _monitor.RecordScanResult(
+                peripheral.Identifier.ToString(),
+                peripheral.Name,
+                rssi.Int32Value,
+                FormatAdvertisementData(advertisementData)
+            );
+        }
+
+        public override void ConnectedPeripheral(CBCentralManager central, CBPeripheral peripheral)
+        {
+            _monitor.RecordConnectionStateChanged(
+                peripheral.Identifier.ToString(),
+                peripheral.Name,
+                "connected"
+            );
+        }
+
+        public override void DisconnectedPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError? error)
+        {
+            _monitor.RecordConnectionStateChanged(
+                peripheral.Identifier.ToString(),
+                peripheral.Name,
+                "disconnected"
+            );
+        }
+
+        public override void FailedToConnectPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError? error)
+        {
+            _monitor.RecordEvent(new BleEvent
+            {
+                Type = "connection_failed",
+                DeviceId = peripheral.Identifier.ToString(),
+                DeviceName = peripheral.Name,
+                Data = error?.LocalizedDescription
+            });
+        }
+
+        private static string? FormatAdvertisementData(NSDictionary? data)
+        {
+            if (data == null || data.Count == 0) return null;
+            var parts = new List<string>();
+            foreach (var key in data.Keys)
+            {
+                var value = data[key];
+                if (value is NSData nsData)
+                    parts.Add($"{key}={Convert.ToHexString(nsData.ToArray())}");
+                else
+                    parts.Add($"{key}={value}");
+            }
+            return string.Join(";", parts);
+        }
+    }
+}
+#endif

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/MacOsBleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/MacOsBleMonitor.cs
@@ -17,6 +17,8 @@ internal sealed class MacOsBleMonitor : BleMonitor
         _centralManager = new CBCentralManager(_delegate, null);
     }
 
+    public override bool SupportsScanning => true;
+
     protected override string? StartPlatformScan()
     {
         if (_centralManager == null)
@@ -43,6 +45,14 @@ internal sealed class MacOsBleMonitor : BleMonitor
             try { _centralManager.StopScan(); }
             catch { }
         }
+    }
+
+    protected override void DisposePlatform()
+    {
+        _centralManager?.Dispose();
+        _centralManager = null;
+        _delegate?.Dispose();
+        _delegate = null;
     }
 
     internal void SnapshotConnectedDevices(CBCentralManager central)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/WindowsBleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/WindowsBleMonitor.cs
@@ -1,0 +1,133 @@
+#if WINDOWS
+using Microsoft.Maui.DevFlow.Agent.Core;
+using Windows.Devices.Bluetooth;
+using Windows.Devices.Bluetooth.Advertisement;
+using Windows.Devices.Enumeration;
+
+namespace Microsoft.Maui.DevFlow.Agent.Ble;
+
+internal sealed class WindowsBleMonitor : BleMonitor
+{
+    private BluetoothLEAdvertisementWatcher? _watcher;
+    private DeviceWatcher? _deviceWatcher;
+
+    public WindowsBleMonitor() : base()
+    {
+        StartConnectionWatcher();
+        SnapshotConnectedDevices();
+    }
+
+    protected override string? StartPlatformScan()
+    {
+        _watcher = new BluetoothLEAdvertisementWatcher
+        {
+            ScanningMode = BluetoothLEScanningMode.Active
+        };
+        _watcher.Received += OnAdvertisementReceived;
+        _watcher.Stopped += OnWatcherStopped;
+        _watcher.Start();
+        return null;
+    }
+
+    protected override void StopPlatformScan()
+    {
+        if (_watcher != null)
+        {
+            _watcher.Received -= OnAdvertisementReceived;
+            _watcher.Stopped -= OnWatcherStopped;
+            try { _watcher.Stop(); }
+            catch { /* may already be stopped */ }
+            _watcher = null;
+        }
+    }
+
+    private void OnAdvertisementReceived(BluetoothLEAdvertisementWatcher sender, BluetoothLEAdvertisementReceivedEventArgs args)
+    {
+        var serviceUuids = args.Advertisement.ServiceUuids;
+        var dataString = serviceUuids.Count > 0
+            ? string.Join(",", serviceUuids)
+            : null;
+
+        RecordScanResult(
+            args.BluetoothAddress.ToString("X12"),
+            args.Advertisement.LocalName,
+            args.RawSignalStrengthInDBm,
+            dataString
+        );
+    }
+
+    private void OnWatcherStopped(BluetoothLEAdvertisementWatcher sender, BluetoothLEAdvertisementWatcherStoppedEventArgs args)
+    {
+        if (args.Error != BluetoothError.Success)
+        {
+            RecordEvent(new BleEvent
+            {
+                Type = "scan_failed",
+                Data = args.Error.ToString()
+            });
+        }
+    }
+
+    private void StartConnectionWatcher()
+    {
+        try
+        {
+            // Watch for BLE device connection/disconnection
+            var selector = BluetoothLEDevice.GetDeviceSelectorFromConnectionStatus(BluetoothConnectionStatus.Connected);
+            _deviceWatcher = DeviceInformation.CreateWatcher(selector);
+            _deviceWatcher.Added += OnDeviceAdded;
+            _deviceWatcher.Removed += OnDeviceRemoved;
+            _deviceWatcher.Start();
+        }
+        catch { /* Bluetooth may not be available */ }
+    }
+
+    private async void OnDeviceAdded(DeviceWatcher sender, DeviceInformation info)
+    {
+        try
+        {
+            using var device = await BluetoothLEDevice.FromIdAsync(info.Id);
+            if (device != null)
+            {
+                RecordConnectionStateChanged(
+                    device.BluetoothAddress.ToString("X12"),
+                    device.Name,
+                    "connected"
+                );
+            }
+        }
+        catch { }
+    }
+
+    private void OnDeviceRemoved(DeviceWatcher sender, DeviceInformationUpdate info)
+    {
+        RecordConnectionStateChanged(info.Id, null, "disconnected");
+    }
+
+    private async void SnapshotConnectedDevices()
+    {
+        try
+        {
+            var selector = BluetoothLEDevice.GetDeviceSelectorFromConnectionStatus(BluetoothConnectionStatus.Connected);
+            var devices = await DeviceInformation.FindAllAsync(selector);
+            foreach (var deviceInfo in devices)
+            {
+                try
+                {
+                    using var device = await BluetoothLEDevice.FromIdAsync(deviceInfo.Id);
+                    if (device != null)
+                    {
+                        RecordConnectionStateChanged(
+                            device.BluetoothAddress.ToString("X12"),
+                            device.Name,
+                            "connected"
+                        );
+                    }
+                }
+                catch { }
+            }
+        }
+        catch { /* Bluetooth may not be available */ }
+    }
+}
+#endif

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/WindowsBleMonitor.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/Ble/WindowsBleMonitor.cs
@@ -10,12 +10,16 @@ internal sealed class WindowsBleMonitor : BleMonitor
 {
     private BluetoothLEAdvertisementWatcher? _watcher;
     private DeviceWatcher? _deviceWatcher;
+    private readonly Dictionary<string, string> _deviceAddresses = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _deviceGate = new();
 
     public WindowsBleMonitor() : base()
     {
         StartConnectionWatcher();
         SnapshotConnectedDevices();
     }
+
+    public override bool SupportsScanning => true;
 
     protected override string? StartPlatformScan()
     {
@@ -38,6 +42,24 @@ internal sealed class WindowsBleMonitor : BleMonitor
             try { _watcher.Stop(); }
             catch { /* may already be stopped */ }
             _watcher = null;
+        }
+    }
+
+    protected override void DisposePlatform()
+    {
+        if (_deviceWatcher != null)
+        {
+            try { _deviceWatcher.Stop(); }
+            catch { /* may already be stopped */ }
+
+            _deviceWatcher.Added -= OnDeviceAdded;
+            _deviceWatcher.Removed -= OnDeviceRemoved;
+            _deviceWatcher = null;
+        }
+
+        lock (_deviceGate)
+        {
+            _deviceAddresses.Clear();
         }
     }
 
@@ -89,8 +111,14 @@ internal sealed class WindowsBleMonitor : BleMonitor
             using var device = await BluetoothLEDevice.FromIdAsync(info.Id);
             if (device != null)
             {
+                var deviceId = device.BluetoothAddress.ToString("X12");
+                lock (_deviceGate)
+                {
+                    _deviceAddresses[info.Id] = deviceId;
+                }
+
                 RecordConnectionStateChanged(
-                    device.BluetoothAddress.ToString("X12"),
+                    deviceId,
                     device.Name,
                     "connected"
                 );
@@ -101,7 +129,16 @@ internal sealed class WindowsBleMonitor : BleMonitor
 
     private void OnDeviceRemoved(DeviceWatcher sender, DeviceInformationUpdate info)
     {
-        RecordConnectionStateChanged(info.Id, null, "disconnected");
+        string deviceId;
+        lock (_deviceGate)
+        {
+            if (_deviceAddresses.Remove(info.Id, out var mappedDeviceId))
+                deviceId = mappedDeviceId;
+            else
+                deviceId = info.Id;
+        }
+
+        RecordConnectionStateChanged(deviceId, null, "disconnected");
     }
 
     private async void SnapshotConnectedDevices()
@@ -117,8 +154,14 @@ internal sealed class WindowsBleMonitor : BleMonitor
                     using var device = await BluetoothLEDevice.FromIdAsync(deviceInfo.Id);
                     if (device != null)
                     {
+                        var deviceId = device.BluetoothAddress.ToString("X12");
+                        lock (_deviceGate)
+                        {
+                            _deviceAddresses[deviceInfo.Id] = deviceId;
+                        }
+
                         RecordConnectionStateChanged(
-                            device.BluetoothAddress.ToString("X12"),
+                            deviceId,
                             device.Name,
                             "connected"
                         );

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -494,6 +494,21 @@ public class PlatformAgentService : DevFlowAgentService
     }
 #endif
 
+    protected override BleMonitor CreateBleMonitor()
+    {
+#if ANDROID
+        return new Ble.AndroidBleMonitor();
+#elif IOS || MACCATALYST
+        return new Ble.AppleBleMonitor();
+#elif WINDOWS
+        return new Ble.WindowsBleMonitor();
+#elif MACOS
+        return new Ble.MacOsBleMonitor();
+#else
+        return base.CreateBleMonitor();
+#endif
+    }
+
     protected override bool TryNativeTap(VisualElement ve)
     {
         try

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -763,6 +763,28 @@ public class AgentClient : IDisposable
     private static string BuildRootQuery(string? root)
         => string.IsNullOrEmpty(root) ? string.Empty : $"?root={Uri.EscapeDataString(root)}";
 
+    // ── BLE ──
+
+    public Task<JsonElement> GetBleStatusAsync()
+        => GetJsonAsync($"{DeviceApi}/ble");
+
+    public Task<JsonElement> GetBleEventsAsync(int limit = 100, string? type = null)
+    {
+        var path = $"{DeviceApi}/ble/events?limit={limit}";
+        if (!string.IsNullOrEmpty(type))
+            path += $"&type={Uri.EscapeDataString(type)}";
+        return GetJsonAsync(path);
+    }
+
+    public Task<bool> StartBleScanAsync()
+        => PostActionAsync($"{DeviceApi}/ble/scan/start", new JsonObject());
+
+    public Task<bool> StopBleScanAsync()
+        => PostActionAsync($"{DeviceApi}/ble/scan/stop", new JsonObject());
+
+    public Task<bool> ClearBleEventsAsync()
+        => DeleteActionAsync($"{DeviceApi}/ble/events");
+
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -785,6 +785,22 @@ public class AgentClient : IDisposable
     public Task<bool> ClearBleEventsAsync()
         => DeleteActionAsync($"{DeviceApi}/ble/events");
 
+    /// <summary>
+    /// Returns the WebSocket URL for live BLE event streaming.
+    /// </summary>
+    public string GetBleWebSocketUrl(bool scan = false, int replay = 100, string? type = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(replay);
+
+        var query = new List<string> { $"replay={replay}" };
+        if (scan)
+            query.Add("scan=true");
+        if (!string.IsNullOrEmpty(type))
+            query.Add($"type={Uri.EscapeDataString(type)}");
+
+        return $"{GetWebSocketBaseUrl()}/ws/v1/ble?{string.Join("&", query)}";
+    }
+
     public void Dispose()
     {
         if (_disposed) return;
@@ -829,9 +845,11 @@ public class AgentClient : IDisposable
     /// </summary>
     public string GetNetworkWebSocketUrl()
     {
-        var wsBase = _baseUrl.Replace("http://", "ws://").Replace("https://", "wss://");
-        return $"{wsBase}/ws/v1/network";
+        return $"{GetWebSocketBaseUrl()}/ws/v1/network";
     }
+
+    private string GetWebSocketBaseUrl()
+        => _baseUrl.Replace("http://", "ws://").Replace("https://", "wss://");
 
     internal sealed class ProfilerSessionEnvelope
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/BleMonitorTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/BleMonitorTests.cs
@@ -1,6 +1,11 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Maui.DevFlow.Agent.Core;
+using Microsoft.Maui.Dispatching;
 
 namespace Microsoft.Maui.DevFlow.Tests;
 
@@ -68,6 +73,37 @@ public class BleMonitorTests
 
         Assert.Empty(monitor.GetEvents());
         Assert.Equal("BLE monitor disposed", monitor.StartScanning());
+    }
+
+    [Fact]
+    public void Subscribe_WithTypeFilter_StreamsMatchingEventsWithoutConsumingBuffer()
+    {
+        var monitor = new BleMonitor();
+        var queue = monitor.Subscribe("connected");
+
+        monitor.RecordScanResult("scan-1", "Scan 1", -70);
+        monitor.RecordConnectionStateChanged("connected-1", "Connected 1", "connected");
+
+        var message = Assert.Single(queue);
+        using var document = JsonDocument.Parse(message);
+        var evt = document.RootElement.GetProperty("event");
+        Assert.Equal("connected", evt.GetProperty("type").GetString());
+        Assert.Equal("connected-1", evt.GetProperty("deviceId").GetString());
+
+        var buffered = monitor.GetEvents(10);
+        Assert.Equal(new[] { "scan-1", "connected-1" }, buffered.Select(e => e.DeviceId));
+    }
+
+    [Fact]
+    public void TryStartScanning_WhenAlreadyScanning_DoesNotClaimScanOwnership()
+    {
+        var monitor = new ScanningBleMonitor();
+
+        Assert.True(monitor.TryStartScanning(out var firstError));
+        Assert.Null(firstError);
+        Assert.False(monitor.TryStartScanning(out var secondError));
+        Assert.Null(secondError);
+        Assert.Equal(1, monitor.StartCount);
     }
 
     [Theory]
@@ -143,11 +179,112 @@ public class BleMonitorTests
         Assert.DoesNotContain("scan", features);
     }
 
+    [Fact]
+    public async Task BleWebSocket_ReplaysBufferedEventsAndStreamsLiveFilteredEvents()
+    {
+        var port = GetFreePort();
+        using var service = new DevFlowAgentService(new AgentOptions { Port = port });
+        service.Ble.RecordScanResult("scan-buffered", "Scan Buffered", -80);
+        service.Ble.RecordConnectionStateChanged("connected-buffered", "Connected Buffered", "connected");
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        using var ws = new ClientWebSocket();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await ws.ConnectAsync(new Uri($"ws://localhost:{port}/ws/v1/ble?replay=10&type=connected"), cts.Token);
+
+        var subscribed = await ReceiveJsonAsync(ws, cts.Token);
+        Assert.Equal("subscribed", subscribed.GetProperty("type").GetString());
+        Assert.Equal(10, subscribed.GetProperty("replay").GetInt32());
+        Assert.Equal("connected", subscribed.GetProperty("eventType").GetString());
+
+        var replay = await ReceiveJsonAsync(ws, cts.Token);
+        Assert.Equal("replay", replay.GetProperty("type").GetString());
+        Assert.Equal(1, replay.GetProperty("count").GetInt32());
+        var replayedEvent = Assert.Single(replay.GetProperty("events").EnumerateArray());
+        Assert.Equal("connected-buffered", replayedEvent.GetProperty("deviceId").GetString());
+
+        service.Ble.RecordScanResult("scan-live", "Scan Live", -81);
+        service.Ble.RecordConnectionStateChanged("connected-live", "Connected Live", "connected");
+
+        var live = await ReceiveJsonAsync(ws, cts.Token);
+        Assert.Equal("ble_event", live.GetProperty("type").GetString());
+        Assert.Equal("connected-live", live.GetProperty("event").GetProperty("deviceId").GetString());
+
+        var bufferedIds = service.Ble.GetEvents(10).Select(e => e.DeviceId ?? "").ToArray();
+        Assert.Equal(["scan-buffered", "connected-buffered", "scan-live", "connected-live"], bufferedIds);
+    }
+
+    [Fact]
+    public async Task BleWebSocket_ReplayZeroSkipsReplayAndStreamsLiveEvents()
+    {
+        var port = GetFreePort();
+        using var service = new DevFlowAgentService(new AgentOptions { Port = port });
+        service.Ble.RecordScanResult("scan-buffered", "Scan Buffered", -80);
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        using var ws = new ClientWebSocket();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await ws.ConnectAsync(new Uri($"ws://localhost:{port}/ws/v1/ble?replay=0"), cts.Token);
+
+        var subscribed = await ReceiveJsonAsync(ws, cts.Token);
+        Assert.Equal("subscribed", subscribed.GetProperty("type").GetString());
+        Assert.Equal(0, subscribed.GetProperty("replay").GetInt32());
+
+        service.Ble.RecordScanResult("scan-live", "Scan Live", -81);
+
+        var live = await ReceiveJsonAsync(ws, cts.Token);
+        Assert.Equal("ble_event", live.GetProperty("type").GetString());
+        Assert.Equal("scan-live", live.GetProperty("event").GetProperty("deviceId").GetString());
+    }
+
+    [Fact]
+    public async Task BleWebSocket_InvalidReplaySendsError()
+    {
+        var port = GetFreePort();
+        using var service = new DevFlowAgentService(new AgentOptions { Port = port });
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        using var ws = new ClientWebSocket();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await ws.ConnectAsync(new Uri($"ws://localhost:{port}/ws/v1/ble?replay=-1"), cts.Token);
+
+        var error = await ReceiveJsonAsync(ws, cts.Token);
+        Assert.Equal("error", error.GetProperty("type").GetString());
+        Assert.Contains("replay", error.GetProperty("error").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
     private static Task<HttpResponse> InvokeHandlerAsync(DevFlowAgentService service, string methodName, HttpRequest request)
     {
         var method = typeof(DevFlowAgentService).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
         return (Task<HttpResponse>)method.Invoke(service, [request])!;
+    }
+
+    private static async Task<JsonElement> ReceiveJsonAsync(ClientWebSocket ws, CancellationToken ct)
+    {
+        var buffer = new byte[8192];
+        using var stream = new MemoryStream();
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await ws.ReceiveAsync(buffer, ct);
+            if (result.MessageType == WebSocketMessageType.Close)
+                throw new InvalidOperationException("WebSocket closed before a text message was received.");
+
+            stream.Write(buffer, 0, result.Count);
+        }
+        while (!result.EndOfMessage);
+
+        var json = Encoding.UTF8.GetString(stream.ToArray());
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
     }
 
     private sealed class DisposableBleMonitor : BleMonitor
@@ -157,6 +294,58 @@ public class BleMonitorTests
         protected override void DisposePlatform()
         {
             PlatformDisposed = true;
+        }
+    }
+
+    private sealed class ScanningBleMonitor : BleMonitor
+    {
+        public int StartCount { get; private set; }
+
+        protected override string? StartPlatformScan()
+        {
+            StartCount++;
+            return null;
+        }
+    }
+
+    private sealed class ImmediateDispatcher : IDispatcher
+    {
+        public bool IsDispatchRequired => false;
+
+        public bool Dispatch(Action action)
+        {
+            action();
+            return true;
+        }
+
+        public bool DispatchDelayed(TimeSpan delay, Action action)
+        {
+            action();
+            return true;
+        }
+
+        public IDispatcherTimer CreateTimer() => new ImmediateDispatcherTimer();
+    }
+
+    private sealed class ImmediateDispatcherTimer : IDispatcherTimer
+    {
+        public bool IsRepeating { get; set; }
+        public TimeSpan Interval { get; set; }
+        public bool IsRunning { get; private set; }
+        public event EventHandler? Tick
+        {
+            add { }
+            remove { }
+        }
+
+        public void Start()
+        {
+            IsRunning = true;
+        }
+
+        public void Stop()
+        {
+            IsRunning = false;
         }
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/BleMonitorTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/BleMonitorTests.cs
@@ -58,6 +58,18 @@ public class BleMonitorTests
         Assert.True(monitor.PlatformDisposed);
     }
 
+    [Fact]
+    public void RecordEvent_AfterDispose_IgnoresEvent()
+    {
+        var monitor = new BleMonitor();
+
+        monitor.Dispose();
+        monitor.RecordScanResult("device-1", "Device 1", -42);
+
+        Assert.Empty(monitor.GetEvents());
+        Assert.Equal("BLE monitor disposed", monitor.StartScanning());
+    }
+
     [Theory]
     [InlineData("-1")]
     [InlineData("not-an-int")]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/BleMonitorTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/BleMonitorTests.cs
@@ -1,0 +1,150 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Maui.DevFlow.Agent.Core;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class BleMonitorTests
+{
+    [Fact]
+    public void GetEvents_NegativeLimit_ReturnsEmpty()
+    {
+        var monitor = new BleMonitor();
+        monitor.RecordScanResult("device-1", "Device 1", -42);
+
+        var events = monitor.GetEvents(-1);
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void GetEvents_FiltersByTypeAndAppliesLimit()
+    {
+        var monitor = new BleMonitor();
+        monitor.RecordScanResult("scan-1", "Scan 1", -70);
+        monitor.RecordConnectionStateChanged("connected-1", "Connected 1", "connected");
+        monitor.RecordConnectionStateChanged("connected-2", "Connected 2", "connected");
+
+        var events = monitor.GetEvents(1, "connected");
+
+        var evt = Assert.Single(events);
+        Assert.Equal("connected", evt.Type);
+        Assert.Equal("connected-2", evt.DeviceId);
+    }
+
+    [Fact]
+    public void RecordEvent_WhenBufferExceedsCapacity_TrimsOldEventsAndReportsBufferedCount()
+    {
+        var monitor = new BleMonitor(maxEvents: 2);
+        monitor.RecordScanResult("device-1", "Device 1", -71);
+        monitor.RecordScanResult("device-2", "Device 2", -72);
+        monitor.RecordScanResult("device-3", "Device 3", -73);
+
+        var events = monitor.GetEvents(10);
+        var status = JsonSerializer.SerializeToElement(monitor.GetStatus());
+
+        Assert.Equal(new[] { "device-2", "device-3" }, events.Select(e => e.DeviceId));
+        Assert.Equal(2, status.GetProperty("eventCount").GetInt32());
+        Assert.False(status.GetProperty("supportsScanning").GetBoolean());
+    }
+
+    [Fact]
+    public void Dispose_CallsPlatformDisposeHook()
+    {
+        var monitor = new DisposableBleMonitor();
+
+        monitor.Dispose();
+
+        Assert.True(monitor.PlatformDisposed);
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("not-an-int")]
+    public async Task HandleBleEvents_InvalidLimit_ReturnsBadRequest(string limit)
+    {
+        using var service = new DevFlowAgentService(new AgentOptions { Enabled = false });
+        var request = new HttpRequest
+        {
+            QueryParams = new Dictionary<string, string> { ["limit"] = limit }
+        };
+
+        var response = await InvokeHandlerAsync(service, "HandleBleEvents", request);
+
+        Assert.Equal(400, response.StatusCode);
+        Assert.NotNull(response.Body);
+
+        var json = JsonDocument.Parse(response.Body!).RootElement;
+        Assert.False(json.GetProperty("success").GetBoolean());
+        Assert.Equal("invalid_limit", json.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public async Task HandleBleEvents_ValidLimit_ReturnsFilteredEvents()
+    {
+        using var service = new DevFlowAgentService(new AgentOptions { Enabled = false });
+        service.Ble.RecordScanResult("scan-1", "Scan 1", -80);
+        service.Ble.RecordConnectionStateChanged("connected-1", "Connected 1", "connected");
+        service.Ble.RecordConnectionStateChanged("connected-2", "Connected 2", "connected");
+
+        var request = new HttpRequest
+        {
+            QueryParams = new Dictionary<string, string>
+            {
+                ["limit"] = "1",
+                ["type"] = "connected"
+            }
+        };
+
+        var response = await InvokeHandlerAsync(service, "HandleBleEvents", request);
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.NotNull(response.Body);
+
+        var json = JsonDocument.Parse(response.Body!).RootElement;
+        Assert.Equal(1, json.GetProperty("count").GetInt32());
+        var evt = Assert.Single(json.GetProperty("events").EnumerateArray());
+        Assert.Equal("connected", evt.GetProperty("type").GetString());
+        Assert.Equal("connected-2", evt.GetProperty("deviceId").GetString());
+    }
+
+    [Fact]
+    public async Task HandleCapabilities_BaseBleMonitor_DoesNotAdvertiseScan()
+    {
+        using var service = new DevFlowAgentService(new AgentOptions { Enabled = false });
+
+        var response = await InvokeHandlerAsync(service, "HandleCapabilities", new HttpRequest());
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.NotNull(response.Body);
+
+        var json = JsonDocument.Parse(response.Body!).RootElement;
+        var ble = json.GetProperty("ble");
+        var features = ble.GetProperty("features").EnumerateArray()
+            .Select(feature => feature.GetString())
+            .ToArray();
+
+        Assert.True(ble.GetProperty("supported").GetBoolean());
+        Assert.Contains("status", features);
+        Assert.Contains("events", features);
+        Assert.Contains("stream", features);
+        Assert.DoesNotContain("scan", features);
+    }
+
+    private static Task<HttpResponse> InvokeHandlerAsync(DevFlowAgentService service, string methodName, HttpRequest request)
+    {
+        var method = typeof(DevFlowAgentService).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (Task<HttpResponse>)method.Invoke(service, [request])!;
+    }
+
+    private sealed class DisposableBleMonitor : BleMonitor
+    {
+        public bool PlatformDisposed { get; private set; }
+
+        protected override void DisposePlatform()
+        {
+            PlatformDisposed = true;
+        }
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
@@ -19,6 +19,24 @@ public class AgentClientTests
     }
 
     [Fact]
+    public void GetBleWebSocketUrl_IncludesStreamOptions()
+    {
+        using var client = new AgentClient("localhost", 19999);
+
+        var url = client.GetBleWebSocketUrl(scan: true, replay: 0, type: "scan result");
+
+        Assert.Equal("ws://localhost:19999/ws/v1/ble?replay=0&scan=true&type=scan%20result", url);
+    }
+
+    [Fact]
+    public void GetBleWebSocketUrl_NegativeReplay_Throws()
+    {
+        using var client = new AgentClient("localhost", 19999);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => client.GetBleWebSocketUrl(replay: -1));
+    }
+
+    [Fact]
     public async Task GetStatus_WhenAgentNotRunning_ReturnsNull()
     {
         using var client = new AgentClient("localhost", 19999);


### PR DESCRIPTION
This PR is a YOLO since it is hard to do Integration testing with BLE.  Plan is to roll this into Sherpa for testing. 

This pull request introduces a comprehensive Bluetooth Low Energy (BLE) monitoring and control feature to the DevFlow agent and CLI. It adds a platform-agnostic BLE event monitor, exposes new HTTP and WebSocket endpoints for BLE operations, and provides CLI tooling for interacting with BLE features. The changes are grouped below by theme.

**Core BLE Monitoring Infrastructure:**

* Added a new `BleMonitor` class, a platform-agnostic singleton for tracking BLE events (e.g., scan results, connections, reads, writes, notifications) with a ring buffer and WebSocket subscriber support. It also provides convenience methods for common BLE event types and can be extended for platform-specific scanning logic. (`src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/BleMonitor.cs`)
* Integrated `BleMonitor` into the agent service as a new property (`Ble`) and ensured its lifecycle is managed (instantiation, disposal, and singleton assignment). (`src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs`) [[1]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR46-R50) [[2]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR256-R257) [[3]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR3985)

**Agent HTTP and WebSocket Endpoints:**

* Registered new HTTP endpoints for BLE status, event listing, scan control, and event clearing, as well as a WebSocket endpoint for real-time BLE event streaming. (`src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs`) [[1]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR505-R511) [[2]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR5897-R6006)
* Updated agent status and capabilities responses to include BLE as a supported feature. (`src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs`) [[1]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR582) [[2]](diffhunk://#diff-8024a9b5c8c7052cf93e36b109198fb543946850cb7a71e9ad05f3e8eb68ddedR644-R648)

**CLI Tooling:**

* Added a new `BleTools` class to the CLI, exposing commands for querying BLE status, retrieving recent BLE events (with optional filtering), starting/stopping BLE scans, and clearing BLE events. (`src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BleTools.cs`)
* Registered `BleTools` with the CLI tool builder to make these commands available. (`src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs`)

These changes provide a unified, extensible foundation for BLE diagnostics and automation across platforms, accessible via both HTTP/WebSocket APIs and CLI commands.