### PR TITLE
Fix NuGet publish: add PackRepoRootReadme opt-out for duplicate README

### DIFF
--- a/eng/Common.props
+++ b/eng/Common.props
@@ -19,8 +19,12 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
-  <!-- Include repo-root README in NuGet package -->
-  <ItemGroup Condition="'$(IsPackable)' != 'false'">
+  <!--
+    Default: pack the repo-root README into NuGet packages.
+    Projects with their own README should add their own <None Include="README.md" Pack="true" PackagePath="/" />
+    and set <PackRepoRootReadme>false</PackRepoRootReadme> to prevent duplicates.
+  -->
+  <ItemGroup Condition="'$(IsPackable)' != 'false' and '$(PackRepoRootReadme)' != 'false'">
     <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 

--- a/platforms/Linux.Gtk4/Directory.Build.props
+++ b/platforms/Linux.Gtk4/Directory.Build.props
@@ -22,5 +22,7 @@
     <RepositoryUrl>https://github.com/dotnet/maui-labs.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!-- Use product-specific README instead of repo-root one -->
+    <PackRepoRootReadme>false</PackRepoRootReadme>
   </PropertyGroup>
 </Project>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/Linux.Gtk4.BlazorWebView.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/Linux.Gtk4.BlazorWebView.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
-
 </Project>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Linux.Gtk4.Essentials.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.Essentials/Linux.Gtk4.Essentials.csproj
@@ -23,7 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
-
 </Project>

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
     <None Include="buildTransitive/**" Pack="true" PackagePath="buildTransitive/" />
   </ItemGroup>
 

--- a/src/Cli/Microsoft.Maui.StartupProfiling/Microsoft.Maui.StartupProfiling.csproj
+++ b/src/Cli/Microsoft.Maui.StartupProfiling/Microsoft.Maui.StartupProfiling.csproj
@@ -12,12 +12,11 @@
     <IsShipping>true</IsShipping>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- No dependencies on MAUI or any other runtime packages -->
-    <!-- NU5118: suppress duplicate README warning — eng/Common.props adds the repo-root README
-         at "/README.md"; we override it with this package's own README below. -->
-    <NoWarn>$(NoWarn);CS1572;CS1573;CA2255;NU5118</NoWarn>
+    <NoWarn>$(NoWarn);CS1572;CS1573;CA2255</NoWarn>
+    <!-- Use product-specific README instead of repo-root one -->
+    <PackRepoRootReadme>false</PackRepoRootReadme>
   </PropertyGroup>
 
-  <!-- Use this package's own README instead of the repo-root one. -->
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>


### PR DESCRIPTION
Fixes the GTK4 NuGet.org publish failure:
> Response status code does not indicate success: 400 (The package contains one or more duplicated files in the same folder.)

## Root Cause

`eng/Common.props` packs the **repo-root** `README.md` into every packable project. Products that also pack their own **product-specific** `README.md` (GTK4, StartupProfiling) end up with two `README.md` files at the nupkg root. NuGet.org rejects packages with duplicate files.

## Fix

Add a `PackRepoRootReadme` opt-out property to `eng/Common.props`. Products with their own README set `<PackRepoRootReadme>false</PackRepoRootReadme>`; all other packages continue getting the repo-root README automatically.

## Changes

| File | Change |
|------|--------|
| `eng/Common.props` | Gate repo-root README include on `PackRepoRootReadme != 'false'` |
| `platforms/Linux.Gtk4/Directory.Build.props` | Set `PackRepoRootReadme=false` (inherited by all 3 GTK4 packages) |
| GTK4 `.csproj` files (3) | Remove `<None Remove>`  no longer needed |workaround 
| `StartupProfiling.csproj` | Set `PackRepoRootReadme=false`, drop NU5118 suppress |

## Affected Packages

- `Microsoft.Maui.Platforms.Linux. **actively failing** on publishGtk4` 
- `Microsoft.Maui.Platforms.Linux.Gtk4. sameBlazorWebView` 
- `Microsoft.Maui.Platforms.Linux.Gtk4. sameEssentials` 
- `Microsoft.Maui. latent (not currently published to NuGet.org, but would fail when it is)StartupProfiling` 

## For future products

Any new product with its own README just needs:
```xml
<PackRepoRootReadme>false</PackRepoRootReadme>
```
