### PR TITLE
fix: DevFlow broker daemon spawn args

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
@@ -243,12 +243,12 @@ public static class BrokerClient
                     return null;
                 }
                 fileName = exePath;
-                arguments = $"\"{dllPath}\" broker start --foreground";
+                arguments = $"\"{dllPath}\" devflow broker start --foreground";
             }
             else
             {
                 fileName = exePath;
-                arguments = "broker start --foreground";
+                arguments = "devflow broker start --foreground";
             }
 
             var startInfo = new ProcessStartInfo

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
@@ -232,7 +232,9 @@ public static class BrokerClient
             string arguments;
 
             // If running via `dotnet run` or `dotnet <dll>`, exePath is the dotnet host.
-            // In that case, use `dotnet <entryDll> broker start --foreground` instead.
+            // In that case, use `dotnet <entryDll> devflow broker start --foreground` instead.
+            // Note: the `devflow` token is required because broker is a subcommand of devflow,
+            // not a top-level CLI command.
             if (exePath.EndsWith("dotnet", StringComparison.OrdinalIgnoreCase)
                 || exePath.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
## Repro

```
$ maui devflow wait
[DevFlow Broker] Daemon process exited prematurely with code 1
[DevFlow Broker] stderr: Unrecognized command or argument 'broker'.
[DevFlow Broker] stderr: Unrecognized command or argument 'start'.
[DevFlow Broker] stderr: Unrecognized command or argument '--foreground'.
Error: Broker unavailable
```

## Root cause

`BrokerClient.EnsureBrokerRunningAsync` spawned the daemon with the wrong argv. The command path is `maui devflow broker start --foreground`, but the spawn args were `maui broker start --foreground` (and `dotnet <dll> broker start --foreground` on the framework-dependent path). The daemon exited immediately, and every `maui devflow ...` that auto-spawned the broker failed.

## Fix

Insert `devflow ` before `broker` in both spawn argument paths in `src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs` (lines 246, 251).

## Validation

After applying the fix and reinstalling `maui` globally, `maui devflow wait` correctly auto-starts the broker on port 19223 and waits for an agent. Verified with a running BaristaNotes agent.