### PR TITLE
Add maui errors list command for error code introspection

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/ErrorsCatalogueTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/ErrorsCatalogueTests.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Maui.Cli.Commands;
+using Microsoft.Maui.Cli.Errors;
+using Microsoft.Maui.Cli.Output;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class ErrorsCatalogueTests
+{
+	[Fact]
+	public void Catalogue_IsNotEmpty() => Assert.NotEmpty(ErrorCodeCatalogue.All);
+
+	[Fact]
+	public void Catalogue_AllCodesMatchErrorCodeFormat()
+	{
+		foreach (var d in ErrorCodeCatalogue.All)
+			Assert.Matches(@"^E\d{4}$", d.Code);
+	}
+
+	[Fact]
+	public void Catalogue_AllNamesAreNonEmpty()
+	{
+		foreach (var d in ErrorCodeCatalogue.All)
+			Assert.False(string.IsNullOrWhiteSpace(d.Name), $"{d.Code} has empty Name");
+	}
+
+	[Fact]
+	public void Catalogue_AllDescriptionsAreNonEmpty()
+	{
+		foreach (var d in ErrorCodeCatalogue.All)
+			Assert.False(string.IsNullOrWhiteSpace(d.Description), $"{d.Code} has empty Description");
+	}
+
+	[Fact]
+	public void Catalogue_CodesAreUnique()
+	{
+		var codes = ErrorCodeCatalogue.All.Select(d => d.Code).ToList();
+		Assert.Equal(codes.Count, codes.Distinct().Count());
+	}
+
+	[Fact]
+	public void Catalogue_CoversEveryConstantInErrorCodes()
+	{
+		var allConstValues = typeof(ErrorCodes)
+			.GetFields(BindingFlags.Public | BindingFlags.Static)
+			.Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+			.Select(f => (string)f.GetRawConstantValue()!)
+			.ToHashSet();
+		var catalogueCodes = ErrorCodeCatalogue.All.Select(d => d.Code).ToHashSet();
+		var missing = allConstValues.Except(catalogueCodes).OrderBy(x => x).ToList();
+		Assert.Empty(missing);
+	}
+
+	[Fact]
+	public void ByCategory_ReturnsOnlyMatchingCategory()
+	{
+		var toolCodes = ErrorCodeCatalogue.ByCategory("tool");
+		Assert.All(toolCodes, d => Assert.Equal("tool", d.Category));
+		Assert.NotEmpty(toolCodes);
+	}
+
+	[Fact]
+	public void ByCategory_IsCaseInsensitive()
+	{
+		Assert.Equal(ErrorCodeCatalogue.ByCategory("platform").Count, ErrorCodeCatalogue.ByCategory("PLATFORM").Count);
+	}
+
+	[Fact]
+	public void ByCategory_UnknownCategoryReturnsEmpty() =>
+		Assert.Empty(ErrorCodeCatalogue.ByCategory("nonexistent"));
+
+	[Fact]
+	public void ByPrefix_ReturnsOnlyCodesWithMatchingPrefix()
+	{
+		var androidCodes = ErrorCodeCatalogue.ByPrefix("E21");
+		Assert.All(androidCodes, d => Assert.StartsWith("E21", d.Code));
+		Assert.NotEmpty(androidCodes);
+	}
+
+	[Fact]
+	public void ByPrefix_IsCaseInsensitive()
+	{
+		Assert.Equal(ErrorCodeCatalogue.ByPrefix("e21").Count, ErrorCodeCatalogue.ByPrefix("E21").Count);
+	}
+
+	[Fact]
+	public void ErrorCodeCatalogueResult_CountMatchesCodes()
+	{
+		var result = new ErrorCodeCatalogueResult { Codes = ErrorCodeCatalogue.All };
+		Assert.Equal(ErrorCodeCatalogue.All.Count, result.Count);
+	}
+
+	[Fact]
+	public void ErrorCodeDescriptor_SerializesToSnakeCase()
+	{
+		var d = new ErrorCodeDescriptor { Code = "E1001", Name = "InternalError", Category = "tool", Description = "Test" };
+		var json = JsonSerializer.Serialize(d, MauiCliJsonContext.Default.ErrorCodeDescriptor);
+		Assert.Contains("\"code\"", json);
+		Assert.Contains("\"name\"", json);
+		Assert.DoesNotContain("\"Code\"", json);
+	}
+
+	[Fact]
+	public void ErrorCodeDescriptor_NullableFieldsOmittedWhenNull()
+	{
+		var d = new ErrorCodeDescriptor { Code = "E1004", Name = "InvalidArgument", Category = "tool", Description = "X" };
+		var json = JsonSerializer.Serialize(d, MauiCliJsonContext.Default.ErrorCodeDescriptor);
+		Assert.DoesNotContain("subcategory", json);
+		Assert.DoesNotContain("default_remediation_type", json);
+	}
+
+	[Fact]
+	public void ErrorsCommand_CanBeConstructed()
+	{
+		var command = ErrorsCommands.Create();
+		Assert.Equal("errors", command.Name);
+		Assert.Contains(command.Subcommands, c => c.Name == "list");
+	}
+
+	[Fact]
+	public void ErrorsListCommand_HasExpectedOptions()
+	{
+		var listCommand = ErrorsCommands.Create().Subcommands.Single(c => c.Name == "list");
+		Assert.Contains(listCommand.Options, o => o.Name == "--category");
+		Assert.Contains(listCommand.Options, o => o.Name == "--prefix");
+	}
+
+	[Fact]
+	public void ErrorsCommand_IsRegisteredInRootCommand()
+	{
+		var rootCommand = Program.BuildRootCommand();
+		Assert.Contains(rootCommand.Subcommands, c => c.Name == "errors");
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/Commands/ErrorsCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/ErrorsCommands.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Microsoft.Maui.Cli.Errors;
+using Microsoft.Maui.Cli.Output;
+
+namespace Microsoft.Maui.Cli.Commands;
+
+public static class ErrorsCommands
+{
+	public static Command Create()
+	{
+		var command = new Command("errors", "Error code catalogue and diagnostics");
+		command.Add(CreateListCommand());
+		return command;
+	}
+
+	static Command CreateListCommand()
+	{
+		var categoryOption = new Option<string?>("--category") { Description = "Filter by category: 'tool' or 'platform'" };
+		var prefixOption = new Option<string?>("--prefix") { Description = "Filter by code prefix, e.g. 'E21' for Android errors" };
+		var listCommand = new Command("list", "List all registered error codes") { categoryOption, prefixOption };
+
+		listCommand.SetAction((ParseResult parseResult) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			var category = parseResult.GetValue(categoryOption);
+			var prefix = parseResult.GetValue(prefixOption);
+
+			IReadOnlyList<ErrorCodeDescriptor> codes = category is not null
+				? ErrorCodeCatalogue.ByCategory(category)
+				: prefix is not null
+					? ErrorCodeCatalogue.ByPrefix(prefix)
+					: ErrorCodeCatalogue.All;
+
+			if (useJson)
+			{
+				formatter.Write(new ErrorCodeCatalogueResult { Codes = codes });
+			}
+			else
+			{
+				if (!codes.Any())
+				{
+					formatter.WriteWarning("No error codes match the specified filter.");
+					return 0;
+				}
+				if (formatter is SpectreOutputFormatter spectre)
+				{
+					spectre.WriteTable(codes,
+						("Code", d => d.Code),
+						("Name", d => d.Name),
+						("Category", d => d.Subcategory is null ? d.Category : $"{d.Category}/{d.Subcategory}"),
+						("Description", d => d.Description));
+				}
+			}
+			return 0;
+		});
+		return listCommand;
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/Commands/ErrorsCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/ErrorsCommands.cs
@@ -30,11 +30,11 @@ public static class ErrorsCommands
 			var category = parseResult.GetValue(categoryOption);
 			var prefix = parseResult.GetValue(prefixOption);
 
-			IReadOnlyList<ErrorCodeDescriptor> codes = category is not null
-				? ErrorCodeCatalogue.ByCategory(category)
-				: prefix is not null
-					? ErrorCodeCatalogue.ByPrefix(prefix)
-					: ErrorCodeCatalogue.All;
+			IReadOnlyList<ErrorCodeDescriptor> codes = ErrorCodeCatalogue.All;
+			if (category is not null)
+				codes = ErrorCodeCatalogue.ByCategory(category);
+			if (prefix is not null)
+				codes = [.. codes.Where(d => d.Code.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))];
 
 			if (useJson)
 			{

--- a/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodeCatalogue.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodeCatalogue.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Maui.Cli.Errors;
+
+public static class ErrorCodeCatalogue
+{
+static readonly ErrorCodeDescriptor[] s_all =
+[
+new ErrorCodeDescriptor { Code = ErrorCodes.InternalError, Name = nameof(ErrorCodes.InternalError), Category = "tool", Description = "An unexpected internal error occurred in the tool", DefaultRemediationType = "file-bug" },
+new ErrorCodeDescriptor { Code = ErrorCodes.InvalidArgument, Name = nameof(ErrorCodes.InvalidArgument), Category = "tool", Description = "An invalid argument was supplied to the command" },
+new ErrorCodeDescriptor { Code = ErrorCodes.DeviceNotFound, Name = nameof(ErrorCodes.DeviceNotFound), Category = "tool", Description = "The requested device could not be found" },
+new ErrorCodeDescriptor { Code = ErrorCodes.PlatformNotSupported, Name = nameof(ErrorCodes.PlatformNotSupported), Category = "tool", Description = "The operation is not supported on this platform" },
+new ErrorCodeDescriptor { Code = ErrorCodes.JdkNotFound, Name = nameof(ErrorCodes.JdkNotFound), Category = "platform", Subcategory = "jdk", Description = "No Java Development Kit installation was found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.JdkVersionUnsupported, Name = nameof(ErrorCodes.JdkVersionUnsupported), Category = "platform", Subcategory = "jdk", Description = "The installed JDK version is not supported", DefaultRemediationType = "upgrade" },
+new ErrorCodeDescriptor { Code = ErrorCodes.JdkInstallFailed, Name = nameof(ErrorCodes.JdkInstallFailed), Category = "platform", Subcategory = "jdk", Description = "JDK installation failed", DefaultRemediationType = "retry" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidSdkNotFound, Name = nameof(ErrorCodes.AndroidSdkNotFound), Category = "platform", Subcategory = "android", Description = "Android SDK installation not found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidSdkManagerNotFound, Name = nameof(ErrorCodes.AndroidSdkManagerNotFound), Category = "platform", Subcategory = "android", Description = "Android SDK manager executable not found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidLicensesNotAccepted, Name = nameof(ErrorCodes.AndroidLicensesNotAccepted), Category = "platform", Subcategory = "android", Description = "Android SDK licenses have not been accepted", DefaultRemediationType = "user-action" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidPackageInstallFailed, Name = nameof(ErrorCodes.AndroidPackageInstallFailed), Category = "platform", Subcategory = "android", Description = "Android SDK package installation failed", DefaultRemediationType = "retry" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidEmulatorNotFound, Name = nameof(ErrorCodes.AndroidEmulatorNotFound), Category = "platform", Subcategory = "android", Description = "Android emulator executable not found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidAvdCreateFailed, Name = nameof(ErrorCodes.AndroidAvdCreateFailed), Category = "platform", Subcategory = "android", Description = "Android virtual device (AVD) creation failed", DefaultRemediationType = "retry" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidAdbNotFound, Name = nameof(ErrorCodes.AndroidAdbNotFound), Category = "platform", Subcategory = "android", Description = "Android Debug Bridge (adb) executable not found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidDeviceNotFound, Name = nameof(ErrorCodes.AndroidDeviceNotFound), Category = "platform", Subcategory = "android", Description = "No Android device or emulator is connected", DefaultRemediationType = "user-action" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AndroidAvdDeleteFailed, Name = nameof(ErrorCodes.AndroidAvdDeleteFailed), Category = "platform", Subcategory = "android", Description = "Android virtual device (AVD) deletion failed", DefaultRemediationType = "retry" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AppleXcodeNotFound, Name = nameof(ErrorCodes.AppleXcodeNotFound), Category = "platform", Subcategory = "apple", Description = "Xcode installation not found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AppleCltNotFound, Name = nameof(ErrorCodes.AppleCltNotFound), Category = "platform", Subcategory = "apple", Description = "Xcode Command Line Tools not found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AppleSimctlFailed, Name = nameof(ErrorCodes.AppleSimctlFailed), Category = "platform", Subcategory = "apple", Description = "Apple simctl command failed", DefaultRemediationType = "retry" },
+new ErrorCodeDescriptor { Code = ErrorCodes.AppleSimulatorNotFound, Name = nameof(ErrorCodes.AppleSimulatorNotFound), Category = "platform", Subcategory = "apple", Description = "No matching Apple simulator found", DefaultRemediationType = "user-action" },
+new ErrorCodeDescriptor { Code = ErrorCodes.WindowsSdkNotFound, Name = nameof(ErrorCodes.WindowsSdkNotFound), Category = "platform", Subcategory = "windows", Description = "Windows SDK installation not found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.DotNetNotFound, Name = nameof(ErrorCodes.DotNetNotFound), Category = "platform", Subcategory = "dotnet", Description = ".NET SDK installation not found", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.MauiWorkloadMissing, Name = nameof(ErrorCodes.MauiWorkloadMissing), Category = "platform", Subcategory = "dotnet", Description = "MAUI workload is not installed", DefaultRemediationType = "install" },
+new ErrorCodeDescriptor { Code = ErrorCodes.DiagnosticsToolNotFound, Name = nameof(ErrorCodes.DiagnosticsToolNotFound), Category = "platform", Subcategory = "dotnet", Description = ".NET diagnostics tool not found", DefaultRemediationType = "install" },
+];
+
+public static IReadOnlyList<ErrorCodeDescriptor> All => s_all;
+
+public static IReadOnlyList<ErrorCodeDescriptor> ByCategory(string category) =>
+s_all.Where(d => d.Category.Equals(category, StringComparison.OrdinalIgnoreCase)).ToList();
+
+public static IReadOnlyList<ErrorCodeDescriptor> ByPrefix(string prefix) =>
+s_all.Where(d => d.Code.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();
+}

--- a/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodeDescriptor.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodeDescriptor.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.Cli.Errors;
+
+public sealed record ErrorCodeDescriptor
+{
+[JsonPropertyName("code")]
+public required string Code { get; init; }
+
+[JsonPropertyName("name")]
+public required string Name { get; init; }
+
+[JsonPropertyName("category")]
+public required string Category { get; init; }
+
+[JsonPropertyName("subcategory")]
+[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+public string? Subcategory { get; init; }
+
+[JsonPropertyName("description")]
+public required string Description { get; init; }
+
+[JsonPropertyName("default_remediation_type")]
+[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+public string? DefaultRemediationType { get; init; }
+}
+
+public sealed record ErrorCodeCatalogueResult
+{
+[JsonPropertyName("codes")]
+public required IReadOnlyList<ErrorCodeDescriptor> Codes { get; init; }
+
+[JsonPropertyName("count")]
+public int Count => Codes.Count;
+}

--- a/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.Providers.Apple;
@@ -45,4 +46,7 @@ namespace Microsoft.Maui.Cli.Output;
 [JsonSerializable(typeof(StatusMessageResult))]
 [JsonSerializable(typeof(VersionResult))]
 [JsonSerializable(typeof(CliCommandResult))]
+[JsonSerializable(typeof(ErrorCodeDescriptor))]
+[JsonSerializable(typeof(List<ErrorCodeDescriptor>))]
+[JsonSerializable(typeof(ErrorCodeCatalogueResult))]
 internal sealed partial class MauiCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/Program.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Program.cs
@@ -107,6 +107,9 @@ public class Program
 		rootCommand.Add(AndroidCommands.Create());
 		rootCommand.Add(AppleCommands.Create());
 
+		// Error code catalogue
+		rootCommand.Add(ErrorsCommands.Create());
+
 		// DevFlow automation commands (maui devflow ...)
 		rootCommand.Add(DevFlow.DevFlowCommands.CreateDevFlowCommand(GlobalOptions.JsonOption));
 


### PR DESCRIPTION
## Summary

Adds the \maui errors list [--json]\ command that emits the registered error code catalogue, enabling AI agents and IDE consumers to statically verify they handle every \MauiToolException\ error code.

## Changes

- \ErrorCodeDescriptor.cs\ — model record with snake_case JSON properties
- \ErrorCodeCatalogue.cs\ — static catalogue covering all 23 registered error codes
- \ErrorsCommands.cs\ — \maui errors list [--category] [--prefix] [--json]\ command
- \MauiCliJsonContext.cs\ — added 3 \[JsonSerializable]\ entries
- \Program.cs\ — registered \ErrorsCommands.Create()\
- \ErrorsCatalogueTests.cs\ — 17 unit tests including reflection-based drift detection

## Usage

\\\
maui errors list
maui errors list --category platform
maui errors list --prefix E21
maui errors list --json
\\\

The \Catalogue_CoversEveryConstantInErrorCodes\ test uses reflection on \ErrorCodes\ to catch future drift when new codes are added.