### PR TITLE
Skills: retarget DevFlow skills to the unified maui CLI

### DIFF
--- a/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   the unified `maui` CLI (devflow, device, android, apple, doctor command
   groups) and dotnet CLI. Falls back to raw `adb` and `xcrun simctl` only for
   operations not yet wrapped by the `maui` CLI (port forwarding, APK install,
-  logcat, simulator create/install/launch/appearance).
+  logcat, simulator appearance/openurl/push/location/addmedia).
 ---
 
 # DevFlow Debug

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
@@ -89,9 +89,12 @@ packages and `builder.AddMauiDevFlowAgent()` registered.
 Always prefer the unified `maui` CLI surface for device prep and DevFlow
 operations. For programmatic consumption:
 
-- Pass `--json` to any command an agent will parse. Errors are emitted as a
+- Pass `--json` to any command an agent will parse. Non-DevFlow commands
+  (e.g. `maui doctor`, `maui android ...`, `maui apple ...`) emit errors as a
   structured envelope at the **top level** of stdout (no `"error"` wrapper),
   with `snake_case` property names. See `references/troubleshooting.md`.
+  **Note:** `maui devflow ...` commands use a different error shape
+  (`{"error":"...","type":"...","retryable":...}`) written to **stderr**.
 - Inspect `code` to branch logic. Categories: `E1xxx` tool, `E2xxx`
   platform/SDK, `E3xxx` user action, `E4xxx` network, `E5xxx` permission.
 - When `remediation` is present and `remediation.type` is `autofixable`

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
@@ -61,9 +61,9 @@ packages and `builder.AddMauiDevFlowAgent()` registered.
 5. Wait for the DevFlow agent before inspecting UI:
 
    ```bash
-   maui devflow wait
-   maui devflow agent status
-   maui devflow ui tree --depth 3 --fields "id,type,text,automationId"
+   maui devflow wait --json
+   maui devflow agent status --json
+   maui devflow ui tree --depth 3 --fields "id,type,text,automationId" --json
    ```
 
    Treat `agent status` as the runtime truth for reachability and app identity.
@@ -75,8 +75,8 @@ packages and `builder.AddMauiDevFlowAgent()` registered.
 6. Prefer AutomationId-first validation for UI flows:
 
    ```bash
-   maui devflow ui query --automationId save-button
-   maui devflow ui tap <element-id-from-query>
+   maui devflow ui query --automationId save-button --json
+   maui devflow ui tap <element-id-from-query> --json
    ```
 
    If important controls do not have stable `AutomationId`s, add them before

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
@@ -8,8 +8,10 @@ description: >-
   Blazor WebView CDP debugging, reading DevFlow logs, and iterative app
   debugging. DO NOT USE FOR: first-time DevFlow package setup (use
   maui-devflow-onboard), or generic desktop automation unrelated to MAUI. INVOKES:
-  maui devflow CLI, dotnet CLI, Android adb/android tools, and Apple simctl
-  tools.
+  the unified `maui` CLI (devflow, device, android, apple, doctor command
+  groups) and dotnet CLI. Falls back to raw `adb` and `xcrun simctl` only for
+  operations not yet wrapped by the `maui` CLI (port forwarding, APK install,
+  logcat, simulator create/install/launch/privacy/appearance).
 ---
 
 # DevFlow Debug
@@ -81,6 +83,20 @@ packages and `builder.AddMauiDevFlowAgent()` registered.
    relying on text, coordinates, screenshots, or brittle tree positions.
 
 7. Inspect, interact, capture evidence, then edit the app and repeat from launch.
+
+## Reading machine-readable output
+
+Always prefer the unified `maui` CLI surface for device prep and DevFlow
+operations. For programmatic consumption:
+
+- Pass `--json` to any command an agent will parse. Errors are emitted as a
+  structured envelope (see `references/troubleshooting.md`).
+- Inspect `error.code` to branch logic. Categories: `E1xxx` tool, `E2xxx`
+  platform/SDK, `E3xxx` user action, `E4xxx` network, `E5xxx` permission.
+- When `error.remediation.type` is `AutoFixable`, run
+  `error.remediation.command` and retry. When it is `UserAction`, follow
+  `error.remediation.manualSteps`.
+- Use `--ci` for non-interactive failure-fast runs (no prompts, fail on first error).
 
 ## Critical Anti-patterns
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   the unified `maui` CLI (devflow, device, android, apple, doctor command
   groups) and dotnet CLI. Falls back to raw `adb` and `xcrun simctl` only for
   operations not yet wrapped by the `maui` CLI (port forwarding, APK install,
-  logcat, simulator create/install/launch/privacy/appearance).
+  logcat, simulator create/install/launch/appearance).
 ---
 
 # DevFlow Debug
@@ -90,12 +90,14 @@ Always prefer the unified `maui` CLI surface for device prep and DevFlow
 operations. For programmatic consumption:
 
 - Pass `--json` to any command an agent will parse. Errors are emitted as a
-  structured envelope (see `references/troubleshooting.md`).
-- Inspect `error.code` to branch logic. Categories: `E1xxx` tool, `E2xxx`
+  structured envelope at the **top level** of stdout (no `"error"` wrapper),
+  with `snake_case` property names. See `references/troubleshooting.md`.
+- Inspect `code` to branch logic. Categories: `E1xxx` tool, `E2xxx`
   platform/SDK, `E3xxx` user action, `E4xxx` network, `E5xxx` permission.
-- When `error.remediation.type` is `AutoFixable`, run
-  `error.remediation.command` and retry. When it is `UserAction`, follow
-  `error.remediation.manualSteps`.
+- When `remediation` is present and `remediation.type` is `autofixable`
+  (lowercase), run `remediation.command` and retry. When it is `useraction`,
+  follow `remediation.manual_steps`. If `remediation` is absent, surface
+  `message` and stop retrying — there is no auto-fix.
 - Use `--ci` for non-interactive failure-fast runs (no prompts, fail on first error).
 
 ## Critical Anti-patterns

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
@@ -81,6 +81,26 @@ for MAUI DevFlow product feedback. Do not run it automatically.
 
 7. Inspect, interact, capture evidence, then edit the app and repeat from launch.
 
+## Reading machine-readable output
+
+Always prefer the unified `maui` CLI surface for device prep and DevFlow
+operations. For programmatic consumption:
+
+- Pass `--json` to any command an agent will parse. For `maui android`, `maui
+  apple`, and `maui device`, errors are emitted as a structured envelope at the
+  **top level** of stdout (no `"error"` wrapper), with `snake_case` property
+  names. See `references/troubleshooting.md`. Two surfaces differ: `maui doctor
+  --json` emits a `DoctorReport` (`status` + `checks[]` with `fix.command`), and
+  `maui devflow …` commands emit `{ "error", "type", "retryable" }` on
+  **stderr**.
+- Inspect `code` to branch logic. Categories: `E1xxx` tool, `E2xxx`
+  platform/SDK, `E3xxx` user action, `E4xxx` network, `E5xxx` permission.
+- When `remediation` is present and `remediation.type` is `autofixable`
+  (lowercase), run `remediation.command` and retry. When it is `useraction`,
+  follow `remediation.manual_steps`. If `remediation` is absent, surface
+  `message` and stop retrying — there is no auto-fix.
+- Use `--ci` for non-interactive failure-fast runs (no prompts, fail on first error).
+
 ## Critical Anti-patterns
 
 - Do not treat an empty `maui devflow list` as proof the project is not integrated. `list` is runtime state; project files are source of truth.

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
@@ -111,7 +111,20 @@ maui android sdk accept-licenses
 `install` and `uninstall` accept package names as **positional** arguments
 (no `--package` flag); pass multiple packages by space-separating them.
 
-For a guided full-stack setup, run:
+### Accepting licenses non-interactively
+
+`maui android sdk accept-licenses` is interactive (prompts for each license).
+For AI agents or CI, use the guided installer with `--accept-licenses` to
+bypass prompts:
+
+```bash
+maui android install --accept-licenses --json
+```
+
+This accepts all pending SDK licenses non-interactively. Combine with `--ci`
+for fully non-interactive failure-fast runs.
+
+For a guided full-stack setup (interactive), run:
 ```bash
 maui android install                             # interactive: platform + scope
 ```

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
@@ -96,19 +96,20 @@ Then verify: `maui devflow ui status` and `maui devflow webview status`.
 
 ### SDK
 ```bash
-maui android sdk check                           # status with --json support
-maui android sdk info                            # SDK location, tool versions
-maui android sdk list                            # all packages
-maui android sdk list --installed
-maui android sdk list --available
-maui android sdk install --package "platforms;android-35"
-maui android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
-maui android sdk install --package "emulator"
-maui android sdk install --package "platform-tools"
-maui android sdk uninstall --package <package-name>
+maui android sdk check                           # status with --json support (also reports SDK path)
+maui android sdk list                            # installed packages
+maui android sdk list --available                # all available packages
+maui android sdk list --all                      # both installed and available
+maui android sdk install "platforms;android-35"
+maui android sdk install "system-images;android-35;google_apis;arm64-v8a"
+maui android sdk install "emulator"
+maui android sdk install "platform-tools"
+maui android sdk uninstall <package-name>
 maui android sdk accept-licenses
-maui android sdk download                        # download cmdline-tools
 ```
+
+`install` and `uninstall` accept package names as **positional** arguments
+(no `--package` flag); pass multiple packages by space-separating them.
 
 For a guided full-stack setup, run:
 ```bash
@@ -118,19 +119,18 @@ maui android install                             # interactive: platform + scope
 ### Typical setup for MAUI Android development
 ```bash
 maui android sdk accept-licenses
-maui android sdk install --package "platforms;android-35"
-maui android sdk install --package "build-tools;35.0.0"
-maui android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
-maui android sdk install --package "emulator"
-maui android sdk install --package "platform-tools"
+maui android sdk install "platforms;android-35"
+maui android sdk install "build-tools;35.0.0"
+maui android sdk install "system-images;android-35;google_apis;arm64-v8a"
+maui android sdk install "emulator"
+maui android sdk install "platform-tools"
 ```
 
 ### JDK
 ```bash
-maui android jdk check                           # current JDK status
+maui android jdk check                           # current JDK status (path, version)
 maui android jdk install --version 17            # install OpenJDK 17 or 21
 maui android jdk list                            # available JDKs
-maui android jdk info                            # current JDK info
 ```
 
 ### Environment variables
@@ -206,14 +206,14 @@ adb -s <serial> shell
 - **Agent not connecting on emulator**: Forgot `adb reverse tcp:19223 tcp:19223`
   for the broker. Run port forwarding, then check `maui devflow list`.
 - **Emulator won't start**: Check installed system images with
-  `maui android sdk list --installed`. Install one with
-  `maui android sdk install --package "system-images;android-XX;..."`.
+  `maui android sdk list`. Install one with
+  `maui android sdk install "system-images;android-XX;..."`.
 - **Build error "No Android devices found"**: Ensure emulator is booted
   (`maui device list --platform android`).
 - **Slow emulator**: Use hardware acceleration. Prefer `arm64-v8a` images on
   Apple Silicon Macs.
 - **JSON error envelope**: When a `maui` command fails with `--json`, parse
-  `error.code` and `error.remediation` (see `troubleshooting.md`). Common
-  Android codes: `E2101` AndroidSdkNotFound, `E2103`
-  AndroidLicensesNotAccepted, `E2106` AndroidEmulatorNotFound, `E2110`
-  AndroidAdbNotFound, `E2111` AndroidDeviceNotFound.
+  the top-level `code` and `remediation` fields (no `error` wrapper; see
+  `troubleshooting.md`). Common Android codes: `E2101` AndroidSdkNotFound,
+  `E2103` AndroidLicensesNotAccepted, `E2106` AndroidEmulatorNotFound,
+  `E2110` AndroidAdbNotFound, `E2111` AndroidDeviceNotFound.

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
@@ -1,8 +1,8 @@
 # Android Reference
 
 Prefer the unified `maui` CLI for Android device prep and DevFlow workflows.
-Raw `adb` and `android` (`androidsdk.tool`) commands are kept only for
-operations that the `maui` CLI does not yet wrap; those are grouped under
+Raw `adb` commands are kept only for operations that the `maui` CLI does not
+yet wrap; those are grouped under
 [Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli).
 
 ## Table of Contents

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
@@ -1,70 +1,63 @@
 # Android Reference
 
+Prefer the unified `maui` CLI for Android device prep and DevFlow workflows.
+Raw `adb` and `android` (`androidsdk.tool`) commands are kept only for
+operations that the `maui` CLI does not yet wrap; those are grouped under
+[Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli).
+
 ## Table of Contents
 - [Emulator Management](#emulator-management)
 - [Building and Deploying](#building-and-deploying)
-- [Android CLI Tool](#android-cli-tool)
-- [ADB Reference](#adb-reference)
-- [SDK Management](#sdk-management)
+- [SDK and JDK Management](#sdk-and-jdk-management)
+- [Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli)
 - [Troubleshooting](#troubleshooting)
 
 ## Emulator Management
 
 ### Avoiding multi-project conflicts
 
-When multiple projects (or AI agents) may deploy to Android emulators simultaneously,
-each project should use its own dedicated AVD. Two apps deployed to the same emulator
-will coexist (unlike iOS), but `adb reverse`/`adb forward` port forwarding is per-device
-and can cause confusion when multiple emulators are running.
+When multiple projects (or AI agents) may deploy to Android emulators
+simultaneously, each project should use its own dedicated AVD. Two apps
+deployed to the same emulator will coexist (unlike iOS), but `adb reverse` /
+`adb forward` port forwarding is per-device and can cause confusion when
+multiple emulators are running.
 
 **Before creating or starting an emulator, check what's already in use:**
 ```bash
-maui devflow list                             # shows agents with platform + port
-adb devices                                   # shows connected emulators
+maui devflow list                                 # agents with platform + port
+maui device list --platform android               # connected emulators / devices
 ```
 
 If an emulator is already running another project's agent, create a new AVD:
 ```bash
-android avd create --name "ProjectName-Pixel8" \
-  --sdk "system-images;android-35;google_apis;arm64-v8a" --device pixel_8
-android avd start --name "ProjectName-Pixel8"
-```
-
-**When multiple emulators are running**, use `-s <serial>` to target a specific one:
-```bash
-adb -s emulator-5554 reverse tcp:19223 tcp:19223   # first emulator
-adb -s emulator-5556 reverse tcp:19223 tcp:19223   # second emulator
-```
-
-**Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-Pixel8`) so it's
-clear which AVD belongs to which project.
-
-### List and start AVDs
-```bash
-android avd list                              # list available AVDs
-android avd start --name <avd-name>           # start emulator
-```
-
-### Create AVD
-```bash
-# List available targets and device profiles
-android avd targets                           # system images
-android avd devices                           # device profiles (pixel, etc.)
-
-android avd create --name "Pixel8API35" \
-  --sdk "system-images;android-35;google_apis;arm64-v8a" \
+maui android emulator create "ProjectName-Pixel8" \
+  --package "system-images;android-35;google_apis;arm64-v8a" \
   --device pixel_8
+maui android emulator start "ProjectName-Pixel8"
 ```
 
-### Delete AVD
+**When multiple emulators are running**, target a specific serial with raw
+`adb -s <serial>` for port forwarding (see fallbacks below).
+
+**Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-Pixel8`)
+so it's clear which AVD belongs to which project.
+
+### List, create, start, stop, delete AVDs
 ```bash
-android avd delete --name <avd-name>
+maui android emulator list                       # available AVDs
+maui android emulator create <name> --package <system-image> --device <device>
+maui android emulator start <name>               # add --cold-boot --wait if needed
+maui android emulator stop <name>
+maui android emulator delete <name>
 ```
+
+All of the above accept `--json` for machine-readable output. The emulator
+`create` command will prompt interactively for system image / device profile
+when run without `--package` / `--device`.
 
 ### Verify emulator is running
 ```bash
-adb devices                                   # should show "emulator-5554 device"
-android device list                           # formatted list
+maui device list --platform android
 ```
 
 ## Building and Deploying
@@ -77,123 +70,67 @@ dotnet build -f net10.0-android -t:Run
 dotnet build -f net10.0-android
 ```
 
