### PR TITLE
feat(cli): wire 'maui go' single-file dev experience

### DIFF
--- a/.github/skills/comet-go/SKILL.md
+++ b/.github/skills/comet-go/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: comet-go
+description: Write and edit Comet Go single-file apps (.cs files using the Comet MVU framework for .NET MAUI). Use when writing, editing, or debugging Comet Go apps, or when the user mentions "maui go", "comet go", or is working with .cs files that import Comet.
+---
+
+# Comet Go — Single-File App Development
+
+Comet Go is a single-file app experience for .NET MAUI using the Comet MVU framework.
+The user writes ONE `.cs` file, runs `maui go`, and it live-reloads on their device.
+
+## How It Works
+
+1. User writes a single `.cs` file with a `MainPage : View` class
+2. `maui go` starts GoDevServer → Roslyn compiles to DLL (OutputKind.DynamicallyLinkedLibrary)
+3. DLL is sent over WebSocket to the companion app
+4. Companion app loads via `Assembly.Load` → `MetadataUpdater.ApplyUpdate` for hot reload
+5. Scaffold new apps with: `maui go create <AppName>`
+
+## Required Imports
+
+Every Comet Go file MUST start with:
+
+```csharp
+#:package Comet
+
+using Comet;
+using Microsoft.Maui;
+using Microsoft.Maui.Graphics;
+using static Comet.CometControls;
+```
+
+- `using static Comet.CometControls;` enables `VStack(...)`, `Text(...)`, `Button(...)` etc. as top-level functions
+- Add `using System;` if you need `Math`, `Convert`, `DateTime`, or `TimeSpan` directly
+- `Action` and `Func<T>` resolve without `using System;` via implicit usings
+
+## App Structure
+
+```csharp
+namespace MyApp;
+
+public class MainPage : View
+{
+    readonly Reactive<int> count = new(0);
+
+    [Body]
+    View body() =>
+        VStack(spacing: 16f,
+            Text(() => $"Count: {count.Value}"),
+            Button("Tap", () => count.Value++)
+        );
+}
+```
+
+## CRITICAL: VStack/HStack Spacing Parameter
+
+`VStack(0, ...)` is **ambiguous** between `VStack(float?, params View[])` and `VStack(LayoutAlignment, params View[])`.
+
+- ✅ `VStack(spacing: 0f, ...)` — named parameter (clearest)
+- ✅ `VStack(16f, ...)` — float literal with `f` suffix
+- ❌ `VStack(0, ...)` — CS0121 ambiguous call
+- ❌ `VStack(16, ...)` — may be ambiguous
+
+Always use `f` suffix or `spacing:` named parameter.
+
+## Available Controls (via `using static Comet.CometControls`)
+
+### Layout
+```csharp
+VStack(float? spacing, params View[] children)     // vertical stack
+HStack(float? spacing, params View[] children)     // horizontal stack
+ZStack(params View[] children)                      // overlay stack
+Grid(object[] columns, object[] rows, params View[] children)
+ScrollView(View content)
+Border(View content)
+Spacer()                                            // flexible space
+```
+
+### Display & Input
+```csharp
+// Text display
+Text("static text")
+Text(() => $"dynamic {reactive.Value}")   // auto-updates when reactive changes
+Text(() => reactive.Value)                // simple reactive binding
+
+// Buttons — MUST use lambda, not method group
+Button("label", () => DoSomething())      // ✅ lambda wrapper
+Button("label", DoSomething)              // ❌ CS1503 — method groups don't work
+
+// Text input — requires Signal<string>, NOT Reactive<string>
+TextField(signal, "placeholder")          // two-way binding with Signal<string>
+SecureField(signal, "Password")
+
+// Toggle / Switch
+Toggle(reactiveBool)
+
+// Slider
+Slider(value: 0.5, minimum: 0, maximum: 1)
+
+// Image
+Image("https://example.com/image.png")
+
+// Picker
+Picker(0, "Option A", "Option B", "Option C")
+
+// Others: ProgressBar, ActivityIndicator, DatePicker, TimePicker, Stepper
+```
+
+### Grid Layout
+```csharp
+Grid(
+    columns: new object[] { "*", "*", "*", "*" },  // 4 equal columns
+    rows: new object[] { 70, 70, 70 },              // 3 rows @ 70px
+    Button("1", () => {}).Cell(row: 0, column: 0),
+    Button("2", () => {}).Cell(row: 0, column: 1),
+    Button("wide", () => {}).Cell(row: 1, column: 0, colSpan: 2)
+)
+.ColumnSpacing(10).RowSpacing(10)
+```
+
+Column/row definitions: `"*"` (star), `"2*"` (weighted), `"Auto"`, or integer pixels.
+
+## Fluent Styling API
+
+Chain these after any control:
+```csharp
+// Typography
+.FontSize(24)
+.FontWeight(FontWeight.Bold)              // Bold, Medium, Semibold, Regular, Light, Heavy, Thin
+.Color(Colors.White)                       // text/foreground color
+.HorizontalTextAlignment(TextAlignment.End)
+
+// Background & shape
+.Background(new SolidPaint(myColor))       // use SolidPaint for Color values
+.Background(Colors.Blue)                   // convenience overload
+.CornerRadius(12)                          // ⚠️ BUTTON ONLY — does NOT work on VStack/HStack/etc
+.RoundedBorder(radius: 12, color: Colors.Gray, width: 1)  // rounded corners on ANY view
+
+// Layout & spacing
+.Frame(width: 100, height: 50)             // fixed size
+.Padding(new Thickness(16))
+.Margin(new Thickness(8))
+.FillHorizontal()                          // expand to fill horizontal space
+.FillVertical()                            // expand to fill vertical space
+.IgnoreSafeArea()                          // extend past safe area (root layout)
+
+// Other
+.Alignment(Alignment.Center)
+.Opacity(0.8)
+.IsVisible(true)
+.AutomationId("my-button")                 // accessibility / test identifier
+```
+
+> ⚠️ **`.CornerRadius()` is Button-only.** Using it on VStack, HStack, TextField, or other non-Button views is silently ignored or crashes. Use `.RoundedBorder()` instead for rounded corners on containers.
+
+## Reactive State: Reactive<T> vs Signal<T>
+
+### Reactive<T> — Display binding (read in UI, write in code)
+```csharp
+readonly Reactive<int> count = new(0);
+readonly Reactive<string> display = new("0");
+
+// Read in reactive lambda — UI auto-updates when .Value changes
+Text(() => $"Count: {count.Value}")
+
+// Write to trigger UI update
+Button("Add", () => count.Value++)
+```
+
+### Signal<T> — Two-way binding (for text input)
+```csharp
+using Comet.Reactive;  // needed for Signal<T>
+
+readonly Signal<string> username = new Signal<string>("");
+
+// TextField REQUIRES Signal<string>, not Reactive<string>
+TextField(username, "Enter name")
+
+// Read signal value reactively
+Text(() => $"Hello, {username.Value}!")
+```
+
+> 🔑 Use `Reactive<T>` for display-only state. Use `Signal<T>` (from `Comet.Reactive`) for `TextField` two-way binding.
+
+## FontWeight Values
+
+Available: `Bold`, `Semibold`, `Medium`, `Regular`, `Light`, `Heavy`, `Thin`, `UltraLight`, `UltraBold`, `Black`
+
+> ❌ `FontWeight.SemiBold` (capital B) does NOT exist — use `FontWeight.Semibold` (lowercase b).
+
+## Color Reference
+
+`Colors.*` from `Microsoft.Maui.Graphics`:
+```
+Colors.White, Colors.Black, Colors.Red, Colors.Green, Colors.Blue,
+Colors.Orange, Colors.Yellow, Colors.Purple, Colors.Pink,
+Colors.Grey, Colors.Gray, Colors.DarkGray, Colors.LightGray,
+Colors.Transparent, Colors.DodgerBlue, Colors.Crimson, Colors.Teal,
+Colors.Coral, Colors.Gold, Colors.Indigo, Colors.Lime, Colors.Navy
+```
+
+Custom hex colors: `Color.FromArgb("#FF9F0A")`
+
+## Hot Reload Constraints
+
+The Go dev server uses Edit-and-Continue (EnC). Know what works and what doesn't:
+
+### ✅ Works — delta produced, UI updates
+- Method body changes (text, colors, layout, logic)
+- Field initializer value changes
+- New methods in existing types
+- Lambda expression changes
+
+### ⚠️ Unreliable — sometimes works, sometimes crashes
+- Adding new fields or properties to existing classes
+
+### ❌ Restart required (`Ctrl+C` and re-run `maui go`)
+- Adding new classes or types
+- Changing constructor signatures
+- Changing method signatures (parameters, return type)
+- Changing base classes or interfaces
+
+### Design Principle
+
+Design your initial file with all methods you'll need. During hot reload, modify method *bodies* freely. If you need structural changes (new types, new fields), restart.
+
+```csharp
+// ✅ SAFE: Multiple methods defined at initial compile. Bodies can change freely.
+void Append(string digit) { /* body can change via hot reload */ }
+void SetOp(string op) { /* body can change via hot reload */ }
+void Calculate() { /* body can change via hot reload */ }
+```
+
+## Anti-Patterns That Cause Crashes
+
+1. **Unicode operators in switch expressions** — `"÷"`, `"×"`, `"−"` cause encoding issues in the hot reload pipeline. Use ASCII: `"/"`, `"x"`, `"-"`.
+
+2. **`.CornerRadius()` on non-Button views** — silently ignored or crashes. Use `.RoundedBorder()` for containers.
+
+3. **`Button("Go", MyMethod)`** — CS1503 error. Method groups don't work. Must be `Button("Go", () => MyMethod())`.
+
+4. **`Reactive<string>` for TextField** — won't bind two-way. TextField requires `Signal<string>`.
+
+5. **`FontWeight.SemiBold`** (capital B) — doesn't exist. Use `FontWeight.Semibold`.
+
+6. **String interpolation lambdas to string params** — `SomeHelper(() => $"val {x}")` fails if the method takes `string`. Inline the interpolation in `body()` since the whole body is reactive.
+
+7. **`using new VStack { ... }`** collection initializer syntax — use `VStack(spacing: 8f, child1, child2)`.
+
+## Common Mistakes to Avoid
+
+1. Missing `using static Comet.CometControls;` — `VStack`, `Text`, `Button` won't resolve
+2. Using `VStack(0, ...)` without `f` suffix — ambiguous overload
+3. Using `new Text(...)` instead of `Text(...)` — use the clean static API
+4. Forgetting `() =>` wrapper for reactive text — `Text(() => $"{x.Value}")` not `Text($"{x.Value}")`
+5. Using MAUI Controls APIs (Shell, NavigationPage) — Comet has its own navigation
+6. Using `Reactive<string>` for TextField — use `Signal<string>` from `Comet.Reactive`
+
+## Example: Calculator App (E2E Verified)
+
+Built from template, hot-reloaded, and interactively tested with button taps and arithmetic verification.
+
+```csharp
+#:package Comet
+
+using Comet;
+using Microsoft.Maui;
+using Microsoft.Maui.Graphics;
+using static Comet.CometControls;
+
+namespace Calculator;
+
+public class MainPage : View
+{
+    readonly Reactive<string> display = new("0");
+    readonly Reactive<string> subDisplay = new("");
+
+    double accumulator = 0;
+    string pendingOp = "";
+    bool resetOnNext = false;
+
+    void Append(string digit)
+    {
+        if (resetOnNext) { display.Value = "0"; resetOnNext = false; }
+        if (display.Value == "0" && digit != ".") display.Value = digit;
+        else if (digit == "." && display.Value.Contains(".")) return;
+        else display.Value += digit;
+    }
+
+    void SetOp(string op)
+    {
+        if (pendingOp != "") DoCalculate();
+        accumulator = double.Parse(display.Value);
+        pendingOp = op;
+        subDisplay.Value = $"{accumulator} {op}";
+        resetOnNext = true;
+    }
+
+    void DoCalculate()
+    {
+        if (pendingOp == "") return;
+        double current = double.Parse(display.Value);
+        double result = pendingOp switch
+        {
+            "+" => accumulator + current,
+            "-" => accumulator - current,
+            "x" => accumulator * current,
+            "/" => current != 0 ? accumulator / current : 0,
+            _ => current
+        };
+        display.Value = result.ToString();
+        subDisplay.Value = "";
+        accumulator = result;
+        pendingOp = "";
+        resetOnNext = true;
+    }
+
+    [Body]
+    View body()
+    {
+        var darkBg = Color.FromArgb("#1C1C1E");
+        var numBg = Color.FromArgb("#3A3A3C");
+        var opBg = Color.FromArgb("#FF9F0A");
+        var fnBg = Color.FromArgb("#636366");
+        var eqBg = Color.FromArgb("#30D158");
+
+        return VStack(spacing: 0f,
+            new Spacer(),
+            Text(() => subDisplay.Value)
+                .FontSize(18).Color(Colors.Grey)
+                .HorizontalTextAlignment(TextAlignment.End)
+                .Margin(new Thickness(20, 0)),
+            Text(() => display.Value)
+                .FontSize(56).FontWeight(FontWeight.Bold)
+                .Color(Colors.White)
+                .HorizontalTextAlignment(TextAlignment.End)
+                .Margin(new Thickness(20, 0, 20, 16)),
+            Grid(
+                columns: new object[] { "*", "*", "*", "*" },
+                rows: new object[] { 70, 70, 70, 70, 70 },
+                Button("AC", () => { display.Value = "0"; subDisplay.Value = ""; accumulator = 0; pendingOp = ""; resetOnNext = false; })
+                    .Color(Colors.White).Background(new SolidPaint(fnBg)).CornerRadius(36).Cell(row: 0, column: 0),
+                Button("+/-", () => { if (display.Value != "0") display.Value = display.Value.StartsWith("-") ? display.Value[1..] : "-" + display.Value; })
+                    .Color(Colors.White).Background(new SolidPaint(fnBg)).CornerRadius(36).Cell(row: 0, column: 1),
+                Button("%", () => { display.Value = (double.Parse(display.Value) / 100).ToString(); })
+                    .Color(Colors.White).Background(new SolidPaint(fnBg)).CornerRadius(36).Cell(row: 0, column: 2),
+                Button("/", () => SetOp("/")).Color(Colors.White).Background(new SolidPaint(opBg)).CornerRadius(36).Cell(row: 0, column: 3),
+                Button("7", () => Append("7")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 1, column: 0),
+                Button("8", () => Append("8")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 1, column: 1),
+                Button("9", () => Append("9")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 1, column: 2),
+                Button("x", () => SetOp("x")).Color(Colors.White).Background(new SolidPaint(opBg)).CornerRadius(36).Cell(row: 1, column: 3),
+                Button("4", () => Append("4")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 2, column: 0),
+                Button("5", () => Append("5")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 2, column: 1),
+                Button("6", () => Append("6")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 2, column: 2),
+                Button("-", () => SetOp("-")).Color(Colors.White).Background(new SolidPaint(opBg)).CornerRadius(36).Cell(row: 2, column: 3),
+                Button("1", () => Append("1")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 3, column: 0),
+                Button("2", () => Append("2")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 3, column: 1),
+                Button("3", () => Append("3")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 3, column: 2),
+                Button("+", () => SetOp("+")).Color(Colors.White).Background(new SolidPaint(opBg)).CornerRadius(36).Cell(row: 3, column: 3),
+                Button("0", () => Append("0")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 4, column: 0, colSpan: 2),
+                Button(".", () => Append(".")).Color(Colors.White).Background(new SolidPaint(numBg)).CornerRadius(36).Cell(row: 4, column: 2),
+                Button("=", () => DoCalculate()).Color(Colors.White).Background(new SolidPaint(eqBg)).CornerRadius(36).Cell(row: 4, column: 3)
+            ).ColumnSpacing(10).RowSpacing(10).Padding(new Thickness(14, 0, 14, 14))
+        ).Background(new SolidPaint(darkBg)).IgnoreSafeArea();
+    }
+}
+```

