### PR TITLE
Expose maui apple simulator create|erase

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AppleSimulatorCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AppleSimulatorCommandsTests.cs
@@ -1,0 +1,162 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.Maui.Cli.Commands;
+using Microsoft.Maui.Cli.Errors;
+using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.Output;
+using Microsoft.Maui.Cli.UnitTests.Fakes;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class AppleSimulatorCommandsTests
+{
+	[Fact]
+	public void SimulatorCommand_HasCreateSubcommand()
+	{
+		var root = Program.BuildRootCommand();
+		var apple = root.Subcommands.FirstOrDefault(c => c.Name == "apple");
+		var simulator = apple?.Subcommands.FirstOrDefault(c => c.Name == "simulator");
+		Assert.NotNull(simulator);
+		Assert.Contains(simulator!.Subcommands, c => c.Name == "create");
+	}
+
+	[Fact]
+	public void SimulatorCommand_HasEraseSubcommand()
+	{
+		var root = Program.BuildRootCommand();
+		var apple = root.Subcommands.FirstOrDefault(c => c.Name == "apple");
+		var simulator = apple?.Subcommands.FirstOrDefault(c => c.Name == "simulator");
+		Assert.NotNull(simulator);
+		Assert.Contains(simulator!.Subcommands, c => c.Name == "erase");
+	}
+
+	[Fact]
+	public void CreateCommand_HasDeviceTypeArgument()
+	{
+		var root = Program.BuildRootCommand();
+		var createCmd = root.Subcommands
+			.First(c => c.Name == "apple").Subcommands
+			.First(c => c.Name == "simulator").Subcommands
+			.First(c => c.Name == "create");
+		Assert.Contains(createCmd.Arguments, a => a.Name == "device-type");
+	}
+
+	[Fact]
+	public void CreateCommand_HasNameAndRuntimeOptions()
+	{
+		var root = Program.BuildRootCommand();
+		var createCmd = root.Subcommands
+			.First(c => c.Name == "apple").Subcommands
+			.First(c => c.Name == "simulator").Subcommands
+			.First(c => c.Name == "create");
+		Assert.Contains(createCmd.Options, o => o.Name == "--name");
+		Assert.Contains(createCmd.Options, o => o.Name == "--runtime");
+	}
+
+	[Fact]
+	public void EraseCommand_HasNameOrUdidArgument()
+	{
+		var root = Program.BuildRootCommand();
+		var eraseCmd = root.Subcommands
+			.First(c => c.Name == "apple").Subcommands
+			.First(c => c.Name == "simulator").Subcommands
+			.First(c => c.Name == "erase");
+		Assert.Contains(eraseCmd.Arguments, a => a.Name == "name-or-udid");
+	}
+
+	[Fact]
+	public void FakeAppleProvider_CreateSimulator_TracksCall()
+	{
+		var fake = new FakeAppleProvider { CreateSimulatorResult = "test-udid-1234" };
+		var udid = fake.CreateSimulator("My iPhone 15", "com.apple.CoreSimulator.SimDeviceType.iPhone-15", "com.apple.CoreSimulator.SimRuntime.iOS-17-2");
+		Assert.Equal("test-udid-1234", udid);
+		Assert.Single(fake.CreatedSimulators);
+		Assert.Equal(("My iPhone 15", "com.apple.CoreSimulator.SimDeviceType.iPhone-15", "com.apple.CoreSimulator.SimRuntime.iOS-17-2"), fake.CreatedSimulators[0]);
+	}
+
+	[Fact]
+	public void FakeAppleProvider_CreateSimulator_ReturnsNull_WhenResultIsNull()
+	{
+		var fake = new FakeAppleProvider { CreateSimulatorResult = null };
+		var udid = fake.CreateSimulator("Ghost", "com.apple.CoreSimulator.SimDeviceType.iPhone-15");
+		Assert.Null(udid);
+	}
+
+	[Fact]
+	public void FakeAppleProvider_EraseSimulator_TracksCall()
+	{
+		var fake = new FakeAppleProvider { EraseSimulatorResult = true };
+		var result = fake.EraseSimulator("ABC-DEF-123");
+		Assert.True(result);
+		Assert.Single(fake.ErasedSimulators);
+		Assert.Equal("ABC-DEF-123", fake.ErasedSimulators[0]);
+	}
+
+	[Fact]
+	public void FakeAppleProvider_EraseSimulator_ReturnsFalse_WhenConfigured()
+	{
+		var fake = new FakeAppleProvider { EraseSimulatorResult = false };
+		var result = fake.EraseSimulator("nonexistent");
+		Assert.False(result);
+	}
+
+	[Fact]
+	public void SimulatorCreateResult_SerializesToSnakeCase()
+	{
+		var model = new SimulatorCreateResult
+		{
+			Udid = "AABBCCDD-1234-5678-ABCD-000000000001",
+			Name = "iPhone 15",
+			DeviceType = "com.apple.CoreSimulator.SimDeviceType.iPhone-15",
+			Runtime = "com.apple.CoreSimulator.SimRuntime.iOS-17-2"
+		};
+		var json = JsonSerializer.Serialize(model, MauiCliJsonContext.Default.SimulatorCreateResult);
+		using var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+		Assert.Equal("AABBCCDD-1234-5678-ABCD-000000000001", root.GetProperty("udid").GetString());
+		Assert.Equal("iPhone 15", root.GetProperty("name").GetString());
+		Assert.Equal("com.apple.CoreSimulator.SimDeviceType.iPhone-15", root.GetProperty("device_type").GetString());
+		Assert.Equal("com.apple.CoreSimulator.SimRuntime.iOS-17-2", root.GetProperty("runtime").GetString());
+	}
+
+	[Fact]
+	public void SimulatorCreateResult_OmitsNullRuntime()
+	{
+		var model = new SimulatorCreateResult { Udid = "AABBCCDD-1234", Name = "iPhone 15", DeviceType = "com.apple.CoreSimulator.SimDeviceType.iPhone-15" };
+		var json = JsonSerializer.Serialize(model, MauiCliJsonContext.Default.SimulatorCreateResult);
+		using var doc = JsonDocument.Parse(json);
+		Assert.False(doc.RootElement.TryGetProperty("runtime", out _));
+	}
+
+	[Fact]
+	public void SimulatorEraseResult_SerializesToSnakeCase()
+	{
+		var model = new SimulatorEraseResult { Target = "My iPhone 15", Erased = true };
+		var json = JsonSerializer.Serialize(model, MauiCliJsonContext.Default.SimulatorEraseResult);
+		using var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+		Assert.Equal("My iPhone 15", root.GetProperty("target").GetString());
+		Assert.True(root.GetProperty("erased").GetBoolean());
+	}
+
+	[Fact]
+	public void SimulatorCreateFailed_ErrorResult_HasCorrectCode()
+	{
+		var ex = new MauiToolException(ErrorCodes.AppleSimulatorCreateFailed, "Create failed");
+		var error = ErrorResult.FromException(ex);
+		Assert.Equal("E2207", error.Code);
+		Assert.Equal("platform", error.Category);
+	}
+
+	[Fact]
+	public void SimulatorEraseFailed_ErrorResult_HasCorrectCode()
+	{
+		var ex = new MauiToolException(ErrorCodes.AppleSimulatorEraseFailed, "Erase failed");
+		var error = ErrorResult.FromException(ex);
+		Assert.Equal("E2208", error.Code);
+		Assert.Equal("platform", error.Category);
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
@@ -29,6 +29,7 @@ public class FakeAppleProvider : IAppleProvider
 	public bool ShutdownSimulatorResult { get; set; } = true;
 	public bool DeleteSimulatorResult { get; set; } = true;
 	public string? CreateSimulatorResult { get; set; } = "new-udid";
+	public bool EraseSimulatorResult { get; set; } = true;
 
 	// --- Call tracking ---
 
@@ -38,6 +39,7 @@ public class FakeAppleProvider : IAppleProvider
 	public List<string> DeletedSimulators { get; } = new();
 	public List<(string Name, string DeviceType, string? Runtime)> CreatedSimulators { get; } = new();
 	public List<(IEnumerable<string>? Platforms, bool DryRun)> InstallCalls { get; } = new();
+	public List<string> ErasedSimulators { get; } = new();
 
 	// --- IAppleProvider implementation ---
 
@@ -92,6 +94,12 @@ public class FakeAppleProvider : IAppleProvider
 	{
 		CreatedSimulators.Add((name, deviceTypeIdentifier, runtimeIdentifier));
 		return CreateSimulatorResult;
+	}
+
+	public bool EraseSimulator(string udidOrName)
+	{
+		ErasedSimulators.Add(udidOrName);
+		return EraseSimulatorResult;
 	}
 
 	public List<HealthCheck> CheckHealth() => HealthChecks;

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using Microsoft.Maui.Cli.Errors;
+using System.CommandLine.Parsing;
 using Microsoft.Maui.Cli.Output;
 using Microsoft.Maui.Cli.Providers.Apple;
 using Microsoft.Maui.Cli.Utils;
@@ -345,6 +345,111 @@ public static class AppleCommands
 		simCommand.Add(startCommand);
 		simCommand.Add(stopCommand);
 		simCommand.Add(deleteCommand);
+		simCommand.Add(CreateSimulatorCreateCommand());
+		simCommand.Add(CreateSimulatorEraseCommand());
 		return simCommand;
+	}
+
+	static Command CreateSimulatorCreateCommand()
+	{
+		var deviceTypeArg = new Argument<string>("device-type") { Description = "Device type identifier (e.g. com.apple.CoreSimulator.SimDeviceType.iPhone-15)" };
+		var nameOption = new Option<string?>("--name") { Description = "Custom name for the new simulator (defaults to a name derived from device-type)" };
+		var runtimeOption = new Option<string?>("--runtime") { Description = "Runtime identifier (e.g. com.apple.CoreSimulator.SimRuntime.iOS-17-2)" };
+
+		var createCommand = new Command("create", "Create a new simulator device") { deviceTypeArg, nameOption, runtimeOption };
+		createCommand.SetAction((ParseResult parseResult) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteWarning("Simulators are only available on macOS.");
+				return 1;
+			}
+
+			var appleProvider = Program.AppleProvider;
+			var deviceType = parseResult.GetValue(deviceTypeArg)!;
+			var runtime = parseResult.GetValue(runtimeOption);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+
+			// Derive a human-readable default name from the device-type identifier
+			var customName = parseResult.GetValue(nameOption);
+			var parts = deviceType.Split('.');
+			var shortType = parts.Length > 1 ? parts[parts.Length - 1].Replace('-', ' ') : deviceType;
+			var name = customName is not null ? customName : shortType;
+			if (customName is null && runtime is not null)
+			{
+				var rParts = runtime.Split('.');
+				var rShort = rParts.Length > 1 ? rParts[rParts.Length - 1] : runtime;
+				name = $"{shortType} ({rShort})";
+			}
+
+			var udid = appleProvider.CreateSimulator(name, deviceType, runtime);
+			if (udid is null)
+			{
+				var ex = new MauiToolException(ErrorCodes.AppleSimulatorCreateFailed, $"Failed to create simulator for device type '{deviceType}'.");
+				if (useJson)
+					formatter.WriteError(ex);
+				else
+					formatter.WriteWarning(ex.Message);
+				return 1;
+			}
+
+			if (useJson)
+			{
+				formatter.Write(new SimulatorCreateResult { Udid = udid, Name = name, DeviceType = deviceType, Runtime = runtime });
+			}
+			else
+			{
+				formatter.WriteSuccess($"Simulator '{name}' created with UDID: {udid}");
+			}
+			return 0;
+		});
+
+		return createCommand;
+	}
+
+	static Command CreateSimulatorEraseCommand()
+	{
+		var nameOrUdidArg = new Argument<string>("name-or-udid") { Description = "Simulator name or UDID to erase" };
+		var eraseCommand = new Command("erase", "Erase (reset) a simulator device to factory state") { nameOrUdidArg };
+		eraseCommand.SetAction((ParseResult parseResult) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteWarning("Simulators are only available on macOS.");
+				return 1;
+			}
+
+			var appleProvider = Program.AppleProvider;
+			var target = parseResult.GetValue(nameOrUdidArg)!;
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+
+			var erased = appleProvider.EraseSimulator(target);
+
+			if (!erased)
+			{
+				var ex = new MauiToolException(ErrorCodes.AppleSimulatorEraseFailed, $"Failed to erase simulator '{target}'.");
+				if (useJson)
+					formatter.WriteError(ex);
+				else
+					formatter.WriteWarning(ex.Message);
+				return 1;
+			}
+
+			if (useJson)
+			{
+				formatter.Write(new SimulatorEraseResult { Target = target, Erased = true });
+			}
+			else
+			{
+				formatter.WriteSuccess($"Simulator '{target}' erased.");
+			}
+			return 0;
+		});
+
+		return eraseCommand;
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -356,7 +356,9 @@ public static class AppleCommands
 		var nameOption = new Option<string?>("--name") { Description = "Custom name for the new simulator (defaults to a name derived from device-type)" };
 		var runtimeOption = new Option<string?>("--runtime") { Description = "Runtime identifier (e.g. com.apple.CoreSimulator.SimRuntime.iOS-17-2)" };
 
