### PR TITLE
feat(go): single-file Comet Go server + companion-app QR scanner fix

### DIFF
--- a/src/Go/CompanionApp/GoApp.cs
+++ b/src/Go/CompanionApp/GoApp.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Threading.Tasks;
 using Comet;
 using Comet.Styles;
 using Microsoft.Maui.Hosting;
@@ -27,6 +28,19 @@ public class GoApp : CometApp
 		// be set BEFORE the runtime initializes the update pipeline.
 		Environment.SetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES", "Debug");
 
+		// Global exception handlers — log but don't crash for user code errors
+		AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+		{
+			var ex = e.ExceptionObject as Exception;
+			Console.WriteLine($"[GoApp] Unhandled exception: {ex?.GetBaseException()?.Message ?? ex?.Message ?? "unknown"}");
+		};
+
+		TaskScheduler.UnobservedTaskException += (_, e) =>
+		{
+			Console.WriteLine($"[GoApp] Unobserved task: {e.Exception.GetBaseException().Message}");
+			e.SetObserved();
+		};
+
 		var builder = MauiApp.CreateBuilder();
 		builder.UseCometApp<GoApp>();
 		builder.UseBarcodeReader();
@@ -37,7 +51,7 @@ public class GoApp : CometApp
 			fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
 		});
 
-		Theme.Current = Defaults.Light;
+		ThemeManager.SetTheme(Defaults.Light);
 
 		return builder.Build();
 	}

--- a/src/Go/CompanionApp/GoMainPage.cs
+++ b/src/Go/CompanionApp/GoMainPage.cs
@@ -20,15 +20,12 @@ namespace Microsoft.Maui.Go.CompanionApp;
 /// </summary>
 public class GoAppState
 {
-	// Use localhost as default -- works with adb reverse on physical devices
-	// and directly on iOS/Mac simulators. For Android emulators without
-	// adb reverse, change to 10.0.2.2 in the UI.
-	public string ServerUrl { get; set; } = $"ws://localhost:{GoProtocol.DefaultPort}{GoProtocol.DefaultPath}";
-	public string Status { get; set; } = "Enter server URL or scan QR code";
-	public string? ErrorMessage { get; set; }
-	public bool IsConnected { get; set; }
-	public int DeltasApplied { get; set; }
-	public View? UserView { get; set; }
+public string ServerUrl { get; set; } = $"ws://localhost:{GoProtocol.DefaultPort}{GoProtocol.DefaultPath}";
+public string Status { get; set; } = "Enter server URL or scan QR code";
+public string? ErrorMessage { get; set; }
+public bool IsConnected { get; set; }
+public int DeltasApplied { get; set; }
+public View? UserView { get; set; }
 }
 
 /// <summary>
