### PR TITLE
Add Essentials.AI to main README and create product README

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -185,6 +185,11 @@ You can also pass a pre-built binary: `./eng/smoke-tests/apple-cli-smoke-test.sh
 
 When adding a new product to this repo you **must** set up two CI surfaces: a GitHub Actions workflow for PR validation and a build job + publish stage in the Azure DevOps official pipeline for signing and NuGet.org publishing.
 
+You **must** also provide documentation:
+
+- **Product README** — create `README.md` in the product root (e.g. `src/{Product}/README.md`). This file is packed into the NuGet package. Add `<None Include="README.md" Pack="true" PackagePath="/" />` to the shipping csproj and set `<PackRepoRootReadme>false</PackRepoRootReadme>` so the repo-root README is not duplicated.
+- **Root README entry** — add a section under `## Products` in the repo-root `README.md` with a brief description and package table.
+
 ### Step 1: GitHub Actions PR / Push Workflow
 
 Create `.github/workflows/ci-{product}.yml`. Use the template below — replace every `{Product}` (PascalCase) and `{product}` (lowercase) placeholder.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -187,8 +187,8 @@ When adding a new product to this repo you **must** set up two CI surfaces: a Gi
 
 You **must** also provide documentation:
 
-- **Product README** — create `README.md` in the product root (e.g. `src/{Product}/README.md`). This file is packed into the NuGet package. Add `<None Include="README.md" Pack="true" PackagePath="/" />` to the shipping csproj and set `<PackRepoRootReadme>false</PackRepoRootReadme>` so the repo-root README is not duplicated.
-- **Root README entry** — add a section under `## Products` in the repo-root `README.md` with a brief description and package table.
+- **Product README** — create `README.md` in the product root (e.g. `src/{Product}/README.md`). This file is packed into the NuGet package. Add `<None Include="README.md" Pack="true" PackagePath="/" />` to the shipping csproj and set `<PackRepoRootReadme>false</PackRepoRootReadme>` so the repo-root README is not duplicated. Include: product name, feature list, platform support matrix, quick start code, package table, build instructions, architecture overview, requirements, and experimental status warning.
+- **Root README entry** — add a section under `## Products` in the repo-root `README.md` with a brief description, feature highlights, and package table.
 
 ### Step 1: GitHub Actions PR / Push Workflow
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -187,7 +187,7 @@ When adding a new product to this repo you **must** set up two CI surfaces: a Gi
 
 You **must** also provide documentation:
 
-- **Product README** — create `README.md` in the product root (e.g. `src/{Product}/README.md`). This file is packed into the NuGet package. Add `<None Include="README.md" Pack="true" PackagePath="/" />` to the shipping csproj and set `<PackRepoRootReadme>false</PackRepoRootReadme>` so the repo-root README is not duplicated. Include: product name, feature list, platform support matrix, quick start code, package table, build instructions, architecture overview, requirements, and experimental status warning.
+- **Product README** — create two READMEs: (1) a contributor README at the product root (`src/{Product}/README.md`) for GitHub browsing with features, build instructions, and architecture; (2) a NuGet README next to the shipping csproj (`src/{Product}/Microsoft.Maui.{Product}/README.md`) with install, quick start, and usage examples. Pack the NuGet README via `<None Include="README.md" Pack="true" PackagePath="/" />` and set `<PackRepoRootReadme>false</PackRepoRootReadme>`. Both should include: product name, features, platform support matrix, quick start, packages, requirements, and experimental status warning. Keep descriptions aligned to avoid drift.
 - **Root README entry** — add a section under `## Products` in the repo-root `README.md` with a brief description, feature highlights, and package table.
 
 ### Step 1: GitHub Actions PR / Push Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,8 +186,16 @@ Each product requires source setup **and** CI/CD configuration across two system
 
 ### Documentation
 
-5. Create a `README.md` in the product root (e.g. `src/{NewProduct}/README.md`) — this is packed into the NuGet package via `<None Include="README.md" Pack="true" PackagePath="/" />`. Set `<PackRepoRootReadme>false</PackRepoRootReadme>` so the repo-root README is not duplicated in the package.
-6. Add a section for the product in the **repo-root `README.md`** under `## Products` with a brief description and package table.
+5. Create a `README.md` in the product root (e.g. `src/{NewProduct}/README.md`). This is packed into the NuGet package via `<None Include="README.md" Pack="true" PackagePath="/" />`. Set `<PackRepoRootReadme>false</PackRepoRootReadme>` so the repo-root README is not duplicated in the package. The product README should include:
+   - Product name and one-line description
+   - Feature list with platform support matrix (if applicable)
+   - Quick start / code example
+   - Package table (package IDs and descriptions)
+   - Build instructions (including any platform-specific steps)
+   - Architecture overview (project structure, key components)
+   - Requirements (SDK version, workloads, OS constraints)
+   - Experimental/preview status warning
+6. Add a section for the product in the **repo-root `README.md`** under `## Products` with a brief description, feature highlights, and package table.
 
 ### CI/CD Setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,15 +186,11 @@ Each product requires source setup **and** CI/CD configuration across two system
 
 ### Documentation
 