-		var createCommand = new Command("create", "Create a new simulator device") { deviceTypeArg, nameOption, runtimeOption };
+		var ifNotExistsOption = new Option<bool>("--if-not-exists") { Description = "Treat name collision as success: if a simulator with this name already exists, return its UDID instead of failing." };
+
+		var createCommand = new Command("create", "Create a new simulator device") { deviceTypeArg, nameOption, runtimeOption, ifNotExistsOption };
 		createCommand.SetAction((ParseResult parseResult) =>
 		{
 			var formatter = Program.GetFormatter(parseResult);
@@ -381,6 +383,31 @@ public static class AppleCommands
 				var rParts = runtime.Split('.');
 				var rShort = (rParts.Length > 1 ? rParts[rParts.Length - 1] : runtime).Replace('-', ' ');
 				name = $"{shortType} ({rShort})";
+			}
+
+			// Idempotency probe: simctl create does not dedupe by name. Without this check
+			// repeated invocations create multiple devices with the same name, which then
+			// makes name-keyed commands (boot/erase/delete) ambiguous.
+			var ifNotExists = parseResult.GetValue(ifNotExistsOption);
+			var existing = appleProvider.GetSimulators().FirstOrDefault(s =>
+				string.Equals(s.Name, name, StringComparison.Ordinal));
+			if (existing is not null)
+			{
+				if (ifNotExists)
+				{
+					var useJson2 = parseResult.GetValue(GlobalOptions.JsonOption);
+					if (useJson2)
+						formatter.Write(new SimulatorCreateResult { Udid = existing.Udid, Name = name, DeviceType = existing.DeviceTypeIdentifier ?? deviceType, Runtime = existing.RuntimeIdentifier ?? runtime });
+					else
+						formatter.WriteSuccess($"Simulator '{name}' already exists with UDID: {existing.Udid}");
+					return 0;
+				}
+
+				var dupEx = new MauiToolException(
+					ErrorCodes.AppleSimulatorCreateFailed,
+					$"A simulator named '{name}' already exists (UDID: {existing.Udid}). Use --name to choose a different name, --if-not-exists to reuse the existing one, or 'maui apple simulator delete {existing.Udid}' first.");
+				formatter.WriteError(dupEx);
+				return 1;
 			}
 
 			var udid = appleProvider.CreateSimulator(name, deviceType, runtime);
@@ -419,11 +446,34 @@ public static class AppleCommands
 			var appleProvider = Program.AppleProvider;
 			var target = parseResult.GetValue(nameOrUdidArg)!;
 
+			// Probe state first so we can distinguish "not found" from "wrong state",
+			// which simctl's bool return value otherwise conflates.
+			var sims = appleProvider.GetSimulators();
+			var match = sims.FirstOrDefault(s =>
+				string.Equals(s.Udid, target, StringComparison.OrdinalIgnoreCase) ||
+				string.Equals(s.Name, target, StringComparison.Ordinal));
+			if (match is null)
+			{
+				var notFoundEx = new MauiToolException(
+					ErrorCodes.AppleSimulatorNotFound,
+					$"No simulator found matching '{target}'. List simulators with 'maui apple simulator list'.");
+				formatter.WriteError(notFoundEx);
+				return 1;
+			}
+			if (match.IsBooted)
+			{
+				var bootedEx = new MauiToolException(
+					ErrorCodes.AppleSimulatorEraseFailed,
+					$"Simulator '{match.Name}' (UDID: {match.Udid}) is booted; shut it down first with 'maui apple simulator stop {match.Udid}'.");
+				formatter.WriteError(bootedEx);
+				return 1;
+			}
+
 			var erased = appleProvider.EraseSimulator(target);
 
 			if (!erased)
 			{
-				var ex = new MauiToolException(ErrorCodes.AppleSimulatorEraseFailed, $"Failed to erase simulator '{target}'. Ensure the simulator is shut down first (maui apple simulator stop).");
+				var ex = new MauiToolException(ErrorCodes.AppleSimulatorEraseFailed, $"Failed to erase simulator '{target}' (UDID: {match.Udid}). Check 'xcrun simctl' is available and the simulator state is 'Shutdown'.");
 				formatter.WriteError(ex);
 				return 1;
 			}

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -363,24 +363,23 @@ public static class AppleCommands
 
 			if (!PlatformDetector.IsMacOS)
 			{
-				formatter.WriteWarning("Simulators are only available on macOS.");
+				formatter.WriteError(new MauiToolException(ErrorCodes.PlatformNotSupported, "Simulators are only available on macOS."));
 				return 1;
 			}
 
 			var appleProvider = Program.AppleProvider;
 			var deviceType = parseResult.GetValue(deviceTypeArg)!;
 			var runtime = parseResult.GetValue(runtimeOption);
-			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 
 			// Derive a human-readable default name from the device-type identifier
 			var customName = parseResult.GetValue(nameOption);
 			var parts = deviceType.Split('.');
 			var shortType = parts.Length > 1 ? parts[parts.Length - 1].Replace('-', ' ') : deviceType;
-			var name = customName is not null ? customName : shortType;
-			if (customName is null && runtime is not null)
+			var name = !string.IsNullOrWhiteSpace(customName) ? customName : shortType;
+			if (string.IsNullOrWhiteSpace(customName) && runtime is not null)
 			{
 				var rParts = runtime.Split('.');
-				var rShort = rParts.Length > 1 ? rParts[rParts.Length - 1] : runtime;
+				var rShort = (rParts.Length > 1 ? rParts[rParts.Length - 1] : runtime).Replace('-', ' ');
 				name = $"{shortType} ({rShort})";
 			}
 
@@ -388,21 +387,15 @@ public static class AppleCommands
 			if (udid is null)
 			{
 				var ex = new MauiToolException(ErrorCodes.AppleSimulatorCreateFailed, $"Failed to create simulator for device type '{deviceType}'.");
-				if (useJson)
-					formatter.WriteError(ex);
-				else
-					formatter.WriteWarning(ex.Message);
+				formatter.WriteError(ex);
 				return 1;
 			}
 
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 			if (useJson)
-			{
 				formatter.Write(new SimulatorCreateResult { Udid = udid, Name = name, DeviceType = deviceType, Runtime = runtime });
-			}
 			else
-			{
 				formatter.WriteSuccess($"Simulator '{name}' created with UDID: {udid}");
-			}
 			return 0;
 		});
 