@@ -36,214 +33,281 @@ public class GoAppState
 /// </summary>
 public class GoMainPage : Component<GoAppState>
 {
-	GoClient? _client;
-	bool _autoConnectAttempted;
-	Type? _userViewType; // Track the user's view type for re-instantiation after deltas
+GoClient? _client;
+bool _autoConnectAttempted;
+Type? _userViewType;
+View? _lastGoodView;
 
-	public GoMainPage()
-	{
-		// Auto-connect if MAUI_GO_SERVER env var is set
-		var autoUrl = Environment.GetEnvironmentVariable("MAUI_GO_SERVER");
-		if (!string.IsNullOrEmpty(autoUrl))
-			State.ServerUrl = autoUrl;
-	}
+public GoMainPage()
+{
+var autoUrl = Environment.GetEnvironmentVariable("MAUI_GO_SERVER");
+if (!string.IsNullOrEmpty(autoUrl))
+State.ServerUrl = autoUrl;
+}
 
-	public override View Render()
+/// <summary>
+/// Unwrap TargetInvocationException / TypeInitializationException to get the real error.
+/// </summary>
+static Exception UnwrapException(Exception ex) => ex.GetBaseException() ?? ex;
+
+/// <summary>
+/// Try to instantiate and preflight-build a user view.
+/// Returns the view on success, null on failure (error message in out param).
+/// This prevents crashes by catching render errors BEFORE committing to state.
+/// </summary>
+View? TryCreateUserView(Type viewType, out string? error)
+{
+error = null;
+View candidate;
+
+// Step 1: Instantiate
+try
+{
+candidate = (Comet.View)Activator.CreateInstance(viewType)!;
+}
+catch (Exception ex)
+{
+var real = UnwrapException(ex);
+error = $"Constructor failed: {real.GetType().Name}: {real.Message}";
+Console.WriteLine($"[GoMainPage] {error}");
+return null;
+}
+
+// Step 2: Preflight — force the [Body] method to execute so we catch
+// render errors BEFORE committing to state.
+try
+{
+candidate.GetView();
+}
+catch (Exception ex)
+{
+var real = UnwrapException(ex);
+error = $"Render failed: {real.GetType().Name}: {real.Message}";
+Console.WriteLine($"[GoMainPage] Preflight render error: {error}");
+return null;
+}
+
+return candidate;
+}
+
+public override View Render()
+{
+// Auto-connect on first render if env var was set
+if (!_autoConnectAttempted && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MAUI_GO_SERVER")))
+{
+_autoConnectAttempted = true;
+_ = Task.Run(async () =>
+{
+await Task.Delay(500);
+Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(OnConnectTapped);
+});
+}
+
+if (State.IsConnected && State.UserView is not null)
+{
+if (State.ErrorMessage is not null)
+{
+// Show error overlay on top of user view — doesn't affect user layout
+return new ZStack
+{
+new VStack
+{
+State.UserView
+.FillHorizontal()
+.FillVertical()
+}
+.IgnoreSafeArea()
+.Padding(0)
+.Margin(0),
+
+new VStack(spacing: 0f)
+{
+new Spacer(),
+Text(State.ErrorMessage)
+.FontSize(12)
+.Color(Colors.White)
+.HorizontalTextAlignment(TextAlignment.Center)
+.Padding(new Thickness(16, 8))
+.Background(new SolidPaint(Color.FromArgb("#CC3333")))
+.Margin(new Thickness(20, 0, 20, 50))
+}
+.IgnoreSafeArea()
+};
+}
+
+return new VStack
+{
+State.UserView
+.FillHorizontal()
+.FillVertical()
+}
+.IgnoreSafeArea()
+.Padding(0)
+.Margin(0);
+}
+
+return RenderConnectScreen();
+}
+
+View RenderConnectScreen()
+{
+var bgColor = new Color(210, 188, 165);
+var accentColor = new Color(139, 90, 43);
+var textColor = new Color(60, 40, 20);
+var borderColor = new Color(120, 80, 40);
+
+return new VStack(spacing: 0)
+{
+new Spacer(),
+
+new Image("comet_logo")
+.Frame(width: 260, height: 87)
+.HorizontalLayoutAlignment(Microsoft.Maui.Primitives.LayoutAlignment.Center),
+
+new Spacer().Frame(height: 16),
+
+Text("Welcome to Comet Go")
+.FontSize(20)
+.Color(new Color(80, 55, 30))
+.HorizontalTextAlignment(TextAlignment.Center),
+
+new Spacer().Frame(height: 48),
+
+Button("Scan QR Code", OnScanQrTapped)
+.Color(Colors.White)
+.FontWeight(FontWeight.Bold)
+.FontSize(18)
+.Background(new SolidPaint(accentColor))
+.CornerRadius(14)
+.Frame(height: 56)
+.RoundedBorder(14, accentColor)
+.AutomationId("ScanQrButton"),
+
+new Spacer().Frame(height: 28),
+
+new HStack(spacing: 0)
+{
+new BoxView().Frame(height: 1).Background(new SolidPaint(borderColor)).VerticalLayoutAlignment(Primitives.LayoutAlignment.Center),
+Text("  or enter manually  ")
+.FontSize(13)
+.Color(new Color(100, 75, 50)),
+new BoxView().Frame(height: 1).Background(new SolidPaint(borderColor)).VerticalLayoutAlignment(Primitives.LayoutAlignment.Center),
+},
+
+new Spacer().Frame(height: 28),
+
+new TextField(new Signal<string>(State.ServerUrl), "ws://192.168.x.x:9000/maui-go")
+.OnTextChanged(url => SetState(s => s.ServerUrl = url))
+.Color(textColor)
+.FontSize(16)
+.Background(new SolidPaint(new Color(235, 220, 200)))
+.Padding(new Thickness(16, 14))
+.Frame(height: 56)
+.RoundedBorder(14, borderColor, 2)
+.AutomationId("ServerUrlField"),
+
+new Spacer().Frame(height: 16),
+
+Button("Connect", OnConnectTapped)
+.Color(accentColor)
+.FontSize(16)
+.FontWeight(FontWeight.Semibold)
+.Background(new SolidPaint(new Color(235, 220, 200)))
+.CornerRadius(14)
+.Frame(height: 56)
+.RoundedBorder(14, accentColor, 2)
+.AutomationId("ConnectButton"),
+
+new Spacer().Frame(height: 20),
+
+State.ErrorMessage is not null
+? Text(State.ErrorMessage)
+.FontSize(13)
+.Color(Colors.OrangeRed)
+.HorizontalTextAlignment(TextAlignment.Center)
+.AutomationId("StatusLabel")
+: (State.Status != "Enter server URL or scan QR code"
+? Text(State.Status)
+.FontSize(13)
+.Color(new Color(100, 80, 60))
+.HorizontalTextAlignment(TextAlignment.Center)
+.AutomationId("StatusLabel")
+: (View)new Spacer().Frame(height: 1)),
+
+new Spacer(),
+}
+.Padding(new Thickness(28))
+.Background(new SolidPaint(bgColor));
+}
+
+async void OnScanQrTapped()
+{
+try
+{
+var tcs = new TaskCompletionSource<string?>();
+var scannerPage = new QrScannerPage(tcs);
+
+if (!ModalPresenter.Present(scannerPage))
+{
+SetState(s => s.ErrorMessage = "Cannot open scanner on this platform");
+return;
+}
+
+var result = await tcs.Task;
+
+if (!string.IsNullOrEmpty(result))
+{
+SetState(s =>
+{
+s.ServerUrl = result;
+s.Status = "QR code scanned - connecting...";
+s.ErrorMessage = null;
+});
+OnConnectTapped();
+}
+}
+catch (Exception ex)
+{
+Console.WriteLine($"[QR] Error: {ex}");
+SetState(s => s.ErrorMessage = $"Scanner error: {ex.Message}");
+}
+}
+
+async void OnConnectTapped()
+{
+	try
 	{
-		// Auto-connect on first render if env var was set
-		if (!_autoConnectAttempted && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MAUI_GO_SERVER")))
+		// Validate the URL synchronously — any throw here would crash the app
+		// because async void doesn't surface exceptions to the caller.
+		var rawUrl = State.ServerUrl?.Trim() ?? "";
+		if (string.IsNullOrEmpty(rawUrl))
 		{
-			_autoConnectAttempted = true;
-			_ = Task.Run(async () =>
+			SetState(s =>
 			{
-				await Task.Delay(500);
-				Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(OnConnectTapped);
+				s.Status = "Enter a server URL or scan the QR code";
+				s.ErrorMessage = "Server URL is empty.";
 			});
+			return;
 		}
 
-		if (State.IsConnected && State.UserView is not null)
-			return RenderUserView();
+		// Auto-prepend ws:// if user typed just an IP/host
+		if (!rawUrl.Contains("://"))
+			rawUrl = "ws://" + rawUrl;
 
-		return RenderConnectScreen();
-	}
-
-	View RenderConnectScreen()
-	{
-		// Match splash screen background color
-		var bgColor = new Color(210, 188, 165); // #D2BCA5
-		var accentColor = new Color(139, 90, 43); // darker warm brown — good contrast on beige
-		var textColor = new Color(60, 40, 20); // dark brown
-		var borderColor = new Color(120, 80, 40); // visible brown border
-
-		return new VStack(spacing: 0)
+		if (!Uri.TryCreate(rawUrl, UriKind.Absolute, out var uri) ||
+			(uri.Scheme != "ws" && uri.Scheme != "wss"))
 		{
-			new Spacer(),
-
-			// Comet logo (same as splash screen — SVG rendered as PNG by Resizetizer)
-			new Image("comet_logo")
-				.Frame(width: 260, height: 87)
-				.HorizontalLayoutAlignment(Microsoft.Maui.Primitives.LayoutAlignment.Center),
-
-			new Spacer().Frame(height: 16),
-
-			// Welcome text
-			Text("Welcome to Comet Go")
-				.FontSize(20)
-				.Color(new Color(80, 55, 30))
-				.HorizontalTextAlignment(TextAlignment.Center),
-
-			new Spacer().Frame(height: 48),
-
-			// PRIMARY: Scan QR Code button — darker brown for contrast
-			Button("Scan QR Code", OnScanQrTapped)
-				.Color(Colors.White)
-				.FontWeight(FontWeight.Bold)
-				.FontSize(18)
-				.Background(new SolidPaint(accentColor))
-				.CornerRadius(14)
-				.Frame(height: 56)
-				.RoundedBorder(14, accentColor)
-				.AutomationId("ScanQrButton"),
-
-			new Spacer().Frame(height: 28),
-
-			// "or enter manually" divider with horizontal lines
-			new HStack(spacing: 0)
+			SetState(s =>
 			{
-				new BoxView().Frame(height: 1).Background(new SolidPaint(borderColor)).VerticalLayoutAlignment(Primitives.LayoutAlignment.Center),
-				Text("  or enter manually  ")
-					.FontSize(13)
-					.Color(new Color(100, 75, 50)),
-				new BoxView().Frame(height: 1).Background(new SolidPaint(borderColor)).VerticalLayoutAlignment(Primitives.LayoutAlignment.Center),
-			},
-
-			new Spacer().Frame(height: 28),
-
-			// Server URL input — outlined with visible brown border
-			new TextField(new Signal<string>(State.ServerUrl), "ws://192.168.x.x:9000/maui-go")
-				.OnTextChanged(url => SetState(s => s.ServerUrl = url))
-				.Color(textColor)
-				.FontSize(16)
-				.Background(new SolidPaint(new Color(235, 220, 200)))
-				.Padding(new Thickness(16, 14))
-				.Frame(height: 56)
-				.RoundedBorder(14, borderColor, 2)
-				.AutomationId("ServerUrlField"),
-
-			new Spacer().Frame(height: 16),
-
-			// SECONDARY: Connect button — outlined with brown border and text
-			Button("Connect", OnConnectTapped)
-				.Color(accentColor)
-				.FontSize(16)
-				.FontWeight(FontWeight.Semibold)
-				.Background(new SolidPaint(new Color(235, 220, 200)))
-				.CornerRadius(14)
-				.Frame(height: 56)
-				.RoundedBorder(14, accentColor, 2)
-				.AutomationId("ConnectButton"),
-
-			new Spacer().Frame(height: 20),
-
-			// Status / error text
-			State.ErrorMessage is not null
-				? Text(State.ErrorMessage)
-					.FontSize(13)
-					.Color(Colors.OrangeRed)
-					.HorizontalTextAlignment(TextAlignment.Center)
-					.AutomationId("StatusLabel")
-				: (State.Status != "Enter server URL or scan QR code"
-					? Text(State.Status)
-						.FontSize(13)
-						.Color(new Color(100, 80, 60))
-						.HorizontalTextAlignment(TextAlignment.Center)
-						.AutomationId("StatusLabel")
-					: (View)new Spacer().Frame(height: 1)),
-
-			new Spacer(),
-		}
-		.Padding(new Thickness(28))
-		.Background(new SolidPaint(bgColor));
-	}
-
-	View RenderUserView()
-	{
-		var children = new List<View>
-		{
-			// Status bar overlay
-			new HStack(spacing: 8)
-			{
-				Text($"Comet Go — {State.DeltasApplied} updates")
-					.FontSize(11)
-					.Color(Colors.White),
-
-				new Spacer(),
-
-				Button("X", OnDisconnectTapped)
-					.Color(Colors.White)
-					.Background(Colors.Transparent)
-					.FontSize(11)
-					.AutomationId("DisconnectButton"),
-			}
-			.Padding(new Thickness(16, 4))
-			.Background(new SolidPaint(new Color(139, 90, 43))),
-		};
-
-		// Show error/warning banner if present (simple text, no nested VStack)
-		if (State.ErrorMessage is not null)
-		{
-			children.Add(
-				Text(State.ErrorMessage)
-					.FontSize(12)
-					.Color(Colors.White)
-					.FontFamily("Courier New")
-					.Background(new SolidPaint(new Color(180, 40, 40)))
-					.Padding(new Thickness(12, 8))
-			);
+				s.Status = "Invalid server URL";
+				s.ErrorMessage = $"\"{rawUrl}\" isn't a valid ws:// or wss:// URL. Example: ws://192.168.0.10:9000/maui-go";
+			});
+			return;
 		}
 
-		// User's view fills the rest
-		children.Add(State.UserView!);
-
-		return new VStack(spacing: 0) { children.ToArray() };
-	}
-
-	async void OnScanQrTapped()
-	{
-		try
-		{
-			var tcs = new System.Threading.Tasks.TaskCompletionSource<string?>();
-			var scannerPage = new QrScannerPage(tcs);
-
-			if (!ModalPresenter.Present(scannerPage))
-			{
-				SetState(s => s.ErrorMessage = "Cannot open scanner on this platform");
-				return;
-			}
-
-			var result = await tcs.Task;
-
-			if (!string.IsNullOrEmpty(result))
-			{
-				SetState(s =>
-				{
-					s.ServerUrl = result;
-					s.Status = "QR code scanned - tap Connect";
-					s.ErrorMessage = null;
-				});
-			}
-		}
-		catch (Exception ex)
-		{
-			Console.WriteLine($"[QR] Error: {ex}");
-			SetState(s => s.ErrorMessage = $"Scanner error: {ex.Message}");
-		}
-	}
-
-	async void OnConnectTapped()
-	{
 		SetState(s =>
 		{
+			s.ServerUrl = rawUrl;
 			s.Status = "Connecting...";
 			s.ErrorMessage = null;
 		});
@@ -266,25 +330,26 @@ public class GoMainPage : Component<GoAppState>
 		_client.DeltaApplied += seq =>
 			Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
 			{
-				// Re-instantiate the user's view to pick up the updated method body.
 				if (_userViewType is not null)
 				{
-					try
+					var candidate = TryCreateUserView(_userViewType, out var error);
+					if (candidate is not null)
 					{
-						var newView = (Comet.View)Activator.CreateInstance(_userViewType)!;
+						_lastGoodView = candidate;
 						SetState(s =>
 						{
-							s.UserView = newView;
+							s.UserView = candidate;
 							s.DeltasApplied = seq;
-							s.ErrorMessage = null; // Clear any previous error
+							s.ErrorMessage = null;
 						});
 					}
-					catch (Exception ex)
+					else
 					{
+						// Keep showing last good view, show error as overlay
 						SetState(s =>
 						{
 							s.DeltasApplied = seq;
-							s.ErrorMessage = $"View update failed: {ex.Message}";
+							s.ErrorMessage = error;
 						});
 					}
 				}
@@ -307,57 +372,88 @@ public class GoMainPage : Component<GoAppState>
 			Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
 				SetState(s => s.ErrorMessage = $"Restart required: {reason}"));
 
-		await _client.ConnectAsync(State.ServerUrl);
+		await _client.ConnectAsync(rawUrl);
 	}
-
-	void OnDisconnectTapped()
+	catch (Exception ex)
 	{
-		_client?.Dispose();
-		_client = null;
+		// async void: if anything escapes here it crashes the app. Log + show inline.
+		Console.WriteLine($"[GoMainPage] Connect failed: {ex}");
 		SetState(s =>
 		{
-			s.IsConnected = false;
-			s.UserView = null;
-			s.DeltasApplied = 0;
-			s.Status = "Disconnected";
+			s.Status = "Connection failed";
+			s.ErrorMessage = ex.Message;
 		});
 	}
+}
 
-	/// <summary>
-	/// Finds the user's main Comet View in the loaded assembly and instantiates it.
-	/// Convention: looks for a class named "MainPage" inheriting from Comet.View.
-	/// </summary>
-	void LoadUserView(Assembly assembly)
-	{
-		var cometViewType = typeof(Comet.View);
+void OnDisconnectTapped()
+{
+_client?.Dispose();
+_client = null;
+_lastGoodView = null;
+SetState(s =>
+{
+s.IsConnected = false;
+s.UserView = null;
+s.DeltasApplied = 0;
+s.Status = "Disconnected";
+});
+}
 
-		// Find MainPage or first public View subclass
-		var viewType = assembly.GetExportedTypes()
-			.FirstOrDefault(t => t.Name == "MainPage" && cometViewType.IsAssignableFrom(t))
-			?? assembly.GetExportedTypes()
-				.FirstOrDefault(t => cometViewType.IsAssignableFrom(t) && !t.IsAbstract);
+/// <summary>
+/// Finds the user's main Comet View in the loaded assembly and instantiates it.
+/// Uses preflight to catch constructor/render errors before committing to state.
+/// </summary>
+void LoadUserView(Assembly assembly)
+{
+static bool IsCometView(Type t)
+{
+var current = t.BaseType;
+while (current is not null)
+{
+if (current.FullName == "Comet.View")
+return true;
+current = current.BaseType;
+}
+return false;
+}
 
-		if (viewType is null)
-		{
-			SetState(s => s.ErrorMessage = "No Comet View found in assembly. Create a class named 'MainPage' inheriting from Comet.View.");
-			return;
-		}
+var viewType = assembly.GetExportedTypes()
+.FirstOrDefault(t => t.Name == "MainPage" && IsCometView(t))
+?? assembly.GetExportedTypes()
+.FirstOrDefault(t => IsCometView(t) && !t.IsAbstract);
 
-		_userViewType = viewType;
+if (viewType is null)
+{
+SetState(s =>
+{
+s.ErrorMessage = "No Comet View found in assembly. Create a class named 'MainPage' inheriting from Comet.View.";
+s.IsConnected = true;
+});
+return;
+}
 
-		try
-		{
-			var view = (Comet.View)Activator.CreateInstance(viewType)!;
-			SetState(s =>
-			{
-				s.UserView = view;
-				s.IsConnected = true;
-				s.ErrorMessage = null;
-			});
-		}
-		catch (Exception ex)
-		{
-			SetState(s => s.ErrorMessage = $"Failed to instantiate {viewType.Name}: {ex.Message}");
-		}
-	}
+_userViewType = viewType;
+Console.WriteLine($"[GoMainPage] Found view type: {viewType.FullName}");
+
+var candidate = TryCreateUserView(viewType, out var error);
+if (candidate is not null)
+{
+_lastGoodView = candidate;
+SetState(s =>
+{
+s.UserView = candidate;
+s.IsConnected = true;
+s.ErrorMessage = null;
+});
+}
+else
+{
+SetState(s =>
+{
+s.IsConnected = true;
+s.ErrorMessage = error;
+});
+}
+}
 }

--- a/src/Go/CompanionApp/QrScannerPage.cs
+++ b/src/Go/CompanionApp/QrScannerPage.cs
@@ -16,8 +16,13 @@ namespace Microsoft.Maui.Go.CompanionApp;
 
 /// <summary>
 /// Full-screen camera QR code scanner page.
-/// Presented modally, returns the scanned URL via TaskCompletionSource.
+/// Presented modally via <see cref="ModalPresenter"/>, returns the scanned URL via TaskCompletionSource.
 /// </summary>
+/// <remarks>
+/// IMPORTANT: <c>ModalPresenter</c> presents this page by calling <c>ToHandler()</c> and pushing the
+/// raw <c>UIViewController</c>, which bypasses MAUI's Page lifecycle — <c>OnAppearing</c> never fires.
+/// Initialization runs from <c>HandlerChanged</c> instead.
+/// </remarks>
 public class QrScannerPage : ContentPage
 {
 	readonly TaskCompletionSource<string?> _tcs;
@@ -25,9 +30,9 @@ public class QrScannerPage : ContentPage
 	readonly Border _viewfinder;
 	readonly Border _statusBorder;
 	readonly Label _statusLabel;
+	bool _initStarted;
 	bool _scanned;
 
-	// Warm brown accent color (matches Comet Go theme)
 	static readonly Color AccentColor = Color.FromArgb("#D4A04A");
 	static readonly Color OverlayColor = Color.FromArgb("#AA281A0D");
 
@@ -37,6 +42,17 @@ public class QrScannerPage : ContentPage
 		Shell.SetNavBarIsVisible(this, false);
 		NavigationPage.SetHasNavigationBar(this, false);
 		BackgroundColor = Colors.Black;
+
+		// ModalPresenter bypasses MAUI's Page lifecycle (presents raw UIViewController),
+		// so OnAppearing never fires. HandlerChanged DOES fire when the platform handler attaches.
+		HandlerChanged += (_, _) =>
+		{
+			if (Handler is not null && !_initStarted)
+			{
+				_initStarted = true;
+				MainThread.BeginInvokeOnMainThread(() => _ = StartScannerAsync());
+			}
+		};
 
 		_barcodeReader = new CameraBarcodeReaderView
 		{
@@ -86,7 +102,6 @@ public class QrScannerPage : ContentPage
 			Content = _statusLabel,
 		};
 
-		// Corner accent marks (warm brown)
 		var cornersGrid = new Grid
 		{
 			HorizontalOptions = LayoutOptions.Center,
@@ -96,7 +111,6 @@ public class QrScannerPage : ContentPage
 		};
 		AddCornerAccents(cornersGrid);
 
-		// Top bar with close button and title
 		var closeButton = CreateCloseButton();
 		var titleLabel = new Label
 		{
@@ -122,7 +136,6 @@ public class QrScannerPage : ContentPage
 		topBar.Add(closeButton, 0);
 		topBar.Add(titleLabel, 1);
 
-		// Instruction BELOW viewfinder
 		var instructionLabel = new Label
 		{
 			Text = "Point your camera at the QR code\nshown by the dev server",
@@ -203,24 +216,29 @@ public class QrScannerPage : ContentPage
 		grid.Add(new BoxView { Color = AccentColor, WidthRequest = 3, HeightRequest = 36, HorizontalOptions = LayoutOptions.End, VerticalOptions = LayoutOptions.End });
 	}
 
-	protected override async void OnAppearing()
+	async Task StartScannerAsync()
 	{
-		base.OnAppearing();
-
-		var status = await Permissions.CheckStatusAsync<Permissions.Camera>();
-		if (status != PermissionStatus.Granted)
+		try
 		{
-			status = await Permissions.RequestAsync<Permissions.Camera>();
+			var status = await Permissions.CheckStatusAsync<Permissions.Camera>();
 			if (status != PermissionStatus.Granted)
 			{
-				_tcs.TrySetResult(null);
-				DismissScanner();
-				return;
+				status = await Permissions.RequestAsync<Permissions.Camera>();
+				if (status != PermissionStatus.Granted)
+				{
+					_tcs.TrySetResult(null);
+					DismissScanner();
+					return;
+				}
 			}
-		}
 
-		await Task.Delay(500);
-		_barcodeReader.IsDetecting = true;
+			await Task.Delay(500);
+			_barcodeReader.IsDetecting = true;
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"[QrScanner] StartScannerAsync error: {ex}");
+		}
 	}
 
 	protected override void OnDisappearing()
@@ -237,7 +255,6 @@ public class QrScannerPage : ContentPage
 		if (result is null) return;
 
 		_scanned = true;
-		Console.WriteLine($"[QrScanner] Scanned: {result.Value}");
 
 		MainThread.BeginInvokeOnMainThread(async () =>
 		{
@@ -245,7 +262,6 @@ public class QrScannerPage : ContentPage
 			{
 				_barcodeReader.IsDetecting = false;
 
-				// Flash viewfinder green
 				_viewfinder.Stroke = Color.FromArgb("#48bb78");
 				_statusLabel.Text = "QR Code detected";
 				_statusBorder.IsVisible = true;
@@ -256,7 +272,7 @@ public class QrScannerPage : ContentPage
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"[QrScanner] Error dismissing: {ex}");
+				Console.WriteLine($"[QrScanner] Dismiss error: {ex}");
 				_tcs.TrySetResult(result.Value);
 				try { DismissScanner(); } catch { }
 			}

--- a/src/Go/Directory.Build.props
+++ b/src/Go/Directory.Build.props
@@ -1,0 +1,51 @@
+<Project>
+
+  <!--
+    Go builds independently within maui-labs. It uses its own global.json
+    (targeting .NET 11 preview, see src/Go/global.json) so it can consume
+    Microsoft.Maui.Controls preview packages, and it does not yet integrate
+    with Arcade SDK. Full Arcade integration (signing, versioning, official
+    CI publishing) is a future step.
+
+    This file's main job is to STOP THE WALK: MSBuild walks up the directory
+    tree looking for Directory.Build.props and stops at the first one it
+    finds. Without this file, Go projects inherit the repo-root
+    Directory.Build.props which imports Microsoft.DotNet.Arcade.Sdk — and
+    Arcade can't be resolved alongside the .NET 11 preview SDK that Go uses.
+
+    See src/Comet/Directory.Build.props for the same pattern.
+  -->
+
+  <!--
+    Note: $(MicrosoftMauiControlsVersion) and other version variables are
+    provided by the repo-root Directory.Packages.props which imports
+    eng/Versions.props. The walk for Directory.Packages.props is independent
+    from Directory.Build.props, so it still applies to Go projects.
+  -->
+
+  <PropertyGroup>
+    <MauiVersion Condition="'$(MauiVersion)' == ''">$(MicrosoftMauiControlsVersion)</MauiVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Common settings (mirrored from repo root, without Arcade SDK import) -->
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <Copyright>.NET Foundation and Contributors</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <!-- Common SupportedOSPlatformVersion (matches CompanionApp targets) -->
+  <PropertyGroup>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">17.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">17.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/Go/Directory.Build.targets
+++ b/src/Go/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+  <!--
+    Empty stop-walk for Go. See Directory.Build.props in this folder for
+    full explanation. MSBuild walks up looking for Directory.Build.targets
+    and stops at the first one, so this file prevents Arcade SDK targets
+    from being applied to Go projects (which use the .NET 11 preview SDK).
+  -->
+</Project>

--- a/src/Go/README.md
+++ b/src/Go/README.md
@@ -35,37 +35,152 @@ It is to Comet what **Expo Go** is to React Native or **DartPad** is to Flutter:
 
 The wire format is documented inline in [`Shared/GoProtocol.cs`](Shared/GoProtocol.cs).
 
-## Quick start
+## Getting started
 
-See **[docs/getting-started.md](docs/getting-started.md)** for a full walkthrough. The short version:
+Comet Go is meant to feel like Expo Go for .NET MAUI: install one tool, install one companion app, write **one `.cs` file**, and watch it run.
+
+### 1. Install prerequisites
 
 ```bash
-# 1. Build the server
-dotnet build src/Go/Server/Microsoft.Maui.Go.Server.csproj -c Release
+# .NET 11 SDK preview (Comet targets net11.0)
+# Download from https://dotnet.microsoft.com/download/dotnet/11.0
 
-# 2. Build and deploy the companion app to a device or simulator
+# MAUI workload (only needed once, for the companion app)
+dotnet workload install maui
+
+# The maui CLI (provides `maui go`)
+# NOTE: not yet published to NuGet.org. Build and install from this repo:
+git clone https://github.com/dotnet/maui-labs.git
+cd maui-labs
+dotnet pack src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj -c Debug
+dotnet tool install -g --add-source ./artifacts/packages/Debug/Shipping Microsoft.Maui.Cli --prerelease
+```
+
+### 2. Install the companion app on a device or simulator
+
+The companion app is the on-device runtime that hosts your `.cs` file and applies live updates.
+
+```bash
+# iOS Simulator
+dotnet build src/Go/CompanionApp/Microsoft.Maui.Go.CompanionApp.csproj \
+    -t:Run -f net11.0-ios -c Debug
+
+# Mac Catalyst (runs on your dev Mac)
 dotnet build src/Go/CompanionApp/Microsoft.Maui.Go.CompanionApp.csproj \
     -t:Run -f net11.0-maccatalyst -c Debug
 
-# 3. Run the server against a folder containing a .cs file
-dotnet run --project src/Go/Server -c Release -- ./MyApp
+# Android Emulator
+dotnet build src/Go/CompanionApp/Microsoft.Maui.Go.CompanionApp.csproj \
+    -t:Run -f net11.0-android -c Debug
 ```
 
-Scan the QR code with the companion app, then start editing.
+> Pre-built companion app installers will ship with future previews. For now, build it once from this repo.
+
+### 3. Create your first app
+
+```bash
+maui go create Hello
+```
+
+That writes a single file, `Hello.cs`, in the current directory:
+
+```csharp
+#:package Comet
+
+using Comet;
+using Microsoft.Maui;
+using Microsoft.Maui.Graphics;
+using static Comet.CometControls;
+
+namespace Hello;
+
+public class MainPage : View
+{
+    readonly Reactive<int> count = new(0);
+
+    [Body]
+    View body() =>
+        VStack(20,
+            Text("Welcome to Hello!")
+                .FontSize(28)
+                .FontWeight(FontWeight.Bold)
+                .Color(Colors.Orange)
+                .HorizontalTextAlignment(TextAlignment.Center),
+
+            Text(() => $"Count: {count.Value}")
+                .FontSize(22)
+                .HorizontalTextAlignment(TextAlignment.Center),
+
+            Button("Tap me!", () => count.Value++)
+                .Color(Colors.White)
+                .Background(new SolidPaint(Colors.Orange))
+                .CornerRadius(12)
+                .Frame(height: 50),
+
+            Text("Edit this file and save -- the UI updates live!")
+                .FontSize(14)
+                .Color(Colors.Gray)
+                .HorizontalTextAlignment(TextAlignment.Center)
+        )
+        .Padding(new Thickness(32))
+        .Alignment(Alignment.Center);
+}
+```
+
+No `.csproj`. No `Program.cs`. No `MauiProgram.cs`. Just one file.
+
+### 4. Run it
+
+```bash
+maui go Hello.cs
+```
+
+You'll see something like:
+
+```
+Comet Go server listening on ws://192.168.1.42:9995/maui-go
+QR code: /var/folders/.../T/comet-go-qr.png
+Watching Hello.cs ...
+```
+
+The QR code PNG opens automatically in your image viewer (Preview on macOS, default image app on Windows/Linux). Open the companion app on your phone or simulator, tap **Scan QR Code**, point at the on-screen PNG — it will auto-fill and connect. (You can also paste the `ws://` URL manually.)
+
+### 5. Edit and save
+
+Open `Hello.cs` in any editor — VS Code, Cursor, Rider, vim — change a string, change a color, add a button. The moment you save, the server compiles a metadata/IL/PDB delta and pushes it over WebSocket; the companion app calls `MetadataUpdater.ApplyUpdate` and Comet re-renders. No rebuild, no reinstall.
+
+Press <kbd>Ctrl+C</kbd> in the terminal to stop the server.
+
+### Next steps
+
+- Read **[docs/getting-started.md](docs/getting-started.md)** for the longer walkthrough (manual companion-app connect, multiple devices, troubleshooting).
+- The **`comet-go` skill** at [`.github/skills/comet-go/SKILL.md`](../../.github/skills/comet-go/SKILL.md) is a complete reference for AI coding agents working in Comet Go (controls, state, fluent styling, hot-reload constraints, common mistakes).
+
+## File-based directives
+
+Comet Go uses [.NET file-based programs](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/file-based-programs). The `#:` lines at the top of a `.cs` file are pre-processor directives the dev server understands:
+
+| Directive | Purpose |
+|---|---|
+| `#:package Comet` | Resolve the `Comet` NuGet package. The server uses it to find the right reference assemblies. Optionally pin a version: `#:package Comet@1.0.0-preview`. |
+| `#:property PublishAot=false` | Pass an MSBuild property hint. Optional; useful when you need to override defaults. |
+| `#!/usr/bin/env dotnet` | Optional shebang — lets you `chmod +x Hello.cs` and run it directly on Unix. |
+
+The server strips these lines before compilation, preserving line numbers so error messages still point at the right place.
 
 ## Requirements
 
-- The **latest .NET 11 SDK preview** — `src/Go/global.json` pins the version with `rollForward: latestPrerelease`, mirroring Comet
-- The MAUI workload — `dotnet workload install maui`. The companion app targets `net11.0-*` and pulls in the .NET 11 runtime packs through the workload.
-- A device or simulator capable of running .NET MAUI apps (iOS Simulator, Android emulator, Mac Catalyst, or Windows)
-- The companion app **must run with `DOTNET_MODIFIABLE_ASSEMBLIES=Debug`** — already wired up in `GoApp.CreateMauiApp`
+- **.NET 11 SDK preview** — `src/Go/global.json` pins the version with `rollForward: latestPrerelease`, mirroring Comet.
+- **MAUI workload** — `dotnet workload install maui`. The companion app targets `net11.0-*` and pulls in the .NET 11 runtime packs through the workload.
+- **A device or simulator** — iOS Simulator, Android emulator, Mac Catalyst, or Windows.
+- **`DOTNET_MODIFIABLE_ASSEMBLIES=Debug`** — required so `MetadataUpdater` will accept deltas. Already wired up in `GoApp.CreateMauiApp`.
 
 ## Limitations
 
 - **Debug runtime only.** `MetadataUpdater` requires a debug-built CoreCLR / Mono runtime. Release builds will reject deltas.
-- **Edit-and-Continue rules apply.** Adding fields to existing types, changing method signatures, and editing generics often emit "rude edits" the runtime can't apply hot — the server logs these and the next save will recover.
-- **Single project.** The server compiles deltas for one `.csproj`; multi-project solutions and source-generated code aren't supported yet.
-- **No NuGet hot-add.** Reference changes in `.csproj` require a full rebuild.
+- **Edit-and-Continue rules apply.** Adding fields to existing types, changing method signatures, and editing generics often emit "rude edits" the runtime can't apply hot — the server logs these, the companion app shows an error banner, and the next save will recover.
+- **One file at a time.** The single-file flow compiles one `.cs` file (multi-file `.csproj` mode is also supported but not the default).
+- **No NuGet hot-add.** Adding a `#:package` line requires restarting `maui go`.
 
 ## Status and roadmap
 

--- a/src/Go/Server/DeltaCompiler.cs
+++ b/src/Go/Server/DeltaCompiler.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.Maui.Go;
 
 namespace Microsoft.Maui.Go.Server;
 
@@ -25,6 +26,7 @@ namespace Microsoft.Maui.Go.Server;
 public sealed class DeltaCompiler
 {
 	readonly string _projectDir;
+	readonly string? _singleFilePath;
 	readonly List<MetadataReference> _references;
 
 	CSharpCompilation? _currentCompilation;
@@ -36,10 +38,31 @@ public sealed class DeltaCompiler
 	public string AssemblyName { get; }
 	public byte[]? CurrentPe { get; private set; }
 	public byte[]? CurrentPdb { get; private set; }
+	public bool IsSingleFileMode => _singleFilePath is not null;
 
 	public DeltaCompiler(string projectDir, string assemblyName)
 	{
 		_projectDir = projectDir;
+		AssemblyName = assemblyName;
+		_references = ResolveReferences();
+	}
+
+	/// <summary>
+	/// Creates a DeltaCompiler in single-file mode.
+	/// The assembly name is derived from the file name.
+	/// </summary>
+	public static DeltaCompiler ForSingleFile(string csFilePath)
+	{
+		var fullPath = Path.GetFullPath(csFilePath);
+		var dir = Path.GetDirectoryName(fullPath)!;
+		var name = Path.GetFileNameWithoutExtension(fullPath);
+		return new DeltaCompiler(dir, name, fullPath);
+	}
+
+	DeltaCompiler(string projectDir, string assemblyName, string singleFilePath)
+	{
+		_projectDir = projectDir;
+		_singleFilePath = singleFilePath;
 		AssemblyName = assemblyName;
 		_references = ResolveReferences();
 	}
@@ -52,10 +75,11 @@ public sealed class DeltaCompiler
 		var sourceFiles = GetSourceFiles();
 		var syntaxTrees = sourceFiles
 			.Select(f => CSharpSyntaxTree.ParseText(
-				File.ReadAllText(f),
+				ReadSourceText(f),
 				CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
 				path: f,
 				encoding: System.Text.Encoding.UTF8))
+			.Append(CreateImplicitUsingsSyntaxTree())
 			.ToArray();
 
 		_currentCompilation = CSharpCompilation.Create(
@@ -155,10 +179,11 @@ public sealed class DeltaCompiler
 		var sourceFiles = GetSourceFiles();
 		var newTrees = sourceFiles
 			.Select(f => CSharpSyntaxTree.ParseText(
-				File.ReadAllText(f),
+				ReadSourceText(f),
 				CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
 				path: f,
 				encoding: System.Text.Encoding.UTF8))
+			.Append(CreateImplicitUsingsSyntaxTree())
 			.ToArray();
 
 		// Create new compilation
@@ -177,7 +202,8 @@ public sealed class DeltaCompiler
 			return new CompilationResult
 			{
 				Success = false,
-				Errors = errors.Select(FormatDiagnostic).ToList()
+				Errors = errors.Select(FormatDiagnostic).ToList(),
+				Diagnostics = errors.Select(ToStructuredDiagnostic).ToList()
 			};
 		}
 
@@ -229,7 +255,8 @@ public sealed class DeltaCompiler
 				return new CompilationResult
 				{
 					Success = true,
-					Errors = rudeEdits.Select(FormatDiagnostic).ToList()
+					Errors = rudeEdits.Select(FormatDiagnostic).ToList(),
+					Diagnostics = rudeEdits.Select(ToStructuredDiagnostic).ToList()
 				};
 			}
 
@@ -239,6 +266,10 @@ public sealed class DeltaCompiler
 				Errors = emitResult.Diagnostics
 					.Where(d => d.Severity == DiagnosticSeverity.Error)
 					.Select(FormatDiagnostic)
+					.ToList(),
+				Diagnostics = emitResult.Diagnostics
+					.Where(d => d.Severity == DiagnosticSeverity.Error)
+					.Select(ToStructuredDiagnostic)
 					.ToList()
 			};
 		}
@@ -318,7 +349,40 @@ public sealed class DeltaCompiler
 						edits.Add(new SemanticEdit(SemanticEditKind.Update, oldSymbol, newSymbol));
 					}
 				}
