### PR TITLE
Extract CLI skills into dedicated project

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main]
     paths:
-      - '.claude/skills/**'
+      - 'plugins/dotnet-maui/skills/maui-devflow-onboard/**'
+      - 'plugins/dotnet-maui/skills/maui-devflow-debug/**'
       - 'src/Cli/**'
       - 'src/DevFlow/Microsoft.Maui.DevFlow.Driver/**'
       - 'eng/**'
@@ -17,7 +18,8 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches: [main]
     paths:
-      - '.claude/skills/**'
+      - 'plugins/dotnet-maui/skills/maui-devflow-onboard/**'
+      - 'plugins/dotnet-maui/skills/maui-devflow-debug/**'
       - 'src/Cli/**'
       - 'src/DevFlow/Microsoft.Maui.DevFlow.Driver/**'
       - 'eng/**'

--- a/MauiLabs.slnx
+++ b/MauiLabs.slnx
@@ -16,6 +16,7 @@
   <Folder Name="/src/Cli/">
     <Project Path="src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj" />
     <Project Path="src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj" />
+    <Project Path="src/Cli/Microsoft.Maui.Cli.Skills/Microsoft.Maui.Cli.Skills.csproj" />
     <Project Path="src/Cli/Microsoft.Maui.StartupProfiling/Microsoft.Maui.StartupProfiling.csproj" />
   </Folder>
   <Folder Name="/src/DevFlow/">

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,7 +2,7 @@
 
 Distributable agent skills for .NET MAUI development. Installable via the Copilot CLI, Claude Code, or VS Code plugin system.
 
-DevFlow runtime skills (`maui-devflow-onboard`, `maui-devflow-debug`) are bundled with the `maui` CLI from `plugins/dotnet-maui/skills/`, installed with `maui devflow init`, and exposed through the plugin manifest.
+DevFlow runtime skills (`maui-devflow-onboard`, `maui-devflow-debug`) are sourced from `plugins/dotnet-maui/skills/`, bundled into the `maui` CLI through the `Microsoft.Maui.Cli.Skills` project, installed with `maui devflow init`, and exposed through the plugin manifest.
 
 ## Plugin
 

