### PR TITLE
fix: DevFlow IView visibility/bounds resolution for Comet

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -292,7 +292,8 @@ public class DevFlowCommands
         var treeDepthOption = new Option<int>("--depth") { Description = "Max tree depth (0=unlimited)", DefaultValueFactory = _ => 0 };
         var treeFieldsOption = new Option<string?>("--fields") { Description = "Comma-separated fields to include (e.g. id,type,text,automationId,bounds)" };
         var treeFormatOption = new Option<string?>("--format") { Description = "Output format: compact (id,type,text,automationId,bounds only)" };
-        var mauiTreeCmd = new Command("tree", "Dump visual tree") { treeDepthOption, treeFieldsOption, treeFormatOption, windowOption };
+        var treeLayoutOption = new Option<bool>("--layout") { Description = "Include Yoga layout info for Comet-driven layout nodes (frame, flex direction, per-child flex props)" };
+        var mauiTreeCmd = new Command("tree", "Dump visual tree") { treeDepthOption, treeFieldsOption, treeFormatOption, treeLayoutOption, windowOption };
         mauiTreeCmd.SetAction(async (ctx, ct) =>
         {
             var host = ctx.GetValue(agentHostOption)!;
@@ -303,7 +304,8 @@ public class DevFlowCommands
             var window = ctx.GetValue(windowOption);
             var fields = ctx.GetValue(treeFieldsOption);
             var format = ctx.GetValue(treeFormatOption);
-            await MauiTreeAsync(host, port, output.ResolveJsonMode(json, noJson), depth, window, fields, format);
+            var layout = ctx.GetValue(treeLayoutOption);
+            await MauiTreeAsync(host, port, output.ResolveJsonMode(json, noJson), depth, window, fields, format, layout);
         });
         mauiCommand.Add(mauiTreeCmd);
 
@@ -2379,12 +2381,12 @@ public class DevFlowCommands
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
-    private static async Task MauiTreeAsync(string host, int port, bool json, int depth, int? window, string? fields, string? format)
+    private static async Task MauiTreeAsync(string host, int port, bool json, int depth, int? window, string? fields, string? format, bool includeLayout = false)
     {
         try
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
-            var tree = await client.GetTreeAsync(depth, window);
+            var tree = await client.GetTreeAsync(depth, window, includeLayout);
             if (json)
             {
                 var projected = ProjectElements(tree, fields, format);
@@ -3352,6 +3354,28 @@ public class DevFlowCommands
             if (!el.IsEnabled) info += " [disabled]";
             if (el.Bounds != null) info += $" ({el.Bounds.X:F0},{el.Bounds.Y:F0} {el.Bounds.Width:F0}x{el.Bounds.Height:F0})";
             Console.WriteLine(info);
+            if (el.Layout != null)
+            {
+                var f = el.Layout.Frame;
+                Console.WriteLine(
+                    $"{prefix}  layout: [{f.X:F0},{f.Y:F0} {f.Width:F0}x{f.Height:F0}]" +
+                    $" dir={el.Layout.FlexDirection}" +
+                    $" align={el.Layout.AlignItems}" +
+                    $" justify={el.Layout.JustifyContent}");
+                if (el.Layout.Children is { Count: > 0 } childList)
+                {
+                    foreach (var c in childList)
+                    {
+                        var cf = c.Frame;
+                        var idPart = c.AutomationId != null ? $" automationId=\"{c.AutomationId}\"" : "";
+                        Console.WriteLine(
+                            $"{prefix}    - {c.ViewTypeName}{idPart}" +
+                            $" frame=[{cf.X:F0},{cf.Y:F0} {cf.Width:F0}x{cf.Height:F0}]" +
+                            $" grow={c.FlexGrow:0.##} shrink={c.FlexShrink:0.##}" +
+                            $" alignSelf={c.AlignSelf} pos={c.PositionType}");
+                    }
+                }
+            }
             if (el.Children != null)
                 PrintTree(el.Children, indent + 1);
         }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/TreeTool.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/TreeTool.cs
@@ -15,10 +15,11 @@ public sealed class TreeTool
 		[Description("Window index for multi-window apps (default: 0)")] int? window = null,
 		[Description("Max tree depth to return (default: 50)")] int depth = 50,
 		[Description("Filter to a specific element type, e.g. 'Label', 'Button', 'Entry'")] string? filter = null,
-		[Description("Return only the subtree rooted at this element ID")] string? elementId = null)
+		[Description("Return only the subtree rooted at this element ID")] string? elementId = null,
+		[Description("Include Yoga layout info for Comet-driven layout nodes (frame + flex props).")] bool layout = false)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var tree = await agent.GetTreeAsync(depth, window);
+		var tree = await agent.GetTreeAsync(depth, window, layout);
 		if (tree == null || tree.Count == 0)
 			return "No visual tree available. Is the agent connected and the app running?";
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/CometViewResolver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/CometViewResolver.cs
@@ -299,6 +299,117 @@ internal static class CometViewResolver
 	}
 
 	/// <summary>
