### PR TITLE
Add concrete CI/CD templates for new product onboarding

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,6 +58,8 @@ For the full repo, open `MauiLabs.sln`.
 
 ## Adding a New Product
 
+### 1. Source code
+
 1. Create `src/{NewProduct}/` with:
    - `Version.props` (copy from an existing product)
    - Project folders with `.csproj` files
@@ -65,8 +67,29 @@ For the full repo, open `MauiLabs.sln`.
    - `{NewProduct}.slnf` solution filter
 2. Add projects to `MauiLabs.sln`
 3. Add any new package versions to `Directory.Packages.props`
-4. Add path filter entry in `.github/workflows/ci.yml`
-5. Create `.github/workflows/release-{newproduct}.yml`
+
+### 2. GitHub Actions CI workflow
+
+Create `.github/workflows/ci-{newproduct}.yml` that calls the reusable `_build.yml` workflow.
+
+> See the **"CI/CD — New Product Checklist"** section in `.github/copilot-instructions.md` for the complete copy-paste template with all required inputs and decision guidance.
+
+Key points:
+- One workflow file per product, path-filtered to its source folder
+- Always include `types: [opened, synchronize, reopened, edited]` on `pull_request` (the `edited` type ensures CI re-runs when a PR is auto-retargeted after a stacked branch merges)
+
+### 3. Azure DevOps official pipeline
+
+The official build/sign/publish pipeline is `eng/pipelines/devflow-official.yml`. For each new product add:
+1. A **boolean parameter** to gate NuGet.org publishing
+2. A **build job** in the `build` stage (parallel with existing jobs)
+3. A **conditional publish stage** that filters your product's `.nupkg` files and pushes to NuGet.org
+
+> See `.github/copilot-instructions.md` for complete annotated YAML snippets for all three blocks.
+
+### 4. Signing
+
+Add entries in `eng/Signing.props` for any new third-party DLLs (`3PartySHA2`).
 
 ## Versioning
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,7 +65,7 @@ For the full repo, open `MauiLabs.sln`.
    - Project folders with `.csproj` files
    - Test project
    - `{NewProduct}.slnf` solution filter
-2. Add projects to `MauiLabs.sln`
+2. Add projects to `MauiLabs.slnx`
 3. Add any new package versions to `Directory.Packages.props`
 
 ### 2. GitHub Actions CI workflow

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,6 +134,180 @@ The repo is at 0.1.0-preview so breaking changes are acceptable, but:
 - **Signing**: configured in `eng/Signing.props`. New third-party DLLs need a `3PartySHA2` entry.
 - **Version**: defined in `eng/Versions.props` (`VersionPrefix` + `VersionSuffix`). Per-product overrides in `src/{Product}/Version.props`.
 
