### PR TITLE
DevFlow: IApplication binding for Comet/custom hosts + Comet view resolution + IView scroll

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -300,7 +300,8 @@ public class DevFlowCommands
         var treeDepthOption = new Option<int>("--depth") { Description = "Max tree depth (0=unlimited)", DefaultValueFactory = _ => 0 };
         var treeFieldsOption = new Option<string?>("--fields") { Description = "Comma-separated fields to include (e.g. id,type,text,automationId,bounds)" };
         var treeFormatOption = new Option<string?>("--format") { Description = "Output format: compact (id,type,text,automationId,bounds only)" };
-        var mauiTreeCmd = new Command("tree", "Dump visual tree") { treeDepthOption, treeFieldsOption, treeFormatOption, windowOption };
+        var treeLayoutOption = new Option<bool>("--layout") { Description = "Include Yoga layout info for Comet-driven layout nodes (frame, flex direction, per-child flex props)" };
+        var mauiTreeCmd = new Command("tree", "Dump visual tree") { treeDepthOption, treeFieldsOption, treeFormatOption, treeLayoutOption, windowOption };
         mauiTreeCmd.SetAction(async (ctx, ct) =>
         {
             var host = ctx.GetValue(agentHostOption)!;
@@ -311,7 +312,8 @@ public class DevFlowCommands
             var window = ctx.GetValue(windowOption);
             var fields = ctx.GetValue(treeFieldsOption);
             var format = ctx.GetValue(treeFormatOption);
-            await MauiTreeAsync(host, port, output.ResolveJsonMode(json, noJson), depth, window, fields, format);
+            var layout = ctx.GetValue(treeLayoutOption);
+            await MauiTreeAsync(host, port, output.ResolveJsonMode(json, noJson), depth, window, fields, format, layout);
         });
         mauiCommand.Add(mauiTreeCmd);
 
@@ -2387,12 +2389,12 @@ public class DevFlowCommands
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
-    private static async Task MauiTreeAsync(string host, int port, bool json, int depth, int? window, string? fields, string? format)
+    private static async Task MauiTreeAsync(string host, int port, bool json, int depth, int? window, string? fields, string? format, bool includeLayout = false)
     {
         try
         {
             using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
-            var tree = await client.GetTreeAsync(depth, window);
+            var tree = await client.GetTreeAsync(depth, window, includeLayout);
             if (json)
             {
                 var projected = ProjectElements(tree, fields, format);
@@ -3360,6 +3362,28 @@ public class DevFlowCommands
             if (!el.IsEnabled) info += " [disabled]";
             if (el.Bounds != null) info += $" ({el.Bounds.X:F0},{el.Bounds.Y:F0} {el.Bounds.Width:F0}x{el.Bounds.Height:F0})";
             Console.WriteLine(info);
+            if (el.Layout != null)
+            {
+                var f = el.Layout.Frame;
+                Console.WriteLine(
+                    $"{prefix}  layout: [{f.X:F0},{f.Y:F0} {f.Width:F0}x{f.Height:F0}]" +
+                    $" dir={el.Layout.FlexDirection}" +
+                    $" align={el.Layout.AlignItems}" +
+                    $" justify={el.Layout.JustifyContent}");
+                if (el.Layout.Children is { Count: > 0 } childList)
+                {
+                    foreach (var c in childList)
+                    {
+                        var cf = c.Frame;
+                        var idPart = c.AutomationId != null ? $" automationId=\"{c.AutomationId}\"" : "";
+                        Console.WriteLine(
+                            $"{prefix}    - {c.ViewTypeName}{idPart}" +
+                            $" frame=[{cf.X:F0},{cf.Y:F0} {cf.Width:F0}x{cf.Height:F0}]" +
+                            $" grow={c.FlexGrow:0.##} shrink={c.FlexShrink:0.##}" +
+                            $" alignSelf={c.AlignSelf} pos={c.PositionType}");
+                    }
+                }
+            }
             if (el.Children != null)
                 PrintTree(el.Children, indent + 1);
         }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/TreeTool.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/TreeTool.cs
@@ -15,10 +15,11 @@ public sealed class TreeTool
 		[Description("Window index for multi-window apps (default: 0)")] int? window = null,
 		[Description("Max tree depth to return (default: 50)")] int depth = 50,
 		[Description("Filter to a specific element type, e.g. 'Label', 'Button', 'Entry'")] string? filter = null,
-		[Description("Return only the subtree rooted at this element ID")] string? elementId = null)
+		[Description("Return only the subtree rooted at this element ID")] string? elementId = null,
+		[Description("Include Yoga layout info for Comet-driven layout nodes (frame + flex props).")] bool layout = false)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var tree = await agent.GetTreeAsync(depth, window);
+		var tree = await agent.GetTreeAsync(depth, window, layout);
 		if (tree == null || tree.Count == 0)
 			return "No visual tree available. Is the agent connected and the app running?";
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/CometViewResolver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/CometViewResolver.cs
@@ -299,6 +299,117 @@ internal static class CometViewResolver
 	}
 
 	/// <summary>
+	/// Attempts to extract display text from a Comet view via reflection.
+	/// Checks for common text-bearing properties: Value (generated Text control),
+	/// Text (Button, TextField), and environment-based text storage.
+	/// </summary>
+	public static string? TryExtractText(object cometView)
+	{
+		if (cometView == null) return null;
+
+		try
+		{
+			var viewType = cometView.GetType();
+
+			// Comet's generated Text control stores text in a "Value" property (from ILabel.Text:Value mapping)
+			var valueProp = viewType.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+			if (valueProp != null && valueProp.PropertyType == typeof(string))
+			{
+				var val = valueProp.GetValue(cometView) as string;
+				if (!string.IsNullOrEmpty(val))
+					return val;
+			}
+
+			// Also check Binding<string> Value (generated controls use Binding<T> wrapper)
+			if (valueProp != null && valueProp.PropertyType.IsGenericType)
+			{
+				try
+				{
+					var bindingObj = valueProp.GetValue(cometView);
+					if (bindingObj != null)
+					{
+						// Binding<T> has a CurrentValue or Value property
+						var currentValueProp = bindingObj.GetType().GetProperty("CurrentValue", BindingFlags.Public | BindingFlags.Instance)
+							?? bindingObj.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+						if (currentValueProp != null)
+						{
+							var val = currentValueProp.GetValue(bindingObj)?.ToString();
+							if (!string.IsNullOrEmpty(val))
+								return val;
+						}
+					}
+				}
+				catch { /* Ignore binding resolution errors */ }
+			}
+
+			// Check "Text" property directly (some Comet controls use it)
+			var textProp = viewType.GetProperty("Text", BindingFlags.Public | BindingFlags.Instance);
+			if (textProp != null)
+			{
+				if (textProp.PropertyType == typeof(string))
+				{
+					var val = textProp.GetValue(cometView) as string;
+					if (!string.IsNullOrEmpty(val))
+						return val;
+				}
+				else if (textProp.PropertyType.IsGenericType)
+				{
+					try
+					{
+						var bindingObj = textProp.GetValue(cometView);
+						if (bindingObj != null)
+						{
+							var currentValueProp = bindingObj.GetType().GetProperty("CurrentValue", BindingFlags.Public | BindingFlags.Instance)
+								?? bindingObj.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+							if (currentValueProp != null)
+							{
+								var val = currentValueProp.GetValue(bindingObj)?.ToString();
+								if (!string.IsNullOrEmpty(val))
+									return val;
+							}
+						}
+					}
+					catch { /* Ignore binding resolution errors */ }
+				}
+			}
+
+			// Try GetEnvironment<string>("Text.Value") — Comet stores text in environment
+			if (_cometViewType != null && _cometViewType.IsInstanceOfType(cometView))
+			{
+				var getEnvMethods = _cometViewType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+					.Where(m => m.Name == "GetEnvironment" && m.IsGenericMethod && m.GetParameters().Length >= 1)
+					.ToList();
+
+				foreach (var getEnvMethod in getEnvMethods)
+				{
+					try
+					{
+						var genericMethod = getEnvMethod.MakeGenericMethod(typeof(string));
+						var paramCount = genericMethod.GetParameters().Length;
+						object? result = null;
+
+						if (paramCount == 1)
+							result = genericMethod.Invoke(cometView, new object[] { "Text.Value" });
+						else if (paramCount == 2)
+							result = genericMethod.Invoke(cometView, new object[] { "Text.Value", false });
+
+						if (result is string envText && !string.IsNullOrEmpty(envText))
+							return envText;
+						break;
+					}
+					catch { continue; }
+				}
+			}
+		}
+		catch
+		{
+			// Reflection failures should not break the tree walk
+		}
+
+		return null;
+	}
+
+	/// <summary>
 	/// Gets the list of environment keys defined in Comet.EnvironmentKeys.
 	/// Returns empty list if Comet not available or reflection fails.
 	/// </summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/CometViewResolver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/CometViewResolver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Maui;
 