-**Critical: Port forwarding after deploy** — the Android emulator runs in its own network.
-Forward the broker port and the agent port:
+**Critical: Port forwarding after deploy** — the Android emulator runs in its
+own network. Both directions need forwarding:
+
 ```bash
-adb reverse tcp:19223 tcp:19223              # Broker (lets agent register)
-adb forward tcp:<port> tcp:<port>            # Agent (lets CLI reach agent)
+# Not yet wrapped by 'maui' CLI — use raw adb
+adb reverse tcp:19223 tcp:19223                  # Broker (lets agent register)
+adb forward tcp:<port> tcp:<port>                # Agent (lets CLI reach agent)
 ```
 
-The broker reverse is needed so the agent inside the emulator can connect to the host's
-broker daemon. The agent forward uses the port shown in `maui devflow list` after the agent
-registers (range 10223–10899).
+The broker `reverse` is needed so the agent inside the emulator can connect to
+the host's broker daemon. The agent `forward` uses the port shown in
+`maui devflow list` after the agent registers (range 10223–10899).
 
-If the broker isn't available (fallback mode), forward the port from `.mauidevflow` instead:
+If the broker isn't available (fallback mode), forward the port from
+`.mauidevflow` instead:
 ```bash
-adb forward tcp:9223 tcp:9223                # Fallback: direct agent port
+# Not yet wrapped by 'maui' CLI — use raw adb
+adb forward tcp:9223 tcp:9223                    # Fallback: direct agent port
 ```
 
 Then verify: `maui devflow ui status` and `maui devflow webview status`.
 
-### Install APK manually
+## SDK and JDK Management
+
+### SDK
 ```bash
-adb install -r path/to/app.apk               # install/reinstall
-android device install --package path/to/app.apk
+maui android sdk check                           # status with --json support
+maui android sdk info                            # SDK location, tool versions
+maui android sdk list                            # all packages
+maui android sdk list --installed
+maui android sdk list --available
+maui android sdk install --package "platforms;android-35"
+maui android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
+maui android sdk install --package "emulator"
+maui android sdk install --package "platform-tools"
+maui android sdk uninstall --package <package-name>
+maui android sdk accept-licenses
+maui android sdk download                        # download cmdline-tools
 ```
 
-## Android CLI Tool
-
-The `android` command (from `androidsdk.tool` NuGet) wraps SDK tools.
-
-### SDK management
-```
-android sdk list                              # all packages
-android sdk list --installed                  # installed only
-android sdk list --available                  # available for install
-android sdk install --package "platforms;android-35"
-android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
-android sdk install --package "emulator"
-android sdk uninstall --package <package-name>
-android sdk info                              # SDK location, tools versions
-android sdk accept-licenses                   # accept all SDK licenses
-android sdk download                          # download cmdline-tools
-```
-
-### AVD management
-```
-android avd list                              # available AVDs
-android avd targets                           # available system images
-android avd devices                           # available device profiles
-android avd create --name <name> --sdk <system-image> --device <device>
-android avd delete --name <name>
-android avd start --name <name>
-```
-
-### Device/emulator operations
-```
-android device list                           # connected devices/emulators
-android device info [--device <serial>]       # device properties
-android device install --package <apk>        # install APK
-android device uninstall --package <pkg-id>   # uninstall by package name
-```
-
-### JDK management
-```
-android jdk list                              # available JDKs
-android jdk info                              # current JDK info
-```
-
-## ADB Reference
-
-### Device/emulator basics
+For a guided full-stack setup, run:
 ```bash
-adb devices                                   # list connected devices
-adb -s <serial> shell                         # shell into specific device
-adb shell pm list packages | grep <name>      # find installed packages
-adb shell am start -n <pkg>/<activity>        # launch activity
-adb shell am force-stop <pkg>                 # kill app
+maui android install                             # interactive: platform + scope
 ```
-
-### Port forwarding (critical for MAUI DevFlow)
-```bash
-adb reverse tcp:19223 tcp:19223              # Broker (agent → host)
-adb forward tcp:<port> tcp:<port>            # Agent (CLI → emulator, get port from `maui devflow list`)
-adb reverse --list                            # verify forwarding
-adb forward --list                            # verify forwarding
-adb reverse --remove-all                      # clean up reverse
-adb forward --remove-all                      # clean up forward
-```
-
-### File operations
-```bash
-adb push local/file /sdcard/path              # push file to device
-adb pull /sdcard/path local/file              # pull file from device
-```
-
-### Logs
-```bash
-adb logcat -s "DOTNET" --format brief         # .NET runtime logs
-adb logcat -s "MauiDevFlow"                   # agent logs
-adb logcat --pid=$(adb shell pidof <pkg>)     # app-specific logs
-adb logcat -c                                 # clear log buffer
-```
-
-### Screenshots and screen recording
-```bash
-adb shell screencap /sdcard/screen.png && adb pull /sdcard/screen.png
-adb shell screenrecord /sdcard/video.mp4      # Ctrl+C to stop
-```
-
-## SDK Management
 
 ### Typical setup for MAUI Android development
 ```bash
-android sdk accept-licenses
-android sdk install --package "platforms;android-35"
-android sdk install --package "build-tools;35.0.0"
-android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
-android sdk install --package "emulator"
-android sdk install --package "platform-tools"
+maui android sdk accept-licenses
+maui android sdk install --package "platforms;android-35"
+maui android sdk install --package "build-tools;35.0.0"
+maui android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
+maui android sdk install --package "emulator"
+maui android sdk install --package "platform-tools"
+```
+
+### JDK
+```bash
+maui android jdk check                           # current JDK status
+maui android jdk install --version 17            # install OpenJDK 17 or 21
+maui android jdk list                            # available JDKs
+maui android jdk info                            # current JDK info
 ```
 
 ### Environment variables
@@ -203,11 +140,80 @@ export ANDROID_SDK_ROOT=$ANDROID_HOME
 export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator
 ```
 
+## Raw fallbacks not yet in `maui` CLI
+
+These operations are not wrapped by the `maui` CLI today. Use the raw tool and
+prefer `maui` for everything else.
+
+### Port forwarding (critical for MAUI DevFlow)
+```bash
+adb reverse tcp:19223 tcp:19223                  # Broker (agent → host)
+adb forward tcp:<port> tcp:<port>                # Agent (CLI → emulator)
+adb reverse --list
+adb forward --list
+adb reverse --remove-all
+adb forward --remove-all
+
+# Target a specific serial when multiple emulators are running:
+adb -s emulator-5554 reverse tcp:19223 tcp:19223
+adb -s emulator-5556 reverse tcp:19223 tcp:19223
+```
+
+### Install / uninstall / launch APK
+```bash
+adb install -r path/to/app.apk
+adb uninstall <pkg>
+adb shell am start -n <pkg>/<activity>
+adb shell am force-stop <pkg>
+adb shell pm list packages | grep <name>
+```
+
+### Logs
+Once a DevFlow agent is connected, prefer in-app logs:
+```bash
+maui devflow ui logs --limit 50
+```
+Pre-agent or for system-level traces, use `adb logcat`:
+```bash
+adb logcat -s "DOTNET" --format brief             # .NET runtime logs
+adb logcat -s "MauiDevFlow"                       # agent logs
+adb logcat --pid=$(adb shell pidof <pkg>)         # app-specific logs
+adb logcat -c                                     # clear log buffer
+```
+
+### Screenshots and screen recording
+For a running MAUI app, prefer:
+```bash
+maui devflow ui screenshot --output screen.png
+```
+For pre-launch / system-level capture:
+```bash
+adb shell screencap /sdcard/screen.png && adb pull /sdcard/screen.png
+adb shell screenrecord /sdcard/video.mp4          # Ctrl+C to stop
+```
+
+### File operations / shell
+```bash
+adb push local/file /sdcard/path
+adb pull /sdcard/path local/file
+adb -s <serial> shell
+```
+
 ## Troubleshooting
 
-- **`adb devices` shows "unauthorized"**: Accept the USB debugging prompt on the device/emulator.
-- **Agent not connecting on emulator**: Forgot `adb reverse tcp:19223 tcp:19223` for the broker. Run port forwarding, then check `maui devflow list`.
-- **Emulator won't start**: Check available system images with `android avd targets`. May need
-  to install with `android sdk install --package "system-images;..."`.
-- **Build error "No Android devices found"**: Ensure emulator is booted (`adb devices`).
-- **Slow emulator**: Use hardware acceleration. Prefer `arm64-v8a` images on Apple Silicon Macs.
+- **`maui device list --platform android` shows "unauthorized"**: Accept the
+  USB debugging prompt on the device/emulator.
+- **Agent not connecting on emulator**: Forgot `adb reverse tcp:19223 tcp:19223`
+  for the broker. Run port forwarding, then check `maui devflow list`.
+- **Emulator won't start**: Check installed system images with
+  `maui android sdk list --installed`. Install one with
+  `maui android sdk install --package "system-images;android-XX;..."`.
+- **Build error "No Android devices found"**: Ensure emulator is booted
+  (`maui device list --platform android`).
+- **Slow emulator**: Use hardware acceleration. Prefer `arm64-v8a` images on
+  Apple Silicon Macs.
+- **JSON error envelope**: When a `maui` command fails with `--json`, parse
+  `error.code` and `error.remediation` (see `troubleshooting.md`). Common
+  Android codes: `E2101` AndroidSdkNotFound, `E2103`
+  AndroidLicensesNotAccepted, `E2106` AndroidEmulatorNotFound, `E2110`
+  AndroidAdbNotFound, `E2111` AndroidDeviceNotFound.

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
@@ -24,8 +24,8 @@ multiple emulators are running.
 
 **Before creating or starting an emulator, check what's already in use:**
 ```bash
-maui devflow list                                 # agents with platform + port
-maui device list --platform android               # connected emulators / devices
+maui devflow list --json                          # agents with platform + port
+maui device list --platform android --json        # connected emulators / devices
 ```
 
 If an emulator is already running another project's agent, create a new AVD:
@@ -57,7 +57,7 @@ when run without `--package` / `--device`.
 
 ### Verify emulator is running
 ```bash
-maui device list --platform android
+maui device list --platform android --json
 ```
 
 ## Building and Deploying
@@ -96,10 +96,10 @@ Then verify: `maui devflow ui status` and `maui devflow webview status`.
 
 ### SDK
 ```bash
-maui android sdk check                           # status with --json support (also reports SDK path)
-maui android sdk list                            # installed packages
-maui android sdk list --available                # all available packages
-maui android sdk list --all                      # both installed and available
+maui android sdk check --json                    # status (also reports SDK path)
+maui android sdk list --json                     # installed packages
+maui android sdk list --available --json         # all available packages
+maui android sdk list --all --json               # both installed and available
 maui android sdk install "platforms;android-35"
 maui android sdk install "system-images;android-35;google_apis;arm64-v8a"
 maui android sdk install "emulator"
@@ -128,9 +128,9 @@ maui android sdk install "platform-tools"
 
 ### JDK
 ```bash
-maui android jdk check                           # current JDK status (path, version)
+maui android jdk check --json                    # current JDK status (path, version)
 maui android jdk install --version 17            # install OpenJDK 17 or 21
-maui android jdk list                            # available JDKs
+maui android jdk list --json                     # available JDKs
 ```
 
 ### Environment variables

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
@@ -171,7 +171,7 @@ adb shell pm list packages | grep <name>
 ### Logs
 Once a DevFlow agent is connected, prefer in-app logs:
 ```bash
-maui devflow ui logs --limit 50
+maui devflow logs --limit 50
 ```
 Pre-agent or for system-level traces, use `adb logcat`:
 ```bash

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
@@ -75,7 +75,7 @@ so broker registration and CLI-to-agent traffic need opposite forwarding
 directions. The `maui` CLI sets up **both** automatically:
 
 ```bash
-maui devflow wait --platform android   # sets up broker reverse + agent forward, waits for the agent
+maui devflow wait --wait-platform android   # sets up broker reverse + agent forward, waits for the agent
 maui devflow list                      # re-establishes (repairs) the agent forward on demand
 maui devflow diagnose                  # reports broker reverse + agent forward status
 ```

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/android.md
@@ -1,70 +1,63 @@
 # Android Reference
 
+Prefer the unified `maui` CLI for Android device prep and DevFlow workflows.
+Raw `adb` and `android` (`androidsdk.tool`) commands are kept only for
+operations that the `maui` CLI does not yet wrap; those are grouped under
+[Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli).
+
 ## Table of Contents
 - [Emulator Management](#emulator-management)
 - [Building and Deploying](#building-and-deploying)
-- [Android CLI Tool](#android-cli-tool)
-- [ADB Reference](#adb-reference)
-- [SDK Management](#sdk-management)
+- [SDK and JDK Management](#sdk-and-jdk-management)
+- [Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli)
 - [Troubleshooting](#troubleshooting)
 
 ## Emulator Management
 
 ### Avoiding multi-project conflicts
 
-When multiple projects (or AI agents) may deploy to Android emulators simultaneously,
-each project should use its own dedicated AVD. Two apps deployed to the same emulator
-will coexist (unlike iOS), but `adb reverse`/`adb forward` port forwarding is per-device
-and can cause confusion when multiple emulators are running.
+When multiple projects (or AI agents) may deploy to Android emulators
+simultaneously, each project should use its own dedicated AVD. Two apps
+deployed to the same emulator will coexist (unlike iOS), but `adb reverse` /
+`adb forward` port forwarding is per-device and can cause confusion when
+multiple emulators are running.
 
 **Before creating or starting an emulator, check what's already in use:**
 ```bash
-maui devflow list                             # shows agents with platform + port
-adb devices                                   # shows connected emulators
+maui devflow list                                 # agents with platform + port
+maui device list --platform android               # connected emulators / devices
 ```
 
 If an emulator is already running another project's agent, create a new AVD:
 ```bash
-android avd create --name "ProjectName-Pixel8" \
-  --sdk "system-images;android-35;google_apis;arm64-v8a" --device pixel_8
-android avd start --name "ProjectName-Pixel8"
-```
-
-**When multiple emulators are running**, use `-s <serial>` to target a specific one:
-```bash
-adb -s emulator-5554 reverse tcp:19223 tcp:19223   # first emulator
-adb -s emulator-5556 reverse tcp:19223 tcp:19223   # second emulator
-```
-
-**Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-Pixel8`) so it's
-clear which AVD belongs to which project.
-
-### List and start AVDs
-```bash
-android avd list                              # list available AVDs
-android avd start --name <avd-name>           # start emulator
-```
-
-### Create AVD
-```bash
-# List available targets and device profiles
-android avd targets                           # system images
-android avd devices                           # device profiles (pixel, etc.)
-
-android avd create --name "Pixel8API35" \
-  --sdk "system-images;android-35;google_apis;arm64-v8a" \
+maui android emulator create "ProjectName-Pixel8" \
+  --package "system-images;android-35;google_apis;arm64-v8a" \
   --device pixel_8
+maui android emulator start "ProjectName-Pixel8"
 ```
 
-### Delete AVD
+**When multiple emulators are running**, target a specific serial with raw
+`adb -s <serial>` for port forwarding (see fallbacks below).
+
+**Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-Pixel8`)
+so it's clear which AVD belongs to which project.
+
+### List, create, start, stop, delete AVDs
 ```bash
-android avd delete --name <avd-name>
+maui android emulator list                       # available AVDs
+maui android emulator create <name> --package <system-image> --device <device>
+maui android emulator start <name>               # add --cold-boot --wait if needed
+maui android emulator stop <name>
+maui android emulator delete <name>
 ```
+
+All of the above accept `--json` for machine-readable output. The emulator
+`create` command will prompt interactively for system image / device profile
+when run without `--package` / `--device`.
 
 ### Verify emulator is running
 ```bash
-adb devices                                   # should show "emulator-5554 device"
-android device list                           # formatted list
+maui device list --platform android
 ```
 
 ## Building and Deploying
@@ -77,123 +70,76 @@ dotnet build -f net10.0-android -t:Run
 dotnet build -f net10.0-android
 ```
 
-**Critical: Port forwarding after deploy** — the Android emulator runs in its own network.
-Forward the broker port and the agent port:
+**Port forwarding after deploy** — the Android emulator runs in its own network,
+so broker registration and CLI-to-agent traffic need opposite forwarding
+directions. The `maui` CLI sets up **both** automatically:
+
 ```bash
-adb reverse tcp:19223 tcp:19223              # Broker (lets agent register)
-adb forward tcp:<port> tcp:<port>            # Agent (lets CLI reach agent)
+maui devflow wait --platform android   # sets up broker reverse + agent forward, waits for the agent
+maui devflow list                      # re-establishes (repairs) the agent forward on demand
+maui devflow diagnose                  # reports broker reverse + agent forward status
 ```
 
