### PR TITLE
Fix flaky CLI tests: serialize Program.Services mutators with [Collection]

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
 
+[Collection("CLI")]
 public class AndroidCommandsTests
 {
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AppleCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AppleCommandsTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
 
+[Collection("CLI")]
 public class AppleCommandsTests
 {
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
 
+[Collection("CLI")]
 public class ServiceConfigurationTests
 {
 	[Fact]


### PR DESCRIPTION
## Why

Three CLI test classes — `AppleCommandsTests`, `AndroidCommandsTests`, `ServiceConfigurationTests` — mutate the **static** `Program.Services` to inject fake providers, but were not part of any xUnit `[Collection]`. They therefore parallelized against each other **and** against the existing `[Collection("CLI")]` DevFlow tests, which also mutate `Program.Services`.

When two such tests ran concurrently, one would overwrite `Program.Services` mid-test, so the action under test resolved a different (or the production) provider. The `try { Program.Services = testProvider; ... } finally { Program.ResetServices(); }` pattern is not safe for parallel execution because `Program.Services` is process-wide.

## Concrete symptom

On macOS CI for PR #202:

```
Microsoft.Maui.Cli.UnitTests.AppleCommandsTests.InstallCommand_Json_ReturnsOneForFailedStatus
  Assert.Equal() Failure: Values differ
  Expected: 1
  Actual:   0
```

The install handler in `AppleCommands.cs` correctly returns `1` for `Status = "failed"`:

```csharp
return result.Status is "ok" or "skipped" ? 0 : 1;
```

…but `Program.AppleProvider` had been replaced by a parallel test's fake (whose default `InstallResult.Status = "ok"`), so the handler saw `"ok"` and returned `0`.

This also explains why the failure was intermittent: PR #200's CI run happened to win the race; PR #202's lost it.

## Fix

Tag all three classes with `[Collection("CLI")]` so they share the `DisableParallelization = true` collection already defined in `Fixtures/CliCollection.cs`. No production code changes.

```diff
+[Collection("CLI")]
 public class AppleCommandsTests
+[Collection("CLI")]
 public class AndroidCommandsTests
+[Collection("CLI")]
 public class ServiceConfigurationTests
```

## Verification

- Local Windows: `dotnet test` over the affected classes — 35/35 pass (`AppleCommandsTests` Install* skip on non-macOS, expected).
- Macros tests will exercise the install path on CI here.

## Follow-up

Unblocks CI on PR #200 and PR #202.
