### PR TITLE
Suppress NU1507 in Go and Comet Directory.Build.props

### DIFF
--- a/src/Comet/Directory.Build.props
+++ b/src/Comet/Directory.Build.props
@@ -25,9 +25,9 @@
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <SignAssembly>false</SignAssembly>
+    <!-- NU1507: official builds inject internal feeds via SetupNugetSources that aren't in packageSourceMapping -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
-
-  <!-- Common SupportedOSPlatformVersion -->
   <PropertyGroup>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">17.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">17.0</SupportedOSPlatformVersion>

--- a/src/Go/Directory.Build.props
+++ b/src/Go/Directory.Build.props
@@ -38,6 +38,8 @@
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <SignAssembly>false</SignAssembly>
+    <!-- NU1507: official builds inject internal feeds via SetupNugetSources that aren't in packageSourceMapping -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 
   <!-- Common SupportedOSPlatformVersion (matches CompanionApp targets) -->


### PR DESCRIPTION
## Problem

The Go and Comet products use isolated `Directory.Build.props` files that stop the MSBuild walk, preventing them from inheriting the repo-root `NoWarn` for NU1507. When CPM encounters multiple NuGet feeds without package source mapping, restore fails with:

> **NU1507**: There are 5 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source.

Failing run: https://github.com/dotnet/maui-labs/actions/runs/25308367178/job/74192312294

## Fix

Add `<NoWarn>$(NoWarn);NU1507</NoWarn>` to both:
- `src/Go/Directory.Build.props`
- `src/Comet/Directory.Build.props`

This mirrors the suppression already in the repo-root `Directory.Build.props` (line 17).

## Follow-up

A better long-term fix would be to add proper `<packageSourceMapping>` to `NuGet.config` instead of suppressing NU1507. Tracked in a follow-up issue.