### PR TITLE
fix: AzDO pipeline YAML errors + NuGet security compliance

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install workloads
         if: inputs.install-workloads
-        run: dotnet workload install ${{ inputs.workloads }}
+        run: dotnet workload install ${{ inputs.workloads }} --version 10.0.203
 
       - name: Install Android SDK dependencies (Windows)
         if: inputs.install-workloads && matrix.os == 'windows-latest'

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -23,6 +23,11 @@ on:
         type: boolean
         default: true
         description: 'Install MAUI workloads and Android SDK (not needed for net10.0-only projects)'
+      workloads:
+        required: false
+        type: string
+        default: 'maui ios maccatalyst macos maui-tizen'
+        description: 'Space-separated list of workloads to install (only used when install-workloads is true)'
       os:
         required: false
         type: string
@@ -83,7 +88,7 @@ jobs:
 
       - name: Install workloads
         if: inputs.install-workloads
-        run: dotnet workload install maui ios maccatalyst macos maui-tizen
+        run: dotnet workload install ${{ inputs.workloads }}
 
       - name: Install Android SDK dependencies (Windows)
         if: inputs.install-workloads && matrix.os == 'windows-latest'

--- a/.github/workflows/ci-devflow.yml
+++ b/.github/workflows/ci-devflow.yml
@@ -32,4 +32,4 @@ jobs:
       run-tests: true
       pack: true
       os: '["windows-latest"]'
-      workloads: 'maui-android maui-ios'
+      workloads: 'maui-android maui-ios macos'

--- a/.github/workflows/ci-devflow.yml
+++ b/.github/workflows/ci-devflow.yml
@@ -32,4 +32,3 @@ jobs:
       run-tests: true
       pack: true
       os: '["windows-latest"]'
-      workloads: 'maui-android maui-ios macos'

--- a/.github/workflows/ci-devflow.yml
+++ b/.github/workflows/ci-devflow.yml
@@ -32,3 +32,4 @@ jobs:
       run-tests: true
       pack: true
       os: '["windows-latest"]'
+      workloads: 'maui-android maui-ios'

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -593,17 +593,12 @@ extends:
     - ${{ if eq(parameters.publishWpfNuget, true) }}:
       - stage: publish_wpf_nuget
         displayName: 'Publish WPF to NuGet.org'
-    # Publish EssentialsAI packages to NuGet.org
-    - ${{ if eq(parameters.publishEssentialsAINuget, true) }}:
-      - stage: publish_essentialsai_nuget
-        displayName: 'Publish EssentialsAI to NuGet.org'
         dependsOn:
         - Validate
         - publish_using_darc
         jobs:
         - job: PrepareArtifacts
           displayName: 'Prepare WPF Artifacts'
-          displayName: 'Prepare EssentialsAI Artifacts'
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
@@ -615,9 +610,6 @@ extends:
               displayName: Publish WPF Packages
               targetPath: '$(Pipeline.Workspace)/WpfPackages'
               artifactName: WpfPackagesForNuGet
-              displayName: Publish EssentialsAI Packages
-              targetPath: '$(Pipeline.Workspace)/EssentialsAIPackages'
-              artifactName: EssentialsAIPackagesForNuGet
           steps:
           - download: current
             artifact: PackageArtifacts
@@ -629,12 +621,6 @@ extends:
 
         - job: PublishNuGet
           displayName: 'Push WPF to NuGet.org'
-              New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/EssentialsAIPackages'
-              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Essentials.AI.*.nupkg' '$(Pipeline.Workspace)/EssentialsAIPackages/' -Verbose
-            displayName: Filter EssentialsAI packages
-
-        - job: PublishNuGet
-          displayName: 'Push EssentialsAI to NuGet.org'
           dependsOn: PrepareArtifacts
           timeoutInMinutes: 30
           pool:
@@ -655,6 +641,52 @@ extends:
               useDotNetTask: false
               packagesToPush: '$(Pipeline.Workspace)/WpfPackages/*.nupkg'
               packageParentPath: '$(Pipeline.Workspace)/WpfPackages'