@@ -98,7 +99,16 @@ internal static class CometViewResolver
 		}
 		catch (AmbiguousMatchException)
 		{
-			// Walk inheritance chain with DeclaredOnly to resolve ambiguity
+			// Generic handlers like ViewHandler<T1,T2> use 'new' to hide base PlatformView.
+			// GetProperty throws AmbiguousMatchException. Use GetProperties to find all,
+			// then prefer the most-derived (non-object return type) version.
+			var candidates = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+				.Where(p => p.Name == name)
+				.OrderByDescending(p => p.PropertyType != typeof(object) ? 1 : 0)
+				.ToArray();
+			if (candidates.Length > 0) return candidates[0];
+
+			// Fallback: walk inheritance chain with DeclaredOnly
 			var current = type;
 			while (current != null)
 			{

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -699,8 +699,12 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         if (request.QueryParams.TryGetValue("depth", out var depthStr))
             int.TryParse(depthStr, out maxDepth);
 
+        bool includeLayout = false;
+        if (request.QueryParams.TryGetValue("layout", out var layoutStr))
+            includeLayout = layoutStr == "1" || string.Equals(layoutStr, "true", StringComparison.OrdinalIgnoreCase);
+
         var windowIndex = ParseWindowIndex(request);
-        var tree = await DispatchAsync(() => _treeWalker.WalkTree(_app, maxDepth, windowIndex));
+        var tree = await DispatchAsync(() => _treeWalker.WalkTree(_app, maxDepth, windowIndex, includeLayout));
         return HttpResponse.Json(tree);
     }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -1587,8 +1587,10 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                         return "ok";
 
                     return $"No tap handler on {el.GetType().FullName} (gestures:{v.GestureRecognizers.Count}, type:{v.GetType().Name})";
-                // Comet views implement IGestureView with Gesture objects that have Invoke().
-                // Check via reflection to avoid a hard Comet dependency.
+                // Comet TabView tab switching — must come before generic IView handlers
+                case IView cometTabChild when TrySwitchCometTabImpl(cometTabChild):
+                    return "ok";
+                // Comet views implement IGestureView with Gesture objects
                 case IView gestureView when TryInvokeCometGestureTap(gestureView):
                     return "ok";
                 // Comet views implement MAUI interfaces (IButton, ISwitch, etc.)
@@ -1606,6 +1608,15 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     iRb.IsChecked = true;
                     return "ok";
                 case IView iView when iView.Handler?.PlatformView != null:
+                    // Comet tab switch for views that weren't caught by the guard above
+                    if ((el.GetType().FullName ?? "").StartsWith("Comet."))
+                    {
+                        var diag = TrySwitchCometTabDiag(iView);
+                        if (diag.Item1) return "ok";
+                        if (TryInvokeCometGestureTap(iView)) return "ok";
+                        if (TryBubbleCometGestureTap(iView)) return "ok";
+                        return $"Comet IView: {el.GetType().FullName} [tab:{diag.Item2}]";
+                    }
                     // Last resort: try native tap via handler's platform view
                     if (TryNativeTapOnHandler(iView))
                         return "ok";
@@ -1619,7 +1630,25 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                         return "ok";
                     return $"Unhandled IView (no handler): {el.GetType().FullName}";
                 default:
-                    return $"Unhandled type: {el.GetType().FullName}";
+                    // Comet views may not match 'case IView' due to framework version
+                    // mismatch (DevFlow targets net10.0/MAUI 10, host app may use MAUI 11).
+                    // Handle Comet-specific interactions by type name via reflection.
+                    var elTypeName = el.GetType().FullName ?? "";
+                    if (elTypeName.StartsWith("Comet."))
+                    {
+                        // Tab switching: walk parent chain to find Comet.TabView
+                        var tabResult = TrySwitchCometTabDiag(el);
+                        if (tabResult.Item1)
+                            return "ok";
+                        // Gesture tap: check IGestureView for tap gestures
+                        if (TryInvokeCometGestureTapByReflection(el))
+                            return "ok";
+                        // Bubble up parent chain for gesture on parent container
+                        if (TryBubbleCometGestureTapByReflection(el))
+                            return "ok";
+                        return $"Comet unhandled: {elTypeName} [tab:{tabResult.Item2}]";
+                    }
+                    return $"DEVFLOW_V2_UNHANDLED: {el.GetType().FullName}";
             }
         });
 
