### PR TITLE
chore: ignore personal agent state under .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -422,3 +422,7 @@ FodyWeavers.xsd
 *.msp
 .DS_Store
 .dotnet
+
+# Personal / per-machine agent state
+.claude/settings.local.json
+.claude/skills/**/.skill-version


### PR DESCRIPTION
Adds two defensive gitignore rules:

- `.claude/settings.local.json` — per-machine PIDs/paths/UDIDs/allowlists; should never be committed. Currently committed on `feature/comet` (introduced in f92dbeb6); these rules ensure a future merge into `main` won't carry it through.
- `.claude/skills/**/.skill-version` — auto-written by `maui devflow update-skill` to track which bundled skill version is installed locally; should be local-only.

`main` does not currently have anything under `.claude/`, so no `git rm --cached` is needed here. (When `feature/comet` merges, the existing `settings.local.json` blob can be removed in that merge — these gitignore rules will prevent it from being re-added.)