### PR TITLE
Include StartupProfiling in CLI NuGet publish

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -284,6 +284,7 @@ extends:
           - powershell: |
               New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/CliPackages'
               Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Cli.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose
+              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.StartupProfiling.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose -ErrorAction Stop
             displayName: Filter Cli packages
 
         - job: PublishNuGet


### PR DESCRIPTION
## Problem

The CLI publish stage in `devflow-official.yml` filters packages with:
```powershell
Copy-Item '...PackageArtifacts/Microsoft.Maui.Cli.*.nupkg' ...
```

This misses `Microsoft.Maui.StartupProfiling` which is built as part of the Cli solution (`Cli.slnf`) but has a different package ID prefix. The package is built and signed but never pushed to NuGet.org.

## Fix

Add a second `Copy-Item` for the StartupProfiling package in the filter step.

## Audit

Full scan of all `IsPackable=true` + `IsShipping=true` packages in the repo against the three publish stage filter globs:

| Package | Publish Stage | Status |
|---------|---------------|--------|
| Microsoft.Maui.DevFlow.* (7 packages) | DevFlow | | 
| Microsoft.Maui.Cli | Cli | | 
| **Microsoft.Maui.StartupProfiling** | **Cli (after this fix Fixed |)** | 
| Microsoft.Maui.Platforms.Linux.Gtk4.* (3 packages) | LinuxGtk4 | | 

No other packages are missing from their respective publish stages.