+	/// Attempts to extract display text from a Comet view via reflection.
+	/// Checks for common text-bearing properties: Value (generated Text control),
+	/// Text (Button, TextField), and environment-based text storage.
+	/// </summary>
+	public static string? TryExtractText(object cometView)
+	{
+		if (cometView == null) return null;
+
+		try
+		{
+			var viewType = cometView.GetType();
+
+			// Comet's generated Text control stores text in a "Value" property (from ILabel.Text:Value mapping)
+			var valueProp = viewType.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+			if (valueProp != null && valueProp.PropertyType == typeof(string))
+			{
+				var val = valueProp.GetValue(cometView) as string;
+				if (!string.IsNullOrEmpty(val))
+					return val;
+			}
+
+			// Also check Binding<string> Value (generated controls use Binding<T> wrapper)
+			if (valueProp != null && valueProp.PropertyType.IsGenericType)
+			{
+				try
+				{
+					var bindingObj = valueProp.GetValue(cometView);
+					if (bindingObj != null)
+					{
+						// Binding<T> has a CurrentValue or Value property
+						var currentValueProp = bindingObj.GetType().GetProperty("CurrentValue", BindingFlags.Public | BindingFlags.Instance)
+							?? bindingObj.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+						if (currentValueProp != null)
+						{
+							var val = currentValueProp.GetValue(bindingObj)?.ToString();
+							if (!string.IsNullOrEmpty(val))
+								return val;
+						}
+					}
+				}
+				catch { /* Ignore binding resolution errors */ }
+			}
+
+			// Check "Text" property directly (some Comet controls use it)
+			var textProp = viewType.GetProperty("Text", BindingFlags.Public | BindingFlags.Instance);
+			if (textProp != null)
+			{
+				if (textProp.PropertyType == typeof(string))
+				{
+					var val = textProp.GetValue(cometView) as string;
+					if (!string.IsNullOrEmpty(val))
+						return val;
+				}
+				else if (textProp.PropertyType.IsGenericType)
+				{
+					try
+					{
+						var bindingObj = textProp.GetValue(cometView);
+						if (bindingObj != null)
+						{
+							var currentValueProp = bindingObj.GetType().GetProperty("CurrentValue", BindingFlags.Public | BindingFlags.Instance)
+								?? bindingObj.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+							if (currentValueProp != null)
+							{
+								var val = currentValueProp.GetValue(bindingObj)?.ToString();
+								if (!string.IsNullOrEmpty(val))
+									return val;
+							}
+						}
+					}
+					catch { /* Ignore binding resolution errors */ }
+				}
+			}
+
+			// Try GetEnvironment<string>("Text.Value") — Comet stores text in environment
+			if (_cometViewType != null && _cometViewType.IsInstanceOfType(cometView))
+			{
+				var getEnvMethods = _cometViewType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+					.Where(m => m.Name == "GetEnvironment" && m.IsGenericMethod && m.GetParameters().Length >= 1)
+					.ToList();
+
+				foreach (var getEnvMethod in getEnvMethods)
+				{
+					try
+					{
+						var genericMethod = getEnvMethod.MakeGenericMethod(typeof(string));
+						var paramCount = genericMethod.GetParameters().Length;
+						object? result = null;
+
+						if (paramCount == 1)
+							result = genericMethod.Invoke(cometView, new object[] { "Text.Value" });
+						else if (paramCount == 2)
+							result = genericMethod.Invoke(cometView, new object[] { "Text.Value", false });
+
+						if (result is string envText && !string.IsNullOrEmpty(envText))
+							return envText;
+						break;
+					}
+					catch { continue; }
+				}
+			}
+		}
+		catch
+		{
+			// Reflection failures should not break the tree walk
+		}
+
+		return null;
+	}
+
+	/// <summary>
 	/// Gets the list of environment keys defined in Comet.EnvironmentKeys.
 	/// Returns empty list if Comet not available or reflection fails.
 	/// </summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/CometViewResolver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/CometViewResolver.cs
@@ -18,6 +18,7 @@ internal static class CometViewResolver
 	private static PropertyInfo? _builtViewProperty;
 	private static PropertyInfo? _bodyProperty;
 	private static PropertyInfo? _currentViewProperty;
+	private static MethodInfo[]? _getEnvironmentMethods;
 
 	/// <summary>
 	/// Checks if Comet is loaded in the current app domain.
@@ -55,6 +56,12 @@ internal static class CometViewResolver
 			_getViewMethod = _cometViewType.GetMethod("GetView", BindingFlags.Public | BindingFlags.Instance);
 			_builtViewProperty = _cometViewType.GetProperty("BuiltView", BindingFlags.Public | BindingFlags.Instance);
 			_bodyProperty = _cometViewType.GetProperty("Body", BindingFlags.Public | BindingFlags.Instance);
+
+			// Cache GetEnvironment generic method overloads — used by TryExtractText to
+			// resolve Comet's environment-stored Text.Value without re-reflecting per call.
+			_getEnvironmentMethods = _cometViewType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+				.Where(m => m.Name == "GetEnvironment" && m.IsGenericMethod && m.GetParameters().Length >= 1)
+				.ToArray();
 
 			// Cache platform-specific CometView (iOS/Android/Windows) CurrentView property
 			// Platform views are in Comet.iOS.CometView, Comet.Droid.CometView, etc.
