### PR TITLE
Simplify README install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,42 @@ Experimental packages and tooling for .NET MAUI. This repository hosts pre-relea
 
 > ⚠️ **These packages are experimental.** APIs may change between releases. These packages are not covered by the [.NET MAUI Support Policy](https://dotnet.microsoft.com/platform/support/policy/maui) and are provided as-is.
 
+## Fastest install path
+
+Install the unified `maui` CLI once, then let it guide the rest of your machine setup:
+
+```bash
+dotnet tool install -g Microsoft.Maui.Cli --prerelease
+maui doctor
+```
+
+For Android development, the CLI can install and configure the JDK, Android SDK, licenses, and an emulator:
+
+```bash
+maui android install
+maui device list
+```
+
+On macOS, use the Apple commands to inspect your Xcode, simulator runtimes, and devices:
+
+```bash
+maui apple xcode list
+maui apple runtime list
+maui apple simulator list
+```
+
+For DevFlow app automation, initialize the bundled agent skills in your app workspace, then add the in-app agent package as described in [DevFlow](src/DevFlow/README.md):
+
+```bash
+maui devflow init
+```
+
+## Manual setup details
+
+If you prefer to install pieces yourself, install the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0), install the MAUI workload with `dotnet workload install maui`, and configure each platform's native tools directly (Xcode on macOS; Android Studio, Android SDK, and JDK for Android).
+
+The CLI can still manage individual pieces when you do not want the full interactive setup: `maui android jdk install`, `maui android sdk install`, `maui android emulator create`, and the `maui apple ...` commands on macOS.
+
 ## Products
 
 ### Cli
@@ -24,11 +60,7 @@ A command-line tool for .NET MAUI development environment setup, device manageme
 |---------|-------------|
 | `Microsoft.Maui.Cli` | CLI global tool (`maui`) |
 
-```bash
-# Microsoft.Maui.Cli is currently released as a pre-release, so make sure to use the --prerelease flag
-dotnet tool install -g Microsoft.Maui.Cli --prerelease
-maui doctor
-```
+Start with the [fastest install path](#fastest-install-path), then run `maui <command> --help` for command-specific options.
 
 ### Comet
 

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -4,29 +4,25 @@ A comprehensive testing, automation, and debugging toolkit for .NET MAUI applica
 
 > ⚠️ **Experimental** — APIs may change between releases. Not covered by the Microsoft Support Policy.
 
-## Packages
+## Fastest path
 
-| Package | Description |
-|---------|-------------|
-| **Microsoft.Maui.DevFlow.Agent** | In-app agent for .NET MAUI apps. Exposes visual tree, element interactions, screenshots, and profiling via HTTP/JSON API. |
-| **Microsoft.Maui.DevFlow.Agent.Core** | Platform-agnostic core: HTTP server, visual tree walker, CSS selector engine, network capture, profiling. |
-| **Microsoft.Maui.DevFlow.Agent.Gtk** | GTK/Linux agent for Maui.Gtk apps. |
-| **Microsoft.Maui.DevFlow.Blazor** | Blazor WebView CDP bridge. Enables Chrome DevTools Protocol access for Blazor Hybrid content via Chobitsu. |
-| **Microsoft.Maui.DevFlow.Blazor.Gtk** | Blazor CDP bridge for WebKitGTK on Linux. |
-| **Microsoft.Maui.DevFlow.CLI** | DevFlow command implementation used by the unified `maui devflow` CLI surface for automation, debugging, and MCP server support. |
-| **Microsoft.Maui.DevFlow.Driver** | Platform-aware app driver for iOS, Android, Mac Catalyst, Windows, and Linux. |
-| **Microsoft.Maui.DevFlow.Logging** | Buffered rotating JSONL file logger. No MAUI dependency. |
+Install the unified `maui` CLI and initialize the bundled DevFlow skills in your app workspace:
 
-## Quick Start
-
-### 1. Install the NuGet packages
-
-```xml
-<PackageReference Include="Microsoft.Maui.DevFlow.Agent" />
-<PackageReference Include="Microsoft.Maui.DevFlow.Blazor" />  <!-- If using Blazor Hybrid -->
+```bash
+dotnet tool install -g Microsoft.Maui.Cli --prerelease
+maui devflow init
 ```
 
-### 2. Register in MauiProgram.cs
+Add the in-app agent package to the MAUI app you want to automate:
+
+```bash
+dotnet add package Microsoft.Maui.DevFlow.Agent --prerelease
+
+# Blazor Hybrid apps only
+dotnet add package Microsoft.Maui.DevFlow.Blazor --prerelease
+```
+
+Register the agent in `MauiProgram.cs` for debug builds:
 
 ```csharp
 using Microsoft.Maui.DevFlow.Agent;
@@ -44,18 +40,53 @@ public static MauiApp CreateMauiApp()
 }
 ```
 
-### 3. Install the unified CLI tool
+Run your app, then connect to it:
+
+```bash
+maui devflow wait
+maui devflow ui tree
+maui devflow ui screenshot -o screenshot.png
+maui devflow mcp
+```
+
+## Manual setup details
+
+### NuGet package references
+
+```xml
+<PackageReference Include="Microsoft.Maui.DevFlow.Agent" />
+<PackageReference Include="Microsoft.Maui.DevFlow.Blazor" />  <!-- If using Blazor Hybrid -->
+```
+
+### MauiProgram.cs registration
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent;
+
+public static MauiApp CreateMauiApp()
+{
+    var builder = MauiApp.CreateBuilder();
+    builder.UseMauiApp<App>();
+
+    #if DEBUG
+    builder.AddMauiDevFlowAgent();
+    #endif
+
+    return builder.Build();
+}
+```
+
+### CLI installation
 
 ```bash
 dotnet tool install -g Microsoft.Maui.Cli --prerelease
 ```
 