--- a/.github/skills/comet-go/SKILL.md
+++ b/.github/skills/comet-go/SKILL.md
@@ -150,7 +150,7 @@ Chain these after any control:
 .AutomationId("my-button")                 // accessibility / test identifier
 ```
 
-> ⚠️ **`.CornerRadius()` is Button-only.** Using it on VStack, HStack, TextField, or other non-Button views is silently ignored or crashes. Use `.RoundedBorder()` instead for rounded corners on containers.
+> ⚠️ **`.CornerRadius()` works on Button and Border but NOT on layout views (VStack, HStack, TextField, etc.).** Using it on unsupported views is silently ignored or crashes. Use `.RoundedBorder()` instead for rounded corners on containers and other views.
 
 ## Reactive State: Reactive<T> vs Signal<T>
 

--- a/src/Cli/Microsoft.Maui.Cli/Commands/GoCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/GoCommands.cs
@@ -39,6 +39,7 @@ public static class GoCommands
 			Arity = ArgumentArity.ZeroOrOne,
 		};
 
+		// TODO: Migrate Go command output to use Program.GetFormatter(parseResult) for --json/--verbose support
 		var goCommand = new Command("go", "Comet Go — instant prototyping without IDE setup")
 		{
 			portOption,
@@ -172,15 +173,17 @@ public static class GoCommands
 			}
 
 			var safeNamespace = name.Replace("-", "_").Replace(" ", "_");
+			safeNamespace = new string(safeNamespace.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+			if (safeNamespace.Length == 0 || char.IsDigit(safeNamespace[0]))
+				safeNamespace = "_" + safeNamespace;
 			var fileName = $"{name}.cs";
 			var cwd = Directory.GetCurrentDirectory();
 			var filePath = Path.GetFullPath(Path.Combine(cwd, fileName));
-			var cwdNormalized = Path.GetFullPath(cwd);
-			var sep = Path.DirectorySeparatorChar;
+			var cwdNormalized = Path.GetFullPath(cwd).TrimEnd(Path.DirectorySeparatorChar);
 
 			// Defensive: confirm the resolved path stays under cwd even though
 			// we already rejected obvious traversal sequences above.
-			if (!filePath.StartsWith(cwdNormalized + sep, StringComparison.Ordinal)
+			if (!filePath.StartsWith(cwdNormalized + Path.DirectorySeparatorChar, StringComparison.Ordinal)
 				&& filePath != cwdNormalized)
 			{
 				Console.Error.WriteLine("Error: Resolved file path escapes the current directory.");
@@ -242,6 +245,7 @@ public static class GoCommands
 				Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
 				".copilot", "skills", "comet-go");
 			var skillPath = Path.Combine(skillDir, "SKILL.md");
+			// Skill file is created once. Users can update via `maui ai update` or delete and re-create.
 			if (!File.Exists(skillPath))
 			{
 				Directory.CreateDirectory(skillDir);
@@ -263,8 +267,8 @@ public static class GoCommands
 	}
 
 	/// <summary>
-	/// Returns the Comet Go skill content in the standard SKILL.md format
-	/// for GitHub Copilot CLI user skills (~/.copilot/skills/comet-go/SKILL.md).
+	/// Returns the Comet Go skill content. This is a copy of .github/skills/comet-go/SKILL.md
+	/// and should be kept in sync with it.
 	/// </summary>
 	static string GetCometGoSkill() => """
 		---
@@ -587,6 +591,8 @@ public static class GoCommands
 		var command = new Command("serve", "Start the Comet Go dev server with hot reload")
 		{
 			fileArg,
+			portOption,
+			noQrOption,
 		};
 
 		command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>

--- a/src/Cli/Microsoft.Maui.Cli/Commands/GoCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/GoCommands.cs
@@ -161,9 +161,31 @@ public static class GoCommands
 				return Task.FromResult(1);
 			}
 
+			// Validate the name as a simple identifier — must not contain path separators
+			// or other characters that could escape the current directory.
+			if (name!.IndexOfAny(new[] { '/', '\\', ':' }) >= 0
+				|| name.Contains("..")
+				|| Path.IsPathRooted(name))
+			{
+				Console.Error.WriteLine("Error: App name must be a simple name (no slashes, drive letters, or '..').");
+				return Task.FromResult(1);
+			}
+
 			var safeNamespace = name.Replace("-", "_").Replace(" ", "_");
 			var fileName = $"{name}.cs";
-			var filePath = Path.Combine(Directory.GetCurrentDirectory(), fileName);
+			var cwd = Directory.GetCurrentDirectory();
+			var filePath = Path.GetFullPath(Path.Combine(cwd, fileName));
+			var cwdNormalized = Path.GetFullPath(cwd);
+			var sep = Path.DirectorySeparatorChar;
+
+			// Defensive: confirm the resolved path stays under cwd even though
+			// we already rejected obvious traversal sequences above.
+			if (!filePath.StartsWith(cwdNormalized + sep, StringComparison.Ordinal)
+				&& filePath != cwdNormalized)
+			{
+				Console.Error.WriteLine("Error: Resolved file path escapes the current directory.");
+				return Task.FromResult(1);
+			}
 
 			if (File.Exists(filePath))
 			{

--- a/src/Cli/Microsoft.Maui.Cli/Commands/GoCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/GoCommands.cs
@@ -8,133 +8,231 @@ namespace Microsoft.Maui.Cli.Commands;
 
 /// <summary>
 /// MAUI Go commands — Expo-like getting started experience.
+///
+/// Primary workflow:
+///   1. User creates a .cs file with a Comet View (or runs "maui go create")
+///   2. User runs "maui go" from that directory
+///   3. Server starts, shows QR code, waits for companion app connection
+///   4. User edits .cs file, UI updates live on device
+///
 /// Subcommands: create, serve, upgrade.
+/// Bare "maui go" is the default action — auto-detects .cs files and starts serving.
 /// </summary>
 public static class GoCommands
 {
 	public static Command Create()
 	{
-		var goCommand = new Command("go", "MAUI Go — instant prototyping without IDE setup");
+		var portOption = new Option<int>("--port")
+		{
+			Description = "Port for the hot reload dev server",
+			DefaultValueFactory = _ => 9000
+		};
+
+		var noQrOption = new Option<bool>("--no-qr")
+		{
+			Description = "Suppress QR code display"
+		};
+
+		var fileArg = new Argument<string?>("file")
+		{
+			Description = "Optional .cs file to serve (auto-detected if omitted)",
+			Arity = ArgumentArity.ZeroOrOne,
+		};
+
+		var goCommand = new Command("go", "Comet Go — instant prototyping without IDE setup")
+		{
+			portOption,
+			noQrOption,
+			fileArg
+		};
+
+		// Bare "maui go" — the primary user experience
+		goCommand.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+		{
+			var port = parseResult.GetValue(portOption);
+			var noQr = parseResult.GetValue(noQrOption);
+			var showQr = !noQr;
+			var file = parseResult.GetValue(fileArg);
+
+			return await RunGoAsync(file, port, showQr, ct);
+		});
 
 		goCommand.Add(CreateCreateCommand());
-		goCommand.Add(CreateServeCommand());
+		goCommand.Add(CreateServeCommand(portOption, noQrOption));
 		goCommand.Add(CreateUpgradeCommand());
 
 		return goCommand;
 	}
 
+	/// <summary>
+	/// Core logic for starting the Go dev server. Used by both bare "maui go" and "maui go serve".
+	///
+	/// Detection priority:
+	///   1. Explicit file argument (e.g., "maui go MyApp.cs")
+	///   2. Single .cs file in current directory → single-file mode
+	///   3. Multiple .cs files in current directory → check for .csproj (project mode)
+	///   4. No .cs files → error with guidance
+	/// </summary>
+	static async Task<int> RunGoAsync(string? file, int port, bool showQr, CancellationToken ct)
+	{
+		var cwd = Directory.GetCurrentDirectory();
+
+		// Explicit file path provided
+		if (file is not null)
+		{
+			var filePath = Path.IsPathRooted(file) ? file : Path.Combine(cwd, file);
+			if (!File.Exists(filePath))
+			{
+				Console.Error.WriteLine($"Error: File not found: {filePath}");
+				return 1;
+			}
+			if (!filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+			{
+				Console.Error.WriteLine("Error: File must be a .cs file.");
+				return 1;
+			}
+#if NET10_0_OR_GREATER
+			return await Microsoft.Maui.Go.Server.GoDevServer.RunSingleFileAsync(filePath, port, showQr, ct);
+#else
+			Console.Error.WriteLine("Error: 'maui go' dev server requires the .NET 10 build of the CLI.");
+			return 1;
+#endif
+		}
+
+		// Auto-detect .cs files in current directory
+		var csFiles = Directory.GetFiles(cwd, "*.cs")
+			.Where(f => !Path.GetFileName(f).StartsWith('.'))
+			.ToArray();
+
+		if (csFiles.Length == 0)
+		{
+			Console.Error.WriteLine("Error: No .cs files found in the current directory.");
+			Console.Error.WriteLine();
+			Console.Error.WriteLine("  To get started, create a Comet view file:");
+			Console.Error.WriteLine("    maui go create MyApp");
+			Console.Error.WriteLine();
+			Console.Error.WriteLine("  Or specify a file path:");
+			Console.Error.WriteLine("    maui go path/to/MyApp.cs");
+			return 1;
+		}
+
+#if NET10_0_OR_GREATER
+		// Single .cs file → single-file mode
+		if (csFiles.Length == 1)
+		{
+			return await Microsoft.Maui.Go.Server.GoDevServer.RunSingleFileAsync(csFiles[0], port, showQr, ct);
+		}
+
+		// Multiple .cs files → project mode (look for .csproj)
+		var csproj = Directory.GetFiles(cwd, "*.csproj").FirstOrDefault();
+		if (csproj is not null)
+		{
+			return await Microsoft.Maui.Go.Server.GoDevServer.RunAsync(cwd, port, showQr, ct);
+		}
+
+		// Multiple .cs files but no .csproj — ask the author to disambiguate.
+		Console.Error.WriteLine($"Found {csFiles.Length} .cs files but no .csproj in current directory.");
+		Console.Error.WriteLine("Specify which file to serve:");
+		foreach (var f in csFiles)
+			Console.Error.WriteLine($"    maui go {Path.GetFileName(f)}");
+		return 1;
+#else
+		Console.Error.WriteLine("Error: 'maui go' dev server requires the .NET 10 build of the CLI.");
+		return 1;
+#endif
+	}
+
 	static Command CreateCreateCommand()
 	{
-		var nameArg = new Argument<string>("name") { Description = "Project name for the new MAUI Go app" };
+		var nameArg = new Argument<string>("name") { Description = "Name for the new Comet Go app" };
 
-		var templateOption = new Option<string>("--template")
-		{
-			Description = "Template to use (default, counter, notes, todo)",
-			DefaultValueFactory = _ => "default"
-		};
-
-		var command = new Command("create", "Create a new MAUI Go project")
+		var command = new Command("create", "Create a new Comet Go single-file app")
 		{
 			nameArg,
-			templateOption
 		};
 
 		command.SetAction((ParseResult parseResult, CancellationToken _) =>
 		{
 			var name = parseResult.GetValue(nameArg);
-			var template = parseResult.GetValue(templateOption);
 
 			if (string.IsNullOrWhiteSpace(name))
 			{
-				Console.Error.WriteLine("Error: Project name is required.");
+				Console.Error.WriteLine("Error: App name is required.");
 				return Task.FromResult(1);
 			}
 
-			var targetDir = Path.Combine(Directory.GetCurrentDirectory(), name);
+			var safeNamespace = name.Replace("-", "_").Replace(" ", "_");
+			var fileName = $"{name}.cs";
+			var filePath = Path.Combine(Directory.GetCurrentDirectory(), fileName);
 
-			if (Directory.Exists(targetDir))
+			if (File.Exists(filePath))
 			{
-				Console.Error.WriteLine($"Error: Directory '{name}' already exists.");
+				Console.Error.WriteLine($"Error: File '{fileName}' already exists.");
 				return Task.FromResult(1);
 			}
 
-			Console.WriteLine($"  Creating MAUI Go project: {name}");
+			var source = $$"""
+				#:package Comet
 
-			// Scaffold the project
-			Directory.CreateDirectory(targetDir);
-
-			// Compute relative path to Comet project from the new project dir
-			var repoRoot = FindRepoRoot(targetDir) ?? FindRepoRoot(AppContext.BaseDirectory);
-			var cometRelativePath = repoRoot is not null
-				? Path.GetRelativePath(targetDir, Path.Combine(repoRoot, "src", "Comet", "src", "Comet", "Comet.csproj"))
-				: @"..\..\src\Comet\src\Comet\Comet.csproj";
-
-			// Write .csproj with ProjectReference to local Comet
-			var csproj = $"""
-				<Project Sdk="Microsoft.NET.Sdk">
-				  <PropertyGroup>
-				    <TargetFramework>net11.0</TargetFramework>
-				    <RootNamespace>{name.Replace("-", "_").Replace(" ", "_")}</RootNamespace>
-				    <ImplicitUsings>enable</ImplicitUsings>
-				    <Nullable>enable</Nullable>
-				  </PropertyGroup>
-				  <ItemGroup>
-				    <ProjectReference Include="{cometRelativePath}" />
-				  </ItemGroup>
-				</Project>
-				""";
-			File.WriteAllText(Path.Combine(targetDir, $"{name}.csproj"), csproj);
-
-			// Write MainPage.cs
-			var mainPage = $$"""
 				using Comet;
 				using Microsoft.Maui;
 				using Microsoft.Maui.Graphics;
+				using static Comet.CometControls;
 
-				namespace {{name.Replace("-", "_").Replace(" ", "_")}};
+				namespace {{safeNamespace}};
 
 				public class MainPage : View
 				{
 				    readonly Reactive<int> count = new(0);
 
 				    [Body]
-				    View body() => new VStack(spacing: 20)
-				    {
-				        new Text("Welcome to {{name}}! 🚀")
-				            .FontSize(28)
-				            .FontWeight(FontWeight.Bold)
-				            .Color(Colors.Purple)
-				            .HorizontalTextAlignment(TextAlignment.Center),
+				    View body() =>
+				        VStack(20,
+				            Text("Welcome to {{name}}!")
+				                .FontSize(28)
+				                .FontWeight(FontWeight.Bold)
+				                .Color(Colors.Orange)
+				                .HorizontalTextAlignment(TextAlignment.Center),
 
-				        new Text(() => $"Count: {count.Value}")
-				            .FontSize(22)
-				            .HorizontalTextAlignment(TextAlignment.Center),
+				            Text(() => $"Count: {count.Value}")
+				                .FontSize(22)
+				                .HorizontalTextAlignment(TextAlignment.Center),
 
-				        new Button("Tap me!", () => count.Value++)
-				            .Color(Colors.White)
-				            .Background(new SolidPaint(Colors.Purple))
-				            .CornerRadius(12)
-				            .Frame(height: 50),
+				            Button("Tap me!", () => count.Value++)
+				                .Color(Colors.White)
+				                .Background(new SolidPaint(Colors.Orange))
+				                .CornerRadius(12)
+				                .Frame(height: 50),
 
-				        new Text("Edit MainPage.cs and save — the UI updates live!")
-				            .FontSize(14)
-				            .Color(Colors.Gray)
-				            .HorizontalTextAlignment(TextAlignment.Center),
-				    }
-				    .Padding(new Thickness(32))
-				    .Alignment(Alignment.Center);
+				            Text("Edit this file and save -- the UI updates live!")
+				                .FontSize(14)
+				                .Color(Colors.Gray)
+				                .HorizontalTextAlignment(TextAlignment.Center)
+				        )
+				        .Padding(new Thickness(32))
+				        .Alignment(Alignment.Center);
 				}
 				""";
-			File.WriteAllText(Path.Combine(targetDir, "MainPage.cs"), mainPage);
+			File.WriteAllText(filePath, source);
+
+			// Install Comet Go skill for AI coding assistants
+			var skillDir = Path.Combine(
+				Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+				".copilot", "skills", "comet-go");
+			var skillPath = Path.Combine(skillDir, "SKILL.md");
+			if (!File.Exists(skillPath))
+			{
+				Directory.CreateDirectory(skillDir);
+				File.WriteAllText(skillPath, GetCometGoSkill());
+			}
 
 			Console.WriteLine();
-			Console.WriteLine($"  ✅ Created '{name}' in ./{name}/");
+			Console.WriteLine($"  Created {fileName}");
 			Console.WriteLine();
-			Console.WriteLine("  Next steps:");
-			Console.WriteLine($"    cd {name}");
-			Console.WriteLine($"    maui go serve --qr");
+			Console.WriteLine("  Next:");
+			Console.WriteLine("    maui go");
 			Console.WriteLine();
-			Console.WriteLine("  Then scan the QR code with the MAUI Go companion app.");
+			Console.WriteLine("  Then connect with the Comet Go companion app.");
 
 			return Task.FromResult(0);
 		});
@@ -143,63 +241,340 @@ public static class GoCommands
 	}
 
 	/// <summary>
-	/// Walk up directory tree to find the repo root (contains MauiLabs.slnx or .git).
+	/// Returns the Comet Go skill content in the standard SKILL.md format
+	/// for GitHub Copilot CLI user skills (~/.copilot/skills/comet-go/SKILL.md).
 	/// </summary>
-	static string? FindRepoRoot(string? startDir)
-	{
-		if (startDir is null) return null;
+	static string GetCometGoSkill() => """
+		---
+		name: comet-go
+		description: Write and edit Comet Go single-file apps (.cs files using the Comet MVU framework for .NET MAUI). Use when writing, editing, or debugging Comet Go apps, or when the user mentions "maui go", "comet go", or is working with .cs files that import Comet.
+		---
 
-		var dir = new DirectoryInfo(startDir);
-		while (dir is not null)
+		# Comet Go -- Single-File App Development
+
+		Comet Go is a single-file app experience for .NET MAUI using the Comet MVU framework.
+		The user writes ONE .cs file, runs `maui go`, and it live-reloads on their device.
+		Follow these rules when writing or editing Comet Go .cs files.
+
+		## What is Comet Go?
+
+		Comet Go is a single-file app experience for .NET MAUI using the Comet MVU framework.
+		You write ONE .cs file, run `maui go`, and it live-reloads on your phone.
+
+		## Required Imports
+
+		Every Comet Go file MUST start with:
+
+		```csharp
+		#:package Comet
+
+		using System;
+		using Comet;
+		using Microsoft.Maui;
+		using Microsoft.Maui.Graphics;
+		using static Comet.CometControls;
+		```
+
+		`using System;` is required for `Action`, `Func<T>`, `Math`, `Convert`, etc.
+		`using static Comet.CometControls;` enables the clean API (no `new` keyword).
+
+		## App Structure
+
+		```csharp
+		public class MainPage : View
 		{
-			if (File.Exists(Path.Combine(dir.FullName, "MauiLabs.slnx")) ||
-				Directory.Exists(Path.Combine(dir.FullName, ".git")))
-				return dir.FullName;
-			dir = dir.Parent;
+		    // State: use Reactive<T> for values that update the UI
+		    readonly Reactive<int> count = new(0);
+		    readonly Reactive<string> name = new("World");
+
+		    // Body method defines the UI -- must have [Body] attribute
+		    [Body]
+		    View body() =>
+		        VStack(16f,
+		            Text(() => $"Hello {name.Value}!"),
+		            Button("Tap", () => count.Value++)
+		        );
 		}