-5. Create a `README.md` in the product root (e.g. `src/{NewProduct}/README.md`). This is packed into the NuGet package via `<None Include="README.md" Pack="true" PackagePath="/" />`. Set `<PackRepoRootReadme>false</PackRepoRootReadme>` so the repo-root README is not duplicated in the package. The product README should include:
-   - Product name and one-line description
-   - Feature list with platform support matrix (if applicable)
-   - Quick start / code example
-   - Package table (package IDs and descriptions)
-   - Build instructions (including any platform-specific steps)
-   - Architecture overview (project structure, key components)
-   - Requirements (SDK version, workloads, OS constraints)
-   - Experimental/preview status warning
+5. Create **two READMEs**:
+   - A **contributor README** at the product root (e.g. `src/{NewProduct}/README.md`) for GitHub browsing — describes features, build instructions, architecture, and links to the NuGet README.
+   - A **NuGet README** next to the shipping csproj (e.g. `src/{NewProduct}/Microsoft.Maui.{NewProduct}/README.md`) — consumer-facing with install, quick start, and usage examples. Pack it via `<None Include="README.md" Pack="true" PackagePath="/" />` in the csproj and set `<PackRepoRootReadme>false</PackRepoRootReadme>` to avoid duplicating the repo-root README.
+   
+   Both should include: product name, feature list, platform support matrix, quick start code, package table, requirements, and experimental status warning. Keep feature descriptions aligned to avoid drift.
 6. Add a section for the product in the **repo-root `README.md`** under `## Products` with a brief description, feature highlights, and package table.
 
 ### CI/CD Setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,10 +184,15 @@ Each product requires source setup **and** CI/CD configuration across two system
 3. Add package versions to `Directory.Packages.props`
 4. Add signing entries in `eng/Signing.props` for any new third-party DLLs
 
+### Documentation
+
+5. Create a `README.md` in the product root (e.g. `src/{NewProduct}/README.md`) — this is packed into the NuGet package via `<None Include="README.md" Pack="true" PackagePath="/" />`. Set `<PackRepoRootReadme>false</PackRepoRootReadme>` so the repo-root README is not duplicated in the package.
+6. Add a section for the product in the **repo-root `README.md`** under `## Products` with a brief description and package table.
+
 ### CI/CD Setup
 
-5. **GitHub Actions**: Create `.github/workflows/ci-{newproduct}.yml` calling the reusable `_build.yml` workflow. Must include `pull_request.types: [opened, synchronize, reopened, edited]` and path filters scoped to the product source plus shared build files.
-6. **Azure DevOps**: Edit `eng/pipelines/devflow-official.yml` — add a publish parameter, a build job in the `build` stage, and a conditional publish stage for NuGet.org.
+7. **GitHub Actions**: Create `.github/workflows/ci-{newproduct}.yml` calling the reusable `_build.yml` workflow. Must include `pull_request.types: [opened, synchronize, reopened, edited]` and path filters scoped to the product source plus shared build files.
+8. **Azure DevOps**: Edit `eng/pipelines/devflow-official.yml` — add a publish parameter, a build job in the `build` stage, and a conditional publish stage for NuGet.org.
 
 > **Complete copy-paste templates** for both the GitHub Actions workflow and all three Azure DevOps blocks (parameter, build job, publish stage) are in `.github/copilot-instructions.md` under **"CI/CD — New Product Checklist"**.
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ A comprehensive MAUI testing, automation, and debugging toolkit. The DevFlow CLI
 
 ### Essentials.AI
 
-On-device AI capabilities for .NET MAUI via `Microsoft.Extensions.AI` abstractions. On Apple platforms, wraps Apple Intelligence (Foundation Models) through native Swift bindings for chat completion, streaming JSON deserialization, tool calling, and NL embedding generation.
+On-device AI capabilities for .NET MAUI via `Microsoft.Extensions.AI` abstractions. On Apple platforms, wraps Apple Intelligence (Foundation Models) for chat completion with streaming and tool calling, and Apple NaturalLanguage APIs for on-device embeddings.
 
 - **`IChatClient`** backed by Apple Intelligence on iOS, macOS, and Mac Catalyst
 - **Streaming infrastructure** — progressive JSON deserialization of LLM responses