@@ -306,6 +313,7 @@ internal static class CometViewResolver
 	public static string? TryExtractText(object cometView)
 	{
 		if (cometView == null) return null;
+		if (!IsCometAvailable()) return null;
 
 		try
 		{
@@ -374,27 +382,27 @@ internal static class CometViewResolver
 			}
 
 			// Try GetEnvironment<string>("Text.Value") — Comet stores text in environment
-			if (_cometViewType != null && _cometViewType.IsInstanceOfType(cometView))
+			if (_cometViewType != null && _getEnvironmentMethods != null && _cometViewType.IsInstanceOfType(cometView))
 			{
-				var getEnvMethods = _cometViewType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-					.Where(m => m.Name == "GetEnvironment" && m.IsGenericMethod && m.GetParameters().Length >= 1)
-					.ToList();
-
-				foreach (var getEnvMethod in getEnvMethods)
+				foreach (var getEnvMethod in _getEnvironmentMethods)
 				{
 					try
 					{
 						var genericMethod = getEnvMethod.MakeGenericMethod(typeof(string));
 						var paramCount = genericMethod.GetParameters().Length;
-						object? result = null;
+						object? result;
 
 						if (paramCount == 1)
 							result = genericMethod.Invoke(cometView, new object[] { "Text.Value" });
 						else if (paramCount == 2)
 							result = genericMethod.Invoke(cometView, new object[] { "Text.Value", false });
+						else
+							continue; // unknown overload shape — try the next one
 
 						if (result is string envText && !string.IsNullOrEmpty(envText))
 							return envText;
+						// Invocation succeeded with a recognized overload but produced no text;
+						// no need to try other overloads of the same method.
 						break;
 					}
 					catch { continue; }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -714,8 +714,12 @@ public class DevFlowAgentService : IDisposable, IMarkerPublisher
         if (request.QueryParams.TryGetValue("depth", out var depthStr))
             int.TryParse(depthStr, out maxDepth);
 
+        bool includeLayout = false;
+        if (request.QueryParams.TryGetValue("layout", out var layoutStr))
+            includeLayout = layoutStr == "1" || string.Equals(layoutStr, "true", StringComparison.OrdinalIgnoreCase);
+
         var windowIndex = ParseWindowIndex(request);
-        var tree = await DispatchAsync(() => _treeWalker.WalkTree(_app, maxDepth, windowIndex));
+        var tree = await DispatchAsync(() => _treeWalker.WalkTree(_app, maxDepth, windowIndex, includeLayout));
         return HttpResponse.Json(tree);
     }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/ElementInfo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/ElementInfo.cs
@@ -140,6 +140,10 @@ public class ElementInfo
     [JsonPropertyName("children")]
     public List<ElementInfo>? Children { get; set; }
 
+    [JsonPropertyName("layout")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LayoutInfo? Layout { get; set; }
+
     [JsonIgnore]
     public bool IsSelected { get; set; }
 
@@ -236,6 +240,76 @@ public class ElementNativeViewInfo
     [JsonPropertyName("properties")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string?>? Properties { get; set; }
+}
+
+/// <summary>
+/// Yoga layout snapshot for a Comet-driven MAUI Layout. Populated by the agent
+/// when <c>?layout=1</c> is requested on the tree endpoint and the underlying
+/// MAUI Layout's manager implements Comet's IYogaLayoutInspector.
+/// </summary>
+public class LayoutInfo
+{
+    [JsonPropertyName("frame")]
+    public LayoutFrameInfo Frame { get; set; } = new();
+
+    [JsonPropertyName("flexDirection")]
+    public string FlexDirection { get; set; } = "";
+
+    [JsonPropertyName("alignItems")]
+    public string AlignItems { get; set; } = "";
+
+    [JsonPropertyName("justifyContent")]
+    public string JustifyContent { get; set; } = "";
+
+    [JsonPropertyName("alignContent")]
+    public string AlignContent { get; set; } = "";
+
+    [JsonPropertyName("flexWrap")]
+    public string FlexWrap { get; set; } = "";
+
+    [JsonPropertyName("children")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<LayoutChildInfo>? Children { get; set; }
+}
+
+public class LayoutFrameInfo
+{
+    [JsonPropertyName("x")]
+    public float X { get; set; }
+
+    [JsonPropertyName("y")]
+    public float Y { get; set; }
+
+    [JsonPropertyName("width")]
+    public float Width { get; set; }
+
+    [JsonPropertyName("height")]
+    public float Height { get; set; }
+}
+
+public class LayoutChildInfo
+{
+    [JsonPropertyName("viewTypeName")]
+    public string ViewTypeName { get; set; } = "";
+
+    [JsonPropertyName("automationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AutomationId { get; set; }
+
+    [JsonPropertyName("frame")]
+    public LayoutFrameInfo Frame { get; set; } = new();
+
+    [JsonPropertyName("flexGrow")]
+    public float FlexGrow { get; set; }
+
+    [JsonPropertyName("flexShrink")]
+    public float FlexShrink { get; set; }
+
+    [JsonPropertyName("alignSelf")]
+    public string AlignSelf { get; set; } = "";
+
+    [JsonPropertyName("positionType")]
+    public string PositionType { get; set; } = "";
 }
 
 /// <summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/LayoutInspectorAdapter.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/LayoutInspectorAdapter.cs
@@ -1,0 +1,170 @@
+// Soft adapter that bridges Comet's IYogaLayoutInspector (in Comet.dll) to the
+// agent's wire-format LayoutInfo DTO. This file deliberately holds NO compile-time
+// reference to Comet — every type is resolved at runtime via reflection and the
+// result is cached. When Comet isn't loaded, every call returns null gracefully.
+
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Maui.DevFlow.Agent.Core;
+
+internal static class LayoutInspectorAdapter
+{
+    // Cache the lookup so we pay the GetType cost once per process. The interface
+    // type may resolve to null if Comet isn't loaded yet — in that case we periodically
+    // retry (lazy via the ScanAttempt counter) so apps that load Comet after the
+    // agent starts still work.
+    private static Type? _inspectorInterface;
+    private static bool _scanned;
+    private static readonly object _gate = new();
+
+    private static Type? InspectorInterface()
+    {
+        if (_scanned && _inspectorInterface != null)
+            return _inspectorInterface;
+
+        lock (_gate)
+        {
+            if (_inspectorInterface != null)
+                return _inspectorInterface;
+
+            // Try AssemblyQualifiedName first — fast path when Comet was loaded
+            // by name resolution.
+            _inspectorInterface = Type.GetType("Comet.Layout.IYogaLayoutInspector, Comet", throwOnError: false);
+
+            // Fallback: scan loaded assemblies for one that exports the type.
+            if (_inspectorInterface == null)
+            {
+                foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    Type? t;
+                    try
+                    {
+                        t = asm.GetType("Comet.Layout.IYogaLayoutInspector", throwOnError: false);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+                    if (t != null)
+                    {
+                        _inspectorInterface = t;
+                        break;
+                    }
+                }
+            }
+
+            _scanned = true;
+            return _inspectorInterface;
+        }
+    }
+
+    /// <summary>
+    /// If <paramref name="layoutManager"/> implements Comet's IYogaLayoutInspector,
+    /// invoke it and project the snapshot into a wire-format <see cref="LayoutInfo"/>.
+    /// Returns null when Comet isn't loaded, the manager doesn't implement the
+    /// interface, or no measure pass has run yet.
+    /// </summary>
+    public static LayoutInfo? TryGetLayoutSnapshot(object? layoutManager)
+    {
+        if (layoutManager is null)
+            return null;
+
+        var iface = InspectorInterface();
+        if (iface == null || !iface.IsInstanceOfType(layoutManager))
+            return null;
+
+        try
+        {
+            var method = iface.GetMethod("GetLayoutSnapshot", BindingFlags.Public | BindingFlags.Instance);
+            if (method == null)
+                return null;
+
+            var snapshot = method.Invoke(layoutManager, null);
+            if (snapshot == null)
+                return null;
+
+            return Project(snapshot);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static LayoutInfo? Project(object snapshot)
+    {
+        var t = snapshot.GetType();
+        var frame = ReadFrame(t.GetProperty("Frame")?.GetValue(snapshot));
+        var info = new LayoutInfo
+        {
+            Frame = frame,
+            FlexDirection = ReadString(t, snapshot, "FlexDirection"),
+            AlignItems = ReadString(t, snapshot, "AlignItems"),
+            JustifyContent = ReadString(t, snapshot, "JustifyContent"),
+            AlignContent = ReadString(t, snapshot, "AlignContent"),
+            FlexWrap = ReadString(t, snapshot, "FlexWrap"),
+        };
+
+        if (t.GetProperty("Children")?.GetValue(snapshot) is IEnumerable children)
+        {
+            var list = new List<LayoutChildInfo>();
+            foreach (var child in children)
+            {
+                if (child == null) continue;
+                var ct = child.GetType();
+                list.Add(new LayoutChildInfo
+                {
+                    ViewTypeName = ReadString(ct, child, "ViewTypeName"),
+                    AutomationId = ct.GetProperty("AutomationId")?.GetValue(child) as string,
+                    Frame = ReadFrame(ct.GetProperty("Frame")?.GetValue(child)),
+                    FlexGrow = ReadFloat(ct, child, "FlexGrow"),
+                    FlexShrink = ReadFloat(ct, child, "FlexShrink"),
+                    AlignSelf = ReadString(ct, child, "AlignSelf"),
+                    PositionType = ReadString(ct, child, "PositionType"),
+                });
+            }
+            info.Children = list;
+        }
+
+        return info;
+    }
+
+    private static string ReadString(Type t, object instance, string prop)
+        => t.GetProperty(prop)?.GetValue(instance) as string ?? "";
+
+    private static float ReadFloat(Type t, object instance, string prop)
+    {
+        var v = t.GetProperty(prop)?.GetValue(instance);
+        return v switch
+        {
+            float f => f,
+            double d => (float)d,
+            _ => 0f,
+        };
+    }
+
+    // YogaLayoutSnapshot.Frame is a ValueTuple<float,float,float,float>.
+    // Read fields by name (Item1..Item4) since runtime types preserve them.
+    private static LayoutFrameInfo ReadFrame(object? frame)
+    {
+        if (frame is null) return new LayoutFrameInfo();
+        var t = frame.GetType();
+        return new LayoutFrameInfo
+        {
+            X = ToFloat(t.GetField("Item1")?.GetValue(frame)),
+            Y = ToFloat(t.GetField("Item2")?.GetValue(frame)),
+            Width = ToFloat(t.GetField("Item3")?.GetValue(frame)),
+            Height = ToFloat(t.GetField("Item4")?.GetValue(frame)),
+        };
+    }
+
+    private static float ToFloat(object? v) => v switch
+    {
+        float f => f,
+        double d => (float)d,
+        _ => 0f,
+    };
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
@@ -1283,10 +1283,13 @@ public class VisualTreeWalker
         // Comet views implement IView but NOT VisualElement — extract info from IView + handler
         else if (element is IView iView)
         {
-            // Check platform-native visibility first (handler's UIView.Hidden/Alpha on iOS, etc.)
-            // Falls back to IView.Visibility if platform check is unavailable
+            // Treat collapsed views as not visible regardless of the platform signal so behavior
+            // matches the VisualElement path (which uses ve.IsVisible == false for both Hidden
+            // and Collapsed). When platform check is unavailable, fall back to IView.Visibility:
+            // Visibility.Hidden means rendered transparently but still not visible to the user.
+            var isCollapsed = iView.Visibility == Visibility.Collapsed;
             var platformVisible = ResolveIViewPlatformVisibility(iView);
-            info.IsVisible = platformVisible ?? (iView.Visibility != Visibility.Collapsed);
+            info.IsVisible = !isCollapsed && (platformVisible ?? (iView.Visibility == Visibility.Visible));
             info.IsEnabled = iView.IsEnabled;
             info.Opacity = double.IsFinite(iView.Opacity) ? iView.Opacity : 1;
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
@@ -284,6 +284,26 @@ public class VisualTreeWalker
     public BoundsInfo? ResolveWindowBoundsPublic(VisualElement ve) => ResolveWindowBounds(ve);
 
     /// <summary>
+    /// Override in platform-specific subclasses to resolve window-absolute bounds
+    /// for an IView (e.g. Comet views) that are NOT VisualElement.
+    /// Uses the IView's Handler?.PlatformView to get native coordinates.
+    /// </summary>
+    protected virtual BoundsInfo? ResolveIViewWindowBounds(IView iView) => null;
+
+    /// <summary>
+    /// Override in platform-specific subclasses to determine actual visibility
+    /// for an IView by checking its platform native view (e.g. UIView.Hidden, Alpha).
+    /// Returns null if platform visibility cannot be determined.
+    /// </summary>
+    protected virtual bool? ResolveIViewPlatformVisibility(IView iView) => null;
+
+    /// <summary>
+    /// Override in platform-specific subclasses to populate native view info
+    /// for an IView (e.g. Comet views) that are NOT VisualElement.
+    /// </summary>
+    protected virtual void PopulateIViewNativeInfo(ElementInfo info, IView iView) { }
+
+    /// <summary>
     /// Walks the visual tree starting from the application's windows.
     /// When windowIndex is null, walks all windows. Otherwise walks only the specified window.
     /// </summary>
@@ -1258,7 +1278,10 @@ public class VisualTreeWalker
         // Comet views implement IView but NOT VisualElement — extract info from IView + handler
         else if (element is IView iView)
         {
-            info.IsVisible = iView.Visibility != Visibility.Collapsed;
+            // Check platform-native visibility first (handler's UIView.Hidden/Alpha on iOS, etc.)
+            // Falls back to IView.Visibility if platform check is unavailable
+            var platformVisible = ResolveIViewPlatformVisibility(iView);
+            info.IsVisible = platformVisible ?? (iView.Visibility != Visibility.Collapsed);
             info.IsEnabled = iView.IsEnabled;
             info.Opacity = double.IsFinite(iView.Opacity) ? iView.Opacity : 1;
 
@@ -1275,9 +1298,47 @@ public class VisualTreeWalker
                 };
             }
 
-            // Try to extract text from Comet views via IText interface
-            if (element is IText iText && !string.IsNullOrEmpty(iText.Text))
+            // Resolve window-absolute bounds via platform handler (same as VisualElement path)
+            info.WindowBounds = ResolveIViewWindowBounds(iView);
+
+            // If IView.Frame had no bounds but platform handler resolved real bounds,
+            // back-fill Bounds from WindowBounds so the element isn't reported as zero-size
+            if (info.Bounds == null && info.WindowBounds != null)
+            {
+                info.Bounds = new BoundsInfo
+                {
+                    X = info.WindowBounds.X,
+                    Y = info.WindowBounds.Y,
+                    Width = info.WindowBounds.Width,
+                    Height = info.WindowBounds.Height
+                };
+            }
+
+            // Populate native view info from handler (type, accessibility, etc.)
+            PopulateIViewNativeInfo(info, iView);
+
+            // Extract text from MAUI interfaces that Comet generated controls implement
+            if (element is ILabel iLabel && !string.IsNullOrEmpty(iLabel.Text))
+                info.Text = iLabel.Text;
+            else if (element is ITextButton iTextButton && !string.IsNullOrEmpty(iTextButton.Text))
+                info.Text = iTextButton.Text;
+            else if (element is IEntry iEntry && !string.IsNullOrEmpty(iEntry.Text))
+                info.Text = iEntry.Text;
+            else if (element is IEditor iEditor && !string.IsNullOrEmpty(iEditor.Text))
+                info.Text = iEditor.Text;
+            else if (element is ISearchBar iSearchBar && !string.IsNullOrEmpty(iSearchBar.Text))
+                info.Text = iSearchBar.Text;
+            else if (element is IText iText && !string.IsNullOrEmpty(iText.Text))
                 info.Text = iText.Text;
+
+            // Fallback: try extracting text via Comet reflection for views that
+            // don't implement standard MAUI text interfaces directly
+            if (string.IsNullOrEmpty(info.Text) && cometResolved != null)
+            {
+                var cometText = CometViewResolver.TryExtractText(cometResolved.Value.CometView);
+                if (!string.IsNullOrEmpty(cometText))
+                    info.Text = cometText;
+            }
         }
 
         // Extract text from common controls (including Shell elements)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
@@ -19,6 +19,10 @@ public class VisualTreeWalker
     private readonly Dictionary<Guid, string> _elementIdToExternalId = new();
     private readonly ConcurrentDictionary<string, (BoundsInfo Bounds, object Marker)> _syntheticBounds = new();
 
+    // Set per WalkTree call; controls whether CreateElementInfo populates a Yoga
+    // layout snapshot for Comet-driven layouts. Default false keeps payload size down.
+    private bool _includeLayout;
+
     /// <summary>
     /// Marker object representing the navigation back button in Shell or NavigationPage.
     /// </summary>
@@ -307,11 +311,12 @@ public class VisualTreeWalker
     /// Walks the visual tree starting from the application's windows.
     /// When windowIndex is null, walks all windows. Otherwise walks only the specified window.
     /// </summary>
-    public List<ElementInfo> WalkTree(Application app, int maxDepth = 0, int? windowIndex = null)
+    public List<ElementInfo> WalkTree(Application app, int maxDepth = 0, int? windowIndex = null, bool includeLayout = false)
     {
         _usedIds.Clear();
         _elementIdToExternalId.Clear();
         _syntheticBounds.Clear();
+        _includeLayout = includeLayout;
         var results = new List<ElementInfo>();
         if (app is not IVisualTreeElement appElement)
             return results;
@@ -1440,7 +1445,54 @@ public class VisualTreeWalker
             // }
         }
 
+        // Yoga layout snapshot (--layout / ?layout=1). Comet's AbstractLayout (and
+        // Microsoft.Maui.Controls.Layout) both expose a LayoutManager property; for
+        // Comet-driven layouts that manager implements IYogaLayoutInspector. Use
+        // reflection so this works against either inheritance path without a hard
+        // reference to Comet.
+        if (_includeLayout)
+        {
+            try
+            {
+                var layoutManager = TryGetLayoutManagerViaReflection(element);
+                var layoutInfo = LayoutInspectorAdapter.TryGetLayoutSnapshot(layoutManager);
+                if (layoutInfo != null)
+                    info.Layout = layoutInfo;
+            }
+            catch
+            {
+                // Layout inspection is best-effort; don't fail the tree walk.
+            }
+        }
+
         return info;
+    }
+
+    // Cache the LayoutManager property per element type (key is the runtime Type) —
+    // most apps have only a handful of distinct layout types so this stays bounded.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> s_layoutManagerProps = new();
+
+    private static object? TryGetLayoutManagerViaReflection(object element)
+    {
+        var t = element.GetType();
+        var prop = s_layoutManagerProps.GetOrAdd(t, static type =>
+        {
+            // Walk up the type chain so we pick up protected/internal LayoutManager
+            // exposed on a base type (e.g. Microsoft.Maui.Controls.Layout).
+            for (var cur = type; cur != null; cur = cur.BaseType)
+            {
+                var p = cur.GetProperty(
+                    "LayoutManager",
+                    System.Reflection.BindingFlags.Public
+                        | System.Reflection.BindingFlags.NonPublic
+                        | System.Reflection.BindingFlags.Instance
+                        | System.Reflection.BindingFlags.DeclaredOnly);
+                if (p != null && p.CanRead)
+                    return p;
+            }
+            return null;
+        });
+        return prop?.GetValue(element);
     }
 
     protected virtual void PopulateNativeInfo(ElementInfo info, VisualElement ve)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/VisualTreeWalker.cs
@@ -271,6 +271,20 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
                     };
                 }
             }
+#elif MACOS
+            if (platformView is AppKit.NSView nsView && nsView.Window?.ContentView != null)
+            {
+                var windowRect = nsView.ConvertRectToView(nsView.Bounds, nsView.Window.ContentView);
+                // NSView uses bottom-left origin; convert to top-left
+                var contentHeight = nsView.Window.ContentView.Bounds.Height;
+                return new BoundsInfo
+                {
+                    X = windowRect.X,
+                    Y = contentHeight - windowRect.Y - windowRect.Height,
+                    Width = windowRect.Width,
+                    Height = windowRect.Height
+                };
+            }
 #endif
             return null;
         }
@@ -289,7 +303,6 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
             {
                 if (uiView.Hidden) return false;
                 if (uiView.Alpha <= 0) return false;
-                if (uiView.Bounds.Width <= 0 && uiView.Bounds.Height <= 0) return false;
                 return true;
             }
 #elif ANDROID
@@ -297,7 +310,6 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
             {
                 if (androidView.Visibility != global::Android.Views.ViewStates.Visible) return false;
                 if (androidView.Alpha <= 0) return false;
-                if (androidView.Width <= 0 && androidView.Height <= 0) return false;
                 return true;
             }
 #elif WINDOWS
@@ -305,6 +317,13 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
             {
                 if (winFe.Visibility != Microsoft.UI.Xaml.Visibility.Visible) return false;
                 if (winFe.Opacity <= 0) return false;
+                return true;
+            }
+#elif MACOS
+            if (platformView is AppKit.NSView nsView)
+            {
+                if (nsView.Hidden) return false;
+                if (nsView.AlphaValue <= 0) return false;
                 return true;
             }
 #endif
@@ -358,13 +377,68 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
                         info.NativeProperties[kvp.Key] = kvp.Value;
                 }
             }
+#elif MACOS
+            if (platformView is AppKit.NSView nsView)
+            {
+                var props = new Dictionary<string, string?>();
+                if (!string.IsNullOrEmpty(nsView.AccessibilityIdentifier))
+                    props["accessibilityIdentifier"] = nsView.AccessibilityIdentifier;
+                if (!string.IsNullOrEmpty(nsView.AccessibilityLabel))
+                    props["accessibilityLabel"] = nsView.AccessibilityLabel;
+                if (nsView is AppKit.NSControl nsControl)
+                {
+                    props["isNSControl"] = "true";
+                    props["isEnabled"] = nsControl.Enabled.ToString();
+                }
+                if (nsView is AppKit.NSButton nsButton)
+                    props["buttonTitle"] = nsButton.Title;
+                if (nsView is AppKit.NSTextField nsTextField)
+                {
+                    props["stringValue"] = nsTextField.StringValue;
+                    props["isEditable"] = nsTextField.Editable.ToString();
+                }
+                props["isHidden"] = nsView.Hidden.ToString();
+                props["alphaValue"] = nsView.AlphaValue.ToString("F2");
+                if (props.Count > 0)
+                {
+                    info.NativeProperties ??= new Dictionary<string, string?>();
+                    foreach (var kvp in props)
+                        info.NativeProperties[kvp.Key] = kvp.Value;
+                }
+            }
 #elif WINDOWS
             if (platformView is Microsoft.UI.Xaml.FrameworkElement frameworkElement)
             {
                 var props = new Dictionary<string, string?>();
+                var automationId = Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(frameworkElement);
+                if (!string.IsNullOrEmpty(automationId))
+                    props["automationId"] = automationId;
                 var automationName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(frameworkElement);
                 if (!string.IsNullOrEmpty(automationName))
                     props["automationName"] = automationName;
+                var helpText = Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(frameworkElement);
+                if (!string.IsNullOrEmpty(helpText))
+                    props["helpText"] = helpText;
+                if (!string.IsNullOrEmpty(frameworkElement.Name))
+                    props["name"] = frameworkElement.Name;
+                if (frameworkElement.Visibility != Microsoft.UI.Xaml.Visibility.Visible)
+                    props["visibility"] = "collapsed";
+                if (!frameworkElement.IsHitTestVisible)
+                    props["isHitTestVisible"] = "false";
+                if (frameworkElement is Microsoft.UI.Xaml.Controls.Control control)
+                {
+                    if (!control.IsEnabled)
+                        props["isEnabled"] = "false";
+                    if (!control.IsTabStop)
+                        props["isTabStop"] = "false";
+                }
+                if (frameworkElement is Microsoft.UI.Xaml.Controls.TextBox textBox)
+                {
+                    if (textBox.IsReadOnly)
+                        props["isReadOnly"] = "true";
+                }
+                if (frameworkElement is Microsoft.UI.Xaml.Controls.PasswordBox)
+                    props["isPassword"] = "true";
                 if (props.Count > 0)
                 {
                     info.NativeProperties ??= new Dictionary<string, string?>();

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/VisualTreeWalker.cs
@@ -222,6 +222,164 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
         catch { return null; }
     }
 
+    protected override BoundsInfo? ResolveIViewWindowBounds(IView iView)
+    {
+        try
+        {
+            var platformView = iView.Handler?.PlatformView;
+            if (platformView == null) return null;
+
+#if IOS || MACCATALYST
+            if (platformView is UIKit.UIView uiView && uiView.Window != null)
+            {
+                var windowRect = uiView.ConvertRectToView(uiView.Bounds, uiView.Window.RootViewController?.View ?? uiView.Window);
+                return new BoundsInfo
+                {
+                    X = windowRect.X,
+                    Y = windowRect.Y,
+                    Width = windowRect.Width,
+                    Height = windowRect.Height
+                };
+            }
+#elif ANDROID
+            if (platformView is global::Android.Views.View androidView)
+            {
+                var location = new int[2];
+                androidView.GetLocationInWindow(location);
+                var density = androidView.Context?.Resources?.DisplayMetrics?.Density ?? 1f;
+                return new BoundsInfo
+                {
+                    X = location[0] / density,
+                    Y = location[1] / density,
+                    Width = androidView.Width / density,
+                    Height = androidView.Height / density
+                };
+            }
+#elif WINDOWS
+            if (platformView is Microsoft.UI.Xaml.UIElement uiElement)
+            {
+                var transform = uiElement.TransformToVisual(null);
+                var point = transform.TransformPoint(new global::Windows.Foundation.Point(0, 0));
+                if (uiElement is Microsoft.UI.Xaml.FrameworkElement fe)
+                {
+                    return new BoundsInfo
+                    {
+                        X = point.X,
+                        Y = point.Y,
+                        Width = fe.ActualWidth,
+                        Height = fe.ActualHeight
+                    };
+                }
+            }
+#endif
+            return null;
+        }
+        catch { return null; }
+    }
+
+    protected override bool? ResolveIViewPlatformVisibility(IView iView)
+    {
+        try
+        {
+            var platformView = iView.Handler?.PlatformView;
+            if (platformView == null) return null;
+
+#if IOS || MACCATALYST
+            if (platformView is UIKit.UIView uiView)
+            {
+                if (uiView.Hidden) return false;
+                if (uiView.Alpha <= 0) return false;
+                if (uiView.Bounds.Width <= 0 && uiView.Bounds.Height <= 0) return false;
+                return true;
+            }
+#elif ANDROID
+            if (platformView is global::Android.Views.View androidView)
+            {
+                if (androidView.Visibility != global::Android.Views.ViewStates.Visible) return false;
+                if (androidView.Alpha <= 0) return false;
+                if (androidView.Width <= 0 && androidView.Height <= 0) return false;
+                return true;
+            }
+#elif WINDOWS
+            if (platformView is Microsoft.UI.Xaml.FrameworkElement winFe)
+            {
+                if (winFe.Visibility != Microsoft.UI.Xaml.Visibility.Visible) return false;
+                if (winFe.Opacity <= 0) return false;
+                return true;
+            }
+#endif
+            return null;
+        }
+        catch { return null; }
+    }
+
+    protected override void PopulateIViewNativeInfo(ElementInfo info, IView iView)
+    {
+        try
+        {
+            var platformView = iView.Handler?.PlatformView;
+            if (platformView == null) return;
+
+            info.NativeType = platformView.GetType().FullName;
+
+#if IOS || MACCATALYST
+            if (platformView is UIKit.UIView uiView)
+            {
+                var props = new Dictionary<string, string?>();
+                if (!string.IsNullOrEmpty(uiView.AccessibilityIdentifier))
+                    props["accessibilityIdentifier"] = uiView.AccessibilityIdentifier;
+                if (!string.IsNullOrEmpty(uiView.AccessibilityLabel))
+                    props["accessibilityLabel"] = uiView.AccessibilityLabel;
+                if (uiView is UIKit.UIControl)
+                    props["isUIControl"] = "true";
+                if (uiView is UIKit.UITextField textField)
+                    props["isSecureTextEntry"] = textField.SecureTextEntry.ToString();
+                if (props.Count > 0)
+                {
+                    info.NativeProperties ??= new Dictionary<string, string?>();
+                    foreach (var kvp in props)
+                        info.NativeProperties[kvp.Key] = kvp.Value;
+                }
+            }
+#elif ANDROID
+            if (platformView is global::Android.Views.View androidView)
+            {
+                var props = new Dictionary<string, string?>();
+                if (!string.IsNullOrEmpty(androidView.ContentDescription))
+                    props["contentDescription"] = androidView.ContentDescription;
+                if (androidView is global::Android.Widget.EditText editText)
+                    props["inputType"] = editText.InputType.ToString();
+                if (androidView.Clickable)
+                    props["clickable"] = "true";
+                if (props.Count > 0)
+                {
+                    info.NativeProperties ??= new Dictionary<string, string?>();
+                    foreach (var kvp in props)
+                        info.NativeProperties[kvp.Key] = kvp.Value;
+                }
+            }
+#elif WINDOWS
+            if (platformView is Microsoft.UI.Xaml.FrameworkElement frameworkElement)
+            {
+                var props = new Dictionary<string, string?>();
+                var automationName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(frameworkElement);
+                if (!string.IsNullOrEmpty(automationName))
+                    props["automationName"] = automationName;
+                if (props.Count > 0)
+                {
+                    info.NativeProperties ??= new Dictionary<string, string?>();
+                    foreach (var kvp in props)
+                        info.NativeProperties[kvp.Key] = kvp.Value;
+                }
+            }
+#endif
+        }
+        catch
+        {
+            // Native info is best-effort; don't fail the tree walk
+        }
+    }
+
 #if IOS || MACCATALYST
     private BoundsInfo? ResolveBoundsApple(object marker)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -45,11 +45,12 @@ public class AgentClient : IDisposable
     /// <summary>
     /// Get the visual tree from the running app.
     /// </summary>
-    public async Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0, int? window = null)
+    public async Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0, int? window = null, bool includeLayout = false)
     {
         var parts = new List<string>();
         if (maxDepth > 0) parts.Add($"depth={maxDepth}");
         if (window != null) parts.Add($"window={window}");
+        if (includeLayout) parts.Add("layout=1");
         var url = parts.Count > 0 ? $"{UiApi}/tree?{string.Join("&", parts)}" : $"{UiApi}/tree";
         return await GetAsync<List<ElementInfo>>(url) ?? new();
     }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AppDriverBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AppDriverBase.cs