-		return null;
-	}
+		```
 
-	static Command CreateServeCommand()
+		## CRITICAL: VStack/HStack Spacing Parameter
+
+		When passing spacing as a literal number, use `f` suffix to avoid ambiguity:
+		- CORRECT: `VStack(16f, ...)`  or `HStack(8f, ...)`
+		- WRONG:   `VStack(0, ...)`  -- ambiguous between float? and LayoutAlignment
+		- WRONG:   `VStack(16, ...)` -- may be ambiguous
+
+		## Available Controls (via `using static Comet.CometControls`)
+
+		### Layout Containers
+		```csharp
+		VStack(float? spacing, params View[] children)     // vertical stack
+		HStack(float? spacing, params View[] children)     // horizontal stack
+		ZStack(params View[] children)                      // overlay stack
+		Grid(object[] columns, object[] rows, params View[] children)
+		ScrollView(View content)
+		ScrollView(Orientation orientation, View content)
+		Border(View content)
+		Spacer()
+		```
+
+		### Controls (source-generated from MAUI interfaces)
+		```csharp
+		// Text display
+		Text("static text")                    // static label
+		Text(() => $"dynamic {value}")         // reactive label (auto-updates)
+		Text(() => someReactive.Value)          // reactive binding
+
+		// Buttons
+		Button("label", () => { /* action */ })
+		Button("label", Action handler)
+
+		// Text input
+		TextField("initial text", "placeholder")
+		TextField(reactiveString, "placeholder")
+		SecureField("", "Password")
+
+		// Toggle / Switch
+		Toggle(false)
+		Toggle(reactiveBool)
+
+		// Slider
+		Slider(value: 0.5, minimum: 0, maximum: 1)
+
+		// Progress
+		ProgressBar(0.75)
+
+		// Activity indicator
+		ActivityIndicator(true)
+
+		// Date/Time
+		DatePicker(DateTime.Now)
+		TimePicker(TimeSpan.FromHours(12))
+
+		// Stepper
+		Stepper(value: 0, minimum: 0, maximum: 100, interval: 1)
+
+		// Image
+		Image("https://example.com/image.png")
+
+		// Picker
+		Picker(0, "Option A", "Option B", "Option C")
+		```
+
+		### Grid Layout
+		```csharp
+		Grid(
+		    columns: new object[] { "*", "*", "*", "*" },  // 4 equal columns
+		    rows: new object[] { 70, 70, 70 },              // 3 rows of 70px
+		    Button("1", () => {}).Cell(row: 0, column: 0),
+		    Button("2", () => {}).Cell(row: 0, column: 1),
+		    Button("wide", () => {}).Cell(row: 1, column: 0, colSpan: 2)
+		)
+		.ColumnSpacing(8f)
+		.RowSpacing(8f)
+		```
+
+		Column/row definitions: `"*"` (star), `"2*"` (weighted), `"Auto"`, or integer pixels.
+
+		## Fluent Styling API
+
+		Chain these after any control:
+		```csharp
+		.FontSize(24)
+		.FontWeight(FontWeight.Bold)          // Bold, Regular, Light, Medium, Heavy, Thin
+		.Color(Colors.White)                   // text/foreground color
+		.Background(Colors.Blue)               // solid color background
+		.Background(new SolidPaint(Colors.Red)) // paint-based background
+		.HorizontalTextAlignment(TextAlignment.Center)  // Start, Center, End
+		.Frame(width: 100, height: 50)         // fixed size
+		.Frame(height: 50)                     // fixed height, auto width
+		.Padding(new Thickness(16))            // uniform padding
+		.Padding(new Thickness(16, 8))         // horizontal, vertical
+		.Padding(new Thickness(16, 8, 16, 8))  // left, top, right, bottom
+		.Margin(new Thickness(8))
+		.CornerRadius(12)
+		.Alignment(Alignment.Center)
+		.ClipShape(new Circle())
+		.Shadow(Colors.Black, radius: 4, x: 0, y: 2)
+		.Opacity(0.8)
+		.IsVisible(true)
+		```
+
+		## FontWeight Values (MAUI enum)
+
+		Available values: `Bold`, `Regular`, `Light`, `Medium`, `Heavy`,
+		`Thin`, `UltraLight`, `UltraBold`, `Black`
+
+		NOTE: `SemiBold` does NOT exist. Use `Medium` or `Bold` instead.
+
+		## Reactive State
+
+		```csharp
+		readonly Reactive<int> count = new(0);         // integer state
+		readonly Reactive<string> text = new("hello");  // string state
+		readonly Reactive<bool> isOn = new(false);      // boolean state
+		readonly Reactive<double> value = new(0.5);     // double state
+
+		// Reading: use .Value in reactive lambdas
+		Text(() => $"Count: {count.Value}")
+
+		// Writing: set .Value to trigger UI update
+		Button("Add", () => count.Value++)
+		```
+
+		## Color Reference
+
+		Use `Colors.*` from `Microsoft.Maui.Graphics`:
+		```
+		Colors.White, Colors.Black, Colors.Red, Colors.Green, Colors.Blue,
+		Colors.Orange, Colors.Yellow, Colors.Purple, Colors.Pink, Colors.Gray,
+		Colors.DarkGray, Colors.LightGray, Colors.Transparent,
+		Colors.DodgerBlue, Colors.Crimson, Colors.Teal, Colors.Coral,
+		Colors.Gold, Colors.Indigo, Colors.Lime, Colors.Navy
+		```
+
+		Custom colors: `Color.FromArgb("#FF9F0A")` or `Color.FromRgba(255, 159, 10, 255)`
+
+		## Hot Reload Constraints
+
+		The Go dev server uses Edit-and-Continue (EnC) for hot reload. These edits work:
+		- Changing method bodies (text, colors, layout, logic)
+		- Changing property values
+		- Changing lambda expressions
+
+		These edits require an app restart (server will say "RESTART REQUIRED"):
+		- Adding new classes or types
+		- Adding new fields to existing classes
+		- Changing method signatures
+		- Adding new methods
+		- Changing base classes or interfaces
+
+		## Common Mistakes to Avoid
+
+		1. Missing `using System;` -- causes `Action`, `Math`, `Func<T>` to not resolve
+		2. Missing `using static Comet.CometControls;` -- causes `VStack`, `Text` etc to not resolve
+		3. Using `FontWeight.SemiBold` -- does not exist, use `Medium` or `Bold`
+		4. Using `VStack(0, ...)` -- ambiguous, use `VStack(0f, ...)` with float suffix
+		5. Using `new Text(...)` instead of `Text(...)` -- use the clean static API
+		6. Using `new VStack { ... }` collection initializer -- use `VStack(spacing, child1, child2)`
+		7. Passing method groups to Button -- use `() => Method()` not `Method`
+		8. Using MAUI Controls APIs (Shell, NavigationPage) -- Comet has its own navigation
+		9. Forgetting `() =>` wrapper for reactive text -- `Text(() => $"{x.Value}")` not `Text($"{x.Value}")`
+
+		## Example: Calculator App
+
+		```csharp
+		#:package Comet
+
+		using System;
+		using Comet;
+		using Microsoft.Maui;
+		using Microsoft.Maui.Graphics;
+		using static Comet.CometControls;
+
+		namespace Calculator;
+
+		public class MainPage : View
+		{
+		    readonly Reactive<string> display = new("0");
+		    double accumulator = 0;
+		    string pendingOp = "";
+		    bool resetOnNext = false;
+
+		    void Append(string digit)
+		    {
+		        if (resetOnNext) { display.Value = "0"; resetOnNext = false; }
+		        display.Value = display.Value == "0" ? digit : display.Value + digit;
+		    }
+
+		    void SetOp(string op)
+		    {
+		        accumulator = double.Parse(display.Value);
+		        pendingOp = op;
+		        resetOnNext = true;
+		    }
+
+		    void Calculate()
+		    {
+		        double current = double.Parse(display.Value);
+		        double result = pendingOp switch
+		        {
+		            "+" => accumulator + current,
+		            "-" => accumulator - current,
+		            "x" => accumulator * current,
+		            "/" => current != 0 ? accumulator / current : 0,
+		            _ => current
+		        };
+		        display.Value = result.ToString();
+		        pendingOp = "";
+		        resetOnNext = true;
+		    }
+
+		    [Body]
+		    View body() =>
+		        VStack(8f,
+		            Spacer(),
+		            Text(() => display.Value)
+		                .FontSize(48)
+		                .FontWeight(FontWeight.Bold)
+		                .HorizontalTextAlignment(TextAlignment.End)
+		                .Margin(new Thickness(20, 0)),
+		            Grid(
+		                columns: new object[] { "*", "*", "*", "*" },
+		                rows: new object[] { 60, 60, 60, 60, 60 },
+		                Button("AC", () => { display.Value = "0"; accumulator = 0; pendingOp = ""; })
+		                    .Cell(row: 0, column: 0),
+		                Button("/", () => SetOp("/")).Cell(row: 0, column: 3),
+		                Button("7", () => Append("7")).Cell(row: 1, column: 0),
+		                Button("8", () => Append("8")).Cell(row: 1, column: 1),
+		                Button("9", () => Append("9")).Cell(row: 1, column: 2),
+		                Button("x", () => SetOp("x")).Cell(row: 1, column: 3),
+		                Button("4", () => Append("4")).Cell(row: 2, column: 0),
+		                Button("5", () => Append("5")).Cell(row: 2, column: 1),
+		                Button("6", () => Append("6")).Cell(row: 2, column: 2),
+		                Button("-", () => SetOp("-")).Cell(row: 2, column: 3),
+		                Button("1", () => Append("1")).Cell(row: 3, column: 0),
+		                Button("2", () => Append("2")).Cell(row: 3, column: 1),
+		                Button("3", () => Append("3")).Cell(row: 3, column: 2),
+		                Button("+", () => SetOp("+")).Cell(row: 3, column: 3),
+		                Button("0", () => Append("0")).Cell(row: 4, column: 0, colSpan: 2),
+		                Button(".", () => Append(".")).Cell(row: 4, column: 2),
+		                Button("=", () => Calculate()).Cell(row: 4, column: 3)
+		            )
+		            .ColumnSpacing(8f)
+		            .RowSpacing(8f)
+		            .Padding(new Thickness(12))
+		        )
+		        .Background(Colors.Black);
+		}
+		```
+		""";
+
+	/// <summary>
+	/// "maui go serve" — explicit serve command (delegates to the same RunGoAsync logic).
+	/// Kept for discoverability and backward compat with existing docs.
+	/// </summary>
+	static Command CreateServeCommand(Option<int> portOption, Option<bool> noQrOption)
 	{
-		var portOption = new Option<int>("--port")
+		var fileArg = new Argument<string?>("file")
 		{
-			Description = "Port for the hot reload dev server",
-			DefaultValueFactory = _ => 9000
+			Description = "Optional .cs file to serve",
+			Arity = ArgumentArity.ZeroOrOne,
 		};
 
-		var qrOption = new Option<bool>("--qr")
+		var command = new Command("serve", "Start the Comet Go dev server with hot reload")
 		{
-			Description = "Display QR code for companion app connection"
-		};
-
-		var command = new Command("serve", "Start the MAUI Go dev server with hot reload")
-		{
-			portOption,
-			qrOption
+			fileArg,
 		};
 
 		command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
 		{
 			var port = parseResult.GetValue(portOption);
-			var showQr = parseResult.GetValue(qrOption);
-			var projectDir = Directory.GetCurrentDirectory();
+			var noQr = parseResult.GetValue(noQrOption);
+			var showQr = !noQr;
+			var file = parseResult.GetValue(fileArg);
 
-			// Verify we're in a Go project
-			var csproj = Directory.GetFiles(projectDir, "*.csproj").FirstOrDefault();
-			if (csproj is null)
-			{
-				Console.Error.WriteLine("Error: No .csproj found in current directory.");
-				Console.Error.WriteLine("Run 'maui go create <name>' first, then cd into the project.");
-				return 1;
-			}
-
-#if NET10_0_OR_GREATER
-			return await Go.Server.GoDevServer.RunAsync(projectDir, port, showQr, ct);
-#else
-			Console.Error.WriteLine("Error: 'maui go dev' requires .NET 10 or later.");
-			return 1;
-#endif
+			return await RunGoAsync(file, port, showQr, ct);
 		});
 
 		return command;
@@ -207,11 +582,11 @@ public static class GoCommands
 
 	static Command CreateUpgradeCommand()
 	{
-		var command = new Command("upgrade", "Graduate a MAUI Go project to a full MAUI project");
+		var command = new Command("upgrade", "Graduate a Comet Go app to a full MAUI project");
 
 		command.SetAction((ParseResult _, CancellationToken __) =>
 		{
-			Console.WriteLine($"[maui go upgrade] Not implemented yet.");
+			Console.WriteLine("[maui go upgrade] Not implemented yet.");
 			Console.WriteLine();
 			Console.WriteLine("  When implemented, this will:");
 			Console.WriteLine("  1. Keep all Comet views (they work in full MAUI too)");

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -15,7 +15,7 @@
     <IsShipping>true</IsShipping>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1572;CS1573;IL2104</NoWarn>
+    <NoWarn>$(NoWarn);CS1572;CS1573;IL2026;IL2104;IL3050</NoWarn>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -15,7 +15,7 @@
     <IsShipping>true</IsShipping>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1572;CS1573</NoWarn>
+    <NoWarn>$(NoWarn);CS1572;CS1573;IL2104</NoWarn>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>

--- a/src/Cli/Microsoft.Maui.Cli/Output/SpectreOutputFormatter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/SpectreOutputFormatter.cs
@@ -370,7 +370,7 @@ public class SpectreOutputFormatter : IOutputFormatter
 		{
 			var totalMinutes = (int)elapsed.TotalMinutes;
 			var tenths = elapsed.Milliseconds / 100;
-			return $"{totalMinutes}:{elapsed.Seconds:00}.{tenths}s";
+			return FormattableString.Invariant($"{totalMinutes}:{elapsed.Seconds:00}.{tenths}s");
 		}
 
 		return elapsed.TotalSeconds.ToString("0.0", CultureInfo.InvariantCulture) + "s";

--- a/src/Cli/Microsoft.Maui.Cli/Output/SpectreOutputFormatter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/SpectreOutputFormatter.cs
@@ -370,10 +370,10 @@ public class SpectreOutputFormatter : IOutputFormatter
 		{
 			var totalMinutes = (int)elapsed.TotalMinutes;
 			var tenths = elapsed.Milliseconds / 100;
-			return string.Create(CultureInfo.InvariantCulture, $"{totalMinutes}:{elapsed.Seconds:00}.{tenths:0}s");
+			return $"{totalMinutes}:{elapsed.Seconds:00}.{tenths}s";
 		}
 
-		return string.Create(CultureInfo.InvariantCulture, $"{elapsed.TotalSeconds:0.0}s");
+		return elapsed.TotalSeconds.ToString("0.0", CultureInfo.InvariantCulture) + "s";
 	}
 
 	internal static string FormatTimedStatusMarkup(string statusMarkup, TimeSpan elapsed)

--- a/src/Cli/Microsoft.Maui.Cli/Program.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Program.cs
@@ -110,6 +110,9 @@ public class Program
 		// DevFlow automation commands (maui devflow ...)
 		rootCommand.Add(DevFlow.DevFlowCommands.CreateDevFlowCommand(GlobalOptions.JsonOption));
 
+		// Comet Go single-file dev experience (maui go ...)
+		rootCommand.Add(Commands.GoCommands.Create());
+
 		return rootCommand;
 	}
 

--- a/src/Go/Shared/GoProtocol.cs
+++ b/src/Go/Shared/GoProtocol.cs
@@ -182,6 +182,7 @@ public static class GoProtocol
 	/// <summary>
 	/// Encode a JSON message (Hello, Welcome, CompilationError, RestartRequired).
 	/// </summary>
+#pragma warning disable IL2026, IL3050 // JSON serialization in dev-time tool
 	public static byte[] EncodeJson<T>(GoMessageType type, T message)
 	{
 		var json = JsonSerializer.SerializeToUtf8Bytes(message, JsonOptions);
@@ -200,6 +201,7 @@ public static class GoProtocol
 	/// </summary>
 	public static T DecodeJson<T>(ReadOnlySpan<byte> payload)
 		=> JsonSerializer.Deserialize<T>(payload, JsonOptions)!;
+#pragma warning restore IL2026, IL3050
 
 	/// <summary>
 	/// Encode a Ping or Pong frame (no payload).

--- a/src/Go/Shared/Microsoft.Maui.Go.Shared.csproj
+++ b/src/Go/Shared/Microsoft.Maui.Go.Shared.csproj
@@ -7,5 +7,7 @@
     <IsAotCompatible>false</IsAotCompatible>
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <!-- Suppress IL warnings that propagate to consuming projects (CLI) during ILC/AOT -->
+    <NoWarn>$(NoWarn);IL2026;IL3050</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Wires the `maui go` command tree into the unified Maui CLI so authors can run a single Comet `.cs` file with hot-reload, scaffold a starter file, and bundle the comet-go agent skill alongside it.

**Stacked on top of #215** (the Go server + companion app PR). Merge that one first.

## Commands

- `maui go [file.cs]` — auto-detects single-file vs project mode and spawns the dev server (`Microsoft.Maui.Go.Server.GoDevServer`)
  - 1 `.cs` file → single-file mode
  - Multiple `.cs` files + `.csproj` → project mode
  - Multiple `.cs` files but no `.csproj` → error with disambiguation message
- `maui go create <Name>` — emits a single-file Comet template (`Hello.cs` with `#:package Comet` file directive, no `.csproj`)
- `maui go upgrade` — graduate a Comet Go app to a full MAUI project
- `maui go serve <path>` — explicit server invocation

`Program.cs` registers the command tree under the root `maui` CLI (3-line wire-up).

## Agent skill

Auto-installs `~/.copilot/skills/comet-go/SKILL.md` on `maui go create` so AI coding assistants have correct Comet authoring guidance for the single-file format. The skill content (366 lines) is committed at `.github/skills/comet-go/SKILL.md`.

## Multi-targeting

The CLI multi-targets `net9.0` + `net10.0`. The `net10.0` build calls into the new server APIs; the `net9.0` build prints "requires .NET 10 build" and exits 1.

## Verified
- `dotnet build src/Cli/Microsoft.Maui.Cli -c Debug` → 0 errors

## Review fixes applied
- `maui go create <name>` now rejects names containing path separators, drive letters, `..`, or absolute paths, and double-checks the resolved path stays under `cwd` (was vulnerable to path traversal).