@@ -419,34 +412,27 @@ public static class AppleCommands
 
 			if (!PlatformDetector.IsMacOS)
 			{
-				formatter.WriteWarning("Simulators are only available on macOS.");
+				formatter.WriteError(new MauiToolException(ErrorCodes.PlatformNotSupported, "Simulators are only available on macOS."));
 				return 1;
 			}
 
 			var appleProvider = Program.AppleProvider;
 			var target = parseResult.GetValue(nameOrUdidArg)!;
-			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 
 			var erased = appleProvider.EraseSimulator(target);
 
 			if (!erased)
 			{
-				var ex = new MauiToolException(ErrorCodes.AppleSimulatorEraseFailed, $"Failed to erase simulator '{target}'.");
-				if (useJson)
-					formatter.WriteError(ex);
-				else
-					formatter.WriteWarning(ex.Message);
+				var ex = new MauiToolException(ErrorCodes.AppleSimulatorEraseFailed, $"Failed to erase simulator '{target}'. Ensure the simulator is shut down first (maui apple simulator stop).");
+				formatter.WriteError(ex);
 				return 1;
 			}
 
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 			if (useJson)
-			{
 				formatter.Write(new SimulatorEraseResult { Target = target, Erased = true });
-			}
 			else
-			{
 				formatter.WriteSuccess($"Simulator '{target}' erased.");
-			}
 			return 0;
 		});
 

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -381,7 +381,11 @@ public static class AppleCommands
 			if (string.IsNullOrWhiteSpace(customName) && runtime is not null)
 			{
 				var rParts = runtime.Split('.');
-				var rShort = (rParts.Length > 1 ? rParts[rParts.Length - 1] : runtime).Replace('-', ' ');
+				var rLast = rParts.Length > 1 ? rParts[rParts.Length - 1] : runtime;
+				var dashIdx = rLast.IndexOf('-');
+				var rShort = dashIdx >= 0
+					? rLast[..dashIdx] + ' ' + rLast[(dashIdx + 1)..].Replace('-', '.')
+					: rLast;
 				name = $"{shortType} ({rShort})";
 			}
 

