### PR TITLE
Combine DevFlow platform package artifacts

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -157,8 +157,80 @@ jobs:
           name: test-results-${{ inputs.project-name }}-${{ matrix.os }}
           path: artifacts/TestResults/**/*.xml
 
+      - name: Upload raw packages
+        if: inputs.pack
+        uses: actions/upload-artifact@v7
+        with:
+          name: raw-packages-${{ inputs.project-name }}-${{ matrix.os }}
+          path: artifacts/packages/**/*.nupkg
+
+  package:
+    if: inputs.pack
+    needs: build
+    runs-on: ${{ inputs.project-name == 'devflow' && 'macos-latest' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Install workloads for DevFlow packaging
+        if: inputs.project-name == 'devflow'
+        run: dotnet workload install maui macos maui-tizen
+
+      - name: Download raw packages
+        uses: actions/download-artifact@v8
+        with:
+          pattern: raw-packages-${{ inputs.project-name }}-*
+          path: artifacts/raw-packages
+
+      - name: Prepare packages
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          project_name='${{ inputs.project-name }}'
+          raw_packages_root="$(pwd)/artifacts/raw-packages"
+          packages_output="$(pwd)/artifacts/packages"
+
+          rm -rf "$packages_output"
+          mkdir -p "$packages_output"
+
+          if [[ "$project_name" == "devflow" ]]; then
+            raw_windows="$raw_packages_root/raw-packages-devflow-windows-latest"
+            if [[ -d "$raw_windows" ]]; then
+              find "$raw_windows" -name '*.nupkg' \
+                ! -name 'Microsoft.Maui.DevFlow.Agent.[0-9]*.nupkg' \
+                ! -name 'Microsoft.Maui.DevFlow.Blazor.[0-9]*.nupkg' \
+                -exec cp {} "$packages_output/" \;
+            fi
+
+            common_msbuild_args=(
+              /p:RawPackageRoot="$raw_packages_root/"
+              /p:PackageOutputPath="$packages_output"
+              /p:EnableWindowsTargeting=true
+              /p:VersionSuffix="$CI_PACKAGE_VERSION_SUFFIX"
+            )
+
+            dotnet restore eng/Packaging/Microsoft.Maui.DevFlow.Agent.Package/Microsoft.Maui.DevFlow.Agent.Package.csproj "${common_msbuild_args[@]}"
+            dotnet pack eng/Packaging/Microsoft.Maui.DevFlow.Agent.Package/Microsoft.Maui.DevFlow.Agent.Package.csproj --no-restore --no-build -c Release "${common_msbuild_args[@]}"
+
+            dotnet restore eng/Packaging/Microsoft.Maui.DevFlow.Blazor.Package/Microsoft.Maui.DevFlow.Blazor.Package.csproj "${common_msbuild_args[@]}"
+            dotnet pack eng/Packaging/Microsoft.Maui.DevFlow.Blazor.Package/Microsoft.Maui.DevFlow.Blazor.Package.csproj --no-restore --no-build -c Release "${common_msbuild_args[@]}"
+          else
+            raw_windows="$raw_packages_root/raw-packages-${project_name}-windows-latest"
+            if [[ -d "$raw_windows" ]]; then
+              find "$raw_windows" -name '*.nupkg' -exec cp {} "$packages_output/" \;
+            else
+              find "$raw_packages_root" -name '*.nupkg' -exec cp {} "$packages_output/" \;
+            fi
+          fi
+
+          find "$packages_output" -name '*.nupkg' -print
+
       - name: Upload packages
-        if: inputs.pack && (matrix.os == 'windows-latest' || !contains(fromJson(inputs.os), 'windows-latest'))
         uses: actions/upload-artifact@v7
         with:
           name: packages-${{ inputs.project-name }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -195,16 +195,83 @@ jobs:
           raw_packages_root="$(pwd)/artifacts/raw-packages"
           packages_output="$(pwd)/artifacts/packages"
 
+          find_raw_package_dir() {
+            local os_prefix="$1"
+            local -a matches=()
+            local candidate
+
+            shopt -s nullglob
+            for candidate in "$raw_packages_root/raw-packages-${project_name}-${os_prefix}"*; do
+              if [[ -d "$candidate" ]]; then
+                matches+=("$candidate")
+              fi
+            done
+            shopt -u nullglob
+
+            if [[ "${#matches[@]}" -eq 0 ]]; then
+              return 1
+            fi
+
+            if [[ "${#matches[@]}" -gt 1 ]]; then
+              echo "::error::Found multiple raw package directories for ${os_prefix}." >&2
+              printf '  %s\n' "${matches[@]}" >&2
+              return 2
+            fi
+
+            printf '%s\n' "${matches[0]}"
+          }
+
+          copy_devflow_passthrough_packages() {
+            local raw_package_dir="$1"
+            local copy_mode="$2"
+            local passthrough_packages
+
+            passthrough_packages="$(find "$raw_package_dir" -name '*.nupkg' \
+              ! -name 'Microsoft.Maui.DevFlow.Agent.[0-9]*.nupkg' \
+              ! -name 'Microsoft.Maui.DevFlow.Blazor.[0-9]*.nupkg' \
+              -type f \
+              | sort)"
+
+            if [[ -z "$passthrough_packages" ]]; then
+              return 1
+            fi
+
+            while IFS= read -r package; do
+              if [[ "$copy_mode" == "no-clobber" ]]; then
+                cp -n "$package" "$packages_output/"
+              else
+                cp "$package" "$packages_output/"
+              fi
+            done <<< "$passthrough_packages"
+          }
+
           rm -rf "$packages_output"
           mkdir -p "$packages_output"
 
           if [[ "$project_name" == "devflow" ]]; then
-            raw_windows="$raw_packages_root/raw-packages-devflow-windows-latest"
-            if [[ -d "$raw_windows" ]]; then
-              find "$raw_windows" -name '*.nupkg' \
-                ! -name 'Microsoft.Maui.DevFlow.Agent.[0-9]*.nupkg' \
-                ! -name 'Microsoft.Maui.DevFlow.Blazor.[0-9]*.nupkg' \
-                -exec cp {} "$packages_output/" \;
+            if raw_windows="$(find_raw_package_dir "windows")"; then
+              :
+            else
+              status=$?
+              if [[ "$status" -eq 2 ]]; then
+                exit "$status"
+              fi
+              echo "::error::Expected Windows raw package artifact matching '$raw_packages_root/raw-packages-${project_name}-windows-*' was not found."
+              exit 1
+            fi
+
+            if ! copy_devflow_passthrough_packages "$raw_windows" "overwrite"; then
+              echo "::error::No pass-through .nupkg files found in '$raw_windows'."
+              exit 1
+            fi
+
+            if raw_macos="$(find_raw_package_dir "macos")"; then
+              copy_devflow_passthrough_packages "$raw_macos" "no-clobber" || true
+            else
+              status=$?
+              if [[ "$status" -eq 2 ]]; then
+                exit "$status"
+              fi
             fi
 
             common_msbuild_args=(
@@ -220,15 +287,47 @@ jobs:
             dotnet restore eng/Packaging/Microsoft.Maui.DevFlow.Blazor.Package/Microsoft.Maui.DevFlow.Blazor.Package.csproj "${common_msbuild_args[@]}"
             dotnet pack eng/Packaging/Microsoft.Maui.DevFlow.Blazor.Package/Microsoft.Maui.DevFlow.Blazor.Package.csproj --no-restore --no-build -c Release "${common_msbuild_args[@]}"
           else
-            raw_windows="$raw_packages_root/raw-packages-${project_name}-windows-latest"
-            if [[ -d "$raw_windows" ]]; then
+            if raw_windows="$(find_raw_package_dir "windows")"; then
               find "$raw_windows" -name '*.nupkg' -exec cp {} "$packages_output/" \;
+
+              if raw_macos="$(find_raw_package_dir "macos")"; then
+                find "$raw_macos" -name '*.nupkg' -exec cp -n {} "$packages_output/" \;
+              else
+                status=$?
+                if [[ "$status" -eq 2 ]]; then
+                  exit "$status"
+                fi
+              fi
             else
+              status=$?
+              if [[ "$status" -eq 2 ]]; then
+                exit "$status"
+              fi
               find "$raw_packages_root" -name '*.nupkg' -exec cp {} "$packages_output/" \;
             fi
           fi
 
-          find "$packages_output" -name '*.nupkg' -print
+          produced_packages="$(find "$packages_output" -name '*.nupkg' -type f | sort)"
+          if [[ -z "$produced_packages" ]]; then
+            echo "::error::No .nupkg files produced in packages output."
+            exit 1
+          fi
+
+          if [[ "$project_name" == "devflow" ]]; then
+            expected_package_ids=(
+              Microsoft.Maui.DevFlow.Agent
+              Microsoft.Maui.DevFlow.Blazor
+            )
+
+            for package_id in "${expected_package_ids[@]}"; do
+              if ! find "$packages_output" -maxdepth 1 -name "$package_id.[0-9]*.nupkg" -type f | grep -q .; then
+                echo "::error::Expected package '$package_id' was not produced in packages output."
+                exit 1
+              fi
+            done
+          fi
+
+          printf '%s\n' "$produced_packages"
 
       - name: Upload packages
         uses: actions/upload-artifact@v7

--- a/eng/Packaging/DevFlowPackagePayload.targets
+++ b/eng/Packaging/DevFlowPackagePayload.targets
@@ -10,19 +10,30 @@
       <_DevFlowPackagePayloadRoot>$([MSBuild]::EnsureTrailingSlash('$(_DevFlowPackagePayloadRoot)'))</_DevFlowPackagePayloadRoot>
       <_DevFlowPackageVersion Condition="'$(PackageVersion)' != ''">$(PackageVersion)</_DevFlowPackageVersion>
       <_DevFlowPackageVersion Condition="'$(_DevFlowPackageVersion)' == ''">$(Version)</_DevFlowPackageVersion>
-      <_DevFlowMacPackagePath>$(_DevFlowRawPackageRoot)raw-packages-devflow-macos-latest/$(PackageId).$(_DevFlowPackageVersion).nupkg</_DevFlowMacPackagePath>
-      <_DevFlowWindowsPackagePath>$(_DevFlowRawPackageRoot)raw-packages-devflow-windows-latest/$(PackageId).$(_DevFlowPackageVersion).nupkg</_DevFlowWindowsPackagePath>
+      <_DevFlowMacPackageRoot>$(_DevFlowRawPackageRoot)raw-packages-devflow-macos-latest/</_DevFlowMacPackageRoot>
+      <_DevFlowWindowsPackageRoot>$(_DevFlowRawPackageRoot)raw-packages-devflow-windows-latest/</_DevFlowWindowsPackageRoot>
+      <_DevFlowPackageFileName>$(PackageId).$(_DevFlowPackageVersion).nupkg</_DevFlowPackageFileName>
     </PropertyGroup>
 
     <ItemGroup>
-      <_DevFlowMacPackage Include="$(_DevFlowMacPackagePath)" Condition="Exists('$(_DevFlowMacPackagePath)')" />
-      <_DevFlowWindowsPackage Include="$(_DevFlowWindowsPackagePath)" Condition="Exists('$(_DevFlowWindowsPackagePath)')" />
+      <_DevFlowMacPackageCandidate Include="$(_DevFlowMacPackageRoot)$(_DevFlowPackageFileName)" Condition="Exists('$(_DevFlowMacPackageRoot)$(_DevFlowPackageFileName)')" />
+      <_DevFlowMacPackageCandidate Include="$(_DevFlowMacPackageRoot)**/$(_DevFlowPackageFileName)" />
+      <_DevFlowWindowsPackageCandidate Include="$(_DevFlowWindowsPackageRoot)$(_DevFlowPackageFileName)" Condition="Exists('$(_DevFlowWindowsPackageRoot)$(_DevFlowPackageFileName)')" />
+      <_DevFlowWindowsPackageCandidate Include="$(_DevFlowWindowsPackageRoot)**/$(_DevFlowPackageFileName)" />
     </ItemGroup>
 
+    <RemoveDuplicates Inputs="@(_DevFlowMacPackageCandidate)">
+      <Output TaskParameter="Filtered" ItemName="_DevFlowMacPackage" />
+    </RemoveDuplicates>
+
+    <RemoveDuplicates Inputs="@(_DevFlowWindowsPackageCandidate)">
+      <Output TaskParameter="Filtered" ItemName="_DevFlowWindowsPackage" />
+    </RemoveDuplicates>
+
     <Error Condition="'@(_DevFlowMacPackage)' == ''"
-           Text="Could not find macOS package payload '$(_DevFlowMacPackagePath)'." />
+           Text="Could not find macOS package payload '$(_DevFlowPackageFileName)' under '$(_DevFlowMacPackageRoot)'." />
     <Error Condition="'@(_DevFlowWindowsPackage)' == ''"
-           Text="Could not find Windows package payload '$(_DevFlowWindowsPackagePath)'." />
+           Text="Could not find Windows package payload '$(_DevFlowPackageFileName)' under '$(_DevFlowWindowsPackageRoot)'." />
 
     <RemoveDir Directories="$(_DevFlowPackagePayloadRoot)" />
     <MakeDir Directories="$(_DevFlowPackagePayloadRoot)macos;$(_DevFlowPackagePayloadRoot)windows" />
@@ -35,13 +46,13 @@
            OverwriteReadOnlyFiles="true" />
 
     <ItemGroup>
-      <_DevFlowPackageMetadata Include="$(_DevFlowPackagePayloadRoot)**/*.nuspec;$(_DevFlowPackagePayloadRoot)**/[Content_Types].xml;$(_DevFlowPackagePayloadRoot)**/.signature.p7s;$(_DevFlowPackagePayloadRoot)**/README.md;$(_DevFlowPackagePayloadRoot)**/_rels/**/*;$(_DevFlowPackagePayloadRoot)**/package/**/*" />
+      <_DevFlowPackageMetadata Include="$(_DevFlowPackagePayloadRoot)**/*.nuspec;$(_DevFlowPackagePayloadRoot)**/[Content_Types].xml;$(_DevFlowPackagePayloadRoot)**/.signature.p7s;$(_DevFlowPackagePayloadRoot)**/Icon.png;$(_DevFlowPackagePayloadRoot)**/README.md;$(_DevFlowPackagePayloadRoot)**/_rels/**/*;$(_DevFlowPackagePayloadRoot)**/package/**/*" />
 
       <_DevFlowMacPayload Include="$(_DevFlowPackagePayloadRoot)macos/**/*"
                           Exclude="@(_DevFlowPackageMetadata);$(_DevFlowPackagePayloadRoot)macos/lib/net10.0-windows*/**/*" />
 
       <_DevFlowWindowsPayload Include="$(_DevFlowPackagePayloadRoot)windows/**/*"
-                              Exclude="@(_DevFlowPackageMetadata);$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-android*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-ios*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-maccatalyst*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-macos*/**/*;$(_DevFlowPackagePayloadRoot)windows/build/**/*;$(_DevFlowPackagePayloadRoot)windows/buildTransitive/**/*;$(_DevFlowPackagePayloadRoot)windows/staticwebassets/**/*" />
+                              Exclude="@(_DevFlowPackageMetadata);$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-android*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-ios*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-maccatalyst*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-macos*/**/*;$(_DevFlowPackagePayloadRoot)windows/build/**/*;$(_DevFlowPackagePayloadRoot)windows/buildMultiTargeting/**/*;$(_DevFlowPackagePayloadRoot)windows/buildTransitive/**/*;$(_DevFlowPackagePayloadRoot)windows/staticwebassets/**/*" />
 
       <None Include="@(_DevFlowMacPayload)"
             Pack="true"

--- a/eng/Packaging/DevFlowPackagePayload.targets
+++ b/eng/Packaging/DevFlowPackagePayload.targets
@@ -10,16 +10,16 @@
       <_DevFlowPackagePayloadRoot>$([MSBuild]::EnsureTrailingSlash('$(_DevFlowPackagePayloadRoot)'))</_DevFlowPackagePayloadRoot>
       <_DevFlowPackageVersion Condition="'$(PackageVersion)' != ''">$(PackageVersion)</_DevFlowPackageVersion>
       <_DevFlowPackageVersion Condition="'$(_DevFlowPackageVersion)' == ''">$(Version)</_DevFlowPackageVersion>
-      <_DevFlowMacPackageRoot>$(_DevFlowRawPackageRoot)raw-packages-devflow-macos-latest/</_DevFlowMacPackageRoot>
-      <_DevFlowWindowsPackageRoot>$(_DevFlowRawPackageRoot)raw-packages-devflow-windows-latest/</_DevFlowWindowsPackageRoot>
+      <_DevFlowMacPackageRootPattern>$(_DevFlowRawPackageRoot)raw-packages-devflow-macos-*/</_DevFlowMacPackageRootPattern>
+      <_DevFlowWindowsPackageRootPattern>$(_DevFlowRawPackageRoot)raw-packages-devflow-windows-*/</_DevFlowWindowsPackageRootPattern>
       <_DevFlowPackageFileName>$(PackageId).$(_DevFlowPackageVersion).nupkg</_DevFlowPackageFileName>
     </PropertyGroup>
 
     <ItemGroup>
-      <_DevFlowMacPackageCandidate Include="$(_DevFlowMacPackageRoot)$(_DevFlowPackageFileName)" Condition="Exists('$(_DevFlowMacPackageRoot)$(_DevFlowPackageFileName)')" />
-      <_DevFlowMacPackageCandidate Include="$(_DevFlowMacPackageRoot)**/$(_DevFlowPackageFileName)" />
-      <_DevFlowWindowsPackageCandidate Include="$(_DevFlowWindowsPackageRoot)$(_DevFlowPackageFileName)" Condition="Exists('$(_DevFlowWindowsPackageRoot)$(_DevFlowPackageFileName)')" />
-      <_DevFlowWindowsPackageCandidate Include="$(_DevFlowWindowsPackageRoot)**/$(_DevFlowPackageFileName)" />
+      <_DevFlowMacPackageCandidate Include="$(_DevFlowMacPackageRootPattern)$(_DevFlowPackageFileName)" />
+      <_DevFlowMacPackageCandidate Include="$(_DevFlowMacPackageRootPattern)**/$(_DevFlowPackageFileName)" />
+      <_DevFlowWindowsPackageCandidate Include="$(_DevFlowWindowsPackageRootPattern)$(_DevFlowPackageFileName)" />
+      <_DevFlowWindowsPackageCandidate Include="$(_DevFlowWindowsPackageRootPattern)**/$(_DevFlowPackageFileName)" />
     </ItemGroup>
 
     <RemoveDuplicates Inputs="@(_DevFlowMacPackageCandidate)">
@@ -31,9 +31,9 @@
     </RemoveDuplicates>
 
     <Error Condition="'@(_DevFlowMacPackage)' == ''"
-           Text="Could not find macOS package payload '$(_DevFlowPackageFileName)' under '$(_DevFlowMacPackageRoot)'." />
+           Text="Could not find macOS package payload '$(_DevFlowPackageFileName)' matching '$(_DevFlowMacPackageRootPattern)'." />
     <Error Condition="'@(_DevFlowWindowsPackage)' == ''"
-           Text="Could not find Windows package payload '$(_DevFlowPackageFileName)' under '$(_DevFlowWindowsPackageRoot)'." />
+           Text="Could not find Windows package payload '$(_DevFlowPackageFileName)' matching '$(_DevFlowWindowsPackageRootPattern)'." />
 
     <RemoveDir Directories="$(_DevFlowPackagePayloadRoot)" />
     <MakeDir Directories="$(_DevFlowPackagePayloadRoot)macos;$(_DevFlowPackagePayloadRoot)windows" />

--- a/eng/Packaging/DevFlowPackagePayload.targets
+++ b/eng/Packaging/DevFlowPackagePayload.targets
@@ -1,0 +1,56 @@
+<Project>
+
+  <Target Name="_PrepareDevFlowPackagePayload"
+          BeforeTargets="_GetPackageFiles"
+          Condition="'$(RawPackageRoot)' != '' and '$(TargetFramework)' == ''">
+    <PropertyGroup>
+      <_DevFlowRawPackageRoot>$([MSBuild]::EnsureTrailingSlash('$(RawPackageRoot)'))</_DevFlowRawPackageRoot>
+      <_DevFlowPackagePayloadRoot Condition="'$(PackagePayloadRoot)' == ''">$(BaseIntermediateOutputPath)package-payload/$(PackageId)/</_DevFlowPackagePayloadRoot>
+      <_DevFlowPackagePayloadRoot Condition="'$(PackagePayloadRoot)' != ''">$(PackagePayloadRoot)</_DevFlowPackagePayloadRoot>
+      <_DevFlowPackagePayloadRoot>$([MSBuild]::EnsureTrailingSlash('$(_DevFlowPackagePayloadRoot)'))</_DevFlowPackagePayloadRoot>
+      <_DevFlowPackageVersion Condition="'$(PackageVersion)' != ''">$(PackageVersion)</_DevFlowPackageVersion>
+      <_DevFlowPackageVersion Condition="'$(_DevFlowPackageVersion)' == ''">$(Version)</_DevFlowPackageVersion>
+      <_DevFlowMacPackagePath>$(_DevFlowRawPackageRoot)raw-packages-devflow-macos-latest/$(PackageId).$(_DevFlowPackageVersion).nupkg</_DevFlowMacPackagePath>
+      <_DevFlowWindowsPackagePath>$(_DevFlowRawPackageRoot)raw-packages-devflow-windows-latest/$(PackageId).$(_DevFlowPackageVersion).nupkg</_DevFlowWindowsPackagePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_DevFlowMacPackage Include="$(_DevFlowMacPackagePath)" Condition="Exists('$(_DevFlowMacPackagePath)')" />
+      <_DevFlowWindowsPackage Include="$(_DevFlowWindowsPackagePath)" Condition="Exists('$(_DevFlowWindowsPackagePath)')" />
+    </ItemGroup>
+
+    <Error Condition="'@(_DevFlowMacPackage)' == ''"
+           Text="Could not find macOS package payload '$(_DevFlowMacPackagePath)'." />
+    <Error Condition="'@(_DevFlowWindowsPackage)' == ''"
+           Text="Could not find Windows package payload '$(_DevFlowWindowsPackagePath)'." />
+
+    <RemoveDir Directories="$(_DevFlowPackagePayloadRoot)" />
+    <MakeDir Directories="$(_DevFlowPackagePayloadRoot)macos;$(_DevFlowPackagePayloadRoot)windows" />
+
+    <Unzip SourceFiles="@(_DevFlowMacPackage)"
+           DestinationFolder="$(_DevFlowPackagePayloadRoot)macos"
+           OverwriteReadOnlyFiles="true" />
+    <Unzip SourceFiles="@(_DevFlowWindowsPackage)"
+           DestinationFolder="$(_DevFlowPackagePayloadRoot)windows"
+           OverwriteReadOnlyFiles="true" />
+
+    <ItemGroup>
+      <_DevFlowPackageMetadata Include="$(_DevFlowPackagePayloadRoot)**/*.nuspec;$(_DevFlowPackagePayloadRoot)**/[Content_Types].xml;$(_DevFlowPackagePayloadRoot)**/.signature.p7s;$(_DevFlowPackagePayloadRoot)**/README.md;$(_DevFlowPackagePayloadRoot)**/_rels/**/*;$(_DevFlowPackagePayloadRoot)**/package/**/*" />
+
+      <_DevFlowMacPayload Include="$(_DevFlowPackagePayloadRoot)macos/**/*"
+                          Exclude="@(_DevFlowPackageMetadata);$(_DevFlowPackagePayloadRoot)macos/lib/net10.0-windows*/**/*" />
+
+      <_DevFlowWindowsPayload Include="$(_DevFlowPackagePayloadRoot)windows/**/*"
+                              Exclude="@(_DevFlowPackageMetadata);$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-android*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-ios*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-maccatalyst*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-macos*/**/*;$(_DevFlowPackagePayloadRoot)windows/build/**/*;$(_DevFlowPackagePayloadRoot)windows/buildTransitive/**/*;$(_DevFlowPackagePayloadRoot)windows/staticwebassets/**/*" />
+
+      <None Include="@(_DevFlowMacPayload)"
+            Pack="true"
+            PackagePath="%(_DevFlowMacPayload.RecursiveDir)%(_DevFlowMacPayload.Filename)%(_DevFlowMacPayload.Extension)" />
+
+      <None Include="@(_DevFlowWindowsPayload)"
+            Pack="true"
+            PackagePath="%(_DevFlowWindowsPayload.RecursiveDir)%(_DevFlowWindowsPayload.Filename)%(_DevFlowWindowsPayload.Extension)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/eng/Packaging/DevFlowPackagePayload.targets
+++ b/eng/Packaging/DevFlowPackagePayload.targets
@@ -48,11 +48,12 @@
     <ItemGroup>
       <_DevFlowPackageMetadata Include="$(_DevFlowPackagePayloadRoot)**/*.nuspec;$(_DevFlowPackagePayloadRoot)**/[Content_Types].xml;$(_DevFlowPackagePayloadRoot)**/.signature.p7s;$(_DevFlowPackagePayloadRoot)**/Icon.png;$(_DevFlowPackagePayloadRoot)**/README.md;$(_DevFlowPackagePayloadRoot)**/_rels/**/*;$(_DevFlowPackagePayloadRoot)**/package/**/*" />
 
+      <!-- DevFlow packages currently put platform-specific assets under lib and shared assets under build, buildMultiTargeting, buildTransitive, and staticwebassets. macOS remains the base payload; Windows contributes only Windows-specific lib assets. -->
       <_DevFlowMacPayload Include="$(_DevFlowPackagePayloadRoot)macos/**/*"
                           Exclude="@(_DevFlowPackageMetadata);$(_DevFlowPackagePayloadRoot)macos/lib/net10.0-windows*/**/*" />
 
       <_DevFlowWindowsPayload Include="$(_DevFlowPackagePayloadRoot)windows/**/*"
-                              Exclude="@(_DevFlowPackageMetadata);$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-android*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-ios*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-maccatalyst*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-macos*/**/*;$(_DevFlowPackagePayloadRoot)windows/build/**/*;$(_DevFlowPackagePayloadRoot)windows/buildMultiTargeting/**/*;$(_DevFlowPackagePayloadRoot)windows/buildTransitive/**/*;$(_DevFlowPackagePayloadRoot)windows/staticwebassets/**/*" />
+                              Exclude="@(_DevFlowPackageMetadata);$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-android*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-ios*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-maccatalyst*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-macos*/**/*;$(_DevFlowPackagePayloadRoot)windows/lib/net10.0-tizen*/**/*;$(_DevFlowPackagePayloadRoot)windows/build/**/*;$(_DevFlowPackagePayloadRoot)windows/buildMultiTargeting/**/*;$(_DevFlowPackagePayloadRoot)windows/buildTransitive/**/*;$(_DevFlowPackagePayloadRoot)windows/staticwebassets/**/*" />
 
       <None Include="@(_DevFlowMacPayload)"
             Pack="true"

--- a/eng/Packaging/Microsoft.Maui.DevFlow.Agent.Package/Microsoft.Maui.DevFlow.Agent.Package.csproj
+++ b/eng/Packaging/Microsoft.Maui.DevFlow.Agent.Package/Microsoft.Maui.DevFlow.Agent.Package.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-macos;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
+    <PackageId>Microsoft.Maui.DevFlow.Agent</PackageId>
+    <Description>In-app agent for .NET MAUI automation. Exposes visual tree, element interactions, and screenshots via HTTP/JSON API.</Description>
+    <PackageTags>maui;automation;testing;visual-tree;agent</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\DevFlow\Microsoft.Maui.DevFlow.Agent.Core\Microsoft.Maui.DevFlow.Agent.Core.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(DevFlowMauiMinVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
+    <PackageReference Include="Platform.Maui.MacOS" />
+  </ItemGroup>
+
+  <Import Project="..\DevFlowPackagePayload.targets" />
+
+</Project>

--- a/eng/Packaging/Microsoft.Maui.DevFlow.Blazor.Package/Microsoft.Maui.DevFlow.Blazor.Package.csproj
+++ b/eng/Packaging/Microsoft.Maui.DevFlow.Blazor.Package/Microsoft.Maui.DevFlow.Blazor.Package.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-macos;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
+    <PackageId>Microsoft.Maui.DevFlow.Blazor</PackageId>
+    <Description>Enable browser developer tools and Playwright MCP automation for .NET MAUI Blazor Hybrid apps. Connects Chrome DevTools Protocol to BlazorWebView via Chobitsu.</Description>
+    <PackageTags>maui;blazor;debugging;devtools;cdp;playwright;mcp;automation</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(DevFlowMauiMinVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" VersionOverride="$(DevFlowMauiMinVersion)" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
+    <PackageReference Include="Platform.Maui.MacOS" />
+    <PackageReference Include="Platform.Maui.MacOS.BlazorWebView" />
+  </ItemGroup>
+
+  <Import Project="..\DevFlowPackagePayload.targets" />
+
+</Project>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/Profiling/RuntimeProfilerCollector.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/Profiling/RuntimeProfilerCollector.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Maui.DevFlow.Agent.Core.Profiling;
 
 public class RuntimeProfilerCollector : IProfilerCollector, IDisposable
 {
+    private const double FallbackRefreshRate = 60d;
+    private const double FallbackFrameTimeMs = 1000d / FallbackRefreshRate;
+
     private readonly Process _process = Process.GetCurrentProcess();
     private readonly INativeFrameStatsProvider? _nativeFrameStatsProvider;
     private readonly ProfilerCapabilities _capabilities;
@@ -13,7 +16,7 @@ public class RuntimeProfilerCollector : IProfilerCollector, IDisposable
     private DateTime _lastSampleTimestampUtc;
     private TimeSpan _lastCpuTime;
     private int _sampleIntervalMs = 500;
-    private double _estimatedFrameTimeMs = 1000d / 60d;
+    private double _estimatedFrameTimeMs = FallbackFrameTimeMs;
     private string _estimatedFrameQuality = "estimated.default-60hz";
 
     public RuntimeProfilerCollector(INativeFrameStatsProvider? nativeFrameStatsProvider = null)
@@ -53,7 +56,7 @@ public class RuntimeProfilerCollector : IProfilerCollector, IDisposable
         if (_nativeFrameStatsProvider?.IsSupported == true)
         {
             // Native providers own frame timing. Keep a safe fallback estimate in case native collection is disabled later.
-            _estimatedFrameTimeMs = 1000d / 60d;
+            _estimatedFrameTimeMs = FallbackFrameTimeMs;
             _estimatedFrameQuality = "estimated.default-60hz";
         }
         else
@@ -175,7 +178,14 @@ public class RuntimeProfilerCollector : IProfilerCollector, IDisposable
         var effectiveElapsedMs = Math.Max(_sampleIntervalMs, elapsedMs);
         var lagRatio = effectiveElapsedMs / _sampleIntervalMs;
         var estimatedFrameTimeMs = _estimatedFrameTimeMs * lagRatio;
-        var estimatedFps = estimatedFrameTimeMs > 0 ? 1000d / estimatedFrameTimeMs : (double?)null;
+        var estimatedFrameQuality = _estimatedFrameQuality;
+        if (!IsPositiveFinite(estimatedFrameTimeMs))
+        {
+            estimatedFrameTimeMs = FallbackFrameTimeMs;
+            estimatedFrameQuality = "estimated.default-60hz";
+        }
+
+        var estimatedFps = 1000d / estimatedFrameTimeMs;
 
         return new ProfilerSample
         {
@@ -187,7 +197,7 @@ public class RuntimeProfilerCollector : IProfilerCollector, IDisposable
             JankFrameCount = estimatedFrameTimeMs >= 24d ? 1 : 0,
             UiThreadStallCount = estimatedFrameTimeMs >= 150d ? 1 : 0,
             FrameSource = "managed.estimated",
-            FrameQuality = $"{_estimatedFrameQuality}.sampling-lag"
+            FrameQuality = $"{estimatedFrameQuality}.sampling-lag"
         };
     }
 
@@ -286,13 +296,16 @@ public class RuntimeProfilerCollector : IProfilerCollector, IDisposable
 
     private static (double FrameTimeMs, string Quality) ResolveFrameEstimate()
     {
-        const double fallbackRefreshRate = 60d;
         var refreshRate = TryReadDisplayRefreshRate();
 
         if (refreshRate.HasValue)
-            return (1000d / refreshRate.Value, "estimated.display-refresh");
+        {
+            var frameTimeMs = 1000d / refreshRate.Value;
+            if (IsPositiveFinite(frameTimeMs))
+                return (frameTimeMs, "estimated.display-refresh");
+        }
 
-        return (1000d / fallbackRefreshRate, "estimated.default-60hz");
+        return (FallbackFrameTimeMs, "estimated.default-60hz");
     }
 
     private static double? TryReadDisplayRefreshRate()
@@ -300,7 +313,7 @@ public class RuntimeProfilerCollector : IProfilerCollector, IDisposable
         try
         {
             var refreshRate = DeviceDisplay.Current.MainDisplayInfo.RefreshRate;
-            if (double.IsNaN(refreshRate) || double.IsInfinity(refreshRate) || refreshRate <= 1d)
+            if (!IsPositiveFinite(refreshRate) || refreshRate <= 1d)
                 return null;
 
             return refreshRate;
@@ -309,6 +322,13 @@ public class RuntimeProfilerCollector : IProfilerCollector, IDisposable
         {
             return null;
         }
+    }
+
+    private static bool IsPositiveFinite(double value)
+    {
+        return !double.IsNaN(value)
+            && !double.IsInfinity(value)
+            && value > 0d;
     }
 
     private static bool IsDisplayInfoAccessException(Exception ex)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ProfilerCoreTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ProfilerCoreTests.cs
@@ -185,6 +185,22 @@ public class ProfilerCoreTests
     }
 
     [Fact]
+    public void RuntimeProfilerCollector_InvalidFrameEstimate_UsesDefaultFrameEstimate()
+    {
+        var collector = new RuntimeProfilerCollector();
+        collector.Start(100);
+        SetPrivateField(collector, "_estimatedFrameTimeMs", 0d);
+
+        var collected = collector.TryCollect(out var sample);
+        collector.Stop();
+
+        Assert.True(collected);
+        Assert.True(sample.Fps > 0, $"Fps was {sample.Fps}, expected > 0");
+        Assert.True(sample.FrameTimeMsP95 > 0, $"FrameTimeMsP95 was {sample.FrameTimeMsP95}, expected > 0");
+        Assert.StartsWith("estimated.default-60hz", sample.FrameQuality);
+    }
+
+    [Fact]
     public void ProfilerSessionStore_IsActiveReflectsLifecycle()
     {
         var store = new ProfilerSessionStore(10, 10, 10);
@@ -353,6 +369,13 @@ public class ProfilerCoreTests
         Assert.True(
             missingInDriver.Length == 0,
             $"Driver contract {typeof(TDriver).Name} is missing properties: {string.Join(", ", missingInDriver)}");
+    }
+
+    private static void SetPrivateField<TValue>(object instance, string fieldName, TValue value)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field.SetValue(instance, value);
     }
 
     private sealed class ThrowingNativeProvider : INativeFrameStatsProvider


### PR DESCRIPTION
DevFlow packages are built on both macOS and Windows because each OS produces a different set of platform assets. Previously the canonical package artifact came from a single matrix leg, which could leave the final nupkgs missing Apple or Windows bits.

This change keeps each matrix leg's packages as raw per-platform artifacts, then adds a final package job that produces the canonical package artifact. For the DevFlow Agent and Blazor packages, packaging-only SDK-style projects unpack the macOS and Windows raw nupkgs and repack the union through `dotnet pack`, so NuGet/MSBuild still generates the final nuspec and dependency metadata.

Key details:

- Raw packages are uploaded as `raw-packages-{project}-{os}` from each matrix job.
- The final package job downloads those raw artifacts and publishes `packages-{project}`.
- `Microsoft.Maui.DevFlow.Agent` and `Microsoft.Maui.DevFlow.Blazor` are repacked through `eng/Packaging` projects instead of a custom `.nuspec` or PowerShell packer.
- macOS payloads are treated as the base payload, with Windows-specific `lib/net10.0-windows*` files added from the Windows package.

Validation:

- Ran a synthetic local package smoke test with global dotnet that combined macOS and Windows raw nupkgs into complete Agent and Blazor packages.
- Checked workflow YAML parsing, packaging XML parsing, and `git diff --check`.