@@ -1761,6 +1790,181 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"[Microsoft.Maui.DevFlow] TryNativeTapOnHandler failed: {ex.GetBaseException().Message}");
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if the view is a child of a Comet TabView and switches to it.
+    /// Walks up the parent chain via reflection to find a TabView parent,
+    /// then sets SelectedIndex to the child's position.
+    /// </summary>
+    /// <summary>
+    /// Accepts 'object' because Comet views may not match the DevFlow assembly's IView
+    /// when framework versions differ (e.g. DevFlow compiled against MAUI 10, app uses MAUI 11).
+    /// All access is via reflection.
+    /// </summary>
+    private static bool TrySwitchCometTabImpl(IView view) => TrySwitchCometTabDiag(view).Item1;
+
+    private static (bool, string) TrySwitchCometTabDiag(object view)
+    {
+        try
+        {
+            // Walk up the parent chain to find a Comet TabView
+            object current = view;
+            object tabView = null;
+            var walkLog = new System.Text.StringBuilder();
+
+            for (int i = 0; i < 10; i++)
+            {
+                var parentProp = current.GetType().GetProperty("Parent",
+                    BindingFlags.Public | BindingFlags.Instance);
+                if (parentProp == null) { walkLog.Append($"noProp@{i};"); break; }
+
+                var parent = parentProp.GetValue(current);
+                if (parent == null) { walkLog.Append($"null@{i};"); break; }
+
+                walkLog.Append($"{i}:{parent.GetType().Name};");
+                if (parent.GetType().FullName == "Comet.TabView")
+                {
+                    tabView = parent;
+                    break;
+                }
+
+                current = parent;
+            }
+
+            if (tabView == null) return (false, $"noTabView({walkLog})");
+
+            // Find the child's index using the public Count property and indexer
+            var tabType = tabView.GetType();
+            var countProp = tabType.GetProperty("Count", BindingFlags.Public | BindingFlags.Instance);
+            var indexerProp = tabType.GetProperty("Item", BindingFlags.Public | BindingFlags.Instance);
+            if (countProp == null || indexerProp == null) return (false, "noCountOrItem");
+
+            int count = (int)countProp.GetValue(tabView);
+            int childIndex = -1;
+            for (int idx = 0; idx < count; idx++)
+            {
+                var child = indexerProp.GetValue(tabView, new object[] { idx });
+                if (ReferenceEquals(child, view))
+                {
+                    childIndex = idx;
+                    break;
+                }
+            }
+
+            if (childIndex < 0) return (false, $"noRefMatch(count={count})");
+
+            // Set SelectedIndex on the Comet TabView
+            var selectedIndexProp = tabType.GetProperty("SelectedIndex",
+                BindingFlags.Public | BindingFlags.Instance);
+            if (selectedIndexProp == null) return (false, "noSelectedIndex");
+            selectedIndexProp.SetValue(tabView, childIndex);
+
+            // Update the native platform view via reflection
+            // (can't use 'as IView' cast — same framework version issue)
+            var handlerProp = tabType.GetProperty("Handler",
+                BindingFlags.Public | BindingFlags.Instance);
+            var handler = handlerProp?.GetValue(tabView);
+            if (handler != null)
+            {
+                // Use GetPropertySafe to avoid AmbiguousMatchException from generic
+                // ViewHandler<T1,T2>.PlatformView hiding the base class version
+                var platformViewProp = CometViewResolver.GetPropertySafe(handler.GetType(), "PlatformView");
+                var platformView = platformViewProp?.GetValue(handler);
+                if (platformView != null)
+                {
+                    // iOS: CUITabView.ApplySelectedIndex(int)
+                    var applyMethod = platformView.GetType().GetMethod("ApplySelectedIndex",
+                        BindingFlags.Public | BindingFlags.Instance);
+                    if (applyMethod != null)
+                    {
+                        applyMethod.Invoke(platformView, new object[] { childIndex });
+                    }
+                    else
+                    {
+                        var selIdxProp = CometViewResolver.GetPropertySafe(platformView.GetType(), "SelectedIndex");
+                        if (selIdxProp != null && selIdxProp.CanWrite)
+                            selIdxProp.SetValue(platformView, (nint)childIndex);
+                    }
+                }
+            }
+
+            return (true, "ok");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"ex:{ex.GetBaseException().Message}");
+        }
+    }
+
+    /// <summary>
+    /// Invokes a Comet tap gesture via reflection.
+    /// Works when Comet views implement IGestureView with Gesture objects.
+    /// All access via reflection — no IView cast needed.
+    /// </summary>
+    private static bool TryInvokeCometGestureTapByReflection(object view)
+    {
+        try
+        {
+            var viewType = view.GetType();
+            // Comet views implementing IGestureView have a Gestures property
+            var gesturesProp = viewType.GetProperty("Gestures",
+                BindingFlags.Public | BindingFlags.Instance);
+            if (gesturesProp == null) return false;
+
+            var gestures = gesturesProp.GetValue(view) as System.Collections.IEnumerable;
+            if (gestures == null) return false;
+
+            foreach (var gesture in gestures)
+            {
+                if (gesture == null) continue;
+                var gestureType = gesture.GetType();
+                // Look for TapGesture or a type with "Tap" in the name
+                if (gestureType.Name.Contains("Tap") || gestureType.FullName?.Contains("TapGesture") == true)
+                {
+                    var invokeMethod = gestureType.GetMethod("Invoke",
+                        BindingFlags.Public | BindingFlags.Instance);
+                    if (invokeMethod != null)
+                    {
+                        invokeMethod.Invoke(gesture, null);
+                        return true;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[MauiDevFlow] TryInvokeCometGestureTapByReflection failed: {ex.GetBaseException().Message}");
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Walks up the Comet parent chain looking for a gesture tap (all via reflection).
+    /// </summary>
+    private static bool TryBubbleCometGestureTapByReflection(object view)
+    {
+        try
+        {
+            object current = view;
+            for (int i = 0; i < 10; i++)
+            {
+                var parentProp = current.GetType().GetProperty("Parent",
+                    BindingFlags.Public | BindingFlags.Instance);
+                var parent = parentProp?.GetValue(current);
+                if (parent == null) break;
+
+                if (TryInvokeCometGestureTapByReflection(parent))
+                    return true;
+
+                current = parent;
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[MauiDevFlow] TryBubbleCometGestureTapByReflection failed: {ex.GetBaseException().Message}");
         }
         return false;
     }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -466,10 +466,17 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     {
         if (_disposed || !_options.Enabled) return;
         if (app is Application controlsApp)
-            _app = controlsApp;
-        else
-            _iApp = app;
+        {
+            BindApp(controlsApp);
+            return;
+        }
+        _iApp = app;
         Console.WriteLine("[Microsoft.Maui.DevFlow.Agent] IApplication bound to running agent");
+        PublishUiEvent("lifecycle", new
+        {
+            state = "started",
+            timestamp = DateTimeOffset.UtcNow.ToString("O")
+        });
     }
 
     /// <summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -1849,7 +1849,9 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             var indexerProp = tabType.GetProperty("Item", BindingFlags.Public | BindingFlags.Instance);
             if (countProp == null || indexerProp == null) return (false, "noCountOrItem");
 
-            int count = (int)countProp.GetValue(tabView);
+            var countObj = countProp.GetValue(tabView);
+            if (countObj == null) return (false, "countNull");
+            int count = (int)countObj;
             int childIndex = -1;
             for (int idx = 0; idx < count; idx++)
             {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -1806,11 +1806,11 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     /// Walks up the parent chain via reflection to find a TabView parent,
     /// then sets SelectedIndex to the child's position.
     /// </summary>
-    /// <summary>
-    /// Accepts 'object' because Comet views may not match the DevFlow assembly's IView
-    /// when framework versions differ (e.g. DevFlow compiled against MAUI 10, app uses MAUI 11).
-    /// All access is via reflection.
-    /// </summary>
+    /// <remarks>
+    /// The diagnostic helper accepts <c>object</c> because Comet views may not match the
+    /// DevFlow assembly's IView when framework versions differ (e.g. DevFlow compiled against
+    /// MAUI 10, app uses MAUI 11). All access is via reflection.
+    /// </remarks>
     private static bool TrySwitchCometTabImpl(IView view) => TrySwitchCometTabDiag(view).Item1;
 
     private static (bool, string) TrySwitchCometTabDiag(object view)
@@ -1819,7 +1819,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         {
             // Walk up the parent chain to find a Comet TabView
             object current = view;
-            object tabView = null;
+            object? tabView = null;
             var walkLog = new System.Text.StringBuilder();
 
             for (int i = 0; i < 10; i++)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -31,8 +31,15 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     private BrokerRegistration? _brokerRegistration;
     private string? _sessionId;
     protected Application? _app;
+    protected IApplication? _iApp;
     protected IDispatcher? _dispatcher;
     private bool _disposed;
+
+    /// <summary>
+    /// Returns the bound application instance, preferring Application (MAUI Controls)
+    /// but falling back to IApplication (Comet/custom hosts).
+    /// </summary>
+    protected IApplication? BoundApplication => (IApplication?)_app ?? _iApp;
 
     /// <summary>
     /// The network request store for capturing HTTP traffic.
@@ -277,10 +284,11 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     /// </summary>
     private Window? GetWindow(int? index)
     {
-        if (_app == null) return null;
-        if (index == null) return _app.Windows.FirstOrDefault() as Window;
-        if (index.Value < 0 || index.Value >= _app.Windows.Count) return null;
-        return _app.Windows[index.Value] as Window;
+        var app = BoundApplication;
+        if (app == null) return null;
+        if (index == null) return app.Windows.FirstOrDefault() as Window;
+        if (index.Value < 0 || index.Value >= app.Windows.Count) return null;
+        return app.Windows[index.Value] as Window;
     }
 
     /// <summary>
@@ -398,7 +406,10 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     /// <summary>
     /// Starts the HTTP server without an Application binding.
     /// Use when Application.Current is unavailable (e.g., Comet apps).
-    /// Endpoints requiring the app will return errors until BindApp() is called.
+    /// After starting, attempts to resolve IApplication from the DI container
+    /// so that tree/element endpoints work immediately for Comet apps.
+    /// Endpoints requiring the app will return errors until BindApp()/BindIApp()
+    /// is called or DI resolution succeeds.
     /// </summary>
     public void StartServerOnly(IDispatcher dispatcher)
     {
@@ -407,7 +418,15 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         try
         {
             _server.Start();
-            Console.WriteLine($"[Microsoft.Maui.DevFlow.Agent] HTTP server started on port {_options.Port} (app not yet bound)");
+
+            // Try to resolve the IApplication from the platform service provider.
+            // Comet apps register IApplication (CometApp) but never set Application.Current.
+            TryResolveIApplicationFromDI();
+
+            if (BoundApplication != null)
+                Console.WriteLine($"[Microsoft.Maui.DevFlow.Agent] HTTP server started on port {_options.Port} (resolved IApplication from DI)");
+            else
+                Console.WriteLine($"[Microsoft.Maui.DevFlow.Agent] HTTP server started on port {_options.Port} (app not yet bound)");
         }
         catch (Exception ex)
         {
@@ -437,6 +456,49 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             state = "started",
             timestamp = DateTimeOffset.UtcNow.ToString("O")
         });
+    }
+
+    /// <summary>
+    /// Late-binds an IApplication instance (e.g. CometApp) after the server is already running.
+    /// Use when the app doesn't extend Microsoft.Maui.Controls.Application.
+    /// </summary>
+    public void BindIApp(IApplication app)
+    {
+        if (_disposed || !_options.Enabled) return;
+        if (app is Application controlsApp)
+            _app = controlsApp;
+        else
+            _iApp = app;
+        Console.WriteLine("[Microsoft.Maui.DevFlow.Agent] IApplication bound to running agent");
+    }
+
+    /// <summary>
+    /// Attempts to resolve IApplication from the platform DI container.
+    /// Works for Comet apps that register IApplication via UseCometApp&lt;T&gt;().
+    /// </summary>
+    private void TryResolveIApplicationFromDI()
+    {
+        try
+        {
+            var services = IPlatformApplication.Current?.Services;
+            if (services == null) return;
+
+            var iApp = services.GetService(typeof(IApplication)) as IApplication;
+            if (iApp == null) return;
+
+            if (iApp is Application controlsApp)
+            {
+                _app = controlsApp;
+            }
+            else
+            {
+                _iApp = iApp;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Microsoft.Maui.DevFlow.Agent] Failed to resolve IApplication from DI: {ex.Message}");
+        }
     }
 
     public async Task StopAsync()
@@ -544,7 +606,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     {
         var windowIndex = ParseWindowIndex(request);
         var appName = TryGetAppInfoString(() => AppInfo.Current.Name)
-            ?? _app?.GetType().Assembly.GetName().Name
+            ?? BoundApplication?.GetType().Assembly.GetName().Name
             ?? "unknown";
         var packageId = TryGetAppInfoString(() => AppInfo.Current.PackageName) ?? "unknown";
         var appVersion = TryGetAppInfoString(() => AppInfo.Current.VersionString) ?? "unknown";
@@ -581,7 +643,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     deviceType = DeviceTypeName,
                     idiom = IdiomName,
                     displayDensity = GetWindowDisplayDensity(window),
-                    windowCount = _app?.Windows.Count ?? 0,
+                    windowCount = BoundApplication?.Windows.Count ?? 0,
                     windowWidth = double.IsFinite(w) ? w : 0,
                     windowHeight = double.IsFinite(h) ? h : 0,
                 },
@@ -604,7 +666,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     profiler = IsProfilerFeatureAvailable,
                     jobs = IsJobsSupported,
                 },
-                running = _app != null,
+                running = BoundApplication != null,
                 cdpReady = _cdpWebViews.Any(v => v.IsReady),
                 cdpWebViewCount = _cdpWebViews.Count,
                 profiler = BuildProfilerCapabilitiesPayload(),
@@ -693,7 +755,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleTree(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         int maxDepth = 0;
         if (request.QueryParams.TryGetValue("depth", out var depthStr))
@@ -704,19 +766,19 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             includeLayout = layoutStr == "1" || string.Equals(layoutStr, "true", StringComparison.OrdinalIgnoreCase);
 
         var windowIndex = ParseWindowIndex(request);
-        var tree = await DispatchAsync(() => _treeWalker.WalkTree(_app, maxDepth, windowIndex, includeLayout));
+        var tree = await DispatchAsync(() => _treeWalker.WalkTree(BoundApplication, maxDepth, windowIndex, includeLayout));
         return HttpResponse.Json(tree);
     }
 
     private async Task<HttpResponse> HandleElement(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
         if (!request.RouteParams.TryGetValue("id", out var id))
             return HttpResponse.Error("Element ID required");
 
         var element = await DispatchAsync(() =>
         {
-            var el = _treeWalker.GetElementById(id, _app);
+            var el = _treeWalker.GetElementById(id, BoundApplication);
             if (el is IVisualTreeElement vte)
                 return (object?)_treeWalker.WalkElement(vte, null, 1, 2);
 
@@ -732,14 +794,14 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleQuery(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         // CSS selector takes precedence over simple filters
         if (request.QueryParams.TryGetValue("selector", out var selector) && !string.IsNullOrWhiteSpace(selector))
         {
             try
             {
-                var results = await DispatchAsync(() => _treeWalker.QueryCss(_app, selector));
+                var results = await DispatchAsync(() => _treeWalker.QueryCss(BoundApplication, selector));
                 return HttpResponse.Json(results);
             }
             catch (FormatException ex)
@@ -755,13 +817,13 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         if (type == null && automationId == null && text == null)
             return HttpResponse.Error("At least one query parameter required: type, automationId, text, or selector");
 
-        var simpleResults = await DispatchAsync(() => _treeWalker.Query(_app, type, automationId, text));
+        var simpleResults = await DispatchAsync(() => _treeWalker.Query(BoundApplication, type, automationId, text));
         return HttpResponse.Json(simpleResults);
     }
 
     private async Task<HttpResponse> HandleHitTest(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         if (!request.QueryParams.TryGetValue("x", out var xStr) || !double.TryParse(xStr, out var x))
             return HttpResponse.Error("x coordinate is required");
@@ -776,7 +838,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             if (window == null) return (object?)null;
 
             // Ensure tree is walked so element IDs are assigned and synthetic bounds are populated
-            _treeWalker.WalkTree(_app!, 0, windowIndex);
+            _treeWalker.WalkTree(BoundApplication!, 0, windowIndex);
 
             // Build active Shell context to filter out inactive ShellItem subtrees
             var activeShellItemIds = BuildActiveShellItemIds(window);
@@ -785,7 +847,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
             // Supplement with bounds-based hit testing — some platforms (e.g. macOS AppKit)
             // don't traverse into all containers via GetVisualTreeElements
-            var boundsHits = _treeWalker.HitTestByBounds(x, y, _app!, windowIndex);
+            var boundsHits = _treeWalker.HitTestByBounds(x, y, BoundApplication!, windowIndex);
             var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
             var allHits = new List<IVisualTreeElement>();
             foreach (var h in platformHits)
@@ -935,7 +997,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     protected virtual async Task<HttpResponse> HandleScreenshot(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         int? maxWidth = null;
         if (request.QueryParams.TryGetValue("maxWidth", out var mwStr) && int.TryParse(mwStr, out var mw) && mw > 0)
@@ -984,7 +1046,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             {
                 var element = await DispatchAsync(() =>
                 {
-                    var el = _treeWalker.GetElementById(elementId, _app);
+                    var el = _treeWalker.GetElementById(elementId, BoundApplication);
                     return el as VisualElement;
                 });
 
@@ -1010,7 +1072,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             {
                 var matchId = await DispatchAsync(() =>
                 {
-                    var results = _treeWalker.QueryCss(_app, selector);
+                    var results = _treeWalker.QueryCss(BoundApplication, selector);
                     return results.Count > 0 ? results[0].Id : null;
                 });
 
@@ -1019,7 +1081,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
                 var element = await DispatchAsync(() =>
                 {
-                    var el = _treeWalker.GetElementById(matchId, _app);
+                    var el = _treeWalker.GetElementById(matchId, BoundApplication);
                     return el as VisualElement;
                 });
 
@@ -1166,7 +1228,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleProperty(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
         if (!request.RouteParams.TryGetValue("id", out var id))
             return HttpResponse.Error("Element ID required");
         if (!request.RouteParams.TryGetValue("name", out var propName))
@@ -1174,7 +1236,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
         var value = await DispatchAsync(() =>
         {
-            var el = _treeWalker.GetElementById(id, _app);
+            var el = _treeWalker.GetElementById(id, BoundApplication);
             if (el == null) return (object?)null;
 
             // Support dot-path notation (e.g., "Shadow.Radius")
@@ -1293,7 +1355,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleSetProperty(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
         if (!request.RouteParams.TryGetValue("id", out var id))
             return HttpResponse.Error("Element ID required");
         if (!request.RouteParams.TryGetValue("name", out var propName))
@@ -1306,7 +1368,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         var startedAtUtc = DateTime.UtcNow;
         var result = await DispatchAsync(() =>
         {
-            var el = _treeWalker.GetElementById(id, _app);
+            var el = _treeWalker.GetElementById(id, BoundApplication);
             if (el == null) return "Element not found";
 
             var type = el.GetType();
@@ -1426,7 +1488,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleTap(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<ActionRequest>();
         if (body?.ElementId == null)
@@ -1435,7 +1497,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         var startedAtUtc = DateTime.UtcNow;
         var result = await DispatchAsync(() =>
         {
-            var el = _treeWalker.GetElementById(body.ElementId, _app);
+            var el = _treeWalker.GetElementById(body.ElementId, BoundApplication);
             if (el == null) return "Element not found";
 
             switch (el)
@@ -1547,7 +1609,15 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     // Last resort: try native tap via handler's platform view
                     if (TryNativeTapOnHandler(iView))
                         return "ok";
+                    // Bubble up parent chain for Comet gesture views (tap may be on parent container)
+                    if (TryBubbleCometGestureTap(iView))
+                        return "ok";
                     return $"Unhandled IView type: {el.GetType().FullName}";
+                case IView iViewNoHandler:
+                    // No handler but might have parent gesture
+                    if (TryBubbleCometGestureTap(iViewNoHandler))
+                        return "ok";
+                    return $"Unhandled IView (no handler): {el.GetType().FullName}";
                 default:
                     return $"Unhandled type: {el.GetType().FullName}";
             }
@@ -1695,9 +1765,37 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         return false;
     }
 
+    /// <summary>
+    /// Walks up the Comet parent chain looking for a parent with a tap gesture.
+    /// Comet uses OnTap on container views (HStack, VStack) — child views like Text
+    /// don't have their own gestures, but tapping them should invoke the parent's gesture.
+    /// </summary>
+    private static bool TryBubbleCometGestureTap(IView view)
+    {
+        try
+        {
+            // Walk up the parent chain via reflection (Comet views have a Parent property)
+            var current = view;
+            for (int i = 0; i < 10; i++) // max 10 levels to prevent infinite loops
+            {
+                var parentProp = current.GetType().GetProperty("Parent",
+                    BindingFlags.Public | BindingFlags.Instance);
+                var parent = parentProp?.GetValue(current) as IView;
+                if (parent == null) break;
+
+                if (TryInvokeCometGestureTap(parent))
+                    return true;
+
+                current = parent;
+            }
+        }
+        catch { }
+        return false;
+    }
+
     private async Task<HttpResponse> HandleFill(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<FillRequest>();
         if (body?.ElementId == null || body.Text == null)
@@ -1706,7 +1804,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         var startedAtUtc = DateTime.UtcNow;
         var result = await DispatchAsync(() =>
         {
-            var el = _treeWalker.GetElementById(body.ElementId, _app);
+            var el = _treeWalker.GetElementById(body.ElementId, BoundApplication);
             if (el == null) return "Element not found";
 
             switch (el)
@@ -1753,7 +1851,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleClear(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<ActionRequest>();
         if (body?.ElementId == null)
@@ -1762,7 +1860,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         var startedAtUtc = DateTime.UtcNow;
         var success = await DispatchAsync(() =>
         {
-            var el = _treeWalker.GetElementById(body.ElementId, _app);
+            var el = _treeWalker.GetElementById(body.ElementId, BoundApplication);
             if (el == null) return false;
 
             switch (el)
@@ -1805,7 +1903,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleFocus(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<ActionRequest>();
         if (body?.ElementId == null)
@@ -1814,7 +1912,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         var startedAtUtc = DateTime.UtcNow;
         var success = await DispatchAsync(() =>
         {
-            var el = _treeWalker.GetElementById(body.ElementId, _app);
+            var el = _treeWalker.GetElementById(body.ElementId, BoundApplication);
             if (el is not VisualElement ve) return false;
             ve.Focus();
             return true;
@@ -1832,7 +1930,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleNavigate(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<NavigateRequest>();
         if (string.IsNullOrEmpty(body?.Route))
@@ -1906,7 +2004,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleResize(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<ResizeRequest>();
         if (body == null || body.Width <= 0 || body.Height <= 0)
@@ -2008,7 +2106,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleBack(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var startedAtUtc = DateTime.UtcNow;
         var windowIndex = ParseWindowIndex(request);
@@ -2052,7 +2150,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleKey(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<KeyActionRequest>();
         if (body == null || (string.IsNullOrWhiteSpace(body.Key) && string.IsNullOrWhiteSpace(body.Text)))
@@ -2065,7 +2163,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             object? el = null;
             if (!string.IsNullOrWhiteSpace(body.ElementId))
             {
-                el = _treeWalker.GetElementById(body.ElementId, _app);
+                el = _treeWalker.GetElementById(body.ElementId, BoundApplication);
                 if (el == null)
                     return "Element not found";
             }
@@ -2149,7 +2247,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleGesture(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<GestureActionRequest>();
         if (body == null || string.IsNullOrWhiteSpace(body.Type))
@@ -2188,7 +2286,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleBatch(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<BatchRequest>();
         if (body?.Actions == null || body.Actions.Count == 0)
@@ -2323,7 +2421,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse> HandleScroll(HttpRequest request)
     {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+        if (BoundApplication == null) return HttpResponse.Error("Agent not bound to app");
 
         var body = request.BodyAs<ScrollRequest>();
         if (body == null)
@@ -2339,7 +2437,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                 object? targetObj = null;
                 if (!string.IsNullOrEmpty(body.ElementId))
                 {
-                    targetObj = _treeWalker.GetElementById(body.ElementId, _app);
+                    targetObj = _treeWalker.GetElementById(body.ElementId, BoundApplication);
                     if (targetObj == null) return "Element not found";
                 }
 
@@ -2368,7 +2466,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             // Priority 2: Scroll element into view
             if (!string.IsNullOrEmpty(body.ElementId))
             {
-                var el = _treeWalker.GetElementById(body.ElementId, _app);
+                var el = _treeWalker.GetElementById(body.ElementId, BoundApplication);
                 if (el == null) return "Element not found";
 
                 if (el is VisualElement ve)
@@ -3118,7 +3216,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private void ScanUiTreeForHooks()
     {
-        if (_app is not IVisualTreeElement appElement)
+        if (BoundApplication is not IVisualTreeElement appElement)
             return;
 
         foreach (var child in appElement.GetVisualChildren())
@@ -4472,7 +4570,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                 timestamp = now,
                 data = new
                 {
-                    state = _app != null ? "started" : "stopped",
+                    state = BoundApplication != null ? "started" : "stopped",
                     timestamp = now
                 }
             }));
@@ -5013,7 +5111,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private async Task<HttpResponse?> TryCaptureRegisteredWebViewAsync(CdpWebViewInfo webView)
     {
-        if (_app == null)
+        if (BoundApplication == null)
             return null;
 
         try
@@ -5022,16 +5120,16 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             {
                 if (!string.IsNullOrWhiteSpace(webView.ElementId))
                 {
-                    var byId = _treeWalker.GetElementById(webView.ElementId!, _app) as VisualElement;
+                    var byId = _treeWalker.GetElementById(webView.ElementId!, BoundApplication) as VisualElement;
                     if (byId != null)
                         return byId;
                 }
 
                 if (!string.IsNullOrWhiteSpace(webView.AutomationId))
                 {
-                    var match = _treeWalker.Query(_app, automationId: webView.AutomationId).FirstOrDefault();
+                    var match = _treeWalker.Query(BoundApplication, automationId: webView.AutomationId).FirstOrDefault();
                     if (match?.Id is { Length: > 0 } matchId)
-                        return _treeWalker.GetElementById(matchId, _app) as VisualElement;
+                        return _treeWalker.GetElementById(matchId, BoundApplication) as VisualElement;
                 }
 
                 return null;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/ElementInfo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/ElementInfo.cs
@@ -140,6 +140,10 @@ public class ElementInfo
     [JsonPropertyName("children")]
     public List<ElementInfo>? Children { get; set; }
 
+    [JsonPropertyName("layout")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LayoutInfo? Layout { get; set; }
+
     [JsonIgnore]
     public bool IsSelected { get; set; }
 
@@ -236,6 +240,76 @@ public class ElementNativeViewInfo
     [JsonPropertyName("properties")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string?>? Properties { get; set; }
+}
+
+/// <summary>
+/// Yoga layout snapshot for a Comet-driven MAUI Layout. Populated by the agent
+/// when <c>?layout=1</c> is requested on the tree endpoint and the underlying
+/// MAUI Layout's manager implements Comet's IYogaLayoutInspector.
+/// </summary>
+public class LayoutInfo
+{
+    [JsonPropertyName("frame")]
+    public LayoutFrameInfo Frame { get; set; } = new();
+
+    [JsonPropertyName("flexDirection")]
+    public string FlexDirection { get; set; } = "";
+
+    [JsonPropertyName("alignItems")]
+    public string AlignItems { get; set; } = "";
+
+    [JsonPropertyName("justifyContent")]
+    public string JustifyContent { get; set; } = "";
+
+    [JsonPropertyName("alignContent")]
+    public string AlignContent { get; set; } = "";
+
+    [JsonPropertyName("flexWrap")]
+    public string FlexWrap { get; set; } = "";
+
+    [JsonPropertyName("children")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<LayoutChildInfo>? Children { get; set; }
+}
+
+public class LayoutFrameInfo
+{
+    [JsonPropertyName("x")]
+    public float X { get; set; }
+
+    [JsonPropertyName("y")]
+    public float Y { get; set; }
+
+    [JsonPropertyName("width")]
+    public float Width { get; set; }
+
+    [JsonPropertyName("height")]
+    public float Height { get; set; }
+}
+
+public class LayoutChildInfo
+{
+    [JsonPropertyName("viewTypeName")]
+    public string ViewTypeName { get; set; } = "";
+
+    [JsonPropertyName("automationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AutomationId { get; set; }
+
+    [JsonPropertyName("frame")]
+    public LayoutFrameInfo Frame { get; set; } = new();
+
+    [JsonPropertyName("flexGrow")]
+    public float FlexGrow { get; set; }
+
+    [JsonPropertyName("flexShrink")]
+    public float FlexShrink { get; set; }
+
+    [JsonPropertyName("alignSelf")]
+    public string AlignSelf { get; set; } = "";
+
+    [JsonPropertyName("positionType")]
+    public string PositionType { get; set; } = "";
 }
 
 /// <summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/LayoutInspectorAdapter.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/LayoutInspectorAdapter.cs
@@ -1,0 +1,170 @@
+// Soft adapter that bridges Comet's IYogaLayoutInspector (in Comet.dll) to the
+// agent's wire-format LayoutInfo DTO. This file deliberately holds NO compile-time
+// reference to Comet — every type is resolved at runtime via reflection and the
+// result is cached. When Comet isn't loaded, every call returns null gracefully.
+
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Maui.DevFlow.Agent.Core;
+
+internal static class LayoutInspectorAdapter
+{
+    // Cache the lookup so we pay the GetType cost once per process. The interface
+    // type may resolve to null if Comet isn't loaded yet — in that case we periodically
+    // retry (lazy via the ScanAttempt counter) so apps that load Comet after the
+    // agent starts still work.
+    private static Type? _inspectorInterface;
+    private static bool _scanned;
+    private static readonly object _gate = new();
+
+    private static Type? InspectorInterface()
+    {
+        if (_scanned && _inspectorInterface != null)
+            return _inspectorInterface;
+
+        lock (_gate)
+        {
+            if (_inspectorInterface != null)
+                return _inspectorInterface;
+
+            // Try AssemblyQualifiedName first — fast path when Comet was loaded
+            // by name resolution.
+            _inspectorInterface = Type.GetType("Comet.Layout.IYogaLayoutInspector, Comet", throwOnError: false);
+
+            // Fallback: scan loaded assemblies for one that exports the type.
+            if (_inspectorInterface == null)
+            {
+                foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    Type? t;
+                    try
+                    {
+                        t = asm.GetType("Comet.Layout.IYogaLayoutInspector", throwOnError: false);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+                    if (t != null)
+                    {
+                        _inspectorInterface = t;
+                        break;
+                    }
+                }
+            }
+
+            _scanned = true;
+            return _inspectorInterface;
+        }
+    }
+
+    /// <summary>
+    /// If <paramref name="layoutManager"/> implements Comet's IYogaLayoutInspector,
+    /// invoke it and project the snapshot into a wire-format <see cref="LayoutInfo"/>.
+    /// Returns null when Comet isn't loaded, the manager doesn't implement the
+    /// interface, or no measure pass has run yet.
+    /// </summary>
+    public static LayoutInfo? TryGetLayoutSnapshot(object? layoutManager)
+    {
+        if (layoutManager is null)
+            return null;
+
+        var iface = InspectorInterface();
+        if (iface == null || !iface.IsInstanceOfType(layoutManager))
+            return null;
+
+        try
+        {
+            var method = iface.GetMethod("GetLayoutSnapshot", BindingFlags.Public | BindingFlags.Instance);
+            if (method == null)
+                return null;
+
+            var snapshot = method.Invoke(layoutManager, null);
+            if (snapshot == null)
+                return null;
+
+            return Project(snapshot);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static LayoutInfo? Project(object snapshot)
+    {
+        var t = snapshot.GetType();
+        var frame = ReadFrame(t.GetProperty("Frame")?.GetValue(snapshot));
+        var info = new LayoutInfo
+        {
+            Frame = frame,
+            FlexDirection = ReadString(t, snapshot, "FlexDirection"),
+            AlignItems = ReadString(t, snapshot, "AlignItems"),
+            JustifyContent = ReadString(t, snapshot, "JustifyContent"),
+            AlignContent = ReadString(t, snapshot, "AlignContent"),
+            FlexWrap = ReadString(t, snapshot, "FlexWrap"),
+        };
+
+        if (t.GetProperty("Children")?.GetValue(snapshot) is IEnumerable children)
+        {
+            var list = new List<LayoutChildInfo>();
+            foreach (var child in children)
+            {
+                if (child == null) continue;
+                var ct = child.GetType();
+                list.Add(new LayoutChildInfo
+                {
+                    ViewTypeName = ReadString(ct, child, "ViewTypeName"),
+                    AutomationId = ct.GetProperty("AutomationId")?.GetValue(child) as string,
+                    Frame = ReadFrame(ct.GetProperty("Frame")?.GetValue(child)),
+                    FlexGrow = ReadFloat(ct, child, "FlexGrow"),
+                    FlexShrink = ReadFloat(ct, child, "FlexShrink"),
+                    AlignSelf = ReadString(ct, child, "AlignSelf"),
+                    PositionType = ReadString(ct, child, "PositionType"),
+                });
+            }
+            info.Children = list;
+        }
+
+        return info;
+    }
+
+    private static string ReadString(Type t, object instance, string prop)
+        => t.GetProperty(prop)?.GetValue(instance) as string ?? "";
+
+    private static float ReadFloat(Type t, object instance, string prop)
+    {
+        var v = t.GetProperty(prop)?.GetValue(instance);
+        return v switch
+        {
+            float f => f,
+            double d => (float)d,
+            _ => 0f,
+        };
+    }
+
+    // YogaLayoutSnapshot.Frame is a ValueTuple<float,float,float,float>.
+    // Read fields by name (Item1..Item4) since runtime types preserve them.
+    private static LayoutFrameInfo ReadFrame(object? frame)
+    {
+        if (frame is null) return new LayoutFrameInfo();
+        var t = frame.GetType();
+        return new LayoutFrameInfo
+        {
+            X = ToFloat(t.GetField("Item1")?.GetValue(frame)),
+            Y = ToFloat(t.GetField("Item2")?.GetValue(frame)),
+            Width = ToFloat(t.GetField("Item3")?.GetValue(frame)),
+            Height = ToFloat(t.GetField("Item4")?.GetValue(frame)),
+        };
+    }
+
+    private static float ToFloat(object? v) => v switch
+    {
+        float f => f,
+        double d => (float)d,
+        _ => 0f,
+    };
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/LayoutInspectorAdapter.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/LayoutInspectorAdapter.cs
@@ -14,21 +14,29 @@ internal static class LayoutInspectorAdapter
 {
     // Cache the lookup so we pay the GetType cost once per process. The interface
     // type may resolve to null if Comet isn't loaded yet — in that case we periodically
-    // retry (lazy via the ScanAttempt counter) so apps that load Comet after the
-    // agent starts still work.
+    // retry so apps that load Comet after the agent starts still work, without
+    // rescanning loaded assemblies on every call.
     private static Type? _inspectorInterface;
     private static bool _scanned;
+    private static long _lastScanTickCount;
     private static readonly object _gate = new();
+    private const int RetryIntervalMilliseconds = 5000;
 
     private static Type? InspectorInterface()
     {
-        if (_scanned && _inspectorInterface != null)
+        if (_inspectorInterface != null)
             return _inspectorInterface;
+
+        if (_scanned && (Environment.TickCount64 - Volatile.Read(ref _lastScanTickCount)) < RetryIntervalMilliseconds)
+            return null;
 
         lock (_gate)
         {
             if (_inspectorInterface != null)
                 return _inspectorInterface;
+
+            if (_scanned && (Environment.TickCount64 - _lastScanTickCount) < RetryIntervalMilliseconds)
+                return null;
 
             // Try AssemblyQualifiedName first — fast path when Comet was loaded
             // by name resolution.
@@ -57,6 +65,7 @@ internal static class LayoutInspectorAdapter
             }
 
             _scanned = true;
+            _lastScanTickCount = Environment.TickCount64;
             return _inspectorInterface;
         }
     }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
@@ -327,33 +327,41 @@ public class VisualTreeWalker
         _usedIds.Clear();
         _elementIdToExternalId.Clear();
         _syntheticBounds.Clear();
+        var previousIncludeLayout = _includeLayout;
         _includeLayout = includeLayout;
-        var results = new List<ElementInfo>();
-        if (app is not IVisualTreeElement appElement)
-            return results;
-
-        if (windowIndex != null)
+        try
         {
-            if (windowIndex.Value < 0 || windowIndex.Value >= app.Windows.Count)
+            var results = new List<ElementInfo>();
+            if (app is not IVisualTreeElement appElement)
                 return results;
-            var window = app.Windows[windowIndex.Value];
-            if (window is IVisualTreeElement windowElement)
+
+            if (windowIndex != null)
             {
-                var info = WalkElement(windowElement, null, 1, maxDepth);
+                if (windowIndex.Value < 0 || windowIndex.Value >= app.Windows.Count)
+                    return results;
+                var window = app.Windows[windowIndex.Value];
+                if (window is IVisualTreeElement windowElement)
+                {
+                    var info = WalkElement(windowElement, null, 1, maxDepth);
+                    if (info != null)
+                        results.Add(info);
+                }
+                return results;
+            }
+
+            foreach (var child in appElement.GetVisualChildren())
+            {
+                var info = WalkElement(child, null, 1, maxDepth);
                 if (info != null)
                     results.Add(info);
             }
+
             return results;
         }
-
-        foreach (var child in appElement.GetVisualChildren())
+        finally
         {
-            var info = WalkElement(child, null, 1, maxDepth);
-            if (info != null)
-                results.Add(info);
+            _includeLayout = previousIncludeLayout;
         }
-
-        return results;
     }
 
     /// <summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
@@ -37,6 +37,9 @@ public class VisualTreeWalker
     /// Returns IVisualTreeElement, ToolbarItem, or other mapped objects.
     /// </summary>
     public object? GetElementById(string id, Application? app)
+        => GetElementById(id, (IApplication?)app);
+
+    public object? GetElementById(string id, IApplication? app)
     {
         if (app == null || string.IsNullOrEmpty(id)) return null;
 
@@ -97,17 +100,22 @@ public class VisualTreeWalker
     /// Returns elements whose window bounds contain the given point.
     /// </summary>
     public List<VisualElement> HitTestByBounds(double x, double y, Application app, int? windowIndex = null)
+        => HitTestByBounds(x, y, (IApplication)app, windowIndex);
+
+    public List<VisualElement> HitTestByBounds(double x, double y, IApplication app, int? windowIndex = null)
     {
         var hits = new List<VisualElement>();
         var window = windowIndex.HasValue && windowIndex.Value < app.Windows.Count
             ? app.Windows[windowIndex.Value]
             : app.Windows.FirstOrDefault();
-        if (window?.Page == null) return hits;
+        // Page is only available on Window (MAUI Controls), not on all IWindow implementations
+        var page = (window as Window)?.Page;
+        if (page == null) return hits;
 
-        HitTestByBoundsRecursive(window.Page, x, y, hits);
+        HitTestByBoundsRecursive(page, x, y, hits);
 
         // Also check modal pages
-        var modalStack = window.Navigation?.ModalStack;
+        var modalStack = (window as Window)?.Navigation?.ModalStack;
         if (modalStack != null)
         {
             foreach (var modal in modalStack)
@@ -312,6 +320,9 @@ public class VisualTreeWalker
     /// When windowIndex is null, walks all windows. Otherwise walks only the specified window.
     /// </summary>
     public List<ElementInfo> WalkTree(Application app, int maxDepth = 0, int? windowIndex = null, bool includeLayout = false)
+        => WalkTree((IApplication)app, maxDepth, windowIndex, includeLayout);
+
+    public List<ElementInfo> WalkTree(IApplication app, int maxDepth = 0, int? windowIndex = null, bool includeLayout = false)
     {
         _usedIds.Clear();
         _elementIdToExternalId.Clear();
@@ -431,6 +442,9 @@ public class VisualTreeWalker
     /// Queries elements matching the given criteria.
     /// </summary>
     public List<ElementInfo> Query(Application app, string? type = null, string? automationId = null, string? text = null)
+        => Query((IApplication)app, type, automationId, text);
+
+    public List<ElementInfo> Query(IApplication app, string? type = null, string? automationId = null, string? text = null)
     {
         var results = new List<ElementInfo>();
         if (app is not IVisualTreeElement appElement)
@@ -1515,6 +1529,9 @@ public class VisualTreeWalker
     /// Walks the full tree, then runs the CSS selector engine against it.
     /// </summary>
     public List<ElementInfo> QueryCss(Application app, string selector)
+        => QueryCss((IApplication)app, selector);
+
+    public List<ElementInfo> QueryCss(IApplication app, string selector)
     {
         var tree = WalkTree(app);
         return CssSelectorEngine.Query(tree, selector);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
@@ -284,6 +284,26 @@ public class VisualTreeWalker
     public BoundsInfo? ResolveWindowBoundsPublic(VisualElement ve) => ResolveWindowBounds(ve);
 
     /// <summary>
+    /// Override in platform-specific subclasses to resolve window-absolute bounds
+    /// for an IView (e.g. Comet views) that are NOT VisualElement.
+    /// Uses the IView's Handler?.PlatformView to get native coordinates.
+    /// </summary>
+    protected virtual BoundsInfo? ResolveIViewWindowBounds(IView iView) => null;
+
+    /// <summary>
+    /// Override in platform-specific subclasses to determine actual visibility
+    /// for an IView by checking its platform native view (e.g. UIView.Hidden, Alpha).
+    /// Returns null if platform visibility cannot be determined.
+    /// </summary>
+    protected virtual bool? ResolveIViewPlatformVisibility(IView iView) => null;
+
+    /// <summary>
+    /// Override in platform-specific subclasses to populate native view info
+    /// for an IView (e.g. Comet views) that are NOT VisualElement.
+    /// </summary>
+    protected virtual void PopulateIViewNativeInfo(ElementInfo info, IView iView) { }
+
+    /// <summary>
     /// Walks the visual tree starting from the application's windows.
     /// When windowIndex is null, walks all windows. Otherwise walks only the specified window.
     /// </summary>
@@ -1258,7 +1278,10 @@ public class VisualTreeWalker
         // Comet views implement IView but NOT VisualElement — extract info from IView + handler
         else if (element is IView iView)
         {
-            info.IsVisible = iView.Visibility != Visibility.Collapsed;
+            // Check platform-native visibility first (handler's UIView.Hidden/Alpha on iOS, etc.)
+            // Falls back to IView.Visibility if platform check is unavailable
+            var platformVisible = ResolveIViewPlatformVisibility(iView);
+            info.IsVisible = platformVisible ?? (iView.Visibility != Visibility.Collapsed);
             info.IsEnabled = iView.IsEnabled;
             info.Opacity = double.IsFinite(iView.Opacity) ? iView.Opacity : 1;
 
@@ -1275,9 +1298,47 @@ public class VisualTreeWalker
                 };
             }
 
-            // Try to extract text from Comet views via IText interface
-            if (element is IText iText && !string.IsNullOrEmpty(iText.Text))
+            // Resolve window-absolute bounds via platform handler (same as VisualElement path)
+            info.WindowBounds = ResolveIViewWindowBounds(iView);
+
+            // If IView.Frame had no bounds but platform handler resolved real bounds,
+            // back-fill Bounds from WindowBounds so the element isn't reported as zero-size
+            if (info.Bounds == null && info.WindowBounds != null)
+            {
+                info.Bounds = new BoundsInfo
+                {
+                    X = info.WindowBounds.X,
+                    Y = info.WindowBounds.Y,
+                    Width = info.WindowBounds.Width,
+                    Height = info.WindowBounds.Height
+                };
+            }
+
+            // Populate native view info from handler (type, accessibility, etc.)
+            PopulateIViewNativeInfo(info, iView);
+
+            // Extract text from MAUI interfaces that Comet generated controls implement
+            if (element is ILabel iLabel && !string.IsNullOrEmpty(iLabel.Text))
+                info.Text = iLabel.Text;
+            else if (element is ITextButton iTextButton && !string.IsNullOrEmpty(iTextButton.Text))
+                info.Text = iTextButton.Text;
+            else if (element is IEntry iEntry && !string.IsNullOrEmpty(iEntry.Text))
+                info.Text = iEntry.Text;
+            else if (element is IEditor iEditor && !string.IsNullOrEmpty(iEditor.Text))
+                info.Text = iEditor.Text;
+            else if (element is ISearchBar iSearchBar && !string.IsNullOrEmpty(iSearchBar.Text))
+                info.Text = iSearchBar.Text;
+            else if (element is IText iText && !string.IsNullOrEmpty(iText.Text))
                 info.Text = iText.Text;
+
+            // Fallback: try extracting text via Comet reflection for views that
+            // don't implement standard MAUI text interfaces directly
+            if (string.IsNullOrEmpty(info.Text) && cometResolved != null)
+            {
+                var cometText = CometViewResolver.TryExtractText(cometResolved.Value.CometView);
+                if (!string.IsNullOrEmpty(cometText))
+                    info.Text = cometText;
+            }
         }
 
         // Extract text from common controls (including Shell elements)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/VisualTreeWalker.cs
@@ -19,6 +19,10 @@ public class VisualTreeWalker
     private readonly Dictionary<Guid, string> _elementIdToExternalId = new();
     private readonly ConcurrentDictionary<string, (BoundsInfo Bounds, object Marker)> _syntheticBounds = new();
 
+    // Set per WalkTree call; controls whether CreateElementInfo populates a Yoga
+    // layout snapshot for Comet-driven layouts. Default false keeps payload size down.
+    private bool _includeLayout;
+
     /// <summary>
     /// Marker object representing the navigation back button in Shell or NavigationPage.
     /// </summary>
@@ -307,11 +311,12 @@ public class VisualTreeWalker
     /// Walks the visual tree starting from the application's windows.
     /// When windowIndex is null, walks all windows. Otherwise walks only the specified window.
     /// </summary>
-    public List<ElementInfo> WalkTree(Application app, int maxDepth = 0, int? windowIndex = null)
+    public List<ElementInfo> WalkTree(Application app, int maxDepth = 0, int? windowIndex = null, bool includeLayout = false)
     {
         _usedIds.Clear();
         _elementIdToExternalId.Clear();
         _syntheticBounds.Clear();
+        _includeLayout = includeLayout;
         var results = new List<ElementInfo>();
         if (app is not IVisualTreeElement appElement)
             return results;
@@ -1440,7 +1445,54 @@ public class VisualTreeWalker
             // }
         }
 
+        // Yoga layout snapshot (--layout / ?layout=1). Comet's AbstractLayout (and
+        // Microsoft.Maui.Controls.Layout) both expose a LayoutManager property; for
+        // Comet-driven layouts that manager implements IYogaLayoutInspector. Use
+        // reflection so this works against either inheritance path without a hard
+        // reference to Comet.
+        if (_includeLayout)
+        {
+            try
+            {
+                var layoutManager = TryGetLayoutManagerViaReflection(element);
+                var layoutInfo = LayoutInspectorAdapter.TryGetLayoutSnapshot(layoutManager);
+                if (layoutInfo != null)
+                    info.Layout = layoutInfo;
+            }
+            catch
+            {
+                // Layout inspection is best-effort; don't fail the tree walk.
+            }
+        }
+
         return info;
+    }
+
+    // Cache the LayoutManager property per element type (key is the runtime Type) —
+    // most apps have only a handful of distinct layout types so this stays bounded.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> s_layoutManagerProps = new();
+
+    private static object? TryGetLayoutManagerViaReflection(object element)
+    {
+        var t = element.GetType();
+        var prop = s_layoutManagerProps.GetOrAdd(t, static type =>
+        {
+            // Walk up the type chain so we pick up protected/internal LayoutManager
+            // exposed on a base type (e.g. Microsoft.Maui.Controls.Layout).
+            for (var cur = type; cur != null; cur = cur.BaseType)
+            {
+                var p = cur.GetProperty(
+                    "LayoutManager",
+                    System.Reflection.BindingFlags.Public
+                        | System.Reflection.BindingFlags.NonPublic
+                        | System.Reflection.BindingFlags.Instance
+                        | System.Reflection.BindingFlags.DeclaredOnly);
+                if (p != null && p.CanRead)
+                    return p;
+            }
+            return null;
+        });
+        return prop?.GetValue(element);
     }
 
     protected virtual void PopulateNativeInfo(ElementInfo info, VisualElement ve)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/VisualTreeWalker.cs
@@ -289,7 +289,7 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
             {
                 if (uiView.Hidden) return false;
                 if (uiView.Alpha <= 0) return false;
-                if (uiView.Bounds.Width <= 0 && uiView.Bounds.Height <= 0) return false;
+                if (uiView.Bounds.Width <= 0 || uiView.Bounds.Height <= 0) return false;
                 return true;
             }
 #elif ANDROID
@@ -297,7 +297,7 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
             {
                 if (androidView.Visibility != global::Android.Views.ViewStates.Visible) return false;
                 if (androidView.Alpha <= 0) return false;
-                if (androidView.Width <= 0 && androidView.Height <= 0) return false;
+                if (androidView.Width <= 0 || androidView.Height <= 0) return false;
                 return true;
             }
 #elif WINDOWS

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/VisualTreeWalker.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/VisualTreeWalker.cs
@@ -222,6 +222,164 @@ public class PlatformVisualTreeWalker : VisualTreeWalker
         catch { return null; }
     }
 
+    protected override BoundsInfo? ResolveIViewWindowBounds(IView iView)
+    {
+        try
+        {
+            var platformView = iView.Handler?.PlatformView;
+            if (platformView == null) return null;
+
+#if IOS || MACCATALYST
+            if (platformView is UIKit.UIView uiView && uiView.Window != null)
+            {
+                var windowRect = uiView.ConvertRectToView(uiView.Bounds, uiView.Window.RootViewController?.View ?? uiView.Window);
+                return new BoundsInfo
+                {
+                    X = windowRect.X,
+                    Y = windowRect.Y,
+                    Width = windowRect.Width,
+                    Height = windowRect.Height
+                };
+            }
+#elif ANDROID
+            if (platformView is global::Android.Views.View androidView)
+            {
+                var location = new int[2];
+                androidView.GetLocationInWindow(location);
+                var density = androidView.Context?.Resources?.DisplayMetrics?.Density ?? 1f;
+                return new BoundsInfo
+                {
+                    X = location[0] / density,
+                    Y = location[1] / density,
+                    Width = androidView.Width / density,
+                    Height = androidView.Height / density
+                };
+            }
+#elif WINDOWS
+            if (platformView is Microsoft.UI.Xaml.UIElement uiElement)
+            {
+                var transform = uiElement.TransformToVisual(null);
+                var point = transform.TransformPoint(new global::Windows.Foundation.Point(0, 0));
+                if (uiElement is Microsoft.UI.Xaml.FrameworkElement fe)
+                {
+                    return new BoundsInfo
+                    {
+                        X = point.X,
+                        Y = point.Y,
+                        Width = fe.ActualWidth,
+                        Height = fe.ActualHeight
+                    };
+                }
+            }
+#endif
+            return null;
+        }
+        catch { return null; }
+    }
+
+    protected override bool? ResolveIViewPlatformVisibility(IView iView)
+    {
+        try
+        {
+            var platformView = iView.Handler?.PlatformView;
+            if (platformView == null) return null;
+
+#if IOS || MACCATALYST
+            if (platformView is UIKit.UIView uiView)
+            {
+                if (uiView.Hidden) return false;
+                if (uiView.Alpha <= 0) return false;
+                if (uiView.Bounds.Width <= 0 && uiView.Bounds.Height <= 0) return false;
+                return true;
+            }
+#elif ANDROID
+            if (platformView is global::Android.Views.View androidView)
+            {
+                if (androidView.Visibility != global::Android.Views.ViewStates.Visible) return false;
+                if (androidView.Alpha <= 0) return false;
+                if (androidView.Width <= 0 && androidView.Height <= 0) return false;
+                return true;
+            }
+#elif WINDOWS
+            if (platformView is Microsoft.UI.Xaml.FrameworkElement winFe)
+            {
+                if (winFe.Visibility != Microsoft.UI.Xaml.Visibility.Visible) return false;
+                if (winFe.Opacity <= 0) return false;
+                return true;
+            }
+#endif
+            return null;
+        }
+        catch { return null; }
+    }
+
+    protected override void PopulateIViewNativeInfo(ElementInfo info, IView iView)
+    {
+        try
+        {
+            var platformView = iView.Handler?.PlatformView;
+            if (platformView == null) return;
+
+            info.NativeType = platformView.GetType().FullName;
+
+#if IOS || MACCATALYST
+            if (platformView is UIKit.UIView uiView)
+            {
+                var props = new Dictionary<string, string?>();
+                if (!string.IsNullOrEmpty(uiView.AccessibilityIdentifier))
+                    props["accessibilityIdentifier"] = uiView.AccessibilityIdentifier;
+                if (!string.IsNullOrEmpty(uiView.AccessibilityLabel))
+                    props["accessibilityLabel"] = uiView.AccessibilityLabel;
+                if (uiView is UIKit.UIControl)
+                    props["isUIControl"] = "true";
+                if (uiView is UIKit.UITextField textField)
+                    props["isSecureTextEntry"] = textField.SecureTextEntry.ToString();
+                if (props.Count > 0)
+                {
+                    info.NativeProperties ??= new Dictionary<string, string?>();
+                    foreach (var kvp in props)
+                        info.NativeProperties[kvp.Key] = kvp.Value;
+                }
+            }
+#elif ANDROID
+            if (platformView is global::Android.Views.View androidView)
+            {
+                var props = new Dictionary<string, string?>();
+                if (!string.IsNullOrEmpty(androidView.ContentDescription))
+                    props["contentDescription"] = androidView.ContentDescription;
+                if (androidView is global::Android.Widget.EditText editText)
+                    props["inputType"] = editText.InputType.ToString();
+                if (androidView.Clickable)
+                    props["clickable"] = "true";
+                if (props.Count > 0)
+                {
+                    info.NativeProperties ??= new Dictionary<string, string?>();
+                    foreach (var kvp in props)
+                        info.NativeProperties[kvp.Key] = kvp.Value;
+                }
+            }
+#elif WINDOWS
+            if (platformView is Microsoft.UI.Xaml.FrameworkElement frameworkElement)
+            {
+                var props = new Dictionary<string, string?>();
+                var automationName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(frameworkElement);
+                if (!string.IsNullOrEmpty(automationName))
+                    props["automationName"] = automationName;
+                if (props.Count > 0)
+                {
+                    info.NativeProperties ??= new Dictionary<string, string?>();
+                    foreach (var kvp in props)
+                        info.NativeProperties[kvp.Key] = kvp.Value;
+                }
+            }
+#endif
+        }
+        catch
+        {
+            // Native info is best-effort; don't fail the tree walk
+        }
+    }
+
 #if IOS || MACCATALYST
     private BoundsInfo? ResolveBoundsApple(object marker)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -45,11 +45,12 @@ public class AgentClient : IDisposable
     /// <summary>
     /// Get the visual tree from the running app.
     /// </summary>
-    public async Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0, int? window = null)
+    public async Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0, int? window = null, bool includeLayout = false)
     {
         var parts = new List<string>();
         if (maxDepth > 0) parts.Add($"depth={maxDepth}");
         if (window != null) parts.Add($"window={window}");
+        if (includeLayout) parts.Add("layout=1");
         var url = parts.Count > 0 ? $"{UiApi}/tree?{string.Join("&", parts)}" : $"{UiApi}/tree";
         return await GetAsync<List<ElementInfo>>(url) ?? new();
     }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AppDriverBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AppDriverBase.cs
@@ -28,8 +28,8 @@ public abstract class AppDriverBase : IAppDriver
     public Task<AgentStatus?> GetStatusAsync()
         => EnsureClient().GetStatusAsync();
 
-    public Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0)
-        => EnsureClient().GetTreeAsync(maxDepth);
+    public Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0, bool includeLayout = false)
+        => EnsureClient().GetTreeAsync(maxDepth, null, includeLayout);
 
     public Task<List<ElementInfo>> QueryAsync(string? type = null, string? automationId = null, string? text = null)
         => EnsureClient().QueryAsync(type, automationId, text);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ElementInfo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ElementInfo.cs
@@ -133,6 +133,10 @@ public class ElementInfo
     [JsonPropertyName("children")]
     public List<ElementInfo>? Children { get; set; }
 
+    [JsonPropertyName("layout")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LayoutInfo? Layout { get; set; }
+
     [JsonIgnore]
     public bool IsSelected { get; set; }
 
@@ -226,4 +230,73 @@ public class ElementNativeViewInfo
     [JsonPropertyName("properties")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string?>? Properties { get; set; }
+}
+
+/// <summary>
+/// Yoga layout snapshot returned by the agent when <c>?layout=1</c> is requested
+/// on the tree endpoint. Populated only for Comet-driven layouts.
+/// </summary>
+public class LayoutInfo
+{
+    [JsonPropertyName("frame")]
+    public LayoutFrameInfo Frame { get; set; } = new();
+
+    [JsonPropertyName("flexDirection")]
+    public string FlexDirection { get; set; } = "";
+
+    [JsonPropertyName("alignItems")]
+    public string AlignItems { get; set; } = "";
+
+    [JsonPropertyName("justifyContent")]
+    public string JustifyContent { get; set; } = "";
+
+    [JsonPropertyName("alignContent")]
+    public string AlignContent { get; set; } = "";
+
+    [JsonPropertyName("flexWrap")]
+    public string FlexWrap { get; set; } = "";
+
+    [JsonPropertyName("children")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<LayoutChildInfo>? Children { get; set; }
+}
+
+public class LayoutFrameInfo
+{
+    [JsonPropertyName("x")]
+    public float X { get; set; }
+
+    [JsonPropertyName("y")]
+    public float Y { get; set; }
+
+    [JsonPropertyName("width")]
+    public float Width { get; set; }
+
+    [JsonPropertyName("height")]
+    public float Height { get; set; }
+}
+
+public class LayoutChildInfo
+{
+    [JsonPropertyName("viewTypeName")]
+    public string ViewTypeName { get; set; } = "";
+
+    [JsonPropertyName("automationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AutomationId { get; set; }
+
+    [JsonPropertyName("frame")]
+    public LayoutFrameInfo Frame { get; set; } = new();
+
+    [JsonPropertyName("flexGrow")]
+    public float FlexGrow { get; set; }
+
+    [JsonPropertyName("flexShrink")]
+    public float FlexShrink { get; set; }
+
+    [JsonPropertyName("alignSelf")]
+    public string AlignSelf { get; set; } = "";
+
+    [JsonPropertyName("positionType")]
+    public string PositionType { get; set; } = "";
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/IAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/IAppDriver.cs
@@ -24,7 +24,7 @@ public interface IAppDriver : IDisposable
     /// <summary>
     /// Get the visual tree.
     /// </summary>
-    Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0);
+    Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0, bool includeLayout = false);
 
     /// <summary>
     /// Query elements matching criteria.

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Microsoft.Maui.DevFlow.Driver.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Microsoft.Maui.DevFlow.Driver.csproj
@@ -8,6 +8,7 @@
     <IsPackable>false</IsPackable>
     <IsPackable Condition="'$(PackDriverNuGet)' == 'true'">true</IsPackable>
     <IsAotCompatible>true</IsAotCompatible>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 
     <PackageId>Microsoft.Maui.DevFlow.Driver</PackageId>
     <IsShipping>true</IsShipping>


### PR DESCRIPTION
Final batch of DevFlow extractions from `feature/comet` so the Comet branch contains zero DevFlow changes. Stacked on top of #174 in spirit (adjacent scope) — both target `main` independently.

## Commits

1. **`40be3367` — fix: DevFlow `_app` binding for Comet/IApplication hosts** (cherry-pick of `02bf58fa`)
   - Adds `_iApp` field + `BoundApplication` property (prefers `Application`, falls back to `IApplication`)
   - `StartServerOnly()` now calls `TryResolveIApplicationFromDI()` via `IPlatformApplication.Current.Services` so Comet apps that register `IApplication` (but never set `Application.Current`) work out of the box
   - New `BindIApp(IApplication)` for late-binding non-`Application` hosts
   - Migrates `_app` → `BoundApplication` in all endpoint handlers (status, tree, element, query, hittest, gestures, properties, network)
   - Adds `IApplication` overloads for `VisualTreeWalker.WalkTree/GetElementById/HitTestByBounds/Query/QueryCss`
   - `HitTestByBounds` safely casts `IWindow` → `Window` for `Page`/`Navigation` access
   - **AgentServiceExtensions:** no net change — main's `EnsureAgentStarted`/`StartWhenApplicationAvailableAsync` already provide the same app-less-start fallback that 02bf58fa added inline
   - Conflict resolutions kept main's `_disposed` checks, `PublishUiEvent`, and the rich nested status payload

2. **`0d3593f4` — feat: DevFlow improve Comet view resolution and IView scroll support** (cherry-pick of `4179da8e`)
   - `CometViewResolver` extended for richer IView scroll handling
   - DFAS handles `IView` scroll commands

3. **`02b650d4` — fix: align IAppDriver.GetTreeAsync with includeLayout + suppress TFM warnings**
   - Interface caught up with `AppDriverBase` (the Yoga-layout commit added `includeLayout` to the impl but missed the interface)
   - `Driver.csproj` adds `SuppressTfmSupportBuildWarnings`

## Result

After this PR + #174 merge, `feature/comet` should contain **zero DevFlow additions** vs main. Remaining diffs are all feature/comet **deletions** of features that landed on main after the Comet branch was cut (BLE Monitoring, Skills system), which is a feature/comet-merge concern, not a DevFlow extraction concern.

## Verification

- Build: relies on CI (sandbox can't fetch Arcade SDK)
- Conflict resolution required: 4 hunks in DFAS (StartServerOnly, BindApp/BindIApp, status payload, tree handler), 1 hunk in VTW (WalkTree overloads), 2 hunks in AgentServiceExtensions (resolved to keep main entirely)
- Bulk migration of remaining `_app` → `BoundApplication` callsites done via scripted regex; verified all leftover `_app` references are intentional (field, assignments, `IsAppBound`)