### PR TITLE
Remove src/Go/global.json that breaks CLI official builds

### DIFF
--- a/src/Go/global.json
+++ b/src/Go/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "11.0.100-preview.2.26159.112",
-    "rollForward": "latestPrerelease"
-  }
-}


### PR DESCRIPTION
Two fixes for AzDO SDK resolution failures.

## Problem

`UseDotNet@2` with `useGlobalJson: true` scans the **entire checkout** for `global.json` files. It finds `src/Comet/global.json` (which requires .NET 11 preview) and tries to install  even for non-Comet jobs like Linux GTK4 verify. This fails with:it 

```
sdk version matching: >=11.0.100 <11.0.200 could not be found
```

## Fixes

1. **Replace `useGlobalJson: true` with `version: 10.0.x`** on all 5 AzDO build jobs. Installs .NET 10 explicitly without scanning nested global.json files.

2. **Remove `src/Go/global. copy of the Comet global.json requiring .NET 11, but Go.Server targets `net10.0`.json`** 

`src/Comet/global.json` is intentionally  used by Comet's own GitHub Actions CI workflow which installs .NET 11 separately.kept 