-The broker reverse is needed so the agent inside the emulator can connect to the host's
-broker daemon. The agent forward uses the port shown in `maui devflow list` after the agent
-registers (range 10223–10899).
+`maui devflow wait` establishes the broker `reverse` (tcp:19223) before polling
+so the agent inside the emulator can register, then the agent `forward` once it
+registers (port from `maui devflow list`, range 10223–10899). Add
+`--device <serial>` when multiple emulators are attached. Drop to raw `adb` only
+to inspect or manually repair those mappings:
 
-If the broker isn't available (fallback mode), forward the port from `.mauidevflow` instead:
 ```bash
-adb forward tcp:9223 tcp:9223                # Fallback: direct agent port
+adb reverse --list && adb forward --list         # inspect
+adb reverse tcp:19223 tcp:19223                  # manual repair: broker
+adb forward tcp:<port> tcp:<port>                # manual repair: agent
+```
+
+If the broker isn't available (fallback mode), forward the direct `.mauidevflow`
+port yourself — this is the one path the CLI does **not** auto-forward (it only
+forwards broker-registered agents):
+```bash
+adb forward tcp:9223 tcp:9223                    # Fallback: direct agent port
 ```
 
 Then verify: `maui devflow ui status` and `maui devflow webview status`.
 
-### Install APK manually
+## SDK and JDK Management
+
+### SDK
 ```bash
-adb install -r path/to/app.apk               # install/reinstall
-android device install --package path/to/app.apk
+maui android sdk check                           # status with --json support (also reports SDK path)
+maui android sdk list                            # installed packages
+maui android sdk list --available                # all available packages
+maui android sdk list --all                      # both installed and available
+maui android sdk install "platforms;android-35"
+maui android sdk install "system-images;android-35;google_apis;arm64-v8a"
+maui android sdk install "emulator"
+maui android sdk install "platform-tools"
+maui android sdk uninstall <package-name>
+maui android sdk accept-licenses
 ```
 
-## Android CLI Tool
+`install` and `uninstall` accept package names as **positional** arguments
+(no `--package` flag); pass multiple packages by space-separating them.
 
-The `android` command (from `androidsdk.tool` NuGet) wraps SDK tools.
-
-### SDK management
-```
-android sdk list                              # all packages
-android sdk list --installed                  # installed only
-android sdk list --available                  # available for install
-android sdk install --package "platforms;android-35"
-android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
-android sdk install --package "emulator"
-android sdk uninstall --package <package-name>
-android sdk info                              # SDK location, tools versions
-android sdk accept-licenses                   # accept all SDK licenses
-android sdk download                          # download cmdline-tools
-```
-
-### AVD management
-```
-android avd list                              # available AVDs
-android avd targets                           # available system images
-android avd devices                           # available device profiles
-android avd create --name <name> --sdk <system-image> --device <device>
-android avd delete --name <name>
-android avd start --name <name>
-```
-
-### Device/emulator operations
-```
-android device list                           # connected devices/emulators
-android device info [--device <serial>]       # device properties
-android device install --package <apk>        # install APK
-android device uninstall --package <pkg-id>   # uninstall by package name
-```
-
-### JDK management
-```
-android jdk list                              # available JDKs
-android jdk info                              # current JDK info
-```
-
-## ADB Reference
-
-### Device/emulator basics
+For a guided full-stack setup, run:
 ```bash
-adb devices                                   # list connected devices
-adb -s <serial> shell                         # shell into specific device
-adb shell pm list packages | grep <name>      # find installed packages
-adb shell am start -n <pkg>/<activity>        # launch activity
-adb shell am force-stop <pkg>                 # kill app
+maui android install                             # interactive: platform + scope
 ```
-
-### Port forwarding (critical for MAUI DevFlow)
-```bash
-adb reverse tcp:19223 tcp:19223              # Broker (agent → host)
-adb forward tcp:<port> tcp:<port>            # Agent (CLI → emulator, get port from `maui devflow list`)
-adb reverse --list                            # verify forwarding
-adb forward --list                            # verify forwarding
-adb reverse --remove-all                      # clean up reverse
-adb forward --remove-all                      # clean up forward
-```
-
-### File operations
-```bash
-adb push local/file /sdcard/path              # push file to device
-adb pull /sdcard/path local/file              # pull file from device
-```
-
-### Logs
-```bash
-adb logcat -s "DOTNET" --format brief         # .NET runtime logs
-adb logcat -s "MauiDevFlow"                   # agent logs
-adb logcat --pid=$(adb shell pidof <pkg>)     # app-specific logs
-adb logcat -c                                 # clear log buffer
-```
-
-### Screenshots and screen recording
-```bash
-adb shell screencap /sdcard/screen.png && adb pull /sdcard/screen.png
-adb shell screenrecord /sdcard/video.mp4      # Ctrl+C to stop
-```
-
-## SDK Management
 
 ### Typical setup for MAUI Android development
 ```bash
-android sdk accept-licenses
-android sdk install --package "platforms;android-35"
-android sdk install --package "build-tools;35.0.0"
-android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
-android sdk install --package "emulator"
-android sdk install --package "platform-tools"
+maui android sdk accept-licenses
+maui android sdk install "platforms;android-35"
+maui android sdk install "build-tools;35.0.0"
+maui android sdk install "system-images;android-35;google_apis;arm64-v8a"
+maui android sdk install "emulator"
+maui android sdk install "platform-tools"
+```
+
+### JDK
+```bash
+maui android jdk check                           # current JDK status (path, version)
+maui android jdk install --version 17            # install OpenJDK 17 or 21
+maui android jdk list                            # available JDKs
 ```
 
 ### Environment variables
@@ -203,11 +149,80 @@ export ANDROID_SDK_ROOT=$ANDROID_HOME
 export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator
 ```
 
+## Raw fallbacks not yet in `maui` CLI
+
+Prefer `maui` for everything it wraps. APK install/launch and logcat below are
+genuinely not wrapped; port forwarding **is** wrapped (`maui devflow wait` /
+`list` / `diagnose`) and is shown here only for manual inspection or repair.
+
+### Port forwarding — inspect / manual repair
+```bash
+adb reverse --list && adb forward --list         # inspect the mappings maui created
+adb reverse tcp:19223 tcp:19223                  # manual repair: Broker (agent → host)
+adb forward tcp:<port> tcp:<port>                # manual repair: Agent (CLI → emulator)
+adb reverse --remove-all
+adb forward --remove-all
+
+# Target a specific serial (or just pass `maui ... --device emulator-5554`):
+adb -s emulator-5554 reverse tcp:19223 tcp:19223
+adb -s emulator-5556 reverse tcp:19223 tcp:19223
+```
+
+### Install / uninstall / launch APK
+```bash
+adb install -r path/to/app.apk
+adb uninstall <pkg>
+adb shell am start -n <pkg>/<activity>
+adb shell am force-stop <pkg>
+adb shell pm list packages | grep <name>
+```
+
+### Logs
+Once a DevFlow agent is connected, prefer in-app logs:
+```bash
+maui devflow logs --limit 50
+```
+Pre-agent or for system-level traces, use `adb logcat`:
+```bash
+adb logcat -s "DOTNET" --format brief             # .NET runtime logs
+adb logcat -s "MauiDevFlow"                       # agent logs
+adb logcat --pid=$(adb shell pidof <pkg>)         # app-specific logs
+adb logcat -c                                     # clear log buffer
+```
+
+### Screenshots and screen recording
+For a running MAUI app, prefer:
+```bash
+maui devflow ui screenshot --output screen.png
+```
+For pre-launch / system-level capture:
+```bash
+adb shell screencap /sdcard/screen.png && adb pull /sdcard/screen.png
+adb shell screenrecord /sdcard/video.mp4          # Ctrl+C to stop
+```
+
+### File operations / shell
+```bash
+adb push local/file /sdcard/path
+adb pull /sdcard/path local/file
+adb -s <serial> shell
+```
+
 ## Troubleshooting
 
-- **`adb devices` shows "unauthorized"**: Accept the USB debugging prompt on the device/emulator.
-- **Agent not connecting on emulator**: Forgot `adb reverse tcp:19223 tcp:19223` for the broker. Run port forwarding, then check `maui devflow list`.
-- **Emulator won't start**: Check available system images with `android avd targets`. May need
-  to install with `android sdk install --package "system-images;..."`.
-- **Build error "No Android devices found"**: Ensure emulator is booted (`adb devices`).
-- **Slow emulator**: Use hardware acceleration. Prefer `arm64-v8a` images on Apple Silicon Macs.
+- **`maui device list --platform android` shows "unauthorized"**: Accept the
+  USB debugging prompt on the device/emulator.
+- **Agent not connecting on emulator**: Forgot `adb reverse tcp:19223 tcp:19223`
+  for the broker. Run port forwarding, then check `maui devflow list`.
+- **Emulator won't start**: Check installed system images with
+  `maui android sdk list`. Install one with
+  `maui android sdk install "system-images;android-XX;..."`.
+- **Build error "No Android devices found"**: Ensure emulator is booted
+  (`maui device list --platform android`).
+- **Slow emulator**: Use hardware acceleration. Prefer `arm64-v8a` images on
+  Apple Silicon Macs.
+- **JSON error envelope**: When a `maui` command fails with `--json`, parse
+  the top-level `code` and `remediation` fields (no `error` wrapper; see
+  `troubleshooting.md`). Common Android codes: `E2101` AndroidSdkNotFound,
+  `E2103` AndroidLicensesNotAccepted, `E2106` AndroidEmulatorNotFound,
+  `E2110` AndroidAdbNotFound, `E2111` AndroidDeviceNotFound.

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -112,13 +112,18 @@ can parse. On failure, error fields are at the **top level** of stdout (no
 {
   "code": "E2106",
   "category": "platform",
-  "message": "No running emulator found with name 'Pixel8'",
+  "severity": "error",
+  "message": "Android emulator not installed",
   "remediation": {
     "type": "autofixable",
-    "command": "maui android emulator start Pixel8"
+    "command": "maui android sdk install emulator"
   }
 }
 ```
+
+Note: the same `E2106` code is also thrown for "no AVD with that name" — that
+throw site emits the code **without** a `remediation` block. Always treat
+`remediation` as optional and fall back to surfacing `message`.
 
 Common code prefixes (see [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors) for the full taxonomy):
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -104,9 +104,14 @@ pgrep -f "YourApp"
 
 ## Reading errors from the CLI
 
-`maui` commands accept `--json` to emit a structured output that an AI agent
-can parse. On failure, error fields are at the **top level** of stdout (no
-`"error"` wrapper) with `snake_case` property names:
+Non-DevFlow `maui` commands (e.g. `maui doctor`, `maui android ...`,
+`maui apple ...`) accept `--json` to emit structured output. On failure,
+error fields are at the **top level** of stdout (no `"error"` wrapper) with
+`snake_case` property names:
+
+**Note:** `maui devflow ...` commands use a different error shape
+(`{"error":"...","type":"...","retryable":...}`) written to **stderr**.
+Parse stderr JSON for DevFlow command failures.
 
 ```json
 {

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -7,7 +7,7 @@ Use this when a project already has DevFlow package references and `builder.AddM
 1. Run the built-in diagnostic:
 
    ```bash
-   maui devflow diagnose
+   maui devflow diagnose --json
    ```
 
    Use the result to separate broker startup, missing project integration, no running app, and target-device networking issues.
@@ -31,10 +31,10 @@ Use this when a project already has DevFlow package references and `builder.AddM
 4. List and wait for agents:
 
    ```bash
-   maui devflow list
-   maui devflow wait
-   maui devflow agent status
-   maui devflow ui tree --depth 1
+   maui devflow list --json
+   maui devflow wait --json
+   maui devflow agent status --json
+   maui devflow ui tree --depth 1 --json
    ```
 
    A successful `agent status` proves the CLI can reach the running app and
@@ -48,8 +48,8 @@ Use this when a project already has DevFlow package references and `builder.AddM
 Android emulators run in a separate network namespace. Broker registration and CLI-to-agent traffic need opposite forwarding directions. Discovery uses the unified `maui` CLI; the actual port forwarding is not yet wrapped by `maui` — use raw `adb`:
 
 ```bash
-maui devflow list                 # note the assigned agent port
-maui device list --platform android  # confirm the emulator is connected
+maui devflow list --json              # note the assigned agent port
+maui device list --platform android --json  # confirm the emulator is connected
 
 # Not yet wrapped by 'maui' CLI — use raw adb
 adb reverse tcp:19223 tcp:19223   # app in emulator -> host broker
@@ -76,7 +76,7 @@ and `--agent-port <port>` until broker registration is restored.
 No forwarding is normally needed because simulators share host networking:
 
 ```bash
