### PR TITLE
docs: document --json error envelope contract in CLI README

### DIFF
--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -15,7 +15,7 @@ non-interactive failure-fast runs.
 The full `--json` error envelope contract (schema, code categories, worked examples, PowerShell and Bash consumers) is documented in
 [`src/Cli/README.md` — Error envelope](../../../../../src/Cli/README.md#error-envelope).
 
-**Quick reference** — when a command fails with `--json`, stdout is a top-level JSON object (no `"error"` wrapper):
+**Quick reference** — when a non-DevFlow command fails with `--json`, stdout is a top-level JSON object (no `"error"` wrapper). Note: `maui devflow ...` uses a different JSON error shape and writes errors to stderr.
 
 ```json
 {

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -1,10 +1,38 @@
 # Troubleshooting
 
 ## Table of Contents
+- [Machine-readable output and error envelope](#machine-readable-output-and-error-envelope)
 - [Connection Refused](#connection-refused--cannot-connect)
 - [Build Failures](#build-failures)
 - [CDP Not Connecting](#cdp-not-connecting-blazor-hybrid)
 - [Mac Catalyst Permission Dialogs](#mac-catalyst-repeated-permission-dialogs-on-rebuild)
+
+## Machine-readable output and error envelope <a name="machine-readable-output-and-error-envelope"></a>
+
+Always pass `--json` to any `maui` command an agent will parse, and `--ci` for
+non-interactive failure-fast runs.
+
+The full `--json` error envelope contract (schema, code categories, worked examples, PowerShell and Bash consumers) is documented in
+[`src/Cli/README.md` — Error envelope](../../../../src/Cli/README.md#error-envelope).
+
+**Quick reference** — when a command fails with `--json`, stdout is a top-level JSON object (no `"error"` wrapper):
+
+```json
+{
+  "code": "E2103",
+  "category": "platform",
+  "severity": "error",
+  "message": "Android SDK licenses have not been accepted.",
+  "remediation": {
+    "type": "autofixable",
+    "command": "maui android sdk accept-licenses"
+  }
+}
+```
+
+Optional fields (`remediation`, `context`, `native_error`, `docs_url`, `correlation_id`) are **omitted entirely** when null.
+When `remediation.type` is `autofixable`, run `remediation.command` then retry the original command.
+When `remediation` is absent, surface `message` and stop retrying.
 
 ## Connection Refused / Cannot Connect
 

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md
@@ -13,7 +13,7 @@ Always pass `--json` to any `maui` command an agent will parse, and `--ci` for
 non-interactive failure-fast runs.
 
 The full `--json` error envelope contract (schema, code categories, worked examples, PowerShell and Bash consumers) is documented in
-[`src/Cli/README.md` — Error envelope](../../../../src/Cli/README.md#error-envelope).
+[`src/Cli/README.md` — Error envelope](../../../../../src/Cli/README.md#error-envelope).
 
 **Quick reference** — when a command fails with `--json`, stdout is a top-level JSON object (no `"error"` wrapper):
 

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -156,13 +156,13 @@ maui doctor --json | jq '.checks[] | select(.status == "failed")'
 
 ### `--json` flag
 
-Most commands accept `--json` for structured output. Some commands may emit multiple JSON objects to stdout (JSONL / newline-delimited JSON) — for example, progress or status records before the final result. The final JSON object is the command result, whose shape is command-specific (see per-command `--help` and examples below). When a non-DevFlow command **fails** and the error is a recognized `MauiToolException`, it emits the canonical error envelope described in the next section. Note: unrecognized parse errors (e.g. invalid flags) do not use this envelope, and `maui devflow ...` uses a different JSON contract and writes structured errors to stderr rather than stdout.
+Most commands accept `--json` for structured output. Some commands may emit multiple JSON objects to stdout (JSONL / newline-delimited JSON) — for example, progress or status records before the final result. The final JSON object is the command result, whose shape is command-specific (see per-command `--help` and examples below). When a non-DevFlow command **fails** and the exception is handled by `HandleCommandException`, it emits the canonical error envelope described in the next section. This applies to both recognized `MauiToolException` errors (which produce specific error codes) and unexpected exceptions (which become `E1001`/`InternalError` via `ErrorResult.FromException`). Note: unrecognized parse errors (e.g. invalid flags) do not use this envelope, `OperationCanceledException` produces a status message with exit code 130 rather than the error envelope, and `maui devflow ...` uses a different JSON contract and writes structured errors to stderr rather than stdout.
 
 Use `--ci` together with `--json` for non-interactive, fail-fast runs in automation contexts. Parse the output as a stream of JSON objects rather than assuming a single top-level document.
 
 ### Error envelope <a name="error-envelope"></a>
 
-For non-DevFlow `maui` commands, when a command exits with a non-zero exit code and `--json` is active, it writes a structured error object to stdout. The fields appear at the **top level** — there is no enclosing `"error"` wrapper. Property names are `snake_case`. This section does not apply to `maui devflow ...`, which uses a different JSON error shape and writes structured errors to stderr.
+For non-DevFlow `maui` commands, when a command throws an exception that is handled by `HandleCommandException` and `--json` is active, it writes a structured error object to stdout. The fields appear at the **top level** — there is no enclosing `"error"` wrapper. Property names are `snake_case`. Note: some commands may return non-zero exit codes without throwing (e.g. validation paths), and `OperationCanceledException` is treated as a cancellation (exit code 130) rather than an error envelope. This section does not apply to `maui devflow ...`, which uses a different JSON error shape and writes structured errors to stderr.
 
 ```json
 {
@@ -201,7 +201,7 @@ For non-DevFlow `maui` commands, when a command exits with a non-zero exit code 
 | `E1xxx` | `tool` | `E1001` InternalError, `E1004` InvalidArgument, `E1006` DeviceNotFound, `E1007` PlatformNotSupported |
 | `E20xx` | `platform` | `E2001` JdkNotFound, `E2002` JdkVersionUnsupported, `E2003` JdkInstallFailed |
 | `E21xx` | `platform` | `E2101` AndroidSdkNotFound, `E2102` AndroidSdkManagerNotFound, `E2103` AndroidLicensesNotAccepted, `E2105` AndroidPackageInstallFailed, `E2106` AndroidEmulatorNotFound, `E2108` AndroidAvdCreateFailed, `E2110` AndroidAdbNotFound, `E2111` AndroidDeviceNotFound, `E2112` AndroidAvdDeleteFailed |
-| `E22xx` | `platform` | `E2201` AppleXcodeNotFound, `E2202` AppleCltNotFound, `E2203` AppleSimctlFailed, `E2204` AppleSimulatorNotFound |
+| `E22xx` | `platform` | `E2201` AppleXcodeNotFound, `E2202` AppleCltNotFound, `E2203` AppleSimctlFailed, `E2204` AppleSimulatorNotFound, `E2205` AppleXcodeLicenseNotAccepted, `E2206` AppleSetupFailed, `E2207` AppleSimulatorCreateFailed, `E2208` AppleSimulatorEraseFailed |
 | `E23xx` | `platform` | `E2301` WindowsSdkNotFound |
 | `E24xx` | `platform` | `E2401` DotNetNotFound, `E2402` MauiWorkloadMissing, `E2403` DiagnosticsToolNotFound |
 | `E3xxx` | `user` | User action required (wrong arguments, missing inputs) |

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -156,7 +156,7 @@ maui doctor --json | jq '.checks[] | select(.status == "failed")'
 
 ### `--json` flag
 
-Most commands accept `--json` for structured output. Successful results emit a top-level JSON object whose shape is command-specific (see per-command `--help` and examples below). When a command **fails**, it always emits the canonical error envelope described in the next section — regardless of which command was run.
+Most commands accept `--json` for structured output. Successful results emit a top-level JSON object whose shape is command-specific (see per-command `--help` and examples below). When a command **fails** and the error is a recognized `MauiToolException`, it emits the canonical error envelope described in the next section. Note: unrecognised parse errors (e.g. invalid flags) and DevFlow sub-commands may emit different shapes.
 
 Use `--ci` together with `--json` for non-interactive, fail-fast runs in automation contexts.
 
@@ -166,9 +166,9 @@ When a `maui` command exits with a non-zero exit code and `--json` is active, it
 
 ```json
 {
-  "code": "E2106",          // stable error code — see `maui errors list` (issue #197)
+  "code": "E2106",          // stable error code — see the error code table below
   "category": "platform",   // tool | platform | user | network | permission
-  "severity": "error",      // info | warning | error
+  "severity": "error",      // always "error" today (info | warning reserved for future use)
   "message": "Android emulator not installed",
 
   // OPTIONAL — omitted entirely when null (never serialized as JSON null)
@@ -180,7 +180,7 @@ When a `maui` command exits with a non-zero exit code and `--json` is active, it
     "command": "maui android sdk install emulator",  // present when type == autofixable
     "manual_steps": ["...", "..."]      // present when type == useraction
   },
-  "docs_url": "https://...",
+  "docs_url": "https://...",          // reserved — not yet populated by any command
   "correlation_id": "..."
 }
 ```
@@ -200,15 +200,15 @@ When a `maui` command exits with a non-zero exit code and `--json` is active, it
 |--------|-----------------|---------|
 | `E1xxx` | `tool` | `E1001` InternalError, `E1004` InvalidArgument, `E1006` DeviceNotFound, `E1007` PlatformNotSupported |
 | `E20xx` | `platform` | `E2001` JdkNotFound, `E2002` JdkVersionUnsupported, `E2003` JdkInstallFailed |
-| `E21xx` | `platform` | `E2101` AndroidSdkNotFound, `E2103` AndroidLicensesNotAccepted, `E2106` AndroidEmulatorNotFound, `E2110` AndroidAdbNotFound |
-| `E22xx` | `platform` | `E2201` AppleXcodeNotFound, `E2204` AppleSimulatorNotFound |
+| `E21xx` | `platform` | `E2101` AndroidSdkNotFound, `E2102` AndroidSdkManagerNotFound, `E2103` AndroidLicensesNotAccepted, `E2105` AndroidPackageInstallFailed, `E2106` AndroidEmulatorNotFound, `E2108` AndroidAvdCreateFailed, `E2110` AndroidAdbNotFound, `E2111` AndroidDeviceNotFound, `E2112` AndroidAvdDeleteFailed |
+| `E22xx` | `platform` | `E2201` AppleXcodeNotFound, `E2202` AppleCltNotFound, `E2203` AppleSimctlFailed, `E2204` AppleSimulatorNotFound |
 | `E23xx` | `platform` | `E2301` WindowsSdkNotFound |
-| `E24xx` | `platform` | `E2401` DotNetNotFound, `E2402` MauiWorkloadMissing |
+| `E24xx` | `platform` | `E2401` DotNetNotFound, `E2402` MauiWorkloadMissing, `E2403` DiagnosticsToolNotFound |
 | `E3xxx` | `user` | User action required (wrong arguments, missing inputs) |
 | `E4xxx` | `network` | Download / connectivity failures |
 | `E5xxx` | `permission` | Privacy / OS permission issues |
 
-Call `maui errors list --json` to get the live catalogue (being added in issue [#197](https://github.com/dotnet/maui-labs/issues/197)).
+A `maui errors list` command is planned (issue [#197](https://github.com/dotnet/maui-labs/issues/197)) to expose this catalogue at runtime. The table above is the authoritative list until then.
 
 ### Consuming the error envelope
 
@@ -219,7 +219,8 @@ if ! out=$(maui android sdk install emulator --json 2>&1); then
   rem_type=$(echo "$out" | jq -r '.remediation.type // "unknown"')
   rem_cmd=$(echo "$out" | jq -r '.remediation.command // empty')
   if [[ "$rem_type" == "autofixable" && -n "$rem_cmd" ]]; then
-    eval "$rem_cmd"
+    # Run the remediation command directly (never pass untrusted input to eval)
+    $rem_cmd
   fi
 fi
 ```
@@ -231,7 +232,9 @@ $json = maui android sdk install emulator --json
 if ($LASTEXITCODE -ne 0) {
     $err = $json | ConvertFrom-Json
     if ($err.remediation.type -eq 'autofixable' -and $err.remediation.command) {
-        Invoke-Expression $err.remediation.command
+        # Split and invoke directly (avoid Invoke-Expression with untrusted input)
+        $parts = $err.remediation.command -split ' '
+        & $parts[0] $parts[1..($parts.Length-1)]
     }
 }
 ```

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -156,13 +156,13 @@ maui doctor --json | jq '.checks[] | select(.status == "failed")'
 
 ### `--json` flag
 
-Most commands accept `--json` for structured output. Successful results emit a top-level JSON object whose shape is command-specific (see per-command `--help` and examples below). When a command **fails** and the error is a recognized `MauiToolException`, it emits the canonical error envelope described in the next section. Note: unrecognised parse errors (e.g. invalid flags) and DevFlow sub-commands may emit different shapes.
+Most commands accept `--json` for structured output. Some commands may emit multiple JSON objects to stdout (JSONL / newline-delimited JSON) — for example, progress or status records before the final result. The final JSON object is the command result, whose shape is command-specific (see per-command `--help` and examples below). When a non-DevFlow command **fails** and the error is a recognized `MauiToolException`, it emits the canonical error envelope described in the next section. Note: unrecognized parse errors (e.g. invalid flags) do not use this envelope, and `maui devflow ...` uses a different JSON contract and writes structured errors to stderr rather than stdout.
 
-Use `--ci` together with `--json` for non-interactive, fail-fast runs in automation contexts.
+Use `--ci` together with `--json` for non-interactive, fail-fast runs in automation contexts. Parse the output as a stream of JSON objects rather than assuming a single top-level document.
 
 ### Error envelope <a name="error-envelope"></a>
 
-When a `maui` command exits with a non-zero exit code and `--json` is active, it writes a structured error object to stdout. The fields appear at the **top level** — there is no enclosing `"error"` wrapper. Property names are `snake_case`.
+For non-DevFlow `maui` commands, when a command exits with a non-zero exit code and `--json` is active, it writes a structured error object to stdout. The fields appear at the **top level** — there is no enclosing `"error"` wrapper. Property names are `snake_case`. This section does not apply to `maui devflow ...`, which uses a different JSON error shape and writes structured errors to stderr.
 
 ```json
 {
@@ -192,7 +192,7 @@ When a `maui` command exits with a non-zero exit code and `--json` is active, it
 - Optional fields (`native_error`, `context`, `remediation`, `docs_url`, `correlation_id`) are **omitted entirely** when null — enforced by `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`.
 - There is **no** outer `"error"` wrapper — all fields are top-level.
 - `code`, `category`, `severity`, and `message` are always present.
-- The shape is stable across CLI versions; new optional fields may be added but existing field names and types will not change without a major version bump.
+- The CLI intends to keep this envelope shape consistent; future changes are expected to be additive (e.g. new optional fields) rather than changing existing field names or types.
 
 ### Error code categories
 
@@ -216,8 +216,10 @@ A `maui errors list` command is planned (issue [#197](https://github.com/dotnet/
 
 ```bash
 if ! out=$(maui android sdk install emulator --json 2>&1); then
-  rem_type=$(echo "$out" | jq -r '.remediation.type // "unknown"')
-  rem_cmd=$(echo "$out" | jq -r '.remediation.command // empty')
+  # Output may contain multiple JSONL lines; extract the error envelope (has a "code" field)
+  err=$(echo "$out" | jq -s '[.[] | select(.code)] | last')
+  rem_type=$(echo "$err" | jq -r '.remediation.type // "unknown"')
+  rem_cmd=$(echo "$err" | jq -r '.remediation.command // empty')
   if [[ "$rem_type" == "autofixable" && -n "$rem_cmd" ]]; then
     # Run the remediation command directly (never pass untrusted input to eval)
     $rem_cmd
@@ -228,9 +230,11 @@ fi
 **PowerShell:**
 
 ```powershell
-$json = maui android sdk install emulator --json
+$lines = maui android sdk install emulator --json
 if ($LASTEXITCODE -ne 0) {
-    $err = $json | ConvertFrom-Json
+    # Output may contain multiple JSONL lines; pick the error envelope (has a "code" property)
+    $err = $lines | ForEach-Object { $_ | ConvertFrom-Json } |
+           Where-Object { $_.code } | Select-Object -Last 1
     if ($err.remediation.type -eq 'autofixable' -and $err.remediation.command) {
         # Split and invoke directly (avoid Invoke-Expression with untrusted input)
         $parts = $err.remediation.command -split ' '

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -154,6 +154,111 @@ maui doctor
 maui doctor --json | jq '.checks[] | select(.status == "failed")'
 ```
 
+### `--json` flag
+
+Most commands accept `--json` for structured output. Successful results emit a top-level JSON object whose shape is command-specific (see per-command `--help` and examples below). When a command **fails**, it always emits the canonical error envelope described in the next section — regardless of which command was run.
+
+Use `--ci` together with `--json` for non-interactive, fail-fast runs in automation contexts.
+
+### Error envelope <a name="error-envelope"></a>
+
+When a `maui` command exits with a non-zero exit code and `--json` is active, it writes a structured error object to stdout. The fields appear at the **top level** — there is no enclosing `"error"` wrapper. Property names are `snake_case`.
+
+```json
+{
+  "code": "E2106",          // stable error code — see `maui errors list` (issue #197)
+  "category": "platform",   // tool | platform | user | network | permission
+  "severity": "error",      // info | warning | error
+  "message": "Android emulator not installed",
+
+  // OPTIONAL — omitted entirely when null (never serialized as JSON null)
+
+  "native_error": "...",    // raw error text from the underlying tool, when available
+  "context": { ... },       // command-specific diagnostics bag
+  "remediation": {
+    "type": "autofixable",              // autofixable | useraction | terminal | unknown
+    "command": "maui android sdk install emulator",  // present when type == autofixable
+    "manual_steps": ["...", "..."]      // present when type == useraction
+  },
+  "docs_url": "https://...",
+  "correlation_id": "..."
+}
+```
+
+**Contract guarantees** (verified line-by-line against `Models/ErrorResult.cs`):
+
+- Property names are `snake_case` — enforced by `[JsonPropertyName]` attributes on `ErrorResult`.
+- `remediation.type` values are **lowercase** strings — serialized via `.ToString().ToLowerInvariant()`.
+- Optional fields (`native_error`, `context`, `remediation`, `docs_url`, `correlation_id`) are **omitted entirely** when null — enforced by `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`.
+- There is **no** outer `"error"` wrapper — all fields are top-level.
+- `code`, `category`, `severity`, and `message` are always present.
+- The shape is stable across CLI versions; new optional fields may be added but existing field names and types will not change without a major version bump.
+
+### Error code categories
+
+| Prefix | `category` value | Examples |
+|--------|-----------------|---------|
+| `E1xxx` | `tool` | `E1001` InternalError, `E1004` InvalidArgument, `E1006` DeviceNotFound, `E1007` PlatformNotSupported |
+| `E20xx` | `platform` | `E2001` JdkNotFound, `E2002` JdkVersionUnsupported, `E2003` JdkInstallFailed |
+| `E21xx` | `platform` | `E2101` AndroidSdkNotFound, `E2103` AndroidLicensesNotAccepted, `E2106` AndroidEmulatorNotFound, `E2110` AndroidAdbNotFound |
+| `E22xx` | `platform` | `E2201` AppleXcodeNotFound, `E2204` AppleSimulatorNotFound |
+| `E23xx` | `platform` | `E2301` WindowsSdkNotFound |
+| `E24xx` | `platform` | `E2401` DotNetNotFound, `E2402` MauiWorkloadMissing |
+| `E3xxx` | `user` | User action required (wrong arguments, missing inputs) |
+| `E4xxx` | `network` | Download / connectivity failures |
+| `E5xxx` | `permission` | Privacy / OS permission issues |
+
+Call `maui errors list --json` to get the live catalogue (being added in issue [#197](https://github.com/dotnet/maui-labs/issues/197)).
+
+### Consuming the error envelope
+
+**Bash / jq:**
+
+```bash
+if ! out=$(maui android sdk install emulator --json 2>&1); then
+  rem_type=$(echo "$out" | jq -r '.remediation.type // "unknown"')
+  rem_cmd=$(echo "$out" | jq -r '.remediation.command // empty')
+  if [[ "$rem_type" == "autofixable" && -n "$rem_cmd" ]]; then
+    eval "$rem_cmd"
+  fi
+fi
+```
+
+**PowerShell:**
+
+```powershell
+$json = maui android sdk install emulator --json
+if ($LASTEXITCODE -ne 0) {
+    $err = $json | ConvertFrom-Json
+    if ($err.remediation.type -eq 'autofixable' -and $err.remediation.command) {
+        Invoke-Expression $err.remediation.command
+    }
+}
+```
+
+### Worked example: `E2106` AndroidEmulatorNotFound
+
+`maui android emulator start <name>` emits `E2106` with an `autofixable` remediation when the Android emulator binary is not installed:
+
+```bash
+maui android emulator start Pixel8 --json
+# → { "code": "E2106",
+#     "category": "platform",
+#     "severity": "error",
+#     "message": "Android emulator not installed",
+#     "remediation": { "type": "autofixable",
+#                      "command": "maui android sdk install emulator" } }
+
+# Auto-fix path:
+maui android sdk install emulator --json
+maui android emulator start Pixel8 --json   # retry original
+```
+
+Other `E2106` throw sites (e.g., "no AVD with that name") emit the same code **without** a `remediation` block — surface `message` and stop retrying.
+
+> For agent-facing usage examples and remediation patterns used by AI coding agents, see
+> [`plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md`](../../plugins/dotnet-maui/skills/maui-devflow-debug/references/troubleshooting.md).
+
 ## Platform Support
 
 | Platform | Status | Notes |


### PR DESCRIPTION
Part of #197 follow-up — documents the `--json` error envelope wire format. No code changes.

## What's documented

- **`--json` flag behavior**: JSONL output (progress records + final result), command-specific success shapes
- **Error envelope schema**: field names, types, optionality, `snake_case` contract (verified against `ErrorResult.cs`)
- **Error code taxonomy**: full catalogue from `ErrorCodes.cs` — tool (E1xxx), platform (E2xxx), user (E3xxx), network (E4xxx), permission (E5xxx)
- **Consumer examples**: Bash/jq and PowerShell snippets that handle JSONL streams safely (no eval/Invoke-Expression)
- **Worked example**: `E2106` AndroidEmulatorNotFound with autofixable remediation
- **Scope clarification**: envelope applies to non-DevFlow commands; `maui devflow` uses a different JSON error shape on stderr
- **Troubleshooting cross-link**: DevFlow skill troubleshooting.md now links to the canonical envelope docs

## Review feedback addressed

- All 8 findings from Expert Code Review (3 critical, 2 moderate, 3 minor)
- All 6 findings from Copilot PR Reviewer (JSONL, DevFlow scoping, spelling, stability wording)