+              nuGetFeedType: external
+              publishFeedCredentials: 'nuget.org (dotnetframework)'
+
+    # Publish EssentialsAI packages to NuGet.org
+    - ${{ if eq(parameters.publishEssentialsAINuget, true) }}:
+      - stage: publish_essentialsai_nuget
+        displayName: 'Publish EssentialsAI to NuGet.org'
+        dependsOn:
+        - Validate
+        - publish_using_darc
+        jobs:
+        - job: PrepareArtifacts
+          displayName: 'Prepare EssentialsAI Artifacts'
+          timeoutInMinutes: 15
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026preview.scout.amd64
+            os: windows
+          templateContext:
+            outputs:
+            - output: pipelineArtifact
+              displayName: Publish EssentialsAI Packages
+              targetPath: '$(Pipeline.Workspace)/EssentialsAIPackages'
+              artifactName: EssentialsAIPackagesForNuGet
+          steps:
+          - download: current
+            artifact: PackageArtifacts
+            displayName: Download PackageArtifacts
+          - powershell: |
+              New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/EssentialsAIPackages'
+              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Essentials.AI.*.nupkg' '$(Pipeline.Workspace)/EssentialsAIPackages/' -Verbose -ErrorAction Stop
+            displayName: Filter EssentialsAI packages
+
+        - job: PublishNuGet
+          displayName: 'Push EssentialsAI to NuGet.org'
+          dependsOn: PrepareArtifacts
+          timeoutInMinutes: 30
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026preview.scout.amd64
+            os: windows
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
               artifactName: EssentialsAIPackagesForNuGet
               targetPath: '$(Pipeline.Workspace)/EssentialsAIPackages'
           steps:

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -105,8 +105,8 @@ extends:
             - script: eng\common\dotnet.cmd --info
               displayName: Provision .NET SDK via Arcade
             # DevFlow packages are built on Windows, including Apple library TFMs.
-            - script: .dotnet\dotnet workload install maui maui-android ios maccatalyst macos maui-tizen
-              displayName: Install MAUI and Apple workloads
+            - script: .dotnet\dotnet workload install maui-android maui-ios
+              displayName: Install MAUI workloads
             - script: .dotnet\dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
               displayName: Install Android SDK dependencies
             - script: eng\common\cibuild.cmd

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -105,7 +105,7 @@ extends:
             - script: eng\common\dotnet.cmd --info
               displayName: Provision .NET SDK via Arcade
             # DevFlow packages are built on Windows, including Apple library TFMs.
-            - script: .dotnet\dotnet workload install maui-android maui-ios
+            - script: .dotnet\dotnet workload install maui-android maui-ios macos
               displayName: Install MAUI workloads
             - script: .dotnet\dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
               displayName: Install Android SDK dependencies

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -105,8 +105,8 @@ extends:
             - script: eng\common\dotnet.cmd --info
               displayName: Provision .NET SDK via Arcade
             # DevFlow packages are built on Windows, including Apple library TFMs.
-            - script: .dotnet\dotnet workload install maui-android maui-ios macos
-              displayName: Install MAUI workloads
+            - script: .dotnet\dotnet workload install maui maui-android ios maccatalyst macos maui-tizen
+              displayName: Install MAUI and Apple workloads
             - script: .dotnet\dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj
               displayName: Install Android SDK dependencies
             - script: eng\common\cibuild.cmd

--- a/src/Comet/sample/CometBaristaNotes/nuget.config
+++ b/src/Comet/sample/CometBaristaNotes/nuget.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="LocalNuGets" value="/Users/davidortinau/work/LocalNuGets" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary

Fixes two AzDO pipeline issues introduced by the Comet merge (#62).

### 1. YAML parse error (informational run)
The WPF and EssentialsAI publish stages were merged/ duplicate `displayName`, `steps`, and artifact entries caused AzDO to reject the YAML. Separated into proper independent stages matching the existing Linux GTK4 pattern.overlapping 

### 2. NuGet Security Analysis failure
`src/Comet/sample/CometBaristaNotes/nuget.config` had a local path source (`/Users/davidortinau/work/LocalNuGets`) that violated Microsoft package feed security policies. Removed.

### Files changed
- `eng/pipelines/devflow-official. separated WPF + EssentialsAI publish stagesyml` 
- `src/Comet/sample/CometBaristaNotes/nuget. removed local path sourceconfig` 