-				// Note: new methods in existing types may also need SemanticEditKind.Insert
+				else
+				{
+					// New method in existing type — this IS an edit
+					edits.Add(new SemanticEdit(SemanticEditKind.Insert, null, newSymbol));
+				}
+			}
+
+			// Compare constructors
+			var newCtors = newRoot.DescendantNodes().OfType<ConstructorDeclarationSyntax>().ToArray();
+			var oldCtors = oldRoot.DescendantNodes().OfType<ConstructorDeclarationSyntax>()
+				.ToDictionary(c => GetConstructorKey(oldModel, c));
+
+			foreach (var newCtor in newCtors)
+			{
+				var newSymbol = newModel.GetDeclaredSymbol(newCtor);
+				if (newSymbol is null) continue;
+
+				var key = GetConstructorKey(newModel, newCtor);
+
+				if (oldCtors.TryGetValue(key, out var oldCtor))
+				{
+					var oldBody = oldCtor.Body?.ToFullString() ?? oldCtor.ExpressionBody?.ToFullString() ?? "";
+					var newBody = newCtor.Body?.ToFullString() ?? newCtor.ExpressionBody?.ToFullString() ?? "";
+
+					if (oldBody != newBody)
+					{
+						var oldSymbol = oldModel.GetDeclaredSymbol(oldCtor);
+						edits.Add(new SemanticEdit(SemanticEditKind.Update, oldSymbol, newSymbol));
+					}
+				}
+				else
+				{
+					edits.Add(new SemanticEdit(SemanticEditKind.Insert, null, newSymbol));
+				}
 			}
 
 			// Compare properties (auto-properties with expression bodies)
