### PR TITLE
docs: add missing maui profile startup command and fix Windows platform claim

### DIFF
--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -108,6 +108,8 @@ maui apple simulator delete "iPhone 16 Pro"
 | `maui devflow diagnose` | Check DevFlow agent health |
 | `maui devflow wait` | Wait for an agent to connect |
 | `maui devflow mcp` | Start the MCP server for AI agent integration |
+| **Profiling** | |
+| `maui profile startup` | Collect a startup trace for a .NET MAUI app (.nettrace, speedscope, or MIBC output) |
 
 Run `maui <command> --help` for detailed options on any command.
 
@@ -153,7 +155,7 @@ maui doctor --json | jq '.checks[] | select(.status == "failed")'
 | Platform | Status | Notes |
 |----------|--------|-------|
 | macOS | ✅ | Full support including Apple commands (Xcode, simulators, runtimes) |
-| Windows | ✅ | Android and Windows SDK commands |
+| Windows | ✅ | Android SDK, JDK, and emulator commands |
 | Linux | ✅ | Android commands |
 
 ## Development


### PR DESCRIPTION
Fixes #181

## Changes

1. Added maui profile startup to the Commands table - registered in Program.cs and implemented in ProfileCommand.cs but was missing from the README.

2. Fixed Windows platform support note - changed Android and Windows SDK commands to Android SDK, JDK, and emulator commands since there are no Windows-specific command groups.