### PR TITLE
feat: restructure maui devflow diagnose --json to per-check shape

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DiagnoseJsonContractTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DiagnoseJsonContractTests.cs
@@ -1,0 +1,153 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.Maui.Cli.Models;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class DiagnoseJsonContractTests
+{
+    private static readonly JsonSerializerOptions _opts = new()
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static string Serialize(DiagnoseResult result) => JsonSerializer.Serialize(result, _opts);
+
+    [Fact]
+    public void TopLevel_HasStatusMessageChecksKeys()
+    {
+        var result = new DiagnoseResult { Status = DiagnoseStatus.Passed, Message = "ok", Checks = [] };
+        using var doc = JsonDocument.Parse(Serialize(result));
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("status", out _));
+        Assert.True(root.TryGetProperty("message", out _));
+        Assert.True(root.TryGetProperty("checks", out _));
+    }
+
+    [Fact]
+    public void TopLevel_DoesNotHaveFlatLegacyKeys()
+    {
+        var result = new DiagnoseResult { Status = DiagnoseStatus.Passed, Message = "ok", Checks = [] };
+        using var doc = JsonDocument.Parse(Serialize(result));
+        var root = doc.RootElement;
+        Assert.False(root.TryGetProperty("broker_running", out _));
+        Assert.False(root.TryGetProperty("broker_port", out _));
+        Assert.False(root.TryGetProperty("agent_count", out _));
+        Assert.False(root.TryGetProperty("agents", out _));
+        Assert.False(root.TryGetProperty("projects", out _));
+        Assert.False(root.TryGetProperty("cli_version", out _));
+    }
+
+    [Fact]
+    public void Check_HasIdNameStatusMessageKeys()
+    {
+        var check = new DiagnoseCheckResult { Id = "broker", Name = "DevFlow broker", Status = DiagnoseCheckStatus.Passed, Message = "Broker running on port 12345" };
+        var result = new DiagnoseResult { Status = DiagnoseStatus.Passed, Message = "ok", Checks = [check] };
+        using var doc = JsonDocument.Parse(Serialize(result));
+        var checkEl = doc.RootElement.GetProperty("checks")[0];
+        Assert.Equal("broker", checkEl.GetProperty("id").GetString());
+        Assert.Equal("DevFlow broker", checkEl.GetProperty("name").GetString());
+        Assert.Equal("passed", checkEl.GetProperty("status").GetString());
+        Assert.Equal("Broker running on port 12345", checkEl.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public void Check_Remediation_OmittedWhenNull()
+    {
+        var check = new DiagnoseCheckResult { Id = "agents", Name = "Connected agents", Status = DiagnoseCheckStatus.Passed, Message = "1 agent(s) connected" };
+        var result = new DiagnoseResult { Status = DiagnoseStatus.Passed, Message = "ok", Checks = [check] };
+        using var doc = JsonDocument.Parse(Serialize(result));
+        Assert.False(doc.RootElement.GetProperty("checks")[0].TryGetProperty("remediation", out _));
+    }
+
+    [Fact]
+    public void Check_Remediation_PresentWhenSet()
+    {
+        var check = new DiagnoseCheckResult
+        {
+            Id = "broker", Name = "DevFlow broker", Status = DiagnoseCheckStatus.Failed, Message = "Broker is not running",
+            Remediation = new RemediationResult { Type = "command", Command = "maui devflow broker start" },
+        };
+        var result = new DiagnoseResult { Status = DiagnoseStatus.Failed, Message = "failed", Checks = [check] };
+        using var doc = JsonDocument.Parse(Serialize(result));
+        var checkEl = doc.RootElement.GetProperty("checks")[0];
+        Assert.True(checkEl.TryGetProperty("remediation", out var rem));
+        Assert.Equal("command", rem.GetProperty("type").GetString());
+        Assert.Equal("maui devflow broker start", rem.GetProperty("command").GetString());
+    }
+
+    [Theory]
+    [InlineData(DiagnoseStatus.Passed, "passed")]
+    [InlineData(DiagnoseStatus.Warning, "warning")]
+    [InlineData(DiagnoseStatus.Failed, "failed")]
+    public void DiagnoseStatus_SerializesLowercase(DiagnoseStatus status, string expected)
+    {
+        var result = new DiagnoseResult { Status = status, Message = "m", Checks = [] };
+        using var doc = JsonDocument.Parse(Serialize(result));
+        Assert.Equal(expected, doc.RootElement.GetProperty("status").GetString());
+    }
+
+    [Theory]
+    [InlineData(DiagnoseCheckStatus.Passed, "passed")]
+    [InlineData(DiagnoseCheckStatus.Warning, "warning")]
+    [InlineData(DiagnoseCheckStatus.Failed, "failed")]
+    [InlineData(DiagnoseCheckStatus.Skipped, "skipped")]
+    public void DiagnoseCheckStatus_SerializesLowercase(DiagnoseCheckStatus status, string expected)
+    {
+        var check = new DiagnoseCheckResult { Id = "x", Name = "X", Status = status, Message = "m" };
+        var result = new DiagnoseResult { Status = DiagnoseStatus.Passed, Message = "ok", Checks = [check] };
+        using var doc = JsonDocument.Parse(Serialize(result));
+        Assert.Equal(expected, doc.RootElement.GetProperty("checks")[0].GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void ComputeStatus_AllPassed_ReturnsPassed()
+    {
+        var checks = new[] { Check(DiagnoseCheckStatus.Passed), Check(DiagnoseCheckStatus.Passed) };
+        Assert.Equal(DiagnoseStatus.Passed, DiagnoseResult.ComputeStatus(checks));
+    }
+
+    [Fact]
+    public void ComputeStatus_AnyWarning_ReturnsWarning()
+    {
+        var checks = new[] { Check(DiagnoseCheckStatus.Passed), Check(DiagnoseCheckStatus.Warning) };
+        Assert.Equal(DiagnoseStatus.Warning, DiagnoseResult.ComputeStatus(checks));
+    }
+
+    [Fact]
+    public void ComputeStatus_AnyFailed_ReturnsFailed()
+    {
+        var checks = new[] { Check(DiagnoseCheckStatus.Warning), Check(DiagnoseCheckStatus.Failed) };
+        Assert.Equal(DiagnoseStatus.Failed, DiagnoseResult.ComputeStatus(checks));
+    }
+
+    [Fact]
+    public void ComputeStatus_SkippedOnly_ReturnsPassed()
+    {
+        var checks = new[] { Check(DiagnoseCheckStatus.Skipped) };
+        Assert.Equal(DiagnoseStatus.Passed, DiagnoseResult.ComputeStatus(checks));
+    }
+
+    [Fact]
+    public void Checks_PreservesOrder()
+    {
+        var checks = new[]
+        {
+            new DiagnoseCheckResult { Id = "broker", Name = "Broker", Status = DiagnoseCheckStatus.Passed, Message = "ok" },
+            new DiagnoseCheckResult { Id = "agents", Name = "Agents", Status = DiagnoseCheckStatus.Warning, Message = "warn" },
+            new DiagnoseCheckResult { Id = "devflow-projects", Name = "Projects", Status = DiagnoseCheckStatus.Passed, Message = "ok" },
+        };
+        var result = new DiagnoseResult { Status = DiagnoseStatus.Warning, Message = "m", Checks = checks };
+        using var doc = JsonDocument.Parse(Serialize(result));
+        var arr = doc.RootElement.GetProperty("checks");
+        Assert.Equal("broker", arr[0].GetProperty("id").GetString());
+        Assert.Equal("agents", arr[1].GetProperty("id").GetString());
+        Assert.Equal("devflow-projects", arr[2].GetProperty("id").GetString());
+    }
+
+    private static DiagnoseCheckResult Check(DiagnoseCheckStatus status) =>
+        new() { Id = "x", Name = "X", Status = status, Message = "m" };
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DiagnoseJsonContractTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DiagnoseJsonContractTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow;
 using Microsoft.Maui.Cli.Models;
 using Xunit;
 
@@ -9,19 +10,19 @@ namespace Microsoft.Maui.Cli.UnitTests;
 
 public class DiagnoseJsonContractTests
 {
-    private static readonly JsonSerializerOptions _opts = new()
-    {
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-    };
-
-    private static string Serialize(DiagnoseResult result) => JsonSerializer.Serialize(result, _opts);
+    // Use the production source-gen context so tests catch issues that would
+    // surface only at runtime under JsonSerializerIsReflectionEnabledByDefault=false.
+    private static string Serialize(DiagnoseResult result) =>
+        JsonSerializer.Serialize(result, DevFlowCliJsonContext.Default.DiagnoseResult);
 
     [Fact]
-    public void TopLevel_HasStatusMessageChecksKeys()
+    public void TopLevel_HasVersionStatusMessageChecksKeys()
     {
         var result = new DiagnoseResult { Status = DiagnoseStatus.Passed, Message = "ok", Checks = [] };
         using var doc = JsonDocument.Parse(Serialize(result));
         var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("version", out var ver));
+        Assert.Equal(1, ver.GetInt32());
         Assert.True(root.TryGetProperty("status", out _));
         Assert.True(root.TryGetProperty("message", out _));
         Assert.True(root.TryGetProperty("checks", out _));
@@ -146,6 +147,12 @@ public class DiagnoseJsonContractTests
         Assert.Equal("broker", arr[0].GetProperty("id").GetString());
         Assert.Equal("agents", arr[1].GetProperty("id").GetString());
         Assert.Equal("devflow-projects", arr[2].GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public void ComputeStatus_EmptyChecks_ReturnsPassed()
+    {
+        Assert.Equal(DiagnoseStatus.Passed, DiagnoseResult.ComputeStatus([]));
     }
 
     private static DiagnoseCheckResult Check(DiagnoseCheckStatus status) =>

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
@@ -24,5 +24,8 @@ namespace Microsoft.Maui.Cli.DevFlow;
 [JsonSerializable(typeof(BrokerState))]
 [JsonSerializable(typeof(RegistrationMessage))]
 [JsonSerializable(typeof(DiagnoseResult))]
+[JsonSerializable(typeof(DiagnoseCheckResult))]
+[JsonSerializable(typeof(IReadOnlyList<DiagnoseCheckResult>))]
 [JsonSerializable(typeof(List<DiagnoseCheckResult>))]
+[JsonSerializable(typeof(RemediationResult))]
 internal sealed partial class DevFlowCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Microsoft.Maui.Cli.DevFlow.Broker;
+using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.Cli.DevFlow;
@@ -22,4 +23,6 @@ namespace Microsoft.Maui.Cli.DevFlow;
 [JsonSerializable(typeof(AgentRegistration[]))]
 [JsonSerializable(typeof(BrokerState))]
 [JsonSerializable(typeof(RegistrationMessage))]
+[JsonSerializable(typeof(DiagnoseResult))]
+[JsonSerializable(typeof(List<DiagnoseCheckResult>))]
 internal sealed partial class DevFlowCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Cli.DevFlow.Skills;
+using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Utils;
 
 namespace Microsoft.Maui.Cli.DevFlow;
@@ -4011,42 +4012,132 @@ public class DevFlowCommands
     {
         await WriteSkillFreshnessHintAsync(json, cancellationToken);
 
-        var diagnostics = new Dictionary<string, object>();
-        
-        // Get CLI version
         var version = typeof(DevFlowCommands).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
-        diagnostics["cli_version"] = version;
-        
-        // Check broker status
+
+        var checks = new List<DiagnoseCheckResult>();
+
+        // Check 1: broker
         var brokerPort = await Broker.BrokerClient.EnsureBrokerRunningAsync();
-        var brokerRunning = brokerPort != null;
-        diagnostics["broker_running"] = brokerRunning;
-        if (brokerRunning)
-            diagnostics["broker_port"] = brokerPort!.Value;
-        
-        // List connected agents
-        var agents = brokerRunning ? await Broker.BrokerClient.ListAgentsAsync(brokerPort!.Value) : null;
+        if (brokerPort != null)
+        {
+            checks.Add(new DiagnoseCheckResult
+            {
+                Id = "broker",
+                Name = "DevFlow broker",
+                Status = DiagnoseCheckStatus.Passed,
+                Message = $"Broker running on port {brokerPort.Value}",
+            });
+        }
+        else
+        {
+            checks.Add(new DiagnoseCheckResult
+            {
+                Id = "broker",
+                Name = "DevFlow broker",
+                Status = DiagnoseCheckStatus.Failed,
+                Message = "Broker is not running",
+                Remediation = new RemediationResult
+                {
+                    Type = "command",
+                    Command = "maui devflow broker start",
+                },
+            });
+        }
+
+        // Check 2: connected agents
+        var agents = brokerPort != null
+            ? await Broker.BrokerClient.ListAgentsAsync(brokerPort.Value)
+            : null;
         var agentCount = agents?.Length ?? 0;
-        diagnostics["agent_count"] = agentCount;
-        diagnostics["agents"] = agents ?? Array.Empty<object>();
-        
-        // Scan for devflow-enabled projects
+
+        if (brokerPort == null)
+        {
+            checks.Add(new DiagnoseCheckResult
+            {
+                Id = "agents",
+                Name = "Connected agents",
+                Status = DiagnoseCheckStatus.Skipped,
+                Message = "Skipped \u2014 broker is not running",
+            });
+        }
+        else if (agentCount == 0)
+        {
+            checks.Add(new DiagnoseCheckResult
+            {
+                Id = "agents",
+                Name = "Connected agents",
+                Status = DiagnoseCheckStatus.Warning,
+                Message = "No agents connected \u2014 run your app in Debug configuration",
+            });
+        }
+        else
+        {
+            checks.Add(new DiagnoseCheckResult
+            {
+                Id = "agents",
+                Name = "Connected agents",
+                Status = DiagnoseCheckStatus.Passed,
+                Message = $"{agentCount} agent(s) connected",
+            });
+        }
+
+        // Check 3: devflow-enabled projects
         var projects = ScanForDevFlowProjects();
-        diagnostics["projects"] = projects;
-        
+        if (projects.Length == 0)
+        {
+            checks.Add(new DiagnoseCheckResult
+            {
+                Id = "devflow-projects",
+                Name = "DevFlow-enabled projects",
+                Status = DiagnoseCheckStatus.Warning,
+                Message = "No DevFlow-enabled projects found in current directory",
+                Remediation = new RemediationResult
+                {
+                    Type = "command",
+                    Command = "maui devflow init",
+                },
+            });
+        }
+        else
+        {
+            checks.Add(new DiagnoseCheckResult
+            {
+                Id = "devflow-projects",
+                Name = "DevFlow-enabled projects",
+                Status = DiagnoseCheckStatus.Passed,
+                Message = $"{projects.Length} DevFlow-enabled project(s) found",
+            });
+        }
+
+        var rollupStatus = DiagnoseResult.ComputeStatus(checks);
+        var rollupMessage = rollupStatus switch
+        {
+            DiagnoseStatus.Passed => "All checks passed",
+            DiagnoseStatus.Warning => "One or more checks require attention",
+            DiagnoseStatus.Failed => "One or more checks failed",
+            _ => string.Empty,
+        };
+
+        var result = new DiagnoseResult
+        {
+            Status = rollupStatus,
+            Message = rollupMessage,
+            Checks = checks,
+        };
+
         if (json)
         {
-            Output.WriteResult(diagnostics, json);
+            Output.WriteResult(result, json);
             return;
         }
-        
+
         // Human-readable output
         Console.WriteLine("DevFlow Diagnostics");
         Console.WriteLine("━━━━━━━━━━━━━━━━━━");
         Console.WriteLine($"✅ CLI version:     {version}");
         
-        if (brokerRunning)
+        if (brokerPort != null)
         {
             Console.WriteLine($"✅ Broker:          Running on port {brokerPort} ({agentCount} agent(s) connected)");
         }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -4116,7 +4116,7 @@ public class DevFlowCommands
             DiagnoseStatus.Passed => "All checks passed",
             DiagnoseStatus.Warning => "One or more checks require attention",
             DiagnoseStatus.Failed => "One or more checks failed",
-            _ => string.Empty,
+            _ => throw new System.Diagnostics.UnreachableException($"Unhandled DiagnoseStatus: {rollupStatus}"),
         };
 
         var result = new DiagnoseResult

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Properties/InternalsVisibleTo.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Properties/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Maui.DevFlow.Tests")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.Cli.UnitTests")]

--- a/src/Cli/Microsoft.Maui.Cli/Models/DiagnoseResult.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Models/DiagnoseResult.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.Cli.Models;
+
+public record DiagnoseResult
+{
+    [JsonPropertyName("status")]
+    public required DiagnoseStatus Status { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    [JsonPropertyName("checks")]
+    public required IReadOnlyList<DiagnoseCheckResult> Checks { get; init; }
+
+    public static DiagnoseStatus ComputeStatus(IEnumerable<DiagnoseCheckResult> checks)
+    {
+        var status = DiagnoseStatus.Passed;
+        foreach (var check in checks)
+        {
+            if (check.Status == DiagnoseCheckStatus.Failed)
+                return DiagnoseStatus.Failed;
+            if (check.Status == DiagnoseCheckStatus.Warning)
+                status = DiagnoseStatus.Warning;
+        }
+        return status;
+    }
+}
+
+public record DiagnoseCheckResult
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("status")]
+    public required DiagnoseCheckStatus Status { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    [JsonPropertyName("remediation")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public RemediationResult? Remediation { get; init; }
+}
+
+[JsonConverter(typeof(DiagnoseStatusConverter))]
+public enum DiagnoseStatus
+{
+    Passed,
+    Warning,
+    Failed,
+}
+
+[JsonConverter(typeof(DiagnoseCheckStatusConverter))]
+public enum DiagnoseCheckStatus
+{
+    Passed,
+    Warning,
+    Failed,
+    Skipped,
+}
+
+internal sealed class DiagnoseStatusConverter()
+    : JsonStringEnumConverter<DiagnoseStatus>(JsonNamingPolicy.CamelCase);
+
+internal sealed class DiagnoseCheckStatusConverter()
+    : JsonStringEnumConverter<DiagnoseCheckStatus>(JsonNamingPolicy.CamelCase);

--- a/src/Cli/Microsoft.Maui.Cli/Models/DiagnoseResult.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Models/DiagnoseResult.cs
@@ -8,6 +8,13 @@ namespace Microsoft.Maui.Cli.Models;
 
 public record DiagnoseResult
 {
+    /// <summary>
+    /// Schema version. Increment when introducing breaking changes to the JSON shape.
+    /// Consumers should treat unknown future versions as best-effort.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public int Version { get; init; } = 1;
+
     [JsonPropertyName("status")]
     public required DiagnoseStatus Status { get; init; }
 


### PR DESCRIPTION
## Summary

Restructures `maui devflow diagnose --json` from an untyped flat dictionary to a per-check structured shape.

### Before

`json
{
  "broker_running": true,
  "broker_port": 52100,
  "agent_count": 0,
  "agents": [],
  "projects": ["MyApp/MyApp.csproj"],
  "cli_version": "0.1.0-preview"
}
`

### After

`json
{
  "status": "warning",
  "message": "One or more checks require attention",
  "checks": [
    {
      "id": "broker",
      "name": "DevFlow broker",
      "status": "passed",
      "message": "Broker running on port 52100"
    },
    {
      "id": "agents",
      "name": "Connected agents",
      "status": "warning",
      "message": "No agents connected — run your app in Debug configuration"
    },
    {
      "id": "devflow-projects",
      "name": "DevFlow-enabled projects",
      "status": "passed",
      "message": "1 DevFlow-enabled project(s) found"
    }
  ]
}
`

### Status values

| Value | Meaning |
|-------|---------|
| `passed` | Check succeeded |
| `warning` | Issue detected but not fatal |
| `failed` | Check failed — action required |
| `skipped` | Check was not run (e.g. agents check when broker is down) |

Rollup `status`: `failed` > `warning` > `passed` (skipped excluded).

## Changes

- `Models/DiagnoseResult.cs` — new `DiagnoseResult`, `DiagnoseCheckResult`, `DiagnoseStatus`, `DiagnoseCheckStatus` models with lowercase CamelCase enum wire values
- `DevFlow/DevFlowCommands.cs` — refactor `DiagnoseCommandAsync` to build per-check results (broker, agents, devflow-projects)
- `DevFlow/DevFlowCliJsonContext.cs` — register `DiagnoseResult` and `List<DiagnoseCheckResult>` in source-gen context
- `DevFlow/Properties/InternalsVisibleTo.cs` — expose internals to test project
- `UnitTests/DiagnoseJsonContractTests.cs` — 17 contract tests

Closes #197