@@ -345,6 +409,48 @@ public sealed class DeltaCompiler
 					}
 				}
 			}
+
+			// Compare field initializers
+			var newFields = newRoot.DescendantNodes().OfType<FieldDeclarationSyntax>().ToArray();
+			var oldFields = oldRoot.DescendantNodes().OfType<FieldDeclarationSyntax>()
+				.ToDictionary(f => GetFieldKey(oldModel, f));
+
+			foreach (var newField in newFields)
+			{
+				var key = GetFieldKey(newModel, newField);
+
+				if (oldFields.TryGetValue(key, out var oldField))
+				{
+					var oldText = oldField.ToFullString();
+					var newText = newField.ToFullString();
+
+					if (oldText != newText)
+					{
+						// Field initializer changed — update the containing type's constructor
+						var containingType = newField.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+						if (containingType is not null)
+						{
+							var typeSymbol = newModel.GetDeclaredSymbol(containingType);
+							if (typeSymbol is INamedTypeSymbol namedType)
+							{
+								// Find the instance constructor (or static constructor for static fields)
+								var isStatic = newField.Modifiers.Any(SyntaxKind.StaticKeyword);
+								var ctorSymbol = namedType.Constructors
+									.FirstOrDefault(c => c.IsStatic == isStatic);
+								if (ctorSymbol is not null)
+								{
+									var oldTypeSymbol = oldSymbols.TryGetValue(
+										typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), out var ots)
+										? ots as INamedTypeSymbol : null;
+									var oldCtorSymbol = oldTypeSymbol?.Constructors
+										.FirstOrDefault(c => c.IsStatic == isStatic);
+									edits.Add(new SemanticEdit(SemanticEditKind.Update, oldCtorSymbol, ctorSymbol));
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 
 		return edits;
@@ -356,10 +462,35 @@ public sealed class DeltaCompiler
 		return symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? method.Identifier.Text;
 	}
 
+	static string GetConstructorKey(SemanticModel model, ConstructorDeclarationSyntax ctor)
+	{
+		var symbol = model.GetDeclaredSymbol(ctor);
+		return symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? ctor.Identifier.Text;
+	}
+
 	static string GetPropertyKey(SemanticModel model, PropertyDeclarationSyntax prop)
 	{
 		var symbol = model.GetDeclaredSymbol(prop);
 		return symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? prop.Identifier.Text;
+	}
+
+	static string GetFieldKey(SemanticModel model, FieldDeclarationSyntax field)
+	{
+		var variable = field.Declaration.Variables.FirstOrDefault();
+		if (variable is null) return field.ToFullString();
+		var symbol = model.GetDeclaredSymbol(variable);
+		return symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? variable.Identifier.Text;
+	}
+
+	static SyntaxTree CreateImplicitUsingsSyntaxTree()
+	{
+		return CSharpSyntaxTree.ParseText(
+			"global using System;\n" +
+			"global using System.Linq;\n" +
+			"global using System.Collections.Generic;\n",
+			CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
+			path: "__implicit_usings.cs",
+			encoding: System.Text.Encoding.UTF8);
 	}
 
 	static void CollectSymbols(CSharpCompilation compilation, Dictionary<string, ISymbol> symbols)
@@ -383,142 +514,202 @@ public sealed class DeltaCompiler
 	}
 
 	string[] GetSourceFiles()
-		=> Directory.GetFiles(_projectDir, "*.cs", SearchOption.AllDirectories)
+	{
+		if (_singleFilePath is not null)
+			return [_singleFilePath];
+
+		return Directory.GetFiles(_projectDir, "*.cs", SearchOption.AllDirectories)
 			.Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") &&
 						!f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
 			.ToArray();
+	}
+
+	/// <summary>
+	/// Reads source text from a file, replacing file-based app directives (#: and #!)
+	/// with blank lines to preserve line number mapping for diagnostics.
+	/// </summary>
+	static string ReadSourceText(string filePath)
+	{
+		var lines = File.ReadAllLines(filePath);
+		var inDirectiveBlock = true;
+		for (var i = 0; i < lines.Length; i++)
+		{
+			if (!inDirectiveBlock) break;
+
+			var trimmed = lines[i].TrimStart();
+			if (trimmed.StartsWith("#:") || trimmed.StartsWith("#!"))
+				lines[i] = ""; // blank line preserves line numbers
+			else if (trimmed.Length == 0)
+				continue; // blank lines between directives are fine
+			else
+				inDirectiveBlock = false; // first real code line ends directive block
+		}
+		return string.Join(Environment.NewLine, lines);
+	}
 
 	List<MetadataReference> ResolveReferences()
 	{
 		var refs = new List<MetadataReference>();
 		var loadedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-		// Strategy: find pre-built Comet + MAUI reference assemblies from Comet.Tests output.
-		// This directory contains BOTH framework types (Comet, MAUI, Extensions) AND BCL types
-		// (System.*, Microsoft.*) all at the correct net11.0 version. Using these avoids
-		// version mismatches with the dev server's own runtime (which may be net10.0).
-		var refAssemblies = FindReferenceAssemblies();
-		var hasFrameworkRefs = refAssemblies.Count > 0;
+		// Step 1: Resolve Comet + MAUI from NuGet package cache
+		var nugetDlls = FindNuGetReferenceAssemblies();
 
-		foreach (var dll in refAssemblies)
+		foreach (var dll in nugetDlls)
 		{
 			if (loadedPaths.Add(dll))
 			{
 				try { refs.Add(MetadataReference.CreateFromFile(dll)); }
-				catch { /* Skip assemblies that can't be loaded as metadata references */ }
-			}
-		}
-
-		// Only add process runtime BCL assemblies if we don't have a complete ref set
-		// (the Comet.Tests output already includes all needed BCL assemblies)
-		if (!hasFrameworkRefs)
-		{
-			var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-			foreach (var dll in Directory.GetFiles(runtimeDir, "*.dll"))
-			{
-				if (loadedPaths.Add(dll))
-				{
-					try { refs.Add(MetadataReference.CreateFromFile(dll)); }
-					catch { }
-				}
-			}
-		}
-
-		return refs;
-	}
-
-	/// <summary>
-	/// Finds Comet + MAUI reference assemblies for compilation.
-	/// Searches in priority order:
-	///   1. Comet.Tests build output (has net11.0 plain TFM with all transitive refs)
-	///   2. Companion app artifacts
-	///   3. Comet src build output (platform-specific, may work for compilation)
-	/// Also includes .NET SDK ref pack assemblies (System.Runtime, etc.)
-	/// </summary>
-	List<string> FindReferenceAssemblies()
-	{
-		var dlls = new List<string>();
-
-		// Walk up from project dir to find the repo root
-		var repoRoot = FindRepoRoot(_projectDir);
-		if (repoRoot is null)
-		{
-			Console.Write("(no repo root found, using runtime refs only)... ");
-			return dlls;
-		}
-
-		// Step 1: Find Comet + MAUI assemblies from Comet.Tests output
-		var cometTestsOutput = Path.Combine(repoRoot, "src", "Comet", "tests", "Comet.Tests", "bin");
-		var testDirs = new[]
-		{
-			Path.Combine(cometTestsOutput, "Release", "net11.0"),
-			Path.Combine(cometTestsOutput, "Debug", "net11.0"),
-		};
-
-		string? foundDir = null;
-		foreach (var dir in testDirs)
-		{
-			if (!Directory.Exists(dir)) continue;
-			var cometDll = Path.Combine(dir, "Comet.dll");
-			if (!File.Exists(cometDll)) continue;
-
-			foreach (var dll in Directory.GetFiles(dir, "*.dll"))
-			{
-				var name = Path.GetFileNameWithoutExtension(dll);
-				if (name.Contains("Tests") || name.Contains("xunit") || name.Contains("nunit") ||
-					name.Contains("testhost") || name.Contains("TestPlatform") || name.Contains("CodeCoverage"))
-					continue;
-				dlls.Add(dll);
-			}
-
-			if (dlls.Count > 0)
-			{
-				foundDir = dir;
-				break;
-			}
-		}
-
-		if (foundDir is null)
-		{
-			// Try building Comet.Tests
-			Console.Write("building Comet.Tests for references... ");
-			var cometTestsProj = Path.Combine(repoRoot, "src", "Comet", "tests", "Comet.Tests", "Comet.Tests.csproj");
-			if (File.Exists(cometTestsProj))
-			{
-				var psi = new ProcessStartInfo("dotnet", $"build \"{cometTestsProj}\" -c Release -f net11.0 --nologo --verbosity quiet")
-				{
-					RedirectStandardOutput = true,
-					RedirectStandardError = true,
-					UseShellExecute = false,
-				};
-				using var proc = Process.Start(psi);
-				proc?.StandardOutput.ReadToEnd();
-				proc?.StandardError.ReadToEnd();
-				proc?.WaitForExit(180_000);
-
-				if (proc?.ExitCode == 0)
-				{
-					var outputDir = Path.Combine(cometTestsOutput, "Release", "net11.0");
-					if (Directory.Exists(outputDir))
-					{
-						foreach (var dll in Directory.GetFiles(outputDir, "*.dll"))
-						{
-							var name = Path.GetFileNameWithoutExtension(dll);
-							if (!name.Contains("Tests") && !name.Contains("xunit") && !name.Contains("nunit") &&
-								!name.Contains("testhost") && !name.Contains("TestPlatform") && !name.Contains("CodeCoverage"))
-								dlls.Add(dll);
-						}
-					}
-				}
+				catch { }
 			}
 		}
 
 		// Step 2: Add .NET SDK ref pack assemblies (System.Runtime, System.Collections, etc.)
-		var sdkRefDlls = FindSdkRefPackAssemblies("net11.0");
-		dlls.AddRange(sdkRefDlls);
+		var sdkDlls = FindSdkRefPackAssemblies("net11.0");
+		foreach (var dll in sdkDlls)
+		{
+			if (loadedPaths.Add(dll))
+			{
+				try { refs.Add(MetadataReference.CreateFromFile(dll)); }
+				catch { }
+			}
+		}
 
-		Console.Write($"({dlls.Count} refs)... ");
+		Console.Write($"({refs.Count} refs)... ");
+		return refs;
+	}
+
+	/// <summary>
+	/// Resolves Comet and MAUI reference assemblies from the NuGet package cache.
+	/// Looks for packages in ~/.nuget/packages/ by name, picking the best available
+	/// TFM (prefer net11.0, fall back to any platform TFM like net11.0-maccatalyst).
+	/// </summary>
+	List<string> FindNuGetReferenceAssemblies()
+	{
+		var dlls = new List<string>();
+		var nugetRoot = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+			".nuget", "packages");
+
+		if (!Directory.Exists(nugetRoot))
+			return dlls;
+
+		// Parse #:package directives from source file (if single-file mode)
+		var requestedPackages = new List<(string Name, string? Version)>();
+		if (_singleFilePath is not null && File.Exists(_singleFilePath))
+		{
+			foreach (var line in File.ReadLines(_singleFilePath))
+			{
+				var trimmed = line.TrimStart();
+				if (trimmed.StartsWith("#:package "))
+				{
+					var spec = trimmed["#:package ".Length..].Trim();
+					var parts = spec.Split('@', 2);
+					requestedPackages.Add((parts[0], parts.Length > 1 ? parts[1] : null));
+				}
+				else if (!trimmed.StartsWith("#:") && !trimmed.StartsWith("#!") && trimmed.Length > 0)
+					break; // past directive block
+			}
+		}
+
+		// Always include Comet and its MAUI dependencies
+		string[] requiredPackages =
+		[
+			"Comet",
+			"Microsoft.Maui.Core",
+			"Microsoft.Maui.Controls",
+			"Microsoft.Maui.Graphics",
+			"Microsoft.Maui.Essentials",
+		];
+
+		foreach (var pkgName in requiredPackages)
+		{
+			var pkgDir = Path.Combine(nugetRoot, pkgName.ToLowerInvariant());
+			if (!Directory.Exists(pkgDir)) continue;
+
+			// Find the requested version or latest available
+			var requestedVersion = requestedPackages
+				.FirstOrDefault(p => string.Equals(p.Name, pkgName, StringComparison.OrdinalIgnoreCase))
+				.Version;
+
+			var dll = FindBestDllFromPackage(pkgDir, requestedVersion);
+			if (dll is not null)
+				dlls.Add(dll);
+		}
+
 		return dlls;
+	}
+
+	/// <summary>
+	/// Finds the best DLL from a NuGet package directory.
+	/// Prefers: requested version > latest preview.3 > latest version.
+	/// For TFM: prefers net11.0 > net11.0-maccatalyst > any net11.0-* > net10.0-*.
+	/// </summary>
+	static string? FindBestDllFromPackage(string packageDir, string? requestedVersion)
+	{
+		// Find the version directory
+		string? versionDir = null;
+
+		if (requestedVersion is not null)
+		{
+			var candidate = Path.Combine(packageDir, requestedVersion);
+			if (Directory.Exists(candidate))
+				versionDir = candidate;
+		}
+
+		if (versionDir is null)
+		{
+			// Pick the latest version, preferring preview.3 for .NET 11
+			var versions = Directory.GetDirectories(packageDir)
+				.Select(Path.GetFileName)
+				.Where(v => v is not null)
+				.OrderByDescending(v => v!.Contains("preview.3") ? 1 : 0)
+				.ThenByDescending(v => v)
+				.ToArray();
+
+			foreach (var ver in versions)
+			{
+				var candidate = Path.Combine(packageDir, ver!);
+				if (Directory.Exists(Path.Combine(candidate, "lib")))
+				{
+					versionDir = candidate;
+					break;
+				}
+			}
+		}
+
+		if (versionDir is null) return null;
+
+		var libDir = Path.Combine(versionDir, "lib");
+		if (!Directory.Exists(libDir)) return null;
+
+		// Find the best TFM directory
+		var tfmDirs = Directory.GetDirectories(libDir)
+			.Select(Path.GetFileName)
+			.Where(d => d is not null)
+			.ToArray();
+
+		// Priority: net11.0 (plain) > net11.0-ios* > net11.0-maccatalyst* > any net11.0-* > net10.0-* > netstandard*
+		// Prefer ios since the companion app typically runs on iOS simulator
+		// Only include TFMs that actually exist in the package
+		var tfmPriority = new List<string>();
+		if (tfmDirs.Contains("net11.0")) tfmPriority.Add("net11.0");
+		tfmPriority.AddRange(tfmDirs.Where(d => d!.StartsWith("net11.0-ios")).OrderByDescending(d => d)!);
+		tfmPriority.AddRange(tfmDirs.Where(d => d!.StartsWith("net11.0-maccatalyst")).OrderByDescending(d => d)!);
+		tfmPriority.AddRange(tfmDirs.Where(d => d!.StartsWith("net11.0-") && !d!.StartsWith("net11.0-ios") && !d!.StartsWith("net11.0-maccatalyst")).OrderByDescending(d => d)!);
+		tfmPriority.AddRange(tfmDirs.Where(d => d!.StartsWith("net10.0")).OrderByDescending(d => d)!);
+		tfmPriority.AddRange(tfmDirs.Where(d => d!.StartsWith("netstandard")).OrderByDescending(d => d)!);
+
+		foreach (var tfm in tfmPriority)
+		{
+			var tfmDir = Path.Combine(libDir, tfm!);
+			if (!Directory.Exists(tfmDir)) continue;
+			var dllFiles = Directory.GetFiles(tfmDir, "*.dll");
+			if (dllFiles.Length > 0)
+				return dllFiles[0];
+		}
+
+		return null;
 	}
 
 	/// <summary>
@@ -567,25 +758,49 @@ public sealed class DeltaCompiler
 		return dlls;
 	}
 
-	static string? FindRepoRoot(string startDir)
-	{
-		var dir = new DirectoryInfo(startDir);
-		while (dir is not null)
-		{
-			if (File.Exists(Path.Combine(dir.FullName, "MauiLabs.slnx")) ||
-				(Directory.Exists(Path.Combine(dir.FullName, ".git")) &&
-				 Directory.Exists(Path.Combine(dir.FullName, "src", "Comet"))))
-				return dir.FullName;
-			dir = dir.Parent;
-		}
-		return null;
-	}
-
 	static string FormatDiagnostic(Diagnostic d)
 	{
 		var location = d.Location.GetLineSpan();
 		var file = Path.GetFileName(location.Path);
-		return $"{file}({location.StartLinePosition.Line + 1},{location.StartLinePosition.Character + 1}): {d.Id}: {d.GetMessage()}";
+		var formatted = $"{file}({location.StartLinePosition.Line + 1},{location.StartLinePosition.Character + 1}): {d.Id}: {d.GetMessage()}";
+		return formatted + AddHint(d);
+	}
+
+	/// <summary>
+	/// Post-processes common Roslyn diagnostics to add actionable hints for Comet users.
+	/// </summary>
+	static string AddHint(Diagnostic d)
+	{
+		var msg = d.GetMessage();
+		return d.Id switch
+		{
+			"CS0121" when msg.Contains("VStack") || msg.Contains("HStack")
+				=> "\nHint: Use named arg, e.g. VStack(spacing: 0f, ...)",
+			"CS0117" when msg.Contains("FontWeight")
+				=> "\nHint: Available values: Bold, Regular, Light, Medium, Heavy, Thin",
+			"CS1503" when msg.Contains("method group") && msg.Contains("Action")
+				=> "\nHint: Wrap in lambda, e.g. () => Method()",
+			"CS0246" when msg.Contains("Action") || msg.Contains("Func")
+				=> "\nHint: Add 'using System;'",
+			_ => ""
+		};
+	}
+
+	/// <summary>
+	/// Extracts structured diagnostic fields from a Roslyn diagnostic.
+	/// </summary>
+	internal static CompilationDiagnostic ToStructuredDiagnostic(Diagnostic d)
+	{
+		var location = d.Location.GetLineSpan();
+		return new CompilationDiagnostic
+		{
+			Id = d.Id,
+			Message = FormatDiagnostic(d),
+			FilePath = location.Path ?? "",
+			Line = location.StartLinePosition.Line + 1,
+			Column = location.StartLinePosition.Character + 1,
+			Severity = d.Severity.ToString(),
+		};
 	}
 }
 
