### PR TITLE
Replace useGlobalJson with explicit SDK version in AzDO pipeline

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -133,7 +133,7 @@ extends:
             - task: UseDotNet@2
               displayName: Install .NET SDK
               inputs:
-                useGlobalJson: true
+                version: 10.0.105
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
@@ -157,7 +157,7 @@ extends:
             - task: UseDotNet@2
               displayName: Install .NET SDK
               inputs:
-                useGlobalJson: true
+                version: 10.0.105
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
@@ -185,7 +185,7 @@ extends:
             - task: UseDotNet@2
               displayName: Install .NET SDK
               inputs:
-                useGlobalJson: true
+                version: 10.0.105
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
@@ -286,7 +286,7 @@ extends:
             - task: UseDotNet@2
               displayName: Install .NET SDK
               inputs:
-                useGlobalJson: true
+                version: 10.0.105
             - script: |
                 sudo apt-get update
                 sudo apt-get install -y \
@@ -355,7 +355,7 @@ extends:
             - task: UseDotNet@2
               displayName: Install .NET SDK
               inputs:
-                useGlobalJson: true
+                version: 10.0.105
             - script: dotnet workload install maui macos --version 10.0.203
               displayName: Install MAUI and macOS workloads
             - script: ./eng/common/cibuild.sh


### PR DESCRIPTION
Follow-up to # the global.json removal wasn't enough because `src/Comet/global.json` still exists and requires .NET 11 preview.227 

## Problem

`UseDotNet@2` with `useGlobalJson: true` scans the **entire checkout** and finds `src/Comet/global.json` (requiring .NET 11 preview). This causes non-Comet AzDO jobs to fail:

```
sdk version matching: >=11.0.100 <11.0.200 could not be found
```

## Fix

Replace `useGlobalJson: true` with `version: 10.0.x` on all 5 AzDO build jobs that use `UseDotNet@2`. This installs .NET 10 explicitly without scanning nested global.json files.

`src/Comet/global.json` is  Comet has its own GitHub Actions CI workflow that installs .NET 11 separately.kept 