+## CI/CD — New Product Checklist
+
+When adding a new product to this repo you **must** set up two CI surfaces: a GitHub Actions workflow for PR validation and a build job + publish stage in the Azure DevOps official pipeline for signing and NuGet.org publishing.
+
+### Step 1: GitHub Actions PR / Push Workflow
+
+Create `.github/workflows/ci-{product}.yml`. Use the template below — replace every `{Product}` (PascalCase) and `{product}` (lowercase) placeholder.
+
+```yaml
+name: CI - {Product}
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/{Product}/**'
+      - 'eng/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'NuGet.config'
+  pull_request:
+    # IMPORTANT: 'edited' is required — without it CI does not run when
+    # GitHub auto-retargets a PR after a stacked branch merges.
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+    paths:
+      - 'src/{Product}/**'
+      - 'eng/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'NuGet.config'
+
+jobs:
+  build:
+    uses: ./.github/workflows/_build.yml
+    with:
+      project-path: src/{Product}/{Product}.slnf   # CUSTOMIZE: path to solution filter
+      project-name: {product}                       # CUSTOMIZE: lowercase, used in artifact names
+      run-tests: true
+      pack: true
+      install-workloads: false                      # CUSTOMIZE: see decision guide below
+      # os: '["macos-latest", "windows-latest"]'    # CUSTOMIZE: default is macOS + Windows
+      # native-deps: 'sudo apt-get install ...'     # CUSTOMIZE: if Linux-only with native libs
+```
+
+#### `_build.yml` inputs reference
+
+| Input | Default | When to change |
+|-------|---------|---------------|
+| `install-workloads` | `true` | Set `false` if the product targets only `net10.0` (no MAUI TFMs) |
+| `os` | `["macos-latest", "windows-latest"]` | Override to `["ubuntu-24.04"]` for Linux-only products |
+| `native-deps` | *(empty)* | Provide an `apt-get install` command if the product needs native libraries (e.g., GTK4) |
+| `pack` | `false` | Set `true` if the product produces NuGet packages |
+| `run-tests` | `true` | Set `false` only if there are no tests yet |
+
+### Step 2: Azure DevOps Official Pipeline
+
+The official pipeline is **`eng/pipelines/devflow-official.yml`**. It handles Arcade-based builds with MicroBuild/ESRP signing and NuGet.org publishing. For each new product, add **three** blocks:
+
+#### a) Publish parameter (at the top, in the `parameters:` section)
+
+```yaml
+- name: publish{Product}Nuget
+  displayName: 'Publish {Product} packages to NuGet.org'
+  type: boolean
+  default: false
+```
+
+#### b) Build job (in the `build` stage, under `jobs:`, parallel with existing jobs)
+
+```yaml
+          - job: {Product}
+            displayName: {Product} - Windows
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+                  _OfficialBuildArgs: /p:DotNetSignType=$(_SignType)
+                    /p:TeamName=$(_TeamName)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            steps:
+            - task: UseDotNet@2
+              displayName: Install .NET SDK
+              inputs:
+                useGlobalJson: true
+            # CUSTOMIZE: If the product needs MAUI workloads, add these steps
+            # before the build (copy from the DevFlow job):
+            #   - Provision .NET SDK via Arcade (eng\common\dotnet.cmd --info)
+            #   - Install MAUI workloads (.dotnet\dotnet workload install maui ...)
+            #   - Install Android SDK dependencies
+            - script: eng\common\cibuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                -projects $(Build.SourcesDirectory)\src\{Product}\{Product}.slnf
+                $(_OfficialBuildArgs)
+              displayName: Build and Test {Product}
+```
+
+#### c) Conditional publish stage (at the bottom, after the other `publish_*_nuget` stages)
+
+This stage filters the product's `.nupkg` files from the shared `PackageArtifacts` artifact, then pushes them to NuGet.org via the `1ES.PublishNuget` task.
+
+```yaml
+    # Publish {Product} packages to NuGet.org
+    - ${{ if eq(parameters.publish{Product}Nuget, true) }}:
+      - stage: publish_{product}_nuget
+        displayName: 'Publish {Product} to NuGet.org'
+        dependsOn:
+        - Validate
+        - publish_using_darc
+        jobs:
+        - job: PrepareArtifacts
+          displayName: 'Prepare {Product} Artifacts'
+          timeoutInMinutes: 15
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026preview.scout.amd64
+            os: windows
+          templateContext:
+            outputs:
+            - output: pipelineArtifact
+              displayName: Publish {Product} Packages
+              targetPath: '$(Pipeline.Workspace)/{Product}Packages'
+              artifactName: {Product}PackagesForNuGet
+          steps:
+          - download: current
+            artifact: PackageArtifacts
+            displayName: Download PackageArtifacts
+          - powershell: |
+              New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/{Product}Packages'
+              # CUSTOMIZE: glob must match the package ID prefix for this product
+              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.{Product}.*.nupkg' '$(Pipeline.Workspace)/{Product}Packages/' -Verbose
+            displayName: Filter {Product} packages
+
+        - job: PublishNuGet
+          displayName: 'Push {Product} to NuGet.org'
+          dependsOn: PrepareArtifacts
+          timeoutInMinutes: 30
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026preview.scout.amd64
+            os: windows
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              artifactName: {Product}PackagesForNuGet
+              targetPath: '$(Pipeline.Workspace)/{Product}Packages'
+          steps:
+          - task: 1ES.PublishNuget@1
+            displayName: 'Push {Product} to NuGet.org'
+            inputs:
+              useDotNetTask: false
+              packagesToPush: '$(Pipeline.Workspace)/{Product}Packages/*.nupkg'
+              packageParentPath: '$(Pipeline.Workspace)/{Product}Packages'
+              nuGetFeedType: external
+              publishFeedCredentials: 'nuget.org (dotnetframework)'
+```
+
+#### Key conventions
+
+- **Package glob pattern**: `Microsoft.Maui.{Product}.*.nupkg` — must match the `<PackageId>` in your `.csproj` files.
+- **`dependsOn: [Validate, publish_using_darc]`**: these stages come from the Arcade post-build template (`eng/common/templates-official/post-build/post-build.yml`) and must always be listed.
+- **Signing**: All shipped NuGet packages must build on Windows so MicroBuild/ESRP can sign the DLLs. If the product is Linux-only, build *and pack* on Windows (signing), then optionally add a separate Linux verification job (see the `LinuxGtk4_LinuxVerify` job for the pattern).
+- **`publishFeedCredentials`**: Always use `'nuget.org (dotnetframework)'` — this is the service connection configured in the Azure DevOps project.
+
 ## Maui.Client Conventions (Future — Not Yet Present)
 
 A Client product (`src/Client/`) is planned but not yet present in this repository. When added, it will use a DI-based architecture with provider interfaces:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -150,6 +150,8 @@ on:
     branches: [main]
     paths:
       - 'src/{Product}/**'
