### PR TITLE
Trigger CI on PR base branch changes

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -14,6 +14,7 @@ on:
       - 'global.json'
       - 'NuGet.config'
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     branches: [main]
     paths:
       - '.claude/skills/**'

--- a/.github/workflows/ci-devflow.yml
+++ b/.github/workflows/ci-devflow.yml
@@ -12,6 +12,7 @@ on:
       - 'global.json'
       - 'NuGet.config'
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     branches: [main]
     paths:
       - 'src/DevFlow/**'

--- a/.github/workflows/ci-linux-gtk4.yml
+++ b/.github/workflows/ci-linux-gtk4.yml
@@ -12,6 +12,7 @@ on:
       - 'global.json'
       - 'NuGet.config'
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     branches: [main]
     paths:
       - 'platforms/Linux.Gtk4/**'


### PR DESCRIPTION
When GitHub auto-retargets a PR after a stacked branch merges, it fires a `pull_request` event with action `edited`. Without the `edited` type in our workflow triggers, CI never runs on these retargeted PRs (e.g. [#169](https://github.com/dotnet/maui-labs/pull/169)).

This adds `types: [opened, synchronize, reopened, edited]` to the `pull_request` trigger on all three CI workflows. The existing `paths` filters still gate whether the workflow actually executes.