### PR TITLE
Add Comet CI workflow with release artifact attachment

### DIFF
--- a/.github/workflows/ci-comet.yml
+++ b/.github/workflows/ci-comet.yml
@@ -1,0 +1,78 @@
+name: CI - Comet
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Comet/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/Comet/**'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET 11 Preview
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui
+
+      - name: Build Comet
+        run: dotnet build src/Comet/src/Comet/Comet.csproj -c Release
+
+      - name: Build Source Generator
+        run: dotnet build src/Comet/src/Comet.SourceGenerator/Comet.SourceGenerator.csproj -c Release
+
+      - name: Run tests
+        run: dotnet test src/Comet/tests/Comet.Tests/Comet.Tests.csproj -c Release --logger "trx;LogFileName=results.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-comet-${{ matrix.os }}
+          path: '**/results.trx'
+
+  package:
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET 11 Preview
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui
+
+      - name: Pack Comet
+        run: dotnet pack src/Comet/src/Comet/Comet.csproj -c Release -o artifacts/packages
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: packages-comet
+          path: artifacts/packages/*.nupkg
+
+      - name: Attach packages to release
+        if: github.event_name == 'release'
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} artifacts/packages/*.nupkg --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions CI workflow for the Comet MVU framework.

## What it does

**On push/PR to `src/Comet/**`:**
- Builds Comet + source generator on macOS and Windows
- Installs .NET 11 preview SDK + MAUI workload (independent of repo-root Arcade SDK)
- Runs the Comet test suite
- Packs and uploads `.nupkg` as a workflow artifact

**On release (when you create a GitHub Release):**
- Builds, tests,  same as abovepacks 
- Attaches the `.nupkg` to the release so it remains permanently available

## Why not Arcade / Azure DevOps?

Comet targets `net11.0` and uses .NET 11 preview SDK. The repo-root `global.json` pins .NET 10 with `allowPrerelease: false`. These are  Arcade cannot provision .NET 11 from the repo-root config. This workflow installs the SDK independently.incompatible 

When the repo upgrades to .NET 11, Comet can migrate into `_build.yml` + `devflow-official.yml`.

## Workflow structure

Follows the same conventions as `ci-cli.yml`, `ci-devflow.yml`, and `ci-linux-gtk4.yml`:
- Path-filtered triggers
- macOS + Windows matrix
- Test results upload
- Package artifact upload