-maui apple simulator list
+maui apple simulator list --json
 ```
 
 ### Mac Catalyst and macOS

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -125,7 +125,7 @@ Note: the same `E2106` code is also thrown for "no AVD with that name" — that
 throw site emits the code **without** a `remediation` block. Always treat
 `remediation` as optional and fall back to surfacing `message`.
 
-Common code prefixes (see [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors) for the full taxonomy):
+Common code prefixes (see [troubleshooting.md](troubleshooting.md#machine-readable-output-and-error-envelope) for the full taxonomy):
 
 | Prefix | Meaning |
 |--------|---------|

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -105,17 +105,17 @@ pgrep -f "YourApp"
 ## Reading errors from the CLI
 
 `maui` commands accept `--json` to emit a structured output that an AI agent
-can parse. On failure, errors include a code, message, and remediation hint:
+can parse. On failure, error fields are at the **top level** of stdout (no
+`"error"` wrapper) with `snake_case` property names:
 
 ```json
 {
-  "error": {
-    "code": "E2106",
-    "message": "No running emulator found with name 'Pixel8'",
-    "remediation": {
-      "type": "AutoFixable",
-      "command": "maui android emulator start Pixel8"
-    }
+  "code": "E2106",
+  "category": "platform",
+  "message": "No running emulator found with name 'Pixel8'",
+  "remediation": {
+    "type": "autofixable",
+    "command": "maui android emulator start Pixel8"
   }
 }
 ```
@@ -130,9 +130,10 @@ Common code prefixes (see [troubleshooting.md](troubleshooting.md#reading-machin
 | `E4xxx` | Network |
 | `E5xxx` | Permission |
 
-Branch on `error.code`. When `error.remediation.type` is `AutoFixable`, run
-`error.remediation.command` and retry. For `UserAction`, present
-`error.remediation.manualSteps`.
+Branch on `code`. When `remediation.type` is `autofixable` (lowercase!), run
+`remediation.command` and retry. For `useraction`, present
+`remediation.manual_steps`. If `remediation` is absent, surface `message`
+and stop retrying.
 
 ## Common symptoms
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -45,10 +45,13 @@ Use this when a project already has DevFlow package references and `builder.AddM
 
 ### Android emulator
 
-Android emulators run in a separate network namespace. Broker registration and CLI-to-agent traffic need opposite forwarding directions:
+Android emulators run in a separate network namespace. Broker registration and CLI-to-agent traffic need opposite forwarding directions. Discovery uses the unified `maui` CLI; the actual port forwarding is not yet wrapped by `maui` — use raw `adb`:
 
 ```bash
 maui devflow list                 # note the assigned agent port
+maui device list --platform android  # confirm the emulator is connected
+
+# Not yet wrapped by 'maui' CLI — use raw adb
 adb reverse tcp:19223 tcp:19223   # app in emulator -> host broker
 adb forward tcp:<port> tcp:<port> # host CLI -> app agent
 adb reverse --list
@@ -73,7 +76,7 @@ and `--agent-port <port>` until broker registration is restored.
 No forwarding is normally needed because simulators share host networking:
 
 ```bash
-xcrun simctl list devices booted
+maui apple simulator list
 ```
 
 ### Mac Catalyst and macOS
@@ -85,7 +88,7 @@ Mac Catalyst needs Debug entitlements that allow the agent and CDP servers to bi
 <true/>
 ```
 
-macOS AppKit and Mac Catalyst otherwise use direct localhost access. Check for explicit port conflicts only after confirming broker discovery:
+macOS AppKit and Mac Catalyst otherwise use direct localhost access. Check for explicit port conflicts only after confirming broker discovery (`lsof` is not yet wrapped by `maui` — use raw):
 
 ```bash
 lsof -i :9223
@@ -98,6 +101,38 @@ These use direct localhost access. On Linux, verify the app process started:
 ```bash
 pgrep -f "YourApp"
 ```
+
+## Reading errors from the CLI
+
+`maui` commands accept `--json` to emit a structured output that an AI agent
+can parse. On failure, errors include a code, message, and remediation hint:
+
+```json
+{
+  "error": {
+    "code": "E2106",
+    "message": "No running emulator found with name 'Pixel8'",
+    "remediation": {
+      "type": "AutoFixable",
+      "command": "maui android emulator start Pixel8"
+    }
+  }
+}
+```
+
+Common code prefixes (see [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors) for the full taxonomy):
+
+| Prefix | Meaning |
+|--------|---------|
+| `E1xxx` | Tool error (likely a bug) |
+| `E2xxx` | Platform / SDK (Android, Apple, .NET) |
+| `E3xxx` | User action required |
+| `E4xxx` | Network |
+| `E5xxx` | Permission |
+
+Branch on `error.code`. When `error.remediation.type` is `AutoFixable`, run
+`error.remediation.command` and retry. For `UserAction`, present
+`error.remediation.manualSteps`.
 
 ## Common symptoms
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -48,7 +48,7 @@ Use this when a project already has DevFlow package references and `builder.AddM
 Android emulators run in a separate network namespace, so broker registration and CLI-to-agent traffic need opposite forwarding directions. The unified `maui` CLI sets up **both** automatically: `maui devflow wait` establishes the broker `reverse` before polling and the agent `forward` once the agent registers, while `maui devflow list` / `agent status` / `ui status` re-establish (repair) the agent forward on demand. All honor `--device <serial>`.
 
 ```bash
-maui devflow wait --platform android  # sets up broker reverse + agent forward, waits for the agent
+maui devflow wait --wait-platform android  # sets up broker reverse + agent forward, waits for the agent
 maui devflow list                 # re-establishes the agent forward + notes the assigned port
 maui device list --platform android  # confirm the emulator is connected
 maui devflow diagnose             # reports broker reverse + agent forward mapping status

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -45,15 +45,22 @@ Use this when a project already has DevFlow package references and `builder.AddM
 
 ### Android emulator
 
-Android emulators run in a separate network namespace. Broker registration and CLI-to-agent traffic need opposite forwarding directions:
+Android emulators run in a separate network namespace, so broker registration and CLI-to-agent traffic need opposite forwarding directions. The unified `maui` CLI sets up **both** automatically: `maui devflow wait` establishes the broker `reverse` before polling and the agent `forward` once the agent registers, while `maui devflow list` / `agent status` / `ui status` re-establish (repair) the agent forward on demand. All honor `--device <serial>`.
 
 ```bash
-maui devflow diagnose             # reports Android forwarding state
-maui devflow list                 # checks/repairs forwarding when one device is online
-adb reverse tcp:19223 tcp:19223   # app in emulator -> host broker
-adb forward tcp:<port> tcp:<port> # host CLI -> app agent
+maui devflow wait --platform android  # sets up broker reverse + agent forward, waits for the agent
+maui devflow list                 # re-establishes the agent forward + notes the assigned port
+maui device list --platform android  # confirm the emulator is connected
+maui devflow diagnose             # reports broker reverse + agent forward mapping status
+```
+
+Drop to raw `adb` only to inspect or manually repair the mappings the CLI created:
+
+```bash
 adb reverse --list
 adb forward --list
+adb reverse tcp:19223 tcp:19223   # manual repair: app in emulator -> host broker
+adb forward tcp:<port> tcp:<port> # manual repair: host CLI -> app agent
 ```
 
 When multiple Android devices/emulators are connected, use the same serial selection the CLI supports:
@@ -63,7 +70,7 @@ maui devflow diagnose --device <serial>
 maui devflow list --device <serial>
 ```
 
-If no broker is available and the app uses a direct `.mauidevflow` port, forward that port instead:
+If no broker is available and the app uses a direct `.mauidevflow` port, forward that port instead — this direct-port forward is the one mapping the CLI does **not** set up automatically (it only auto-forwards broker-registered agents):
 
 ```bash
 adb devices
@@ -81,7 +88,7 @@ and `--agent-port <port>` until broker registration is restored.
 No forwarding is normally needed because simulators share host networking:
 
 ```bash
-xcrun simctl list devices booted
+maui apple simulator list
 ```
 
 ### Mac Catalyst and macOS
@@ -93,7 +100,7 @@ Mac Catalyst needs Debug entitlements that allow the agent and CDP servers to bi
 <true/>
 ```
 
-macOS AppKit and Mac Catalyst otherwise use direct localhost access. Check for explicit port conflicts only after confirming broker discovery:
+macOS AppKit and Mac Catalyst otherwise use direct localhost access. Check for explicit port conflicts only after confirming broker discovery (`lsof` is not yet wrapped by `maui` — use raw):
 
 ```bash
 lsof -i :9223
@@ -106,6 +113,65 @@ These use direct localhost access. On Linux, verify the app process started:
 ```bash
 pgrep -f "YourApp"
 ```
+
+## Reading errors from the CLI
+
+`maui` commands accept `--json` to emit a structured output that an AI agent
+can parse. On failure, error fields are at the **top level** of stdout (no
+`"error"` wrapper) with `snake_case` property names:
+
+```json
+{
+  "code": "E2106",
+  "category": "platform",
+  "severity": "error",
+  "message": "Android emulator not installed",
+  "remediation": {
+    "type": "autofixable",
+    "command": "maui android sdk install emulator"
+  }
+}
+```
+
+Note: the same `E2106` code is also thrown for "no AVD with that name" — that
+throw site emits the code **without** a `remediation` block. Always treat
+`remediation` as optional and fall back to surfacing `message`.
+
+Common code prefixes (see [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors) for the full taxonomy):
+
+| Prefix | Meaning |
+|--------|---------|
+| `E1xxx` | Tool error (likely a bug) |
+| `E2xxx` | Platform / SDK (Android, Apple, .NET) |
+| `E3xxx` | User action required |
+| `E4xxx` | Network |
+| `E5xxx` | Permission |
+
+Branch on `code`. When `remediation.type` is `autofixable` (lowercase!), run
+`remediation.command` and retry. For `useraction`, present
+`remediation.manual_steps`. If `remediation` is absent, surface `message`
+and stop retrying.
+
+> **DevFlow commands differ.** The flat stdout envelope above applies to `maui
+> android`, `maui apple`, and `maui device`. The `maui devflow …` commands used
+> throughout this file instead emit `{ "error", "type", "retryable",
+> "suggestions" }` on **stderr**, so read stderr (not stdout) when a `maui
+> devflow` invocation fails.
+
+## Extension tools registered by the app
+
+Apps can register custom DevFlow extension tools that the CLI surfaces dynamically.
+When a tool the agent expects is missing or behaving unexpectedly, list and
+inspect what the running app actually advertises:
+
+```bash
+maui devflow extensions list                       # all registered extensions and tools
+maui devflow extensions describe <namespace>       # detailed tool schemas
+maui devflow extensions call <namespace> <tool>    # invoke a tool with JSON parameters
+```
+
+Use this before assuming a custom DevFlow Action is unimplemented — it may simply
+not be registered with the connected agent.
 
 ## Common symptoms
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -1,9 +1,11 @@
 # iOS & Mac Catalyst Reference
 
 Prefer the unified `maui` CLI for simulator/runtime/Xcode discovery and basic
-lifecycle. Raw `xcrun simctl` is kept only for operations not yet wrapped by
-the `maui` CLI (create / erase / install / launch / privacy / appearance /
-openurl / push / location / addmedia). Those are grouped under
+lifecycle. Permission management uses `maui devflow ui permission` (wraps
+`xcrun simctl privacy` with auto-detection). Raw `xcrun simctl` is kept only
+for operations not yet wrapped by the `maui` CLI (create / erase / install /
+launch / appearance / openurl / push / location / addmedia). Those are
+grouped under
 [Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli).
 
 The standalone `apple` command from `appledev.tools` covers some of the same
@@ -186,7 +188,7 @@ xcrun simctl io booted screenshot output.png
 | `xcrun simctl location <UDID> set 37.33,-122.03` | Set GPS location |
 | `xcrun simctl pbcopy <UDID>` / `pbpaste <UDID>` | Clipboard bridge |
 | `xcrun simctl ui <UDID> appearance dark\|light` | Toggle dark mode |
-| `xcrun simctl privacy <UDID> grant\|revoke\|reset …` | Permission management |
+| `xcrun simctl privacy <UDID> grant\|revoke\|reset …` | Permission management — prefer `maui devflow ui permission` (see [Permission & Dialog Handling](#permission--dialog-handling)) |
 
 ## Troubleshooting
 
@@ -214,28 +216,42 @@ xcrun simctl io booted screenshot output.png
 
 ### Pre-grant permissions (prevents dialogs from appearing)
 
-Permissions are not yet wrapped by the `maui` CLI — use raw `xcrun simctl
-privacy`:
+Use the `maui devflow ui permission` command — it wraps `xcrun simctl
+privacy` and auto-detects the booted simulator UDID and bundle id when the
+DevFlow agent is connected:
 
 ```bash
-# Not yet wrapped by 'maui' CLI — use raw xcrun simctl
-xcrun simctl privacy <UDID> grant location com.company.appid
-xcrun simctl privacy <UDID> grant camera com.company.appid
-xcrun simctl privacy <UDID> grant photos com.company.appid
-xcrun simctl privacy <UDID> grant contacts com.company.appid
-xcrun simctl privacy <UDID> grant microphone com.company.appid
+maui devflow ui permission grant location  --bundle-id com.company.appid
+maui devflow ui permission grant camera    --bundle-id com.company.appid
+maui devflow ui permission grant photos    --bundle-id com.company.appid
+maui devflow ui permission grant contacts  --bundle-id com.company.appid
+maui devflow ui permission grant microphone --bundle-id com.company.appid
 
 # Grant all permissions at once
-xcrun simctl privacy <UDID> grant all com.company.appid
+maui devflow ui permission grant all --bundle-id com.company.appid
 
 # Revoke (deny) a permission
-xcrun simctl privacy <UDID> revoke location com.company.appid
+maui devflow ui permission revoke location --bundle-id com.company.appid
 
 # Reset (next request will show dialog again)
-xcrun simctl privacy <UDID> reset all com.company.appid
+maui devflow ui permission reset all --bundle-id com.company.appid
 ```
 
-Available services: `all`, `calendar`, `contacts`, `contacts-limited`, `location`, `location-always`, `photos`, `photos-add`, `media-library`, `microphone`, `motion`, `reminders`, `siri`.
+`--udid <UDID>` is optional and only needed if multiple simulators are
+booted; `--bundle-id` may be omitted when the DevFlow agent has it cached.
+
+Available services (passed straight through to `simctl privacy`): `all`,
+`calendar`, `contacts`, `contacts-limited`, `location`, `location-always`,
+`photos`, `photos-add`, `media-library`, `microphone`, `motion`,
+`reminders`, `siri`.
+
+If the agent is not connected and you need raw access:
+
+```bash
+# Not yet covered by 'maui devflow ui permission' — use raw xcrun simctl
+xcrun simctl privacy <UDID> grant all com.company.appid
+xcrun simctl privacy <UDID> reset all com.company.appid
+```
 
 ### Using MAUI DevFlow Driver for permissions
 ```csharp

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -38,8 +38,12 @@ maui device list --platform apple --json         # cross-platform device discove
 
 If a booted simulator is already running another project's agent, create a new one:
 ```bash
-maui apple simulator create "iPhone 17 Pro" --name "ProjectName-iPhone17Pro" --runtime "iOS 26.2"
+maui apple simulator create "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro" \
+  --name "ProjectName-iPhone17Pro" --runtime "com.apple.CoreSimulator.SimRuntime.iOS-26-2"
 ```
+
+To avoid creating duplicates, add `--if-not-exists` — reuses an existing
+simulator with the same name instead of failing.
 
 **Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-iPhone17Pro`) so
 it's clear which simulator belongs to which project.
@@ -58,13 +62,17 @@ maui apple simulator delete <name-or-udid>
 
 ### Create / erase / install / launch / terminate
 ```bash
-maui apple simulator create "iPhone 17 Pro" --name "MyApp" --runtime "iOS 26.2"
+maui apple simulator create <device-type> --name <name> --runtime <runtime-id>
 maui apple simulator erase <name-or-udid>        # factory reset
 maui apple simulator install <udid> /path/to/App.app
 maui apple simulator uninstall <udid> com.company.appid
 maui apple simulator launch <udid> com.company.appid
 maui apple simulator terminate <udid> com.company.appid
 ```
+
+`device-type` is a positional arg (e.g. `com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro`).
+Discover available types with `xcrun simctl list devicetypes` and runtimes
+with `maui apple runtime list --json`.
 
 ### Screenshots (Mac Catalyst, macOS, iOS — when DevFlow agent is connected)
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -226,8 +226,9 @@ maui devflow ui permission revoke location --bundle-id com.company.appid
 maui devflow ui permission reset all --bundle-id com.company.appid
 ```
 
-`--udid <UDID>` is optional and only needed if multiple simulators are
-booted; `--bundle-id` may be omitted when the DevFlow agent has it cached.
+`--udid <UDID>` is optional (auto-detects the booted simulator); `--bundle-id`
+is required for per-app grants — omitting it applies the permission to all
+apps on the simulator.
 
 Available services (passed straight through to `simctl privacy`): `all`,
 `calendar`, `contacts`, `contacts-limited`, `location`, `location-always`,

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -1,10 +1,10 @@
 # iOS & Mac Catalyst Reference
 
-Prefer the unified `maui` CLI for simulator/runtime/Xcode discovery and basic
-lifecycle. Permission management uses `maui devflow ui permission` (wraps
-`xcrun simctl privacy` with auto-detection). Raw `xcrun simctl` is kept only
-for operations not yet wrapped by the `maui` CLI (create / erase / install /
-launch / appearance / openurl / push / location / addmedia). Those are
+Prefer the unified `maui` CLI for simulator/runtime/Xcode discovery, full
+lifecycle (create / erase / install / uninstall / launch / terminate), and
+permission management (`maui devflow ui permission`). Raw `xcrun simctl` is
+kept only for a few utilities not yet wrapped by the `maui` CLI (appearance /
+openurl / push / location / addmedia / pbcopy / screenshots). Those are
 grouped under
 [Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli).
 
@@ -36,12 +36,9 @@ maui apple simulator list                        # all simulators (use --json fo
 maui device list --platform apple                # cross-platform device discovery
 ```
 
-If a booted simulator is already running another project's agent, create a new one
-(creation is not yet wrapped by `maui` — use raw `xcrun simctl`):
+If a booted simulator is already running another project's agent, create a new one:
 ```bash
-# Not yet wrapped by 'maui' CLI — use raw xcrun simctl
-xcrun simctl create "ProjectName-iPhone17Pro" "iPhone 17 Pro" "iOS 26.2"
-# Use the returned UDID with maui apple simulator start <UDID>
+maui apple simulator create "iPhone 17 Pro" --name "ProjectName-iPhone17Pro" --runtime "iOS 26.2"
 ```
 
 **Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-iPhone17Pro`) so
@@ -57,6 +54,16 @@ maui apple simulator list                        # formatted table (or --json)
 maui apple simulator start <name-or-udid>
 maui apple simulator stop <name-or-udid>         # accepts 'all' to stop everything
 maui apple simulator delete <name-or-udid>
+```
+
+### Create / erase / install / launch / terminate
+```bash
+maui apple simulator create "iPhone 17 Pro" --name "MyApp" --runtime "iOS 26.2"
+maui apple simulator erase <name-or-udid>        # factory reset
+maui apple simulator install <udid> /path/to/App.app
+maui apple simulator uninstall <udid> com.company.appid
+maui apple simulator launch <udid> com.company.appid
+maui apple simulator terminate <udid> com.company.appid
 ```
 
 ### Screenshots (Mac Catalyst, macOS, iOS — when DevFlow agent is connected)
@@ -155,25 +162,6 @@ These operations are not wrapped by the `maui` CLI today. Use raw `xcrun
 simctl` (preferred — built into Xcode) or the `apple` command from
 `appledev.tools` if installed.
 
-### Create / erase / delete
-```bash
-xcrun simctl list devicetypes                    # discover device types
-xcrun simctl list runtimes                       # discover runtimes
-xcrun simctl create "My iPhone" "iPhone 16 Pro" "iOS 18.2"
-xcrun simctl erase <UDID>                        # factory reset
-xcrun simctl delete <UDID>                       # permanently remove
-xcrun simctl delete unavailable                  # clean up old sims
-```
-
-### Install / launch / uninstall apps on simulator
-```bash
-xcrun simctl install booted /path/to/App.app
-xcrun simctl launch booted com.company.appid
-xcrun simctl uninstall booted com.company.appid
-xcrun simctl listapps <UDID>
-xcrun simctl get_app_container <UDID> com.company.appid
-```
-
 ### System-level simulator screenshots
 ```bash
 xcrun simctl io booted screenshot output.png
@@ -188,7 +176,8 @@ xcrun simctl io booted screenshot output.png
 | `xcrun simctl location <UDID> set 37.33,-122.03` | Set GPS location |
 | `xcrun simctl pbcopy <UDID>` / `pbpaste <UDID>` | Clipboard bridge |
 | `xcrun simctl ui <UDID> appearance dark\|light` | Toggle dark mode |
-| `xcrun simctl privacy <UDID> grant\|revoke\|reset …` | Permission management — prefer `maui devflow ui permission` (see [Permission & Dialog Handling](#permission--dialog-handling)) |
+| `xcrun simctl listapps <UDID>` | List all installed apps |
+| `xcrun simctl get_app_container <UDID> bundle` | Get app container path |
 
 ## Troubleshooting
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -31,9 +31,9 @@ will replace each other — only the last-deployed app survives.
 
 **Before creating or booting a simulator, check what's already in use:**
 ```bash
-maui devflow list                                # agents with platform + port
-maui apple simulator list                        # all simulators (use --json for parsing)
-maui device list --platform apple                # cross-platform device discovery
+maui devflow list --json                         # agents with platform + port
+maui apple simulator list --json                 # all simulators
+maui device list --platform apple --json         # cross-platform device discovery
 ```
 
 If a booted simulator is already running another project's agent, create a new one:
@@ -46,7 +46,7 @@ it's clear which simulator belongs to which project.
 
 ### List simulators
 ```bash
-maui apple simulator list                        # formatted table (or --json)
+maui apple simulator list --json                 # formatted table or JSON
 ```
 
 ### Boot / shutdown / delete
@@ -149,9 +149,9 @@ Common values: `net9.0-ios`, `net9.0-maccatalyst`, `net10.0-ios`, `net10.0-macca
 ## Xcode and Runtime Discovery
 
 ```bash
-maui apple xcode list                            # installed Xcode versions
-maui apple runtime list                          # installed simulator runtimes
-maui apple runtime list --platform ios           # filter by platform
+maui apple xcode list --json                     # installed Xcode versions
+maui apple runtime list --json                   # installed simulator runtimes
+maui apple runtime list --platform ios --json    # filter by platform
 ```
 
 All accept `--json` for machine-readable output.

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -1,11 +1,23 @@
 # iOS & Mac Catalyst Reference
 
+Prefer the unified `maui` CLI for simulator/runtime/Xcode discovery and basic
+lifecycle. Raw `xcrun simctl` is kept only for operations not yet wrapped by
+the `maui` CLI (create / erase / install / launch / privacy / appearance /
+openurl / push / location / addmedia). Those are grouped under
+[Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli).
+
+The standalone `apple` command from `appledev.tools` covers some of the same
+gaps and can be used interchangeably with `xcrun simctl`; install it only if
+you cannot use raw `xcrun simctl`.
+
 ## Table of Contents
 - [Simulator Management](#simulator-management)
 - [Building and Deploying](#building-and-deploying)
-- [Apple CLI Tool](#apple-cli-tool)
-- [xcrun simctl Reference](#xcrun-simctl-reference)
+- [Xcode and Runtime Discovery](#xcode-and-runtime-discovery)
+- [Raw fallbacks not yet in `maui` CLI](#raw-fallbacks-not-yet-in-maui-cli)
 - [Troubleshooting](#troubleshooting)
+- [Permission & Dialog Handling](#permission--dialog-handling)
+- [Dark Mode Testing](#dark-mode-testing)
 
 ## Simulator Management
 
@@ -17,14 +29,17 @@ will replace each other — only the last-deployed app survives.
 
 **Before creating or booting a simulator, check what's already in use:**
 ```bash
-maui devflow list                             # shows agents with platform + port
-xcrun simctl list devices booted              # shows all booted simulators
+maui devflow list                                # agents with platform + port
+maui apple simulator list                        # all simulators (use --json for parsing)
+maui device list --platform apple                # cross-platform device discovery
 ```
 
-If a booted simulator is already running another project's agent, create a new one:
+If a booted simulator is already running another project's agent, create a new one
+(creation is not yet wrapped by `maui` — use raw `xcrun simctl`):
 ```bash
+# Not yet wrapped by 'maui' CLI — use raw xcrun simctl
 xcrun simctl create "ProjectName-iPhone17Pro" "iPhone 17 Pro" "iOS 26.2"
-# Use the returned UDID in your build command
+# Use the returned UDID with maui apple simulator start <UDID>
 ```
 
 **Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-iPhone17Pro`) so
@@ -32,59 +47,29 @@ it's clear which simulator belongs to which project.
 
 ### List simulators
 ```bash
-xcrun simctl list devices                     # all devices by runtime
-xcrun simctl list devices booted              # only booted
-xcrun simctl list devices available            # only available
-apple simulator list                          # formatted table
-apple simulator list --booted                 # booted only
+maui apple simulator list                        # formatted table (or --json)
 ```
 
-### Create simulator
+### Boot / shutdown / delete
 ```bash
-# List available device types and runtimes first
-xcrun simctl list devicetypes                 # e.g. "iPhone 16 Pro"
-xcrun simctl list runtimes                    # e.g. "iOS 18.2"
-
-xcrun simctl create "My iPhone" "iPhone 16 Pro" "iOS 18.2"
-apple simulator create "My iPhone" --device-type "iPhone 16 Pro" --runtime "iOS 18.2"
+maui apple simulator start <name-or-udid>
+maui apple simulator stop <name-or-udid>         # accepts 'all' to stop everything
+maui apple simulator delete <name-or-udid>
 ```
 
-### Boot / shutdown
-```bash
-xcrun simctl boot <UDID>
-xcrun simctl shutdown <UDID>
-apple simulator boot <UDID>
-apple simulator shutdown <UDID>
-```
+### Screenshots (Mac Catalyst, macOS, iOS — when DevFlow agent is connected)
 
-### Install and launch app
-```bash
-xcrun simctl install booted /path/to/App.app
-xcrun simctl launch booted com.company.appid
-```
-
-### Screenshots (iOS Simulator)
-```bash
-xcrun simctl io booted screenshot output.png
-apple simulator screenshot <UDID> --output output.png
-```
-
-### Screenshots (Mac Catalyst)
-
-**Use `maui devflow ui screenshot`** for Mac Catalyst apps — it captures the UI in-process
-and does NOT require the app to be in the foreground. Never use `osascript` to bring the window
-to the front or `screencapture` for Mac Catalyst screenshots; they are unnecessary and unreliable.
+**Use `maui devflow ui screenshot`** for any running MAUI app — it captures the UI in-process
+and does NOT require the app to be in the foreground (important for Mac Catalyst). Never use
+`osascript` to bring the window to the front or `screencapture` for Mac Catalyst screenshots;
+they are unnecessary and unreliable.
 
 ```bash
 maui devflow ui screenshot --output screen.png
 ```
 
-### Delete / erase
-```bash
-xcrun simctl erase <UDID>                     # factory reset
-xcrun simctl delete <UDID>                    # permanently remove
-xcrun simctl delete unavailable               # clean up old sims
-```
+For pre-launch / system-level simulator captures, use raw `xcrun simctl` (see
+[Raw fallbacks](#raw-fallbacks-not-yet-in-maui-cli)).
 
 ## Building and Deploying
 
@@ -152,51 +137,56 @@ grep -i TargetFramework *.csproj
 ```
 Common values: `net9.0-ios`, `net9.0-maccatalyst`, `net10.0-ios`, `net10.0-maccatalyst`.
 
-## Apple CLI Tool
+## Xcode and Runtime Discovery
 
-The `apple` command (from `appledev.tools` NuGet) provides higher-level wrappers.
-
-### Simulator commands
-```
-apple simulator list [--booted|--available|--unavailable|--name "..."]
-apple simulator create <name> --device-type "..." [--runtime "..."]
-apple simulator boot <target>
-apple simulator shutdown <target>
-apple simulator erase <target>
-apple simulator delete <target>
-apple simulator screenshot <target> [--output path.png]
-apple simulator app install <target> <app-path>
-apple simulator app launch <target> <bundle-id>
-apple simulator app uninstall <target> <bundle-id>
-apple simulator open [<target>]
-apple simulator open-url <target> <url>
-apple simulator logs <target> [--filter "..."]
-apple simulator push <target> <bundle-id> [--payload "..."]
-apple simulator location set <target> --lat <lat> --lon <lon>
-apple simulator privacy grant <target> <service> <bundle-id>
+```bash
+maui apple xcode list                            # installed Xcode versions
+maui apple runtime list                          # installed simulator runtimes
+maui apple runtime list --platform ios           # filter by platform
 ```
 
-### Device commands
+All accept `--json` for machine-readable output.
+
+## Raw fallbacks not yet in `maui` CLI
+
+These operations are not wrapped by the `maui` CLI today. Use raw `xcrun
+simctl` (preferred — built into Xcode) or the `apple` command from
+`appledev.tools` if installed.
+
+### Create / erase / delete
+```bash
+xcrun simctl list devicetypes                    # discover device types
+xcrun simctl list runtimes                       # discover runtimes
+xcrun simctl create "My iPhone" "iPhone 16 Pro" "iOS 18.2"
+xcrun simctl erase <UDID>                        # factory reset
+xcrun simctl delete <UDID>                       # permanently remove
+xcrun simctl delete unavailable                  # clean up old sims
 ```
-apple device list
-apple xcode list                                # installed Xcode versions
+
+### Install / launch / uninstall apps on simulator
+```bash
+xcrun simctl install booted /path/to/App.app
+xcrun simctl launch booted com.company.appid
+xcrun simctl uninstall booted com.company.appid
+xcrun simctl listapps <UDID>
+xcrun simctl get_app_container <UDID> com.company.appid
 ```
 
-## xcrun simctl Reference
+### System-level simulator screenshots
+```bash
+xcrun simctl io booted screenshot output.png
+```
 
-Key subcommands beyond the basics:
-
+### Other simctl utilities
 | Command | Use |
 |---------|-----|
-| `simctl addmedia <UDID> file.jpg` | Add photos/videos to sim |
-| `simctl openurl <UDID> "url"` | Open URL / deep link |
-| `simctl push <UDID> bundle payload.json` | Simulate push notification |
-| `simctl privacy <UDID> grant location bundle` | Grant permissions |
-| `simctl location <UDID> set 37.33,-122.03` | Set GPS location |
-| `simctl pbcopy <UDID>` | Copy stdin to clipboard |
-| `simctl pbpaste <UDID>` | Read clipboard |
-| `simctl get_app_container <UDID> bundle` | App container path |
-| `simctl listapps <UDID>` | Installed apps |
+| `xcrun simctl addmedia <UDID> file.jpg` | Add photos/videos to sim |
+| `xcrun simctl openurl <UDID> "url"` | Open URL / deep link |
+| `xcrun simctl push <UDID> bundle payload.json` | Simulate push notification |
+| `xcrun simctl location <UDID> set 37.33,-122.03` | Set GPS location |
+| `xcrun simctl pbcopy <UDID>` / `pbpaste <UDID>` | Clipboard bridge |
+| `xcrun simctl ui <UDID> appearance dark\|light` | Toggle dark mode |
+| `xcrun simctl privacy <UDID> grant\|revoke\|reset …` | Permission management |
 
 ## Troubleshooting
 
@@ -209,7 +199,8 @@ Key subcommands beyond the basics:
   If the "Reopen windows?" dialog is already on screen, ask the user to dismiss it manually,
   then relaunch. Do not use AppleScript here by default — it steals focus from the user's
   desktop session.
-- **"Unable to lookup in current state: Shutdown"**: Simulator not booted. Run `xcrun simctl boot <UDID>`.
+- **"Unable to lookup in current state: Shutdown"**: Simulator not booted. Run
+  `maui apple simulator start <UDID>`.
 - **Build error NETSDK1005 "Assets file doesn't have a target"**: Wrong TFM. Check
   `<TargetFrameworks>` in .csproj and use matching version (e.g. `net10.0-ios` not `net9.0-ios`).
 - **Agent not connecting after deploy**: The app may still be launching. Poll
@@ -222,8 +213,12 @@ Key subcommands beyond the basics:
 ## Permission & Dialog Handling
 
 ### Pre-grant permissions (prevents dialogs from appearing)
+
+Permissions are not yet wrapped by the `maui` CLI — use raw `xcrun simctl
+privacy`:
+
 ```bash
-# Grant specific permission before the app requests it
+# Not yet wrapped by 'maui' CLI — use raw xcrun simctl
 xcrun simctl privacy <UDID> grant location com.company.appid
 xcrun simctl privacy <UDID> grant camera com.company.appid
 xcrun simctl privacy <UDID> grant photos com.company.appid
@@ -238,9 +233,6 @@ xcrun simctl privacy <UDID> revoke location com.company.appid
 
 # Reset (next request will show dialog again)
 xcrun simctl privacy <UDID> reset all com.company.appid
-
-# Via apple CLI
-apple simulator privacy grant <UDID> location com.company.appid
 ```
 
 Available services: `all`, `calendar`, `contacts`, `contacts-limited`, `location`, `location-always`, `photos`, `photos-add`, `media-library`, `microphone`, `motion`, `reminders`, `siri`.
@@ -305,9 +297,10 @@ Use these to test and validate dialog detection and dismissal workflows.
 
 ### Toggle dark mode
 ```bash
-# Preferred when available: use an in-app theme toggle so the host desktop is unaffected.
+# Preferred: use an in-app theme toggle so the host desktop is unaffected.
 #
-# iOS Simulator (safe: affects the simulator only)
+# iOS Simulator (safe: affects the simulator only) —
+# not yet wrapped by 'maui' CLI, use raw xcrun simctl:
 xcrun simctl ui <UDID> appearance dark
 xcrun simctl ui <UDID> appearance light
 ```

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -32,41 +32,55 @@ it's clear which simulator belongs to which project.
 
 ### List simulators
 ```bash
-xcrun simctl list devices                     # all devices by runtime
-xcrun simctl list devices booted              # only booted
-xcrun simctl list devices available            # only available
-apple simulator list                          # formatted table
-apple simulator list --booted                 # booted only
+maui apple simulator list                     # formatted table (State column shows Booted/Shutdown); add --json for agents
+xcrun simctl list devices booted              # raw: filter to only booted
+xcrun simctl list devices available           # raw: filter to only available
 ```
 
 ### Create simulator
 ```bash
-# List available device types and runtimes first
-xcrun simctl list devicetypes                 # e.g. "iPhone 16 Pro"
-xcrun simctl list runtimes                    # e.g. "iOS 18.2"
+# List available device types and runtimes first (identifiers, not friendly names)
+xcrun simctl list devicetypes                 # e.g. com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro
+xcrun simctl list runtimes                    # e.g. com.apple.CoreSimulator.SimRuntime.iOS-18-2
 
+# Preferred: unified maui CLI (device-type is positional; --name/--runtime optional).
+# --if-not-exists makes it idempotent: returns the existing UDID instead of failing.
+maui apple simulator create com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro \
+  --name "My iPhone" --runtime com.apple.CoreSimulator.SimRuntime.iOS-18-2 --if-not-exists
+
+# Raw simctl equivalent (name, device-type, runtime are all positional)
 xcrun simctl create "My iPhone" "iPhone 16 Pro" "iOS 18.2"
-apple simulator create "My iPhone" --device-type "iPhone 16 Pro" --runtime "iOS 18.2"
 ```
 
 ### Boot / shutdown
 ```bash
+# Preferred: unified maui CLI (accepts a name or UDID; `start` also opens the Simulator UI)
+maui apple simulator start <name-or-UDID>     # add --no-open to boot headless
+maui apple simulator stop <name-or-UDID>      # or `stop all`
+
+# Raw simctl fallback
 xcrun simctl boot <UDID>
 xcrun simctl shutdown <UDID>
-apple simulator boot <UDID>
-apple simulator shutdown <UDID>
 ```
 
 ### Install and launch app
 ```bash
+# Preferred: unified maui CLI (JSON output + structured errors)
+maui apple simulator install <UDID> /path/to/App.app
+maui apple simulator launch <UDID> com.company.appid
+
+# Raw simctl fallback (`booted` targets the active simulator)
 xcrun simctl install booted /path/to/App.app
 xcrun simctl launch booted com.company.appid
 ```
 
 ### Screenshots (iOS Simulator)
 ```bash
+# Preferred: unified maui CLI (output path is positional — no --output flag)
+maui apple simulator screenshot <UDID> output.png
+
+# Raw simctl fallback
 xcrun simctl io booted screenshot output.png
-apple simulator screenshot <UDID> --output output.png
 ```
 
 ### Screenshots (Mac Catalyst)
@@ -156,6 +170,13 @@ Common values: `net9.0-ios`, `net9.0-maccatalyst`, `net10.0-ios`, `net10.0-macca
 
 The `apple` command (from `appledev.tools` NuGet) provides higher-level wrappers.
 
+> **Prefer `maui apple simulator …`** (unified CLI) for new automation — it adds
+> `--json` output and the standard error envelope. The standalone `apple` syntax
+> below differs from `maui`: it uses `boot`/`shutdown` (maui: `start`/`stop`),
+> supports `list --booted` (maui has no such flag), and takes `create <name>
+> --device-type …` (maui inverts this: `create <device-type> --name …`). Don't
+> blindly prefix these with `maui`.
+
 ### Simulator commands
 ```
 apple simulator list [--booted|--available|--unavailable|--name "..."]
@@ -190,6 +211,11 @@ the standard error envelope:
 
 | Command | Use | `maui` equivalent |
 |---------|-----|-------------------|
+| `simctl boot <UDID>` | Boot a simulator | `maui apple simulator start <name-or-UDID>` |
+| `simctl shutdown <UDID>` | Shut down | `maui apple simulator stop <name-or-UDID>` (or `stop all`) |
+| `simctl create "name" "type" "runtime"` | Create | `maui apple simulator create <device-type> --name "name" --runtime <runtime>` |
+| `simctl erase <UDID>` | Factory reset | `maui apple simulator erase <UDID>` |
+| `simctl delete <UDID>` | Remove permanently | `maui apple simulator delete <name-or-UDID>` |
 | `simctl addmedia <UDID> file.jpg` | Add photos/videos to sim | `maui apple simulator add-media <UDID> file.jpg` |
 | `simctl openurl <UDID> "url"` | Open URL / deep link | `maui apple simulator openurl <UDID> "url"` |
 | `simctl push <UDID> bundle payload.json` | Simulate push notification | `maui apple simulator push <UDID> bundle payload.json` |
@@ -236,6 +262,12 @@ maui apple simulator privacy grant <UDID> location --bundle-id com.company.appid
 maui apple simulator privacy grant <UDID> photos          # all apps (no bundle id)
 maui devflow ui permission grant location --bundle-id com.company.appid
 ```
+
+> If `maui devflow ui permission` reports `'ui' was not matched`, your installed
+> `maui` CLI predates that subcommand. Use the `maui apple simulator privacy`
+> path above (it needs only a UDID — no running agent) or update the CLI with
+> `dotnet tool update --global Microsoft.Maui.Cli` (see setup.md → "Checking for
+> Updates").
 
 Raw `xcrun simctl` fallback (only if the `maui` CLI is unavailable):
 ```bash
@@ -319,12 +351,22 @@ Use these to test and validate dialog detection and dismissal workflows.
 ## Dark Mode Testing
 
 ### Toggle dark mode
+
+Prefer the unified `maui` CLI. Use an **app-scoped** theme so the host desktop
+is unaffected; fall back to simulator-wide appearance when you need the OS to
+change too:
 ```bash
-# Preferred when available: use an in-app theme toggle so the host desktop is unaffected.
-#
-# iOS Simulator (safe: affects the simulator only)
+# App-scoped theme via the DevFlow agent (does not touch the host or OS)
+maui devflow theme set dark --scope app
+maui devflow theme set light --scope app
+maui devflow theme get                          # read the current app theme
+
+# iOS Simulator appearance (affects the simulator only)
+maui apple simulator appearance dark <UDID>
+maui apple simulator appearance light <UDID>
+
+# Raw simctl fallback
 xcrun simctl ui <UDID> appearance dark
-xcrun simctl ui <UDID> appearance light
 ```
 
 For **Mac Catalyst**, changing system appearance affects the user's entire macOS desktop. Only do

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -256,11 +256,13 @@ the standard error envelope:
 
 **Prefer the `maui` CLI** — `maui apple simulator privacy` now wraps `simctl privacy`
 (the `bundle-id` is optional, so you can grant for all apps), and `maui devflow ui permission`
-drives it for the agent-detected simulator:
+drives it for the booted simulator (auto-detected). When more than one simulator
+is booted, pass `--udid` to target a specific one:
 ```bash
 maui apple simulator privacy grant <UDID> location --bundle-id com.company.appid
 maui apple simulator privacy grant <UDID> photos          # all apps (no bundle id)
 maui devflow ui permission grant location --bundle-id com.company.appid
+maui devflow ui permission grant location --udid <UDID>   # target a specific booted simulator
 ```
 
 > If `maui devflow ui permission` reports `'ui' was not matched`, your installed

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
@@ -26,9 +26,9 @@ Verify: `maui devflow version` and `maui doctor` (with optional `--json`).
 ### Optional extras for operations not yet in `maui` CLI
 
 These standalone tools cover a few operations that the `maui` CLI does not yet
-wrap (simulator create/erase/install/launch/privacy/appearance, advanced
-Android SDK manager flows). Install only if you need them; raw `xcrun simctl`
-and `adb` already cover most gaps without an extra global tool.
+wrap (advanced Android SDK manager flows, some simctl utilities like
+appearance/openurl/push/location). Install only if you need them; raw
+`xcrun simctl` and `adb` already cover most gaps without an extra global tool.
 
 ```bash
 dotnet tool install --global androidsdk.tool               # `android` (Android only)
@@ -305,7 +305,7 @@ If status commands fail:
 - **All platforms:** Ensure the app is running and the `#if DEBUG` block is active
 - **Port conflict:** Check if another process holds the port: `lsof -i :9223` (raw; not yet wrapped by `maui`)
 - **Wrong port:** Use `maui devflow list` to find the assigned port, or ensure CLI is run from the project directory
-- **Reading errors:** Pass `--json` to any failing `maui` command and inspect the top-level `code` / `remediation` fields (no `error` wrapper; see [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors))
+- **Reading errors:** Pass `--json` to any failing `maui` command and inspect the top-level `code` / `remediation` fields (no `error` wrapper; see [troubleshooting.md](troubleshooting.md#machine-readable-output-and-error-envelope))
 
 ## Quick Checklist
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
@@ -15,13 +15,25 @@ Complete guide for integrating MAUI DevFlow into a .NET MAUI app.
 
 ## 1. Install CLI Tools
 
+The unified `maui` CLI is the only required global tool:
+
 ```bash
 dotnet tool install --global Microsoft.Maui.Cli --prerelease
-dotnet tool install --global androidsdk.tool               # android (Android only)
-dotnet tool install --global appledev.tools                # apple (iOS/Mac only)
 ```
 
-Verify: `maui devflow version`
+Verify: `maui devflow version` and `maui doctor` (with optional `--json`).
+
+### Optional extras for operations not yet in `maui` CLI
+
+These standalone tools cover a few operations that the `maui` CLI does not yet
+wrap (simulator create/erase/install/launch/privacy/appearance, advanced
+Android SDK manager flows). Install only if you need them; raw `xcrun simctl`
+and `adb` already cover most gaps without an extra global tool.
+
+```bash
+dotnet tool install --global androidsdk.tool               # `android` (Android only)
+dotnet tool install --global appledev.tools                # `apple` (iOS/Mac only)
+```
 
 ## 2. Add NuGet Packages
 
@@ -249,9 +261,12 @@ instead of the home directory root. This path is not TCC-protected.
 
 ## 6. Android: Port Forwarding
 
-After deploying to an Android emulator, set up port forwarding for the broker and agent:
+After deploying to an Android emulator, set up port forwarding for the broker
+and agent. Port forwarding is **not yet wrapped by the `maui` CLI** — use raw
+`adb`:
 
 ```bash
+# Not yet wrapped by 'maui' CLI — use raw adb
 adb reverse tcp:19223 tcp:19223  # Broker (lets agent register with host broker)
 adb forward tcp:<port> tcp:<port> # Agent (lets CLI reach agent — get port from `maui devflow list`)
 ```
@@ -272,6 +287,8 @@ adb forward tcp:9223 tcp:9223    # Direct agent port (single port for Agent + CD
 After building and running the app:
 
 ```bash
+maui doctor                       # Environment health check (--json supported)
+maui devflow diagnose             # Connectivity diagnostic
 maui devflow list                 # Should show registered agents (via broker)
 maui devflow ui status            # Should show agent info, platform, app name
 maui devflow webview status       # Should show "Connected" (Blazor Hybrid only)
@@ -282,12 +299,13 @@ If status commands fail:
 - **Agent not registered?** `maui devflow list` — wait a few seconds for the agent to register
 - **Mac Catalyst:** Check entitlements (Step 5)
 - **macOS (AppKit):** Ensure `AddMacOSEssentials()` is called — see [references/macos.md](macos.md)
-- **Android:** Check port forwarding (Step 6) — need both `adb reverse tcp:19223` and `adb forward tcp:<port>`
+- **Android:** Check port forwarding (Step 6) — need both `adb reverse tcp:19223` and `adb forward tcp:<port>` (raw `adb`; not yet wrapped by `maui`)
 - **iOS Simulator:** Should work without extra config
 - **Linux/GTK:** Should work without extra config — runs directly on localhost
 - **All platforms:** Ensure the app is running and the `#if DEBUG` block is active
-- **Port conflict:** Check if another process holds the port: `lsof -i :9223` (or your configured port)
+- **Port conflict:** Check if another process holds the port: `lsof -i :9223` (raw; not yet wrapped by `maui`)
 - **Wrong port:** Use `maui devflow list` to find the assigned port, or ensure CLI is run from the project directory
+- **Reading errors:** Pass `--json` to any failing `maui` command and inspect `error.code` / `error.remediation` (see [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors))
 
 ## Quick Checklist
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
@@ -305,7 +305,7 @@ If status commands fail:
 - **All platforms:** Ensure the app is running and the `#if DEBUG` block is active
 - **Port conflict:** Check if another process holds the port: `lsof -i :9223` (raw; not yet wrapped by `maui`)
 - **Wrong port:** Use `maui devflow list` to find the assigned port, or ensure CLI is run from the project directory
-- **Reading errors:** Pass `--json` to any failing `maui` command and inspect `error.code` / `error.remediation` (see [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors))
+- **Reading errors:** Pass `--json` to any failing `maui` command and inspect the top-level `code` / `remediation` fields (no `error` wrapper; see [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors))
 
 ## Quick Checklist
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
@@ -286,11 +286,11 @@ adb forward tcp:9223 tcp:9223    # Direct agent port (single port for Agent + CD
 After building and running the app:
 
 ```bash
-maui doctor                       # Environment health check (--json supported)
-maui devflow diagnose             # Connectivity diagnostic
-maui devflow list                 # Should show registered agents (via broker)
-maui devflow ui status            # Should show agent info, platform, app name
-maui devflow webview status       # Should show "Connected" (Blazor Hybrid only)
+maui doctor --json                    # Environment health check
+maui devflow diagnose --json          # Connectivity diagnostic
+maui devflow list --json              # Should show registered agents (via broker)
+maui devflow ui status --json         # Should show agent info, platform, app name
+maui devflow webview status --json    # Should show "Connected" (Blazor Hybrid only)
 ```
 
 If status commands fail:

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
@@ -25,13 +25,12 @@ Verify: `maui devflow version` and `maui doctor` (with optional `--json`).
 
 ### Optional extras for operations not yet in `maui` CLI
 
-These standalone tools cover a few operations that the `maui` CLI does not yet
-wrap (advanced Android SDK manager flows, some simctl utilities like
-appearance/openurl/push/location). Install only if you need them; raw
-`xcrun simctl` and `adb` already cover most gaps without an extra global tool.
+These standalone tools cover a few simctl utilities that the `maui` CLI does
+not yet wrap (appearance/openurl/push/location). Install only if you need
+them; raw `xcrun simctl` already covers these gaps without an extra global
+tool.
 
 ```bash
-dotnet tool install --global androidsdk.tool               # `android` (Android only)
 dotnet tool install --global appledev.tools                # `apple` (iOS/Mac only)
 ```
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
@@ -285,7 +285,7 @@ traffic need opposite forwarding directions. The `maui` CLI sets up **both**
 automatically — you normally don't run `adb` by hand:
 
 ```bash
-maui devflow wait --platform android  # sets up broker reverse + agent forward
+maui devflow wait --wait-platform android  # sets up broker reverse + agent forward
 maui devflow list                     # re-establishes (repairs) the agent forward
 maui devflow diagnose                 # reports broker reverse + agent forward status
 ```
@@ -318,7 +318,7 @@ If status commands fail:
 - **Agent not registered?** `maui devflow list` — wait a few seconds for the agent to register
 - **Mac Catalyst:** Check entitlements (Step 5)
 - **macOS (AppKit):** Ensure `AddMacOSEssentials()` is called — see [references/macos.md](macos.md)
-- **Android:** `maui devflow wait --platform android` (or `list`) sets up the broker reverse + agent forward automatically; `maui devflow diagnose` reports mapping status. Drop to raw `adb reverse`/`adb forward` only to manually repair (Step 6).
+- **Android:** `maui devflow wait --wait-platform android` (or `list`) sets up the broker reverse + agent forward automatically; `maui devflow diagnose` reports mapping status. Drop to raw `adb reverse`/`adb forward` only to manually repair (Step 6).
 - **iOS Simulator:** Should work without extra config
 - **Linux/GTK:** Should work without extra config — runs directly on localhost
 - **All platforms:** Ensure the app is running and the `#if DEBUG` block is active

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/setup.md
@@ -15,13 +15,44 @@ Complete guide for integrating MAUI DevFlow into a .NET MAUI app.
 
 ## 1. Install CLI Tools
 
+The unified `maui` CLI is the only required global tool:
+
 ```bash
 dotnet tool install --global Microsoft.Maui.Cli --prerelease
-dotnet tool install --global androidsdk.tool               # android (Android only)
-dotnet tool install --global appledev.tools                # apple (iOS/Mac only)
 ```
 
-Verify: `maui devflow version`
+Verify: `maui devflow version` and `maui doctor` (with optional `--json`).
+
+### Optional standalone tools (rarely needed)
+
+The unified `maui` CLI now wraps the common Android and Apple operations —
+including `maui apple simulator privacy/openurl/push/location/appearance` and
+the `maui android sdk`/`jdk` managers. These predecessor standalone tools stay
+available for occasional edge cases but are optional; raw `xcrun simctl` and
+`adb` cover the rest without an extra global tool.
+
+```bash
+dotnet tool install --global androidsdk.tool               # `android` (Android only)
+dotnet tool install --global appledev.tools                # `apple` (iOS/Mac only)
+```
+
+### Guided environment setup
+
+For first-time setup or when `maui doctor` reports missing components, the CLI
+provides guided installers for each platform:
+
+```bash
+maui android install              # Android SDK, JDK, platform-tools, accept licenses
+maui apple install --platform iOS # Xcode CLT and iOS simulator runtime (macOS only)
+maui apple install --platform all # Install runtimes for every available Apple platform
+```
+
+If your SDKs live in non-default locations, every `maui android` subcommand
+accepts global path overrides (no env-var change required):
+
+```bash
+maui android --sdk /opt/android-sdk --jdk /opt/openjdk-17 sdk check
+```
 
 ## 2. Add NuGet Packages
 
@@ -249,20 +280,23 @@ instead of the home directory root. This path is not TCC-protected.
 
 ## 6. Android: Port Forwarding
 
-After deploying to an Android emulator, set up port forwarding for the broker and agent:
+After deploying to an Android emulator, broker registration and CLI-to-agent
+traffic need opposite forwarding directions. The `maui` CLI sets up **both**
+automatically — you normally don't run `adb` by hand:
 
 ```bash
-adb reverse tcp:19223 tcp:19223  # Broker (lets agent register with host broker)
-adb forward tcp:<port> tcp:<port> # Agent (lets CLI reach agent — get port from `maui devflow list`)
+maui devflow wait --platform android  # sets up broker reverse + agent forward
+maui devflow list                     # re-establishes (repairs) the agent forward
+maui devflow diagnose                 # reports broker reverse + agent forward status
 ```
 
-The broker reverse (`tcp:19223`) is needed so the agent inside the emulator can connect to
-the host's broker daemon. Set this up once per emulator session.
+The broker reverse (`tcp:19223`) lets the agent inside the emulator reach the
+host's broker daemon; `maui devflow wait` establishes it before polling. The
+agent forward uses the port shown in `maui devflow list` after the agent
+registers (range 10223–10899). Add `--device <serial>` for multiple emulators.
 
-The agent forward uses the port shown in `maui devflow list` after the agent registers
-(range 10223–10899).
-
-**Fallback (no broker):** If using direct mode with a `.mauidevflow` config file:
+**Fallback (no broker):** the direct `.mauidevflow` port is the one path the CLI
+does **not** auto-forward — forward it yourself:
 ```bash
 adb forward tcp:9223 tcp:9223    # Direct agent port (single port for Agent + CDP)
 ```
@@ -272,6 +306,8 @@ adb forward tcp:9223 tcp:9223    # Direct agent port (single port for Agent + CD
 After building and running the app:
 
 ```bash
+maui doctor                       # Environment health check (--json supported)
+maui devflow diagnose             # Connectivity diagnostic
 maui devflow list                 # Should show registered agents (via broker)
 maui devflow ui status            # Should show agent info, platform, app name
 maui devflow webview status       # Should show "Connected" (Blazor Hybrid only)
@@ -282,12 +318,13 @@ If status commands fail:
 - **Agent not registered?** `maui devflow list` — wait a few seconds for the agent to register
 - **Mac Catalyst:** Check entitlements (Step 5)
 - **macOS (AppKit):** Ensure `AddMacOSEssentials()` is called — see [references/macos.md](macos.md)
-- **Android:** Check port forwarding (Step 6) — need both `adb reverse tcp:19223` and `adb forward tcp:<port>`
+- **Android:** `maui devflow wait --platform android` (or `list`) sets up the broker reverse + agent forward automatically; `maui devflow diagnose` reports mapping status. Drop to raw `adb reverse`/`adb forward` only to manually repair (Step 6).
 - **iOS Simulator:** Should work without extra config
 - **Linux/GTK:** Should work without extra config — runs directly on localhost
 - **All platforms:** Ensure the app is running and the `#if DEBUG` block is active
-- **Port conflict:** Check if another process holds the port: `lsof -i :9223` (or your configured port)
+- **Port conflict:** Check if another process holds the port: `lsof -i :9223` (raw; not yet wrapped by `maui`)
 - **Wrong port:** Use `maui devflow list` to find the assigned port, or ensure CLI is run from the project directory
+- **Reading errors:** For `maui android`/`apple`/`device` commands, pass `--json` and inspect the top-level `code` / `remediation` fields (no `error` wrapper). `maui doctor --json` emits a `DoctorReport` (`status` + `checks[]`), and `maui devflow …` emits `{error,type,retryable}` on stderr. See [troubleshooting.md](troubleshooting.md#reading-machine-readable-output-and-errors)
 
 ## Quick Checklist
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -156,7 +156,7 @@ If `maui devflow webview status` fails but `ui status` works:
 
 1. **Chobitsu not loading?** Check logs for `[BlazorDevFlow]` messages. If auto-injection failed, add `<script src="chobitsu.js"></script>` manually to `wwwroot/index.html`
 2. **Blazor not initialized?** Navigate to a Blazor page first, then retry
-3. Check app logs: `maui devflow ui logs --limit 20` — look for `[BlazorDevFlow]` errors
+3. Check app logs: `maui devflow logs --limit 20` — look for `[BlazorDevFlow]` errors
 
 ## Mac Catalyst: Repeated Permission Dialogs on Rebuild
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -137,7 +137,7 @@ Fix: Install the required .NET SDK version, or check `global.json` for version p
 ```
 error XA0000: Could not find Android SDK
 ```
-Fix: Install Android SDK via `maui android sdk install --package "platforms;android-35"`
+Fix: Install Android SDK via `maui android sdk install "platforms;android-35"`
 (or run `maui android install` for guided setup), or set `$ANDROID_HOME`.
 Error code via `maui` JSON: `E2101` AndroidSdkNotFound.
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -35,21 +35,54 @@ Optional fields (`remediation`, `context`, `native_error`, `docs_url`, `correlat
 When `remediation.type` is `autofixable`, run `remediation.command` then retry the original command.
 When `remediation` is absent, surface `message` and stop retrying.
 
+### Code categories
+
+| Prefix | Category | Examples |
+|--------|----------|----------|
+| `E1xxx` | Tool error (likely an internal bug) | `E1001` InternalError, `E1004` InvalidArgument, `E1006` DeviceNotFound, `E1007` PlatformNotSupported |
+| `E2xxx` | Platform / SDK | `E2001` JdkNotFound, `E2101` AndroidSdkNotFound, `E2103` AndroidLicensesNotAccepted, `E2106` AndroidEmulatorNotFound, `E2110` AndroidAdbNotFound, `E2201` AppleXcodeNotFound, `E2204` AppleSimulatorNotFound, `E2402` MauiWorkloadMissing |
+| `E3xxx` | User action required | (e.g., choose a target when multiple match) |
+| `E4xxx` | Network | (download / fetch failures) |
+| `E5xxx` | Permission | (sandbox / elevation issues) |
+
+### Remediation
+
+`remediation.type` is one of:
+
+- `autofixable` — run `remediation.command` and retry the original command.
+- `useraction` — present `remediation.manual_steps` to the user.
+- `terminal` — cannot be fixed (e.g., unsupported OS); abort.
+- `unknown` — fall back to displaying `message`.
+
+### Worked example
+
+```bash
+maui android emulator start Pixel8 --json
+# → { "code": "E2106", "remediation": { "type": "autofixable", "command": "maui android emulator create Pixel8 --package ..." } }
+
+# Auto-fix path:
+maui android emulator create Pixel8 --package "system-images;android-35;google_apis;arm64-v8a" --device pixel_8 --json
+maui android emulator start Pixel8 --json   # retry original
+```
+
 ## Connection Refused / Cannot Connect
 
 If `maui devflow ui status` fails with connection refused:
 
 1. **App not running?** Verify the app launched: check the build output for errors.
-2. **Check the broker:** Run `maui devflow list` to see if the agent registered. If the list
+2. **Run the diagnostic first:** `maui devflow diagnose` separates broker
+   startup, project integration, no running app, and target-device networking.
+3. **Check the broker:** Run `maui devflow list` to see if the agent registered. If the list
    is empty, the app may not have connected to the broker yet (wait a few seconds and retry).
-3. **Wrong port?** If using `.mauidevflow`, ensure the port matches between build and CLI.
+4. **Wrong port?** If using `.mauidevflow`, ensure the port matches between build and CLI.
    Run CLI from the project directory so it auto-detects the config file.
-4. **Port already in use?** Another process may hold the port. Check with:
+5. **Port already in use?** Another process may hold the port. Check with:
    ```bash
+   # Not yet wrapped by 'maui' CLI — use raw lsof
    lsof -i :<port>       # macOS/Linux
    ```
    With the broker, this is less common since ports are auto-assigned.
-5. **Android?** Did you run `adb reverse tcp:19223 tcp:19223` (for broker) and
+6. **Android?** Did you run `adb reverse tcp:19223 tcp:19223` (for broker) and
    `adb forward tcp:<port> tcp:<port>` (for agent)? Re-run after each deploy.
    If broker/list is empty, still try direct status:
    ```bash
@@ -57,12 +90,13 @@ If `maui devflow ui status` fails with connection refused:
    adb forward tcp:9223 tcp:9223
    maui devflow agent status --agent-host localhost --agent-port 9223
    ```
-6. **Mac Catalyst?** Check entitlements include `network.server` (see setup.md step 5).
-7. **macOS (AppKit)?** Ensure `AddMacOSEssentials()` is called and the app window appeared.
+   (Port forwarding is not yet wrapped by `maui` — use raw `adb`.)
+7. **Mac Catalyst?** Check entitlements include `network.server` (see setup.md step 5).
+8. **macOS (AppKit)?** Ensure `AddMacOSEssentials()` is called and the app window appeared.
    See [references/macos.md](macos.md) for troubleshooting.
-8. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
-9. **Broker issues?** `maui devflow broker status` to check. `maui devflow broker stop` then
-   retry (CLI will auto-restart it).
+9. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
+10. **Broker issues?** `maui devflow broker status` to check. `maui devflow broker stop` then
+    retry (CLI will auto-restart it).
 
 ## Android UI Thread Exceptions
 
@@ -91,6 +125,7 @@ validation fallback.
 error NETSDK1147: To build this project, the following workloads must be installed: maui-ios
 ```
 Fix: `dotnet workload install maui` (installs all MAUI workloads).
+Error code via `maui` JSON: `E2402` MauiWorkloadMissing (often `autofixable`).
 
 **SDK version mismatch:**
 ```
@@ -102,11 +137,13 @@ Fix: Install the required .NET SDK version, or check `global.json` for version p
 ```
 error XA0000: Could not find Android SDK
 ```
-Fix: Install Android SDK via `android sdk install` or set `$ANDROID_HOME`.
+Fix: Install Android SDK via `maui android sdk install --package "platforms;android-35"`
+(or run `maui android install` for guided setup), or set `$ANDROID_HOME`.
+Error code via `maui` JSON: `E2101` AndroidSdkNotFound.
 
 **iOS provisioning / signing errors:**
 Fix: For simulators, ensure no signing is configured (default). For devices, set up provisioning
-profiles via `apple appstoreconnect profiles list`.
+profiles via your Apple Developer account.
 
 **General build failure recovery:**
 1. `dotnet clean` then retry the build

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -35,6 +35,10 @@ Optional fields (`remediation`, `context`, `native_error`, `docs_url`, `correlat
 When `remediation.type` is `autofixable`, run `remediation.command` then retry the original command.
 When `remediation` is absent, surface `message` and stop retrying.
 
+> **Tip for AI agents:** `maui android sdk accept-licenses` is interactive
+> (prompts for each license). For non-interactive acceptance, use
+> `maui android install --accept-licenses --json` instead.
+
 ### Code categories
 
 | Prefix | Category | Examples |

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -58,10 +58,11 @@ When `remediation` is absent, surface `message` and stop retrying.
 
 ```bash
 maui android emulator start Pixel8 --json
-# → { "code": "E2106", "remediation": { "type": "autofixable", "command": "maui android emulator create Pixel8 --package ..." } }
+# → { "code": "E2106", "message": "Android emulator not installed",
+#     "remediation": { "type": "autofixable", "command": "maui android sdk install emulator" } }
 
 # Auto-fix path:
-maui android emulator create Pixel8 --package "system-images;android-35;google_apis;arm64-v8a" --device pixel_8 --json
+maui android sdk install emulator --json
 maui android emulator start Pixel8 --json   # retry original
 ```
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -107,7 +107,7 @@ If `maui devflow ui status` fails with connection refused:
    lsof -i :<port>       # macOS/Linux
    ```
    With the broker, this is less common since ports are auto-assigned.
-6. **Android?** `maui devflow wait --platform android` (or `maui devflow list`)
+6. **Android?** `maui devflow wait --wait-platform android` (or `maui devflow list`)
    sets up the broker reverse (tcp:19223) and agent forward automatically; re-run
    `list` after each deploy to repair the agent forward. If broker/list is empty,
    the direct `.mauidevflow` port is the one forward the CLI does *not* auto-set —

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -1,22 +1,31 @@
 # Troubleshooting
 
 ## Table of Contents
-- [Machine-readable output and error envelope](#machine-readable-output-and-error-envelope)
+- [Reading machine-readable output and errors](#reading-machine-readable-output-and-errors)
 - [Connection Refused](#connection-refused--cannot-connect)
 - [Android UI Thread Exceptions](#android-ui-thread-exceptions)
 - [Build Failures](#build-failures)
 - [CDP Not Connecting](#cdp-not-connecting-blazor-hybrid)
 - [Mac Catalyst Permission Dialogs](#mac-catalyst-repeated-permission-dialogs-on-rebuild)
 
-## Machine-readable output and error envelope <a name="machine-readable-output-and-error-envelope"></a>
+## Reading machine-readable output and errors
 
 Always pass `--json` to any `maui` command an agent will parse, and `--ci` for
 non-interactive failure-fast runs.
 
-The full `--json` error envelope contract (schema, code categories, worked examples, PowerShell and Bash consumers) is documented in
-[`src/Cli/README.md` — Error envelope](../../../../../src/Cli/README.md#error-envelope).
+> **Which commands this applies to.** The flat stdout envelope below covers the
+> top-level command groups (`maui android`, `maui apple`, `maui device`, …).
+> Two exceptions: (1) `maui devflow …` subcommands (`wait`, `diagnose`, `ui …`,
+> etc.) write a `{ "error", "type", "retryable", "suggestions" }` object to
+> **stderr** and keep stdout for data; (2) `maui doctor --json` emits a
+> `DoctorReport` (top-level `status` plus `checks[].fix`), not this envelope.
+> See [connectivity.md](connectivity.md) for the DevFlow error shape.
 
-**Quick reference** — when a non-DevFlow command fails with `--json`, stdout is a top-level JSON object (no `"error"` wrapper). Note: `maui devflow ...` uses a different JSON error shape and writes errors to stderr.
+### Error envelope
+
+When a `maui` command fails with `--json`, it writes a structured error object
+at the **top level** of stdout (there is no enclosing `"error"` wrapper).
+Property names are `snake_case`:
 
 ```json
 {
@@ -27,42 +36,93 @@ The full `--json` error envelope contract (schema, code categories, worked examp
   "remediation": {
     "type": "autofixable",
     "command": "maui android sdk accept-licenses"
-  }
+  },
+  "context": { "sdk_path": "/Users/me/Library/Android/sdk" },
+  "native_error": "..."
 }
 ```
 
-Optional fields (`remediation`, `context`, `native_error`, `docs_url`, `correlation_id`) are **omitted entirely** when null.
-When `remediation.type` is `autofixable`, run `remediation.command` then retry the original command.
-When `remediation` is absent, surface `message` and stop retrying.
+Optional fields (`remediation`, `context`, `native_error`, `docs_url`,
+`correlation_id`) are **omitted entirely** when null — agents must null-check
+before dereferencing.
+
+### Code categories
+
+| Prefix | Category | Examples |
+|--------|----------|----------|
+| `E1xxx` | Tool error (likely an internal bug) | `E1001` InternalError, `E1004` InvalidArgument, `E1006` DeviceNotFound, `E1007` PlatformNotSupported |
+| `E2xxx` | Platform / SDK | `E2001` JdkNotFound, `E2101` AndroidSdkNotFound, `E2103` AndroidLicensesNotAccepted, `E2106` AndroidEmulatorNotFound, `E2110` AndroidAdbNotFound, `E2201` AppleXcodeNotFound, `E2204` AppleSimulatorNotFound, `E2402` MauiWorkloadMissing |
+| `E3xxx` | User action required | (e.g., choose a target when multiple match) |
+| `E4xxx` | Network | (download / fetch failures) |
+| `E5xxx` | Permission | (sandbox / elevation issues) |
+
+### Remediation
+
+When present, `remediation.type` is a **lowercase** string, one of:
+
+- `autofixable` — run `remediation.command` and retry the original command.
+- `useraction` — present `remediation.manual_steps` to the user.
+- `terminal` — cannot be fixed (e.g., unsupported OS); abort.
+- `unknown` — fall back to displaying `message`.
+
+If `remediation` is missing from the envelope, the failure has no auto-fix
+hint — surface `message` (and `native_error` if present) and stop retrying.
+
+### Worked example
+
+`maui android emulator start <name>` will throw `E2106` *with* an
+`autofixable` remediation when the Android emulator binary is not installed:
+
+```bash
+maui android emulator start Pixel8 --json
+# → { "code": "E2106",
+#     "category": "platform",
+#     "message": "Android emulator not installed",
+#     "remediation": { "type": "autofixable",
+#                      "command": "maui android sdk install emulator" } }
+
+# Auto-fix path:
+maui android sdk install emulator --json
+maui android emulator start Pixel8 --json   # retry original
+```
+
+Other E2106 throw sites (e.g., "no AVD with that name") emit the same code
+**without** a `remediation` block — that's the case where the agent should
+stop and surface the message instead of looping.
 
 ## Connection Refused / Cannot Connect
 
 If `maui devflow ui status` fails with connection refused:
 
 1. **App not running?** Verify the app launched: check the build output for errors.
-2. **Check the broker:** Run `maui devflow list` to see if the agent registered. If the list
+2. **Run the diagnostic first:** `maui devflow diagnose` separates broker
+   startup, project integration, no running app, and target-device networking.
+3. **Check the broker:** Run `maui devflow list` to see if the agent registered. If the list
    is empty, the app may not have connected to the broker yet (wait a few seconds and retry).
-3. **Wrong port?** If using `.mauidevflow`, ensure the port matches between build and CLI.
+4. **Wrong port?** If using `.mauidevflow`, ensure the port matches between build and CLI.
    Run CLI from the project directory so it auto-detects the config file.
-4. **Port already in use?** Another process may hold the port. Check with:
+5. **Port already in use?** Another process may hold the port. Check with:
    ```bash
+   # Not yet wrapped by 'maui' CLI — use raw lsof
    lsof -i :<port>       # macOS/Linux
    ```
    With the broker, this is less common since ports are auto-assigned.
-5. **Android?** Did you run `adb reverse tcp:19223 tcp:19223` (for broker) and
-   `adb forward tcp:<port> tcp:<port>` (for agent)? Re-run after each deploy.
-   If broker/list is empty, still try direct status:
+6. **Android?** `maui devflow wait --platform android` (or `maui devflow list`)
+   sets up the broker reverse (tcp:19223) and agent forward automatically; re-run
+   `list` after each deploy to repair the agent forward. If broker/list is empty,
+   the direct `.mauidevflow` port is the one forward the CLI does *not* auto-set —
+   do it manually and check direct status:
    ```bash
    adb devices
    adb forward tcp:9223 tcp:9223
    maui devflow agent status --agent-host localhost --agent-port 9223
    ```
-6. **Mac Catalyst?** Check entitlements include `network.server` (see setup.md step 5).
-7. **macOS (AppKit)?** Ensure `AddMacOSEssentials()` is called and the app window appeared.
+7. **Mac Catalyst?** Check entitlements include `network.server` (see setup.md step 5).
+8. **macOS (AppKit)?** Ensure `AddMacOSEssentials()` is called and the app window appeared.
    See [references/macos.md](macos.md) for troubleshooting.
-8. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
-9. **Broker issues?** `maui devflow broker status` to check. `maui devflow broker stop` then
-   retry (CLI will auto-restart it).
+9. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
+10. **Broker issues?** `maui devflow broker status` to check. `maui devflow broker stop` then
+    retry (CLI will auto-restart it).
 
 ## Android UI Thread Exceptions
 
@@ -91,6 +151,7 @@ validation fallback.
 error NETSDK1147: To build this project, the following workloads must be installed: maui-ios
 ```
 Fix: `dotnet workload install maui` (installs all MAUI workloads).
+Error code via `maui` JSON: `E2402` MauiWorkloadMissing (often `autofixable`).
 
 **SDK version mismatch:**
 ```
@@ -102,11 +163,13 @@ Fix: Install the required .NET SDK version, or check `global.json` for version p
 ```
 error XA0000: Could not find Android SDK
 ```
-Fix: Install Android SDK via `android sdk install` or set `$ANDROID_HOME`.
+Fix: Install Android SDK via `maui android sdk install "platforms;android-35"`
+(or run `maui android install` for guided setup), or set `$ANDROID_HOME`.
+Error code via `maui` JSON: `E2101` AndroidSdkNotFound.
 
 **iOS provisioning / signing errors:**
 Fix: For simulators, ensure no signing is configured (default). For devices, set up provisioning
-profiles via `apple appstoreconnect profiles list`.
+profiles via your Apple Developer account.
 
 **General build failure recovery:**
 1. `dotnet clean` then retry the build
@@ -119,7 +182,7 @@ If `maui devflow webview status` fails but `ui status` works:
 
 1. **Chobitsu not loading?** Check logs for `[BlazorDevFlow]` messages. If auto-injection failed, add `<script src="chobitsu.js"></script>` manually to `wwwroot/index.html`
 2. **Blazor not initialized?** Navigate to a Blazor page first, then retry
-3. Check app logs: `maui devflow ui logs --limit 20` — look for `[BlazorDevFlow]` errors
+3. Check app logs: `maui devflow logs --limit 20` — look for `[BlazorDevFlow]` errors
 
 ## Mac Catalyst: Repeated Permission Dialogs on Rebuild
 

--- a/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
@@ -39,10 +39,10 @@ Use this skill to add MAUI DevFlow to a project after `maui devflow init` has in
 7. Verify with:
 
    ```bash
-   maui doctor                # environment health check (supports --json)
-   maui devflow diagnose      # connectivity diagnostic
-   maui devflow wait
-   maui devflow ui tree --depth 1
+   maui doctor --json             # environment health check
+   maui devflow diagnose --json   # connectivity diagnostic
+   maui devflow wait --json
+   maui devflow ui tree --depth 1 --json
    ```
 
    For programmatic use, pass `--json` to `maui doctor` and read the

--- a/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
@@ -45,8 +45,10 @@ Use this skill to add MAUI DevFlow to a project after `maui devflow init` has in
    maui devflow ui tree --depth 1
    ```
 
-   For programmatic use, pass `--json` to any of the above and read
-   `error.code` and `error.remediation.command` to recover automatically. See
+   For programmatic use, pass `--json` to `maui doctor` / `maui devflow
+   diagnose` and read the top-level `code` and `remediation.command` (no
+   `error` wrapper; `snake_case` property names; `remediation.type` is
+   lowercase, e.g. `autofixable`). See
    `maui-devflow-debug` references/troubleshooting.md for the full code
    taxonomy (E1xxx tool, E2xxx platform/SDK, E3xxx user action, etc.).
 

--- a/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
@@ -45,12 +45,14 @@ Use this skill to add MAUI DevFlow to a project after `maui devflow init` has in
    maui devflow ui tree --depth 1
    ```
 
-   For programmatic use, pass `--json` to `maui doctor` / `maui devflow
-   diagnose` and read the top-level `code` and `remediation.command` (no
-   `error` wrapper; `snake_case` property names; `remediation.type` is
-   lowercase, e.g. `autofixable`). See
-   `maui-devflow-debug` references/troubleshooting.md for the full code
-   taxonomy (E1xxx tool, E2xxx platform/SDK, E3xxx user action, etc.).
+   For programmatic use, pass `--json` to `maui doctor` and read the
+   top-level `code` and `remediation.command` (no `error` wrapper;
+   `snake_case` property names; `remediation.type` is lowercase, e.g.
+   `autofixable`). **Note:** `maui devflow` commands use a different error
+   shape (`{"error":"...","type":"...","retryable":...}`) written to
+   **stderr**. See `maui-devflow-debug` references/troubleshooting.md for
+   the full code taxonomy (E1xxx tool, E2xxx platform/SDK, E3xxx user
+   action, etc.).
 
 If verification fails after integration, switch to `maui-devflow-debug` for connectivity recovery.
 

--- a/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
@@ -39,10 +39,16 @@ Use this skill to add MAUI DevFlow to a project after `maui devflow init` has in
 7. Verify with:
 
    ```bash
-   maui devflow diagnose
+   maui doctor                # environment health check (supports --json)
+   maui devflow diagnose      # connectivity diagnostic
    maui devflow wait
    maui devflow ui tree --depth 1
    ```
+
+   For programmatic use, pass `--json` to any of the above and read
+   `error.code` and `error.remediation.command` to recover automatically. See
+   `maui-devflow-debug` references/troubleshooting.md for the full code
+   taxonomy (E1xxx tool, E2xxx platform/SDK, E3xxx user action, etc.).
 
 If verification fails after integration, switch to `maui-devflow-debug` for connectivity recovery.
 

--- a/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
@@ -54,8 +54,12 @@ feedback. Do not run it automatically.
      `Warning` with an auto-fixable `maui android sdk accept-licenses`). Doctor
      status enums are PascalCase (`Ok`/`Warning`/`Error`/`Skipped`/
      `NotApplicable`), distinct from the lowercase error envelope below.
-   - `maui devflow diagnose --json` emits DevFlow's error shape
-     (`{ "error", "type", "retryable", "suggestions" }`) on **stderr**.
+   - `maui devflow diagnose --json` writes a health report to **stdout** on
+     success — `cli_version`, `broker_running`, `agent_count`, `agents`,
+     `projects`, plus optional `broker_port` (when the broker is up) and
+     `android` (emulator forwarding status). It only emits DevFlow's error
+     shape (`{ "error", "type", "retryable", "suggestions" }`) on **stderr**
+     when the command itself fails.
 
    The flat `code` / `remediation` envelope (no `error` wrapper; `snake_case`;
    lowercase `remediation.type`, e.g. `autofixable`) applies to the other `maui`

--- a/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
@@ -39,10 +39,29 @@ feedback. Do not run it automatically.
 7. Verify with:
 
    ```bash
-   maui devflow diagnose
+   maui doctor                # environment health check (supports --json)
+   maui devflow diagnose      # connectivity diagnostic
    maui devflow wait
    maui devflow ui tree --depth 1
    ```
+
+   Both commands support `--json`, but their schemas differ:
+   - `maui doctor --json` emits a `DoctorReport`: read the top-level `status`
+     (`Healthy`/`Degraded`/`Unhealthy`) and iterate `checks[]`, running
+     `fix.command` for any check that carries a `fix` with `auto_fixable: true`.
+     Key off `fix.auto_fixable`, **not** `status`: auto-fixable fixes appear on
+     both `Error` and `Warning` checks (e.g. Android SDK licenses surface as a
+     `Warning` with an auto-fixable `maui android sdk accept-licenses`). Doctor
+     status enums are PascalCase (`Ok`/`Warning`/`Error`/`Skipped`/
+     `NotApplicable`), distinct from the lowercase error envelope below.
+   - `maui devflow diagnose --json` emits DevFlow's error shape
+     (`{ "error", "type", "retryable", "suggestions" }`) on **stderr**.
+
+   The flat `code` / `remediation` envelope (no `error` wrapper; `snake_case`;
+   lowercase `remediation.type`, e.g. `autofixable`) applies to the other `maui`
+   groups — `maui android`, `maui apple`, `maui device`. See `maui-devflow-debug`
+   references/troubleshooting.md for the full code taxonomy (E1xxx tool, E2xxx
+   platform/SDK, E3xxx user action, etc.).
 
 If verification fails after integration, switch to `maui-devflow-debug` for connectivity recovery.
 


### PR DESCRIPTION
## Summary

Retargets the `maui-devflow-debug` and `maui-devflow-onboard` agent skills (under `plugins/dotnet-maui/skills/`) so AI agents prefer the unified **`maui` CLI** (`Microsoft.Maui.Cli`) for device prep and management, instead of mixing `androidsdk.tool` (`android …`), `appledev.tools` (`apple …`), raw `adb`, and raw `xcrun simctl`.

Raw fallbacks are kept **only** for operations the `maui` CLI does not yet wrap, and are grouped under clearly labeled sections so future CLI work has a concrete target list.

Also adds inline JSON / error-troubleshooting guidance so agents pass `--json`, branch on error codes, and follow remediation hints emitted by `MauiToolException`.

Closes #197

## What's in this PR (skill markdown only)

- **`maui-devflow-debug/SKILL.md`** — INVOKES rewritten to lead with `maui` CLI; new **"Reading machine-readable output"** section covering `--json`, error code categories `E1xxx`–`E5xxx`, `remediation.type` (`autofixable`/`useraction`/`terminal` — lowercase), and `--ci`. Explicitly notes that `maui devflow` commands use a different stderr JSON shape.
- **`references/android.md`** — fully rewritten `maui`-first. Raw `adb` ops (port forwarding, install, logcat, screencap, push/pull/shell) grouped under **"Raw fallbacks not yet in `maui` CLI"**. `sdk install` uses positional args (no `--package` flag).
- **`references/ios-and-mac.md`** — restructured around `maui apple xcode|runtime|simulator …` including newly promoted commands: `create`, `erase`, `install`, `uninstall`, `launch`, `terminate`. Raw `xcrun simctl` ops (appearance/openurl/push/location/addmedia/screenshots) grouped under the labeled fallback section. Permission leads with `maui apple simulator privacy` / `maui devflow ui permission`; `--bundle-id` is documented as **optional** — omit to apply to all apps, supply to scope a grant to one app (matches the CLI's own `--bundle-id` option description).
- **`references/connectivity.md`** — leads with `maui devflow diagnose` + `maui device list`; new **"Reading errors from the CLI"** section scoped to non-DevFlow commands with the flat JSON error envelope (no `"error"` wrapper).
- **`references/troubleshooting.md`** — new top section **"Machine-readable output and error envelope"** with flat JSON (no wrapper), code taxonomy, lowercase remediation types, `manual_steps` (snake_case), and a worked example (`E2106` emulator binary missing → `maui android sdk install emulator`).
- **`references/setup.md`** — `Microsoft.Maui.Cli` is the only required global tool; optional extras shrunk to only truly unwrapped ops; `maui doctor` added to verify.
- **`maui-devflow-onboard/SKILL.md`** — `maui doctor` + `--json` error guidance added to verify step, scoped to non-DevFlow commands with DevFlow stderr shape noted.

`references/macos.md`, `linux.md`, and `batch.md` were verified clean (no changes needed).

## Audit highlights

Verified against `src/Cli/Microsoft.Maui.Cli/Commands/` and `Models/ErrorResult.cs`.

| Replaced | Kept as raw fallback |
|---|---|
| `android avd\|sdk\|jdk\|device …` → `maui android emulator\|sdk\|jdk …` | `adb reverse\|forward` (broker port + agent port) |
| `apple simulator list/start/stop/delete/create/erase/install/launch/terminate` → `maui apple simulator …` | `adb install\|uninstall`, `am start\|force-stop`, `pm uninstall` |
| `adb devices` / `xcrun simctl list devices` → `maui device list --platform …` | `adb logcat`, `adb shell screencap\|screenrecord`, `adb push\|pull\|shell` |
| Connectivity diagnostic surfaced as `maui devflow diagnose` first | `xcrun simctl appearance\|openurl\|push\|location\|addmedia` |
| Environment health: `maui doctor` added to setup + onboard verify | `lsof -i :<port>`, `pgrep -f "App"` |

## JSON / error troubleshooting improvements

Skills now teach agents to:

1. Pass `--json` to any command that will be parsed.
2. Branch on the top-level `code` field (flat JSON, no `"error"` wrapper):
   - `E1xxx` — tool/internal
   - `E2xxx` — platform/SDK (`E20xx` JDK, `E21xx` Android, `E22xx` Apple, `E23xx` Windows, `E24xx` .NET)
   - `E3xxx` — user action
   - `E4xxx` — network
   - `E5xxx` — permission
3. When `remediation.type == "autofixable"` (lowercase), run `remediation.command` and retry.
4. When `remediation.type == "useraction"`, follow `remediation.manual_steps` (snake_case).
5. Use `--ci` for non-interactive failure-fast runs.
6. **DevFlow commands** (`maui devflow …`) use a different error shape (`{"error":"…","type":"…","retryable":…}`) written to **stderr** — not the `ErrorResult` envelope.

A worked example (auto-fixable `E2106` recovery: missing emulator binary → `maui android sdk install emulator`) is included in `references/troubleshooting.md`.

## Verification

```
rg -n '^\s*(android |apple |xcrun simctl |adb )' \
  plugins/dotnet-maui/skills/maui-devflow-debug \
  plugins/dotnet-maui/skills/maui-devflow-onboard
```

Every remaining match is inside a clearly labeled "Raw fallbacks not yet in `maui` CLI" section **or** is preceded by a `# Not yet wrapped by 'maui' CLI` comment.

Post-review fixes verified with multi-model code review (GPT-5.4, Claude Opus 4.7, Claude Haiku 4.5). **Rebased onto current `main`** — the one content conflict (`maui-devflow-debug/SKILL.md` frontmatter) was resolved in favor of main's compressed 0.5.0 `description` while preserving the newer simulator-wrapper guidance in the body and `references/ios-and-mac.md`. All review threads resolved.

## Out of scope

- The legacy `maui-ai-debugging` skill (already redirects to `maui-devflow-debug`).
- The `devflow-automation` skill (about `[DevFlowAction]`, not devices).
- **No new `maui` CLI commands** — the follow-up CLI gaps are tracked in #197 and intentionally deferred.

## Test plan

These are markdown skill files only — no build/test target. Validation is by re-read + grep verification (above), automated code review (2 rounds), and multi-model review.