--- a/src/Cli/Cli.slnf
+++ b/src/Cli/Cli.slnf
@@ -3,6 +3,7 @@
     "path": "../../MauiLabs.slnx",
     "projects": [
       "src\\Cli\\Microsoft.Maui.Cli\\Microsoft.Maui.Cli.csproj",
+      "src\\Cli\\Microsoft.Maui.Cli.Skills\\Microsoft.Maui.Cli.Skills.csproj",
       "src\\Cli\\Microsoft.Maui.Cli.UnitTests\\Microsoft.Maui.Cli.UnitTests.csproj",
       "src\\Cli\\Microsoft.Maui.StartupProfiling\\Microsoft.Maui.StartupProfiling.csproj",
       "src\\DevFlow\\Microsoft.Maui.DevFlow.Driver\\Microsoft.Maui.DevFlow.Driver.csproj"

--- a/src/Cli/Microsoft.Maui.Cli.Skills/MauiCliSkillResources.cs
+++ b/src/Cli/Microsoft.Maui.Cli.Skills/MauiCliSkillResources.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+
+namespace Microsoft.Maui.Cli.Skills;
+
+public static class MauiCliSkillResources
+{
+    public const string ResourceRoot = "devflow.skills";
+
+    public static Assembly Assembly => typeof(MauiCliSkillResources).Assembly;
+
+    public static IReadOnlyList<MauiCliSkillDefinition> BundledSkills { get; } =
+    [
+        new("maui-devflow-onboard", "MAUI DevFlow Onboard", "Guides first-time MAUI DevFlow project integration.", Recommended: true),
+        new("maui-devflow-debug", "MAUI DevFlow Debug", "Guides build, deploy, connection recovery, inspect, and debug loops with MAUI DevFlow.", Recommended: true)
+    ];
+}
+
+public sealed record MauiCliSkillDefinition(string Id, string DisplayName, string Description, bool Recommended);

--- a/src/Cli/Microsoft.Maui.Cli.Skills/Microsoft.Maui.Cli.Skills.csproj
+++ b/src/Cli/Microsoft.Maui.Cli.Skills/Microsoft.Maui.Cli.Skills.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <RootNamespace>Microsoft.Maui.Cli.Skills</RootNamespace>
+    <AssemblyName>Microsoft.Maui.Cli.Skills</AssemblyName>
+    <Description>Bundled agent skills for the .NET MAUI CLI</Description>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-onboard\**\*" LogicalName="devflow.skills/maui-devflow-onboard/%(RecursiveDir)%(Filename)%(Extension)">
+      <WithCulture>false</WithCulture>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-debug\**\*" LogicalName="devflow.skills/maui-devflow-debug/%(RecursiveDir)%(Filename)%(Extension)">
+      <WithCulture>false</WithCulture>
+    </EmbeddedResource>
+  </ItemGroup>
+
+</Project>

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowSkillManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowSkillManagerTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using Microsoft.Maui.Cli.DevFlow;
 using Microsoft.Maui.Cli.DevFlow.Skills;
+using Microsoft.Maui.Cli.Skills;
 using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
@@ -11,6 +12,20 @@ namespace Microsoft.Maui.Cli.UnitTests;
 [Collection("CLI")]
 public sealed class DevFlowSkillManagerTests
 {
+    [Fact]
+    public void BundledSkillResources_AreLoadedFromSkillsAssembly()
+    {
+        var skillsAssembly = MauiCliSkillResources.Assembly;
+        var cliAssembly = typeof(DevFlowSkillManager).Assembly;
+        var skillsResources = skillsAssembly.GetManifestResourceNames();
+        var cliResources = cliAssembly.GetManifestResourceNames();
+
+        Assert.NotSame(cliAssembly, skillsAssembly);
+        Assert.Contains($"{MauiCliSkillResources.ResourceRoot}/maui-devflow-onboard/SKILL.md", skillsResources);
+        Assert.Contains($"{MauiCliSkillResources.ResourceRoot}/maui-devflow-debug/SKILL.md", skillsResources);
+        Assert.DoesNotContain(cliResources, resource => resource.StartsWith($"{MauiCliSkillResources.ResourceRoot}/maui-devflow-", StringComparison.Ordinal));
+    }
+
     [Fact]
     public async Task InstallRecommended_ProjectScope_WritesBundledSkillsAndUserLevelState()
     {

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Maui.Cli.Skills\Microsoft.Maui.Cli.Skills.csproj" />
     <ProjectReference Include="..\Microsoft.Maui.Cli\Microsoft.Maui.Cli.csproj" />
   </ItemGroup>
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Skills/DevFlowSkillManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Skills/DevFlowSkillManager.cs
@@ -3,12 +3,13 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.Maui.Cli.Skills;
 
 namespace Microsoft.Maui.Cli.DevFlow.Skills;
 
 internal static class DevFlowSkillManager
 {
-    const string ResourceRoot = "devflow.skills";
+    const string ResourceRoot = MauiCliSkillResources.ResourceRoot;
     const string PackageId = "Microsoft.Maui.Cli";
     const string StateRootEnvironmentVariable = "MAUIDEVFLOW_STATE_ROOT";
     const string AutoTarget = "auto";
@@ -19,11 +20,9 @@ internal static class DevFlowSkillManager
     static readonly TimeSpan FreshnessCheckInterval = TimeSpan.FromDays(7);
     static readonly TimeSpan FreshnessPromptInterval = TimeSpan.FromDays(1);
 
-    static readonly DevFlowSkillDefinition[] s_skills =
-    [
-        new("maui-devflow-onboard", "MAUI DevFlow Onboard", "Guides first-time MAUI DevFlow project integration.", Recommended: true),
-        new("maui-devflow-debug", "MAUI DevFlow Debug", "Guides build, deploy, connection recovery, inspect, and debug loops with MAUI DevFlow.", Recommended: true)
-    ];
+    static readonly DevFlowSkillDefinition[] s_skills = MauiCliSkillResources.BundledSkills
+        .Select(skill => new DevFlowSkillDefinition(skill.Id, skill.DisplayName, skill.Description, skill.Recommended))
+        .ToArray();
 
     static readonly string[] s_legacySkillIds =
     [
@@ -463,7 +462,7 @@ internal static class DevFlowSkillManager
 
     static async Task<SkillBundle> LoadSkillBundleAsync(DevFlowSkillDefinition skill, CancellationToken cancellationToken)
     {
-        var assembly = typeof(DevFlowSkillManager).Assembly;
+        var assembly = MauiCliSkillResources.Assembly;
         var prefix = $"{ResourceRoot}/{skill.Id}/";
         var resources = assembly.GetManifestResourceNames()
             .Where(name => name.StartsWith(prefix, StringComparison.Ordinal))
@@ -488,7 +487,7 @@ internal static class DevFlowSkillManager
             files.Add(new SkillAssetFile(relativePath, content, HashContent(content)));
         }
 
-        return new SkillBundle(skill.Id, GetCurrentCliVersion(), files, HashBundle(files));
+        return new SkillBundle(skill.Id, GetBundledSkillVersion(), files, HashBundle(files));
     }
 
     static bool ShouldExcludeSkillAsset(string relativePath)
@@ -1143,6 +1142,12 @@ internal static class DevFlowSkillManager
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
            ?? typeof(DevFlowSkillManager).Assembly.GetName().Version?.ToString()
            ?? "unknown";
+
+    static string GetBundledSkillVersion()
+        => MauiCliSkillResources.Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+           ?? MauiCliSkillResources.Assembly.GetName().Version?.ToString()
+           ?? GetCurrentCliVersion();
 
     static string? GetString(JsonObject node, string propertyName)
         => node.TryGetPropertyValue(propertyName, out var value) ? value?.GetValue<string>() : null;

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -55,6 +55,7 @@
   </Target>
 
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Maui.Cli.Skills\Microsoft.Maui.Cli.Skills.csproj" />
     <ProjectReference Include="..\Microsoft.Maui.StartupProfiling\Microsoft.Maui.StartupProfiling.csproj" />
     <ProjectReference Include="..\..\DevFlow\Microsoft.Maui.DevFlow.Driver\Microsoft.Maui.DevFlow.Driver.csproj" />
   </ItemGroup>
@@ -68,15 +69,6 @@
     <Compile Remove="Build\MauiStartupProfiling.AutoInitialize.cs" />
     <Content Include="Build\MauiStartupProfilingInjection.targets" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="Build\MauiStartupProfiling.AutoInitialize.cs" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-onboard\**\*" LogicalName="devflow.skills/maui-devflow-onboard/%(RecursiveDir)%(Filename)%(Extension)">
-      <WithCulture>false</WithCulture>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-debug\**\*" LogicalName="devflow.skills/maui-devflow-debug/%(RecursiveDir)%(Filename)%(Extension)">
-      <WithCulture>false</WithCulture>
-    </EmbeddedResource>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
DevFlow skills were embedded directly by `Microsoft.Maui.Cli`, which made them harder to treat as their own buildable and versioned component. This extracts the bundled skills into a dedicated project while keeping the existing CLI install flow intact.

## Changes

- Adds `Microsoft.Maui.Cli.Skills`, a `net9.0;net10.0` class library that embeds the existing DevFlow skill assets from `plugins/dotnet-maui/skills`.
- Updates `DevFlowSkillManager` to load bundled skill resources from the referenced skills assembly instead of the `maui` assembly.
- Wires the new project into `MauiLabs.slnx`, `src/Cli/Cli.slnf`, CLI CI path filters, docs, and unit tests.

## Validation

- `.dotnet/dotnet build src/Cli/Cli.slnf`
- `.dotnet/dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj --no-build`
- Publish smoke check confirming `Microsoft.Maui.Cli.Skills.dll` is copied with the CLI and `maui devflow init` installs both bundled skills.