--- a/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodes.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodes.cs
@@ -44,6 +44,8 @@ public static class ErrorCodes
 	public const string AppleSimulatorNotFound = "E2204";
 	public const string AppleXcodeLicenseNotAccepted = "E2205";
 	public const string AppleSetupFailed = "E2206";
+	public const string AppleSimulatorCreateFailed = "E2207";
+	public const string AppleSimulatorEraseFailed = "E2208";
 
 	// Platform/SDK errors - Windows (E23xx)
 	public const string WindowsSdkNotFound = "E2301";

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
@@ -98,25 +98,25 @@ internal sealed record CliCommandResult
 
 internal sealed record SimulatorCreateResult
 {
-	[System.Text.Json.Serialization.JsonPropertyName("udid")]
+	[JsonPropertyName("udid")]
 	public required string Udid { get; init; }
 
-	[System.Text.Json.Serialization.JsonPropertyName("name")]
+	[JsonPropertyName("name")]
 	public required string Name { get; init; }
 
-	[System.Text.Json.Serialization.JsonPropertyName("device_type")]
+	[JsonPropertyName("device_type")]
 	public required string DeviceType { get; init; }
 
-	[System.Text.Json.Serialization.JsonPropertyName("runtime")]
-	[System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("runtime")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string? Runtime { get; init; }
 }
 
 internal sealed record SimulatorEraseResult
 {
-	[System.Text.Json.Serialization.JsonPropertyName("target")]
+	[JsonPropertyName("target")]
 	public required string Target { get; init; }
 
-	[System.Text.Json.Serialization.JsonPropertyName("erased")]
+	[JsonPropertyName("erased")]
 	public bool Erased { get; init; }
 }

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
@@ -112,6 +112,10 @@ internal sealed record SimulatorCreateResult
 	public string? Runtime { get; init; }
 }
 