+      # CUSTOMIZE: add paths for cross-product ProjectReference dependencies, e.g.:
+      # - 'src/OtherProduct/SharedLib/**'
       - 'eng/**'
       - 'Directory.Build.props'
       - 'Directory.Build.targets'
@@ -163,6 +165,8 @@ on:
     branches: [main]
     paths:
       - 'src/{Product}/**'
+      # CUSTOMIZE: add paths for cross-product ProjectReference dependencies, e.g.:
+      # - 'src/OtherProduct/SharedLib/**'
       - 'eng/**'
       - 'Directory.Build.props'
       - 'Directory.Build.targets'
@@ -174,11 +178,11 @@ jobs:
   build:
     uses: ./.github/workflows/_build.yml
     with:
-      project-path: src/{Product}/{Product}.slnf   # CUSTOMIZE: path to solution filter
+      project-path: src/{Product}/{Product}.slnf   # CUSTOMIZE: path to solution filter (.slnf or .slnx)
       project-name: {product}                       # CUSTOMIZE: lowercase, used in artifact names
       run-tests: true
       pack: true
-      install-workloads: false                      # CUSTOMIZE: see decision guide below
+      install-workloads: true                       # CUSTOMIZE: set false for net10.0-only products (no MAUI TFMs)
       # os: '["macos-latest", "windows-latest"]'    # CUSTOMIZE: default is macOS + Windows
       # native-deps: 'sudo apt-get install ...'     # CUSTOMIZE: if Linux-only with native libs
 ```
@@ -303,7 +307,7 @@ This stage filters the product's `.nupkg` files from the shared `PackageArtifact
 
 #### Key conventions
 
-- **Package glob pattern**: `Microsoft.Maui.{Product}.*.nupkg` — must match the `<PackageId>` in your `.csproj` files.
+- **Package glob pattern**: example: `Microsoft.Maui.{Product}.*.nupkg` — use the actual `<PackageId>` prefix from your `.csproj` files (e.g., Linux GTK4 uses `Microsoft.Maui.Platforms.Linux.Gtk4.*.nupkg`).
 - **`dependsOn: [Validate, publish_using_darc]`**: these stages come from the Arcade post-build template (`eng/common/templates-official/post-build/post-build.yml`) and must always be listed.
 - **Signing**: All shipped NuGet packages must build on Windows so MicroBuild/ESRP can sign the DLLs. If the product is Linux-only, build *and pack* on Windows (signing), then optionally add a separate Linux verification job (see the `LinuxGtk4_LinuxVerify` job for the pattern).
 - **`publishFeedCredentials`**: Always use `'nuget.org (dotnetframework)'` — this is the service connection configured in the Azure DevOps project.

--- a/.github/instructions/packaging.instructions.md
+++ b/.github/instructions/packaging.instructions.md
@@ -86,7 +86,7 @@ When adding a new third-party dependency that gets bundled into a NuGet package,
 ## Publishing Flow
 
 1. **GitHub Actions CI**: Build + test on PR (no publishing)
-2. **Azure DevOps official build**: Build → Sign (MicroBuild) → Validate → Publish to internal feeds via DARC
-3. **NuGet.org release**: Separate pipeline (`eng/pipelines/release-publish-nuget.yml`) with `networkIsolationPolicy: Permissive`
+2. **Azure DevOps official build** (`eng/pipelines/devflow-official.yml`): Build → Sign (MicroBuild/ESRP) → Validate → Publish to internal feeds via DARC
+3. **NuGet.org release**: Conditional publish stages in `eng/pipelines/devflow-official.yml`, gated per-product by boolean parameters (e.g., `publishDevFlowNuget`). Uses `1ES.PublishNuget@1` with `networkIsolationPolicy: Permissive`.
 
-The official build pipeline (`eng/pipelines/devflow-official.yml`) has `enableMicrobuild: true` which enforces CFS network isolation — this is why NuGet.org publishing must happen in a separate pipeline.
+See `.github/copilot-instructions.md` § "CI/CD — New Product Checklist" for templates when adding a new product.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,17 +136,22 @@ maui-labs/
 
 ### GitHub Actions (PR validation)
 
-- Workflow: `.github/workflows/ci-devflow.yml` → calls `_build.yml`
-- **Matrix**: macOS + Windows
-- **Path-filtered**: only triggers for changed product paths
+Each product has its own workflow file: `.github/workflows/ci-{product}.yml`, calling the shared `_build.yml` reusable workflow.
+
+- **Matrix**: macOS + Windows (configurable per product via `os` input)
+- **Path-filtered**: only triggers for changed product paths + shared build infrastructure (`eng/**`, `Directory.Build.props`, etc.)
+- **`pull_request.types`**: Must always include `[opened, synchronize, reopened, edited]` — the `edited` type ensures CI re-runs when GitHub auto-retargets a PR after a stacked branch merges
 - Steps: restore → build → test → upload test results + packages
