### PR TITLE
fix: Add UI.Init() to TabViewTests

### DIFF
--- a/src/Comet/tests/Comet.Tests/FrameworkFeaturesTests.cs
+++ b/src/Comet/tests/Comet.Tests/FrameworkFeaturesTests.cs
@@ -195,13 +195,8 @@ Assert.Equal("default", ValueConverters.Coalesce(value, fallback));
 }
 }
 
-public class TabViewTests
+public class TabViewTests : TestBase
 {
-public TabViewTests()
-{
-	UI.Init();
-}
-
 [Fact]
 public void TabView_Creation()
 {

--- a/src/Comet/tests/Comet.Tests/FrameworkFeaturesTests.cs
+++ b/src/Comet/tests/Comet.Tests/FrameworkFeaturesTests.cs
@@ -197,6 +197,11 @@ Assert.Equal("default", ValueConverters.Coalesce(value, fallback));
 
 public class TabViewTests
 {
+public TabViewTests()
+{
+	UI.Init();
+}
+
 [Fact]
 public void TabView_Creation()
 {


### PR DESCRIPTION
3 TabView tests fail on CI (Windows) because `ThreadHelper.FireOnMainThread` defaults to `MainThread.BeginInvokeOnMainThread` which throws `NotImplementedInReferenceAssemblyException` on non-platform test hosts.

The existing `UI.Init()` helper already sets up a synchronous fallback. Just need to call it from the TabViewTests constructor.

Fixes the Comet test failure from https://github.com/dotnet/maui-labs/actions/runs/25215774420