@@ -626,6 +841,8 @@ public sealed class CompilationResult
 {
 	public bool Success { get; init; }
 	public List<string> Errors { get; init; } = [];
+	/// <summary>Structured diagnostics from Roslyn (populated for compilation errors).</summary>
+	public List<CompilationDiagnostic> Diagnostics { get; init; } = [];
 	public byte[]? Pe { get; init; }
 	public byte[]? Pdb { get; init; }
 	public byte[]? MetadataDelta { get; init; }

--- a/src/Go/Server/GoDevServer.cs
+++ b/src/Go/Server/GoDevServer.cs
@@ -261,7 +261,7 @@ public static class GoDevServer
 		};
 
 		// Debounce: wait for writes to settle
-		var debounceTimer = new System.Timers.Timer(300) { AutoReset = false };
+		using var debounceTimer = new System.Timers.Timer(300) { AutoReset = false };
 		var pendingFiles = new HashSet<string>();
 		var pendingLock = new Lock();
 
@@ -320,7 +320,7 @@ public static class GoDevServer
 			EnableRaisingEvents = true,
 		};
 
-		var debounceTimer = new System.Timers.Timer(300) { AutoReset = false };
+		using var debounceTimer = new System.Timers.Timer(300) { AutoReset = false };
 
 		debounceTimer.Elapsed += async (_, _) =>
 		{
@@ -537,7 +537,7 @@ public static class GoDevServer
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
 			};