+
+Existing workflows: `ci-cli.yml`, `ci-devflow.yml`, `ci-linux-gtk4.yml`
 
 ### Azure DevOps (official builds)
 
-- Pipeline: `eng/pipelines/devflow-official.yml`
-- Builds, signs, and publishes to internal feeds via Maestro/DARC
+- **Single pipeline**: `eng/pipelines/devflow-official.yml` — all products build in parallel
+- Builds, signs (MicroBuild/ESRP), and publishes to internal feeds via Maestro/DARC
 - **MicroBuild signing** enabled (`enableMicrobuild: true`) — this enforces CFS network isolation
-- NuGet.org publishing: separate pipeline (`eng/pipelines/release-publish-nuget.yml`) with `networkIsolationPolicy: Permissive`
+- NuGet.org publishing: conditional stages per product, gated by boolean parameters (e.g., `publishDevFlowNuget`), using `1ES.PublishNuget@1`
+- Each product has: a parameter, a build job, and a publish stage
 
 ### NuGet Feed Configuration
 
@@ -157,11 +162,21 @@ NuGet.config uses **internal dnceng proxy feeds only** — no direct nuget.org r
 
 ## Adding a New Product
 
+Each product requires source setup **and** CI/CD configuration across two systems.
+
+### Source Setup
+
 1. Create `src/{NewProduct}/` with `Version.props`, project folders, test project, `{NewProduct}.slnf`
 2. Add projects to `MauiLabs.sln`
 3. Add package versions to `Directory.Packages.props`
-4. Add path filter in `.github/workflows/ci.yml`
-5. Add signing entries in `eng/Signing.props` for any new third-party DLLs
+4. Add signing entries in `eng/Signing.props` for any new third-party DLLs
+
+### CI/CD Setup
+
+5. **GitHub Actions**: Create `.github/workflows/ci-{newproduct}.yml` calling the reusable `_build.yml` workflow. Must include `pull_request.types: [opened, synchronize, reopened, edited]` and path filters scoped to the product source plus shared build files.
+6. **Azure DevOps**: Edit `eng/pipelines/devflow-official.yml` — add a publish parameter, a build job in the `build` stage, and a conditional publish stage for NuGet.org.
+
+> **Complete copy-paste templates** for both the GitHub Actions workflow and all three Azure DevOps blocks (parameter, build job, publish stage) are in `.github/copilot-instructions.md` under **"CI/CD — New Product Checklist"**.
 
 ## DevFlow MCP Tools
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ Each product requires source setup **and** CI/CD configuration across two system
 ### Source Setup
 
 1. Create `src/{NewProduct}/` with `Version.props`, project folders, test project, `{NewProduct}.slnf`
-2. Add projects to `MauiLabs.sln`
+2. Add projects to `MauiLabs.slnx`
 3. Add package versions to `Directory.Packages.props`
 4. Add signing entries in `eng/Signing.props` for any new third-party DLLs
 


### PR DESCRIPTION
## Problem

Three docs files (`AGENTS.md`, `CONTRIBUTING.md`, `copilot-instructions.md`) gave incorrect or missing guidance for adding new products to CI/CD:
- Referenced a nonexistent `.github/workflows/ci.yml` and `release-{product}.yml`
- `copilot-instructions.md` had **zero** CI/CD content
- The Azure DevOps pipeline pattern (1ES templates, publish stages, signing) was completely undocumented

An AI agent asked to "add a new product" would miss the ADO pipeline entirely and get the GitHub Actions workflow wrong.

## What changed

### `copilot-instructions. new "CI/ New Product Checklist" sectionCD md` 
- Complete GitHub Actions workflow template with `# CUSTOMIZE` annotations
- `_build.yml` inputs reference table (install-workloads, os, native-deps, pack, run-tests)
- Three complete Azure DevOps YAML snippets: publish parameter, build job, conditional publish stage
- Key conventions: nupkg glob pattern, stage dependencies, signing requirements, feed credentials

### `CONTRIBUTING. fixed "Adding a New Product" sectionmd` 
- Replaced stale steps referencing nonexistent files
- Cross-references copilot-instructions.md for the full templates

### `AGENTS. fixed CI/CD overview and new product checklistmd` 
- CI/CD section now lists all workflow files and describes per-product ADO pipeline structure
- New product section includes CI/CD as explicit steps

## Validation

Used multi-model analysis (Claude Opus + GPT-5.2) to red-team the  Opus audited discoverability gaps, GPT-5.2 role-played as an AI agent attempting the task to confirm the templates are sufficient.documentation 