-- **NL embeddings** — on-device semantic search via `NLEmbeddingGenerator`
+- **NL embeddings** — on-device semantic search via Apple's NaturalLanguage framework (`NLEmbeddingGenerator`)
 - **Tool calling** — function-calling support for on-device models
 
 | Package | Description |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ A comprehensive MAUI testing, automation, and debugging toolkit. The DevFlow CLI
 | `Microsoft.Maui.DevFlow.Driver` | Platform driver library |
 | `Microsoft.Maui.DevFlow.Logging` | Buffered JSONL file logger |
 
+### Essentials.AI
+
+On-device AI capabilities for .NET MAUI via `Microsoft.Extensions.AI` abstractions. On Apple platforms, wraps Apple Intelligence (Foundation Models) through native Swift bindings for chat completion, streaming JSON deserialization, tool calling, and NL embedding generation.
+
+- **`IChatClient`** backed by Apple Intelligence on iOS, macOS, and Mac Catalyst
+- **Streaming infrastructure** — progressive JSON deserialization of LLM responses
+- **NL embeddings** — on-device semantic search via `NLEmbeddingGenerator`
+- **Tool calling** — function-calling support for on-device models
+
+| Package | Description |
+|---------|-------------|
+| `Microsoft.Maui.Essentials.AI` | On-device AI APIs for MAUI |
+
 ## Getting Started
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development setup.

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -1,0 +1,53 @@
+# Microsoft.Maui.Essentials.AI
+
+On-device AI capabilities for .NET MAUI via [`Microsoft.Extensions.AI`](https://www.nuget.org/packages/Microsoft.Extensions.AI.Abstractions) abstractions.
+
+## Features
+
+- **`IChatClient`** — backed by Apple Intelligence (Foundation Models) on iOS, macOS, and Mac Catalyst
+- **Streaming** — progressive JSON deserialization of LLM responses via `JsonStreamChunker` and `PlainTextStreamChunker`
+- **Tool calling** — function-calling support for on-device models
+- **NL embeddings** — on-device semantic search via `NLEmbeddingGenerator`
+- **Cross-platform** — targets net10.0, Android, iOS, Mac Catalyst, macOS, and Windows (Apple Intelligence features require iOS 26+ / macOS 26+)
+
+## Quick Start
+
+```csharp
+using Microsoft.Extensions.AI;
+using Microsoft.Maui.Essentials.AI;
+
+// Register in MauiProgram.cs
+builder.Services.AddChatClient(new AppleIntelligenceChatClient());
+
+// Use via DI
+var client = serviceProvider.GetRequiredService<IChatClient>();
+var response = await client.GetResponseAsync("Plan a weekend trip to Portland");
+```
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| `Microsoft.Maui.Essentials.AI` | On-device AI APIs for MAUI |
+
+## Building
+
+```bash
+# macOS (builds Swift bindings + .NET library)
+dotnet build src/AI/EssentialsAI.slnf
+
+# Windows (requires pre-built native artifacts from macOS CI)
+dotnet build src/AI/EssentialsAI.slnf
+```
+
+The CI pipeline handles the macOS → Windows artifact flow automatically. See `.github/workflows/ci-essentialsai.yml` for details.
+
+## Architecture
+
+- **Native Swift bindings** (`AppleNative/EssentialsAI/`) compiled via Xcode, producing `.xcframework` bundles
+- **`AppleBindings.targets`** — MSBuild targets for cross-platform native artifact flow
+- **Streaming infrastructure** — `JsonStreamChunker`, `PlainTextStreamChunker`, `StreamingResponseHandler` for progressive deserialization
+
+## Documentation
+
+- [JSON Stream Chunker Design](../../docs/ai/json-stream-chunker-design.md)

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -7,7 +7,7 @@ On-device AI capabilities for .NET MAUI via [`Microsoft.Extensions.AI`](https://
 - **`IChatClient`** — backed by Apple Intelligence (Foundation Models) on iOS, macOS, and Mac Catalyst
 - **Streaming** — progressive JSON deserialization of LLM responses via `JsonStreamChunker` and `PlainTextStreamChunker`
 - **Tool calling** — function-calling support for on-device models
-- **NL embeddings** — on-device semantic search via `NLEmbeddingGenerator`
+- **NL embeddings** — on-device semantic search via Apple's NaturalLanguage framework (`NLEmbeddingGenerator`)
 
 ### Platform Support
 
@@ -26,7 +26,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Maui.Essentials.AI;
 
 // Register in MauiProgram.cs
-builder.Services.AddChatClient(new AppleIntelligenceChatClient());
+builder.Services.AddSingleton<IChatClient>(new AppleIntelligenceChatClient());
 
 // Use via DI
 var client = serviceProvider.GetRequiredService<IChatClient>();
@@ -45,8 +45,9 @@ var response = await client.GetResponseAsync("Plan a weekend trip to Portland");
 # macOS (builds Swift bindings + .NET library)
 dotnet build src/AI/EssentialsAI.slnf
 
-# Windows (requires pre-built native artifacts from macOS CI)
-dotnet build src/AI/EssentialsAI.slnf
+# Windows (CI only — the Azure DevOps pipeline downloads macOS-built
+# native artifacts automatically. Local Windows builds require CI=true
+# or TF_BUILD=true for the pre-built artifact path to activate.)
 ```
 
 The CI pipeline handles the macOS → Windows artifact flow automatically. See `.github/workflows/ci-essentialsai.yml` for details.
@@ -65,6 +66,6 @@ The CI pipeline handles the macOS → Windows artifact flow automatically. See `
 
 - .NET 10
 - MAUI workload (`dotnet workload install maui`)
-- Apple Intelligence requires iOS 26+, macOS 26+, or Mac Catalyst 26+
+- Apple Intelligence features require iOS 26+, Mac Catalyst 26+, or macOS 26+
 
 > ⚠️ **This package is experimental** (always ships as `-preview`). APIs may change between releases.

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -8,7 +8,16 @@ On-device AI capabilities for .NET MAUI via [`Microsoft.Extensions.AI`](https://
 - **Streaming** — progressive JSON deserialization of LLM responses via `JsonStreamChunker` and `PlainTextStreamChunker`
 - **Tool calling** — function-calling support for on-device models
 - **NL embeddings** — on-device semantic search via `NLEmbeddingGenerator`
-- **Cross-platform** — targets net10.0, Android, iOS, Mac Catalyst, macOS, and Windows (Apple Intelligence features require iOS 26+ / macOS 26+)
+
+### Platform Support
+
+| Platform | Chat (IChatClient) | Embeddings (IEmbeddingGenerator) |
+|----------|-------------------|----------------------------------|
+| iOS 26+ | ✅ Apple Intelligence | ✅ NL Embeddings |
+| Mac Catalyst 26+ | ✅ Apple Intelligence | ✅ NL Embeddings |
+| macOS 26+ | ✅ Apple Intelligence | ✅ NL Embeddings |
+| Android | 🔜 Coming soon | 🔜 Coming soon |
+| Windows | 🔜 Coming soon | 🔜 Coming soon |
 
 ## Quick Start
 
@@ -51,3 +60,11 @@ The CI pipeline handles the macOS → Windows artifact flow automatically. See `
 ## Documentation
 
 - [JSON Stream Chunker Design](../../docs/ai/json-stream-chunker-design.md)
+
+## Requirements
+
+- .NET 10
+- MAUI workload (`dotnet workload install maui`)
+- Apple Intelligence requires iOS 26+, macOS 26+, or Mac Catalyst 26+
+
+> ⚠️ **This package is experimental** (always ships as `-preview`). APIs may change between releases.

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -2,6 +2,8 @@
 
 On-device AI capabilities for .NET MAUI via [`Microsoft.Extensions.AI`](https://www.nuget.org/packages/Microsoft.Extensions.AI.Abstractions) abstractions.
 
+> **Note:** This is the contributor/repo-browsing README. The NuGet consumer README with install instructions and full usage examples is at [`Microsoft.Maui.Essentials.AI/README.md`](Microsoft.Maui.Essentials.AI/README.md).
+
 ## Features
 
 - **`IChatClient`** — backed by Apple Intelligence (Foundation Models) on iOS, macOS, and Mac Catalyst


### PR DESCRIPTION
Following the merge of #171 (Microsoft.Maui.Essentials.AI), this adds the new product to the repo documentation.

## Changes

1. **Main `README. Added Essentials.AI section under Products, between DevFlow and Getting Startedmd`** 
2. **`src/AI/README. New product README with features, quick start, package table, build instructions, and architecture overviewmd`** 

Every other product (Cli, Comet, Go, DevFlow) has a section in the main README and a product-level README. This brings Essentials.AI in line.