-### 4. Interact with your running app
+### Common commands
 
 ```bash
 # Install DevFlow skills for AI agent integration (auto-detects target directory;
 # defaults to .claude/skills/ — configurable via --target: claude, github, agent, agents, or auto)
-# (configurable via --target: claude, github, agent, agents, or auto)
 maui devflow init
 
 # Visual tree
@@ -70,6 +101,19 @@ maui devflow ui tap --automationid "MyButton"
 # Start MCP server for AI agent integration
 maui devflow mcp
 ```
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| **Microsoft.Maui.DevFlow.Agent** | In-app agent for .NET MAUI apps. Exposes visual tree, element interactions, screenshots, and profiling via HTTP/JSON API. |
+| **Microsoft.Maui.DevFlow.Agent.Core** | Platform-agnostic core: HTTP server, visual tree walker, CSS selector engine, network capture, profiling. |
+| **Microsoft.Maui.DevFlow.Agent.Gtk** | GTK/Linux agent for Maui.Gtk apps. |
+| **Microsoft.Maui.DevFlow.Blazor** | Blazor WebView CDP bridge. Enables Chrome DevTools Protocol access for Blazor Hybrid content via Chobitsu. |
+| **Microsoft.Maui.DevFlow.Blazor.Gtk** | Blazor CDP bridge for WebKitGTK on Linux. |
+| **Microsoft.Maui.DevFlow.CLI** | DevFlow command implementation used by the unified `maui devflow` CLI surface for automation, debugging, and MCP server support. |
+| **Microsoft.Maui.DevFlow.Driver** | Platform-aware app driver for iOS, Android, Mac Catalyst, Windows, and Linux. |
+| **Microsoft.Maui.DevFlow.Logging** | Buffered rotating JSONL file logger. No MAUI dependency. |
 
 ### Session identity
 


### PR DESCRIPTION
These READMEs currently lead with package lists and setup details, which makes the first steps feel heavier than necessary. This PR moves the simplest install path to the top while preserving manual setup and package reference details below for readers who need them.

## Summary

- Add a root `Fastest install path` for installing the `maui` CLI, running `maui doctor`, using `maui android install`, inspecting Apple tooling on macOS, and initializing DevFlow.
- Rewrite the DevFlow README lead section around CLI install, `maui devflow init`, adding the in-app agent package, debug registration, and first connection commands.
- Keep manual XML package references, CLI install details, and package tables below the quick path sections.

## Testing

Not run; documentation-only change.