+/// <summary>
+/// Result of a successful simulator erase. The <see cref="Erased"/> field is always <c>true</c>;
+/// failure is reported via a MauiToolException before this model is emitted.
+/// </summary>
 internal sealed record SimulatorEraseResult
 {
 	[JsonPropertyName("target")]

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
@@ -95,3 +95,28 @@ internal sealed record CliCommandResult
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public List<int>? Versions { get; init; }
 }
+
+internal sealed record SimulatorCreateResult
+{
+	[System.Text.Json.Serialization.JsonPropertyName("udid")]
+	public required string Udid { get; init; }
+
+	[System.Text.Json.Serialization.JsonPropertyName("name")]
+	public required string Name { get; init; }
+
+	[System.Text.Json.Serialization.JsonPropertyName("device_type")]
+	public required string DeviceType { get; init; }
+
+	[System.Text.Json.Serialization.JsonPropertyName("runtime")]
+	[System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+	public string? Runtime { get; init; }
+}
+
+internal sealed record SimulatorEraseResult
+{
+	[System.Text.Json.Serialization.JsonPropertyName("target")]
+	public required string Target { get; init; }
+
+	[System.Text.Json.Serialization.JsonPropertyName("erased")]
+	public bool Erased { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
@@ -46,4 +46,6 @@ namespace Microsoft.Maui.Cli.Output;
 [JsonSerializable(typeof(StatusMessageResult))]
 [JsonSerializable(typeof(VersionResult))]
 [JsonSerializable(typeof(CliCommandResult))]
+[JsonSerializable(typeof(SimulatorCreateResult))]
+[JsonSerializable(typeof(SimulatorEraseResult))]
 internal sealed partial class MauiCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
@@ -159,6 +159,11 @@ public class AppleProvider : IAppleProvider
 		return _simulatorService?.Create(name, deviceTypeIdentifier, runtimeIdentifier);
 	}
 
+	public bool EraseSimulator(string udidOrName)
+	{
+		return _simulatorService?.Erase(udidOrName) ?? false;
+	}
+
 	public List<HealthCheck> CheckHealth()
 	{
 		var checks = new List<HealthCheck>();

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
@@ -67,6 +67,11 @@ public interface IAppleProvider
 	string? CreateSimulator(string name, string deviceTypeIdentifier, string? runtimeIdentifier = null);
 
 	/// <summary>
+	/// Erases (resets) a simulator device to factory state.
+	/// </summary>
+	bool EraseSimulator(string udidOrName);
+
+	/// <summary>
 	/// Gets the health status of Apple tooling (Xcode, CLT, simulators).
 	/// </summary>
 	List<HealthCheck> CheckHealth();

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
@@ -69,7 +69,7 @@ public interface IAppleProvider
 	/// <summary>
 	/// Erases (resets) a simulator device to factory state.
 	/// </summary>
-	bool EraseSimulator(string udidOrName);
+	bool EraseSimulator(string udidOrName) => false;
 
 	/// <summary>
 	/// Gets the health status of Apple tooling (Xcode, CLT, simulators).

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
@@ -69,7 +69,7 @@ public interface IAppleProvider
 	/// <summary>
 	/// Erases (resets) a simulator device to factory state.
 	/// </summary>
-	bool EraseSimulator(string udidOrName) => false;
+	bool EraseSimulator(string udidOrName);
 
 	/// <summary>
 	/// Gets the health status of Apple tooling (Xcode, CLT, simulators).


### PR DESCRIPTION
Adds two new subcommands to `maui apple simulator`:

- `create <device-type> [--name NAME] [--runtime RUNTIME]` — wraps `SimulatorService.Create()`
- `erase <name-or-udid>` — wraps `SimulatorService.Erase()`

## Changes

- `IAppleProvider`: new `EraseSimulator(string udidOrName)` method
- `AppleProvider`: delegates to `SimulatorService.Erase()`
- `ErrorCodes`: `AppleSimulatorCreateFailed = "E2205"`, `AppleSimulatorEraseFailed = "E2206"`
- `JsonOutputModels`: `SimulatorCreateResult` (udid, name, device_type, runtime?) and `SimulatorEraseResult` (target, erased) records
- `MauiCliJsonContext`: registers the new JSON types
- `AppleCommands`: `create` and `erase` subcommands wired up
- `FakeAppleProvider`: `EraseSimulator` support for tests
- `AppleSimulatorCommandsTests`: 14 new unit tests

## Testing

All 14 new tests pass:
- 5 command structure tests (verify subcommands/arguments/options exist)
- 4 fake provider behavior tests
- 3 JSON serialization/shape tests
- 2 error code tests (E2205, E2206)

Closes #197