-			System.Diagnostics.Process.Start(psi);
+			using var _ = System.Diagnostics.Process.Start(psi);
 		}
 		catch
 		{

--- a/src/Go/Server/GoDevServer.cs
+++ b/src/Go/Server/GoDevServer.cs
@@ -21,10 +21,12 @@ public static class GoDevServer
 	static DeltaCompiler? _compiler;
 	static int _sequence;
 	static string? _projectDir;
+	static string? _singleFilePath;
 
 	public static async Task<int> RunAsync(string projectDir, int port, bool showQr, CancellationToken ct)
 	{
 		_projectDir = Path.GetFullPath(projectDir);
+		_singleFilePath = null;
 
 		// Discover project
 		var csproj = Directory.GetFiles(_projectDir, "*.csproj").FirstOrDefault();
@@ -35,20 +37,49 @@ public static class GoDevServer
 		}
 
 		var projectName = Path.GetFileNameWithoutExtension(csproj);
+
+		_compiler = new DeltaCompiler(_projectDir, projectName);
+		return await RunCoreAsync(projectName, _projectDir, port, showQr, ct);
+	}
+
+	/// <summary>
+	/// Runs in single-file mode — watches and compiles a single .cs file.
+	/// </summary>
+	public static async Task<int> RunSingleFileAsync(string csFilePath, int port, bool showQr, CancellationToken ct)
+	{
+		var fullPath = Path.GetFullPath(csFilePath);
+		if (!File.Exists(fullPath))
+		{
+			Console.Error.WriteLine($"File not found: {fullPath}");
+			return 1;
+		}
+
+		_singleFilePath = fullPath;
+		_projectDir = Path.GetDirectoryName(fullPath)!;
+
+		var projectName = Path.GetFileNameWithoutExtension(fullPath);
+
+		_compiler = DeltaCompiler.ForSingleFile(fullPath);
+		return await RunCoreAsync(projectName, fullPath, port, showQr, ct);
+	}
+
+	static async Task<int> RunCoreAsync(string projectName, string displayPath, int port, bool showQr, CancellationToken ct)
+	{
+		var mode = _singleFilePath is not null ? "single-file" : "project";
 		Console.WriteLine();
 		Console.WriteLine("╔══════════════════════════════════════════════════════════╗");
 		Console.WriteLine("║           Comet Go Dev Server                            ║");
 		Console.WriteLine("╚══════════════════════════════════════════════════════════╝");
 		Console.WriteLine();
+		Console.WriteLine($"  Mode:     {mode}");
 		Console.WriteLine($"  Project:  {projectName}");
-		Console.WriteLine($"  Path:     {_projectDir}");
+		Console.WriteLine($"  Path:     {displayPath}");
 		Console.WriteLine($"  Port:     {port}");
 
 		// Initialize the incremental compiler
 		Console.WriteLine();
 		Console.Write("  Compiling initial assembly...");
-		_compiler = new DeltaCompiler(_projectDir, projectName);
-		var initResult = _compiler.CompileInitial();
+		var initResult = _compiler!.CompileInitial();
 
 		if (!initResult.Success)
 		{
@@ -96,7 +127,9 @@ public static class GoDevServer
 		var acceptTask = AcceptClientsAsync(httpListener, projectName, ct);
 
 		// Start file watcher
-		var watcherTask = WatchFilesAsync(ct);
+		var watcherTask = _singleFilePath is not null
+			? WatchSingleFileAsync(_singleFilePath, ct)
+			: WatchFilesAsync(ct);
 
 		// Keepalive
 		var pingTask = PingLoopAsync(ct);
@@ -168,13 +201,36 @@ public static class GoDevServer
 			});
 			await ws.SendAsync(welcome, WebSocketMessageType.Binary, true, ct);
 