@@ -28,8 +28,8 @@ public abstract class AppDriverBase : IAppDriver
     public Task<AgentStatus?> GetStatusAsync()
         => EnsureClient().GetStatusAsync();
 
-    public Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0)
-        => EnsureClient().GetTreeAsync(maxDepth);
+    public Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0, bool includeLayout = false)
+        => EnsureClient().GetTreeAsync(maxDepth, null, includeLayout);
 
     public Task<List<ElementInfo>> QueryAsync(string? type = null, string? automationId = null, string? text = null)
         => EnsureClient().QueryAsync(type, automationId, text);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ElementInfo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ElementInfo.cs
@@ -133,6 +133,10 @@ public class ElementInfo
     [JsonPropertyName("children")]
     public List<ElementInfo>? Children { get; set; }
 
+    [JsonPropertyName("layout")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LayoutInfo? Layout { get; set; }
+
     [JsonIgnore]
     public bool IsSelected { get; set; }
 
@@ -226,4 +230,73 @@ public class ElementNativeViewInfo
     [JsonPropertyName("properties")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string?>? Properties { get; set; }
+}
+
+/// <summary>
+/// Yoga layout snapshot returned by the agent when <c>?layout=1</c> is requested
+/// on the tree endpoint. Populated only for Comet-driven layouts.
+/// </summary>
+public class LayoutInfo
+{
+    [JsonPropertyName("frame")]
+    public LayoutFrameInfo Frame { get; set; } = new();
+
+    [JsonPropertyName("flexDirection")]
+    public string FlexDirection { get; set; } = "";
+
+    [JsonPropertyName("alignItems")]
+    public string AlignItems { get; set; } = "";
+
+    [JsonPropertyName("justifyContent")]
+    public string JustifyContent { get; set; } = "";
+
+    [JsonPropertyName("alignContent")]
+    public string AlignContent { get; set; } = "";
+
+    [JsonPropertyName("flexWrap")]
+    public string FlexWrap { get; set; } = "";
+
+    [JsonPropertyName("children")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<LayoutChildInfo>? Children { get; set; }
+}
+
+public class LayoutFrameInfo
+{
+    [JsonPropertyName("x")]
+    public float X { get; set; }
+
+    [JsonPropertyName("y")]
+    public float Y { get; set; }
+
+    [JsonPropertyName("width")]
+    public float Width { get; set; }
+
+    [JsonPropertyName("height")]
+    public float Height { get; set; }
+}
+
+public class LayoutChildInfo
+{
+    [JsonPropertyName("viewTypeName")]
+    public string ViewTypeName { get; set; } = "";
+
+    [JsonPropertyName("automationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AutomationId { get; set; }
+
+    [JsonPropertyName("frame")]
+    public LayoutFrameInfo Frame { get; set; } = new();
+
+    [JsonPropertyName("flexGrow")]
+    public float FlexGrow { get; set; }
+
+    [JsonPropertyName("flexShrink")]
+    public float FlexShrink { get; set; }
+
+    [JsonPropertyName("alignSelf")]
+    public string AlignSelf { get; set; } = "";
+
+    [JsonPropertyName("positionType")]
+    public string PositionType { get; set; } = "";
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/IAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/IAppDriver.cs
@@ -24,7 +24,7 @@ public interface IAppDriver : IDisposable
     /// <summary>
     /// Get the visual tree.
     /// </summary>
-    Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0);
+    Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0, bool includeLayout = false);
 
     /// <summary>
     /// Query elements matching criteria.


### PR DESCRIPTION
Extracts DevFlow-only changes from PR #68 / `feature/comet` so they can ship independently of the Comet app framework.

## Commits

1. **`6f7efa29` — fix: DevFlow IView visibility/bounds resolution**
   - `CometViewResolver` (new) bridges `IView` → handler-native view via reflection (no compile-time Comet ref)
   - `VisualTreeWalker` uses it for visibility/bounds when `Element` lookup yields nothing

2. **`93101e0a` — feat(devflow): Yoga layout inspection across agent, driver, and CLI**
   - New `?layout=1` query param on `/api/v1/tree` (and `--layout` CLI flag, `layout` MCP param)
   - `LayoutInspectorAdapter` reflects against `Comet.Layout.IYogaLayoutInspector` so the agent picks up Yoga snapshots when Comet is loaded — zero hard dependency on Comet
   - Adds `LayoutInfo` DTOs to both Agent.Core and Driver
   - Cached per-Type `LayoutManager` PropertyInfo lookup (walks the type chain) for low overhead

## Scope notes

- DevFlow is an independent product in this monorepo; it must not block on Comet shipping
- Two further DevFlow commits remain on `feature/comet` (`_app`→`BoundApplication` migration + Comet view-resolution / IView scroll support). They have non-trivial conflicts with BLE work that landed on `main` post-branch, so they're deferred to a later DevFlow PR with build verification — they don't block this one
- Closes the DevFlow concerns of #68

## Verification

- Local: cherry-picks of `cae8b05e` and `0d033ed6`; conflicts resolved manually keeping main's BLE/status/dispatcher work intact
- Build: relies on CI (Arcade SDK + sandbox network restrictions prevent local build here)