### PR TITLE
Add arcade-skills plugin for Copilot

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "dotnet-arcade-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/arcade-skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dotnet-dnceng@dotnet-arcade-skills": true
+  }
+}


### PR DESCRIPTION
Adds `dotnet/arcade-skills` marketplace and enables the `dotnet-dnceng` plugin, matching the `dotnet/maui` configuration.

This provides CI analysis, Helix investigation, flow analysis, and other dotnet-specific skills to Copilot sessions working in this repo.