### PR TITLE
Use unique CI package versions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -34,6 +34,9 @@ on:
         default: ''
         description: 'Shell command to install native dependencies (e.g. apt-get for GTK4)'
 
+env:
+  CI_PACKAGE_VERSION_SUFFIX: ci.${{ github.run_number }}.${{ github.run_attempt }}
+
 jobs:
   build:
     strategy:
@@ -72,6 +75,7 @@ jobs:
           -configuration Release
           -prepareMachine
           -projects %CD%\${{ inputs.project-path }}
+          /p:VersionSuffix=%CI_PACKAGE_VERSION_SUFFIX%
         shell: cmd
 
       - name: Build and Test (macOS)
@@ -81,6 +85,7 @@ jobs:
           --configuration Release
           --prepareMachine
           --projects $(pwd)/${{ inputs.project-path }}
+          /p:VersionSuffix=$CI_PACKAGE_VERSION_SUFFIX
 
       - name: Build and Test (Linux)
         if: startsWith(matrix.os, 'ubuntu')
@@ -89,6 +94,7 @@ jobs:
           --configuration Release
           --prepareMachine
           --projects $(pwd)/${{ inputs.project-path }}
+          /p:VersionSuffix=$CI_PACKAGE_VERSION_SUFFIX
 
       - name: NativeAOT publish smoke test (macOS)
         if: matrix.os == 'macos-latest' && inputs.project-name == 'cli'


### PR DESCRIPTION
CI package artifacts currently reuse the same prerelease version across runs, which makes it easy to hit NuGet/cache collisions while testing workflow artifacts. This changes GitHub Actions CI builds to stamp packages with a run-specific prerelease suffix.

## Summary

- Adds a shared `CI_PACKAGE_VERSION_SUFFIX` in the reusable GitHub Actions build workflow using `github.run_number` and `github.run_attempt`.
- Passes that suffix into Windows, macOS, and Linux Arcade build invocations via `VersionSuffix`.
- Produces versions like `0.1.0-ci.12345.1`, including a different suffix for reruns.

## Validation

- Evaluated `PackageVersion` with `VersionSuffix=ci.12345.1` and confirmed it resolves to `0.1.0-ci.12345.1`.
- Confirmed default local package versioning remains unchanged.