-			// Send initial assembly
+			// Send initial assembly — recompile from current source for reconnecting
+			// clients so they get latest code, not stale startup assembly.
+			byte[] peToSend, pdbToSend;
+			if (_sequence > 0)
+			{
+				var freshCompiler = _singleFilePath is not null
+					? DeltaCompiler.ForSingleFile(_singleFilePath)
+					: new DeltaCompiler(_projectDir!, _compiler.AssemblyName);
+				var freshResult = freshCompiler.CompileInitial();
+				if (freshResult.Success && freshResult.Pe is not null)
+				{
+					peToSend = freshResult.Pe;
+					pdbToSend = freshResult.Pdb!;
+					Console.WriteLine($"  Recompiled fresh assembly for reconnect ({peToSend.Length} bytes)");
+				}
+				else
+				{
+					peToSend = _compiler.CurrentPe!;
+					pdbToSend = _compiler.CurrentPdb!;
+				}
+			}
+			else
+			{
+				peToSend = _compiler.CurrentPe!;
+				pdbToSend = _compiler.CurrentPdb!;
+			}
 			var initFrame = GoProtocol.EncodeInitialAssembly(
-				_compiler.AssemblyName,
-				_compiler.CurrentPe!,
-				_compiler.CurrentPdb!);
+				_compiler.AssemblyName, peToSend, pdbToSend);
 			await ws.SendAsync(initFrame, WebSocketMessageType.Binary, true, ct);
-			Console.WriteLine($"  Sent initial assembly ({_compiler.CurrentPe!.Length} bytes)");
+			Console.WriteLine($"  Sent initial assembly ({peToSend.Length} bytes)");
 
 			// Keep reading (for pong responses, future commands)
 			while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
@@ -247,6 +303,51 @@ public static class GoDevServer
 		await Task.Delay(Timeout.Infinite, ct);
 	}
 
+	/// <summary>
+	/// Watches a single .cs file for changes. Handles Changed and Renamed events
+	/// since many editors save via temp-file + rename.
+	/// </summary>
+	static async Task WatchSingleFileAsync(string filePath, CancellationToken ct)
+	{
+		var dir = Path.GetDirectoryName(filePath)!;
+		var fileName = Path.GetFileName(filePath);
+
+		using var watcher = new FileSystemWatcher(dir)
+		{
+			Filter = fileName,
+			IncludeSubdirectories = false,
+			NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+			EnableRaisingEvents = true,
+		};
+
+		var debounceTimer = new System.Timers.Timer(300) { AutoReset = false };
+
+		debounceTimer.Elapsed += async (_, _) =>
+		{
+			await CompileAndPushDelta([filePath]);
+		};
+
+		void OnFileChanged(object sender, FileSystemEventArgs e)
+		{
+			debounceTimer.Stop();
+			debounceTimer.Start();
+		}
+
+		watcher.Changed += OnFileChanged;
+		watcher.Created += OnFileChanged;
+		watcher.Renamed += (_, e) =>
+		{
+			// Editors save via temp+rename — if the target is our file, trigger
+			if (string.Equals(e.Name, fileName, StringComparison.OrdinalIgnoreCase))
+			{
+				debounceTimer.Stop();
+				debounceTimer.Start();
+			}
+		};
+
+		await Task.Delay(Timeout.Infinite, ct);
+	}
+
 	static async Task CompileAndPushDelta(string[] changedFiles)
 	{
 		var relativePaths = changedFiles
@@ -264,11 +365,13 @@ public static class GoDevServer
 			// Send compilation errors to clients
 			var errorMsg = GoProtocol.EncodeJson(GoMessageType.CompilationError, new CompilationErrorMessage
 			{
-				Errors = result.Errors.Select(e => new CompilationDiagnostic
-				{
-					Message = e,
-					Severity = "Error",
-				}).ToList()
+				Errors = result.Diagnostics.Count > 0
+					? result.Diagnostics
+					: result.Errors.Select(e => new CompilationDiagnostic
+					{
+						Message = e,
+						Severity = "Error",
+					}).ToList()
 			});
 
 			await BroadcastAsync(errorMsg);
@@ -314,12 +417,25 @@ public static class GoDevServer
 		lock (_clientsLock)
 			clients = [.. _clients];
 
-		var tasks = clients
-			.Where(ws => ws.State == WebSocketState.Open)
-			.Select(ws => ws.SendAsync(frame, WebSocketMessageType.Binary, true, CancellationToken.None));
+		var deadClients = new List<WebSocket>();
 
-		try { await Task.WhenAll(tasks); }
-		catch (WebSocketException) { }
+		foreach (var ws in clients)
+		{
+			if (ws.State != WebSocketState.Open)
+			{
+				deadClients.Add(ws);
+				continue;
+			}
+			try { await ws.SendAsync(frame, WebSocketMessageType.Binary, true, CancellationToken.None); }
+			catch (WebSocketException) { deadClients.Add(ws); }
+		}
+
+		if (deadClients.Count > 0)
+		{
+			lock (_clientsLock)
+				foreach (var ws in deadClients)
+					_clients.Remove(ws);
+		}
 	}
 
 	static async Task PingLoopAsync(CancellationToken ct)
@@ -357,14 +473,75 @@ public static class GoDevServer
 		try
 		{
 			var qrGenerator = new QRCoder.QRCodeGenerator();
-			var qrData = qrGenerator.CreateQrCode(url, QRCoder.QRCodeGenerator.ECCLevel.L);
+			// Use M (medium) error correction so partial obstructions / camera glare still scan.
+			var qrData = qrGenerator.CreateQrCode(url, QRCoder.QRCodeGenerator.ECCLevel.M);
+
+			// Generate a real PNG with guaranteed-square modules and write it
+			// to a temp file. Terminal-rendered ASCII QRs depend on the
+			// terminal's character aspect ratio (which varies by font and
+			// terminal app) — modules can stretch and become unscannable.
+			// A PNG sidesteps the problem entirely.
+			var pngBytes = new QRCoder.PngByteQRCode(qrData).GetGraphic(20);
+			var pngPath = Path.Combine(Path.GetTempPath(), "comet-go-qr.png");
+			File.WriteAllBytes(pngPath, pngBytes);
+
+			Console.WriteLine($"  QR code:  {pngPath}");
+			Console.WriteLine();
+
+			// Try to auto-open the PNG with the platform image viewer so the
+			// user can scan from screen. If it fails, no harm — they can open
+			// the file manually using the path above, or fall back to the
+			// ASCII QR below.
+			TryOpenInImageViewer(pngPath);
+
+			// Also print an ASCII QR as a fallback (for headless/SSH where the
+			// PNG can't be auto-opened). repeatPerModule=2 makes each module
+			// 4 chars wide × 2 chars tall — closer to square than 2×1 in
+			// most terminal fonts. The tight 1× rendering looks nicer but
+			// fails to scan in many terminals (e.g. VS Code's default font).
 			var qrCode = new QRCoder.AsciiQRCode(qrData);
-			var qrString = qrCode.GetGraphic(1, drawQuietZones: false);
+			var qrString = qrCode.GetGraphic(2, drawQuietZones: true);
 			Console.WriteLine(qrString);
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"  (QR generation failed — {ex.Message})");
+			Console.WriteLine($"  Connect manually: {url}");
+		}
+	}
+
+	static void TryOpenInImageViewer(string path)
+	{
+		try
+		{
+			string fileName;
+			string args;
+			if (OperatingSystem.IsMacOS())
+			{
+				fileName = "open"; args = $"\"{path}\"";
+			}
+			else if (OperatingSystem.IsWindows())
+			{
+				fileName = "cmd"; args = $"/c start \"\" \"{path}\"";
+			}
+			else if (OperatingSystem.IsLinux())
+			{
+				fileName = "xdg-open"; args = $"\"{path}\"";
+			}
+			else { return; }
+
+			var psi = new System.Diagnostics.ProcessStartInfo(fileName, args)
+			{
+				UseShellExecute = false,
+				CreateNoWindow = true,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+			};
+			System.Diagnostics.Process.Start(psi);
 		}
 		catch
 		{
-			Console.WriteLine($"  (QR generation failed — connect manually: {url})");
+			// Best effort — silently swallow if open command fails.
 		}
 	}
 }

--- a/src/Go/Server/Program.cs
+++ b/src/Go/Server/Program.cs
@@ -6,11 +6,14 @@ using Microsoft.Maui.Go.Server;
 // Entry point
 if (args.Length == 0)
 {
-	Console.Error.WriteLine("Usage: Microsoft.Maui.Go.Server <project-dir> [--port 9000] [--no-qr]");
+	Console.Error.WriteLine("Usage: Microsoft.Maui.Go.Server <project-dir-or-file.cs> [--port 9000] [--no-qr]");
+	Console.Error.WriteLine();
+	Console.Error.WriteLine("  <project-dir>   Directory containing a .csproj (project mode)");
+	Console.Error.WriteLine("  <file.cs>        Single .cs file (single-file mode)");
 	return 1;
 }
 
-var projectDir = args[0];
+var target = args[0];
 var port = 9000;
 var showQr = true;
 
@@ -25,4 +28,9 @@ for (var i = 1; i < args.Length; i++)
 using var cts = new CancellationTokenSource();
 Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
-return await GoDevServer.RunAsync(projectDir, port, showQr, cts.Token);
+// Detect single-file mode: argument ends with .cs and is a file
+if (target.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) && File.Exists(target))
+	return await GoDevServer.RunSingleFileAsync(target, port, showQr, cts.Token);
+
+// Otherwise treat as project directory
+return await GoDevServer.RunAsync(target, port, showQr, cts.Token);


### PR DESCRIPTION
Comet Go now runs as a **file-based program** — one `.cs` file, no `.csproj` — backed by the dev server's new single-file mode. This is the developer-facing version of the Comet Go workflow that `maui go` will spawn (the CLI wiring lives in a stacked PR).

## Changes

### Server (`src/Go/Server`)
- **DeltaCompiler**: `ForSingleFile` factory + `IsSingleFileMode`; structured `CompilationDiagnostic` with hint authoring; implicit-usings synthesis so single-file authors don't need `global using`; package version resolution and best-DLL pick from the per-package nupkg cache.
- **GoDevServer**: `RunSingleFileAsync` entry point + `WatchSingleFileAsync` file watcher; `RunCoreAsync` shared core. PNG QR (auto-opened via `open`/`xdg-open`/`start`) with a safer 2× ASCII fallback for terminals where 1× modules get distorted by font aspect ratio.
- **Program**: argv handling for the new mode.

### CompanionApp (`src/Go/CompanionApp`)
- **GoMainPage**: rewritten connect/render UI with structured exception surfacing (`UnwrapException`) and `IsCometView` render-target detection.
- **QrScannerPage**: scanner now starts on `HandlerChanged` instead of `OnAppearing` — `ModalPresenter` calls `page.ToHandler()` + `PresentViewController` directly, which bypasses MAUI's Page lifecycle so `OnAppearing` never fires. Documented the gotcha in remarks.
- **GoApp.cs**: small wiring update for the new page.

### Build infrastructure (`src/Go`)
- **`Directory.Build.props/targets`**: stop walking up to the repo root so VS Code can load the Go `.csproj` files independently of Arcade.
- **README.md**: end-user getting-started rewrite (single-file workflow, `maui go` / `maui go create` commands, QR PNG flow).

## Verified
- `dotnet build src/Go/Server -c Debug` → 0 errors
- `dotnet build src/Go/CompanionApp -f net11.0-maccatalyst` → 0 errors
- Manual: scanner registers QR codes on iPhone after `HandlerChanged` fix.

## Review fixes applied
- Disposed `System.Timers.Timer` in both file watchers (was leaking)
- Disposed `Process` handle from `open`/`xdg-open`/`start` in `TryOpenInImageViewer`

## Stacked PR
The CLI command (`maui go ...`) that invokes this server is in a separate PR stacked on this branch.
