### PR TITLE
Add DevFlow extension descriptors

### DIFF
--- a/docs/DevFlow/spec/README.md
+++ b/docs/DevFlow/spec/README.md
@@ -12,3 +12,15 @@ These spec files are intended to stay framework-agnostic so the same DevFlow con
 Do not commit a generated JSON copy of the OpenAPI document. If a consumer needs JSON, generate it from `openapi.yaml` as part of that workflow so there is only one source of truth.
 
 The DevFlow unit tests parse `openapi.yaml` with OpenAPI tooling and validate YAML/JSON syntax plus `$ref` targets across this directory.
+
+## Extension discovery
+
+Agents can expose app-specific diagnostics or automation under `/api/v1/ext/{namespace}/...`. Extension namespaces use reverse-domain notation such as `com.example.diagnostics`.
+
+Extensions are discovered through `GET /api/v1/agent/capabilities`. The response includes an `extensions` object keyed by namespace. Each extension descriptor includes:
+
+- `version`: semantic version for the extension descriptor contract
+- `description`: human-readable summary
+- `tools[]`: self-describing tool descriptors with `name`, `description`, `method`, `path`, optional JSON Schema `parameters`, optional JSON Schema `returns`, and optional behavior `annotations`
+
+`GET /api/v1/agent/status` includes an `extensions` marker with `count` and `hash`. Clients can cache extension descriptors by hash and avoid fetching full capabilities when the marker has not changed.

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -1921,6 +1921,152 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  # ─────────────────────────────── Extensions ───────────────────────────
+  /api/v1/ext/{namespace}/{path}:
+    get:
+      operationId: callExtensionGet
+      tags: [extensions]
+      summary: Call extension endpoint (GET)
+      description: >
+        Proxy route for custom extension GET endpoints. The namespace uses
+        reverse-domain notation (e.g. `com.example.diagnostics`). Available
+        extensions and their self-describing tools are discoverable via
+        `GET /api/v1/agent/capabilities`. The `path` segment represents the
+        extension-defined relative path; agents may accept nested sub-paths.
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Extension namespace in reverse-domain notation.
+          schema:
+            type: string
+            pattern: "^[a-z][a-z0-9]*\\.[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)*$"
+        - name: path
+          in: path
+          required: true
+          description: Extension-defined sub-path.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Extension-defined response.
+          content:
+            application/json:
+              schema: {}
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    post:
+      operationId: callExtensionPost
+      tags: [extensions]
+      summary: Call extension endpoint (POST)
+      description: >
+        Proxy route for custom extension POST endpoints. Request and response
+        schemas are extension-defined and advertised by the tool descriptor in
+        the capabilities response.
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Extension namespace in reverse-domain notation.
+          schema:
+            type: string
+            pattern: "^[a-z][a-z0-9]*\\.[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)*$"
+        - name: path
+          in: path
+          required: true
+          description: Extension-defined sub-path.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: {}
+      responses:
+        "200":
+          description: Extension-defined response.
+          content:
+            application/json:
+              schema: {}
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    put:
+      operationId: callExtensionPut
+      tags: [extensions]
+      summary: Call extension endpoint (PUT)
+      description: >
+        Proxy route for custom extension PUT endpoints. Request and response
+        schemas are extension-defined and advertised by the tool descriptor in
+        the capabilities response.
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Extension namespace in reverse-domain notation.
+          schema:
+            type: string
+            pattern: "^[a-z][a-z0-9]*\\.[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)*$"
+        - name: path
+          in: path
+          required: true
+          description: Extension-defined sub-path.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: {}
+      responses:
+        "200":
+          description: Extension-defined response.
+          content:
+            application/json:
+              schema: {}
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: callExtensionDelete
+      tags: [extensions]
+      summary: Call extension endpoint (DELETE)
+      description: >
+        Proxy route for custom extension DELETE endpoints. Available extension
+        tools and behavior annotations are discoverable from
+        `GET /api/v1/agent/capabilities`.
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          description: Extension namespace in reverse-domain notation.
+          schema:
+            type: string
+            pattern: "^[a-z][a-z0-9]*\\.[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)*$"
+        - name: path
+          in: path
+          required: true
+          description: Extension-defined sub-path.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Extension-defined response.
+          content:
+            application/json:
+              schema: {}
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
 # ═══════════════════════════ Components ═══════════════════════════════
 components:
   parameters:

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -1931,8 +1931,9 @@ paths:
         Proxy route for custom extension GET endpoints. The namespace uses
         reverse-domain notation (e.g. `com.example.diagnostics`). Available
         extensions and their self-describing tools are discoverable via
-        `GET /api/v1/agent/capabilities`. The `path` segment represents the
-        extension-defined relative path; agents may accept nested sub-paths.
+        `GET /api/v1/agent/capabilities`. This generic OpenAPI template
+        represents a single path segment; clients should use each descriptor's
+        concrete `path` value when an extension advertises a nested sub-path.
       parameters:
         - name: namespace
           in: path
@@ -2056,6 +2057,11 @@ paths:
           description: Extension-defined sub-path.
           schema:
             type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: {}
       responses:
         "200":
           description: Extension-defined response.

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -174,40 +174,110 @@
     },
     "extensions": {
       "type": "object",
-      "description": "Map of extension namespaces (reverse-domain notation) to their route registrations.",
+      "description": "Map of extension namespaces (reverse-domain notation) to their self-describing tool registrations. Each extension is discoverable and invocable by CLI and MCP clients without hardcoded extension-specific code.",
       "additionalProperties": {
-        "type": "object",
-        "required": [
-          "routes"
-        ],
-        "properties": {
-          "routes": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "method",
-                "path"
-              ],
-              "properties": {
-                "method": {
-                  "type": "string",
-                  "description": "HTTP method for this route (e.g. 'GET', 'POST')."
-                },
-                "path": {
-                  "type": "string",
-                  "description": "URL path for this route."
-                }
-              }
-            },
-            "description": "Routes registered by this extension."
-          },
-          "description": {
-            "type": "string",
-            "description": "Human-readable description of this extension."
-          }
+        "$ref": "#/$defs/ExtensionDescriptor"
+      }
+    }
+  },
+  "$defs": {
+    "ExtensionDescriptor": {
+      "type": "object",
+      "required": [
+        "version",
+        "description",
+        "tools"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Semantic version of this extension. Changes to this value signal clients to refresh cached tool definitions.",
+          "pattern": "^\\d+\\.\\d+\\.\\d+"
         },
-        "description": "Extension details including registered routes."
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this extension provides."
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExtensionTool"
+          },
+          "description": "Self-describing tools exposed by this extension. Each tool maps to an HTTP endpoint under /api/v1/ext/{namespace}/."
+        }
+      },
+      "description": "Extension descriptor with version, description, and self-describing tools."
+    },
+    "ExtensionTool": {
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "method",
+        "path"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Machine-readable tool name, unique within the extension (e.g. 'build_info', 'capture_message').",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this tool does. Used by CLI help text and MCP tool metadata."
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE"
+          ],
+          "description": "HTTP method for this tool's endpoint."
+        },
+        "path": {
+          "type": "string",
+          "description": "Full URL path for this tool (e.g. '/api/v1/ext/com.example.diagnostics/build-info')."
+        },
+        "parameters": {
+          "type": "object",
+          "description": "JSON Schema describing the tool's input parameters. For GET requests, parameters are query strings. For POST and PUT, parameters are the JSON request body.",
+          "additionalProperties": true
+        },
+        "returns": {
+          "type": "object",
+          "description": "JSON Schema describing the tool's response body.",
+          "additionalProperties": true
+        },
+        "annotations": {
+          "$ref": "#/$defs/ExtensionToolAnnotations"
+        }
+      }
+    },
+    "ExtensionToolAnnotations": {
+      "type": "object",
+      "description": "Hints about the tool's behavior, modeled after MCP tool annotations.",
+      "properties": {
+        "readOnly": {
+          "type": "boolean",
+          "description": "True if the tool only reads data and has no side effects.",
+          "default": false
+        },
+        "idempotent": {
+          "type": "boolean",
+          "description": "True if calling the tool multiple times with the same input has the same effect as calling it once.",
+          "default": false
+        },
+        "destructive": {
+          "type": "boolean",
+          "description": "True if the tool may delete data or cause irreversible changes.",
+          "default": false
+        },
+        "category": {
+          "type": "string",
+          "description": "Optional grouping category (e.g. 'diagnostics', 'testing')."
+        }
       }
     }
   }

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -192,7 +192,7 @@
         "version": {
           "type": "string",
           "description": "Semantic version of this extension. Changes to this value signal clients to refresh cached tool definitions.",
-          "pattern": "^\\d+\\.\\d+\\.\\d+"
+          "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
         },
         "description": {
           "type": "string",
@@ -224,7 +224,7 @@
         },
         "description": {
           "type": "string",
-          "description": "Human-readable description of what this tool does. Used by CLI help text and MCP tool metadata."
+          "description": "Human-readable description of what this tool does. Used by extension discovery clients."
         },
         "method": {
           "type": "string",
@@ -242,7 +242,7 @@
         },
         "parameters": {
           "type": "object",
-          "description": "JSON Schema describing the tool's input parameters. For GET requests, parameters are query strings. For POST and PUT, parameters are the JSON request body.",
+          "description": "JSON Schema describing the tool's input parameters. For GET requests, parameters are query strings. For POST, PUT, and DELETE, parameters are the JSON request body.",
           "additionalProperties": true
         },
         "returns": {

--- a/docs/DevFlow/spec/schemas/agent-status.json
+++ b/docs/DevFlow/spec/schemas/agent-status.json
@@ -138,6 +138,26 @@
       "type": "string",
       "description": "Agent uptime as an ISO 8601 duration (e.g. 'PT1H30M15S').",
       "pattern": "^P"
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Lightweight marker indicating registered extensions. Allows clients to skip the heavier capabilities fetch when no extensions are present or when cached extension descriptors are still current.",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "description": "Number of registered extensions. When 0, clients can skip the capabilities call for extension discovery.",
+          "minimum": 0
+        },
+        "hash": {
+          "type": "string",
+          "description": "SHA-256 hash of the serialized extensions map from the capabilities response. Clients cache extension metadata keyed by this hash and only re-fetch capabilities when it changes.",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      },
+      "required": [
+        "count",
+        "hash"
+      ]
     }
   }
 }

--- a/samples/DevFlow.Sample/MauiProgram.cs
+++ b/samples/DevFlow.Sample/MauiProgram.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.DevFlow.Agent;
+using Microsoft.Maui.DevFlow.Agent.Core;
 using Microsoft.Maui.DevFlow.Blazor;
 
 namespace DevFlow.Sample;
@@ -42,6 +44,73 @@ public static class MauiProgram
 		{
 			options.Port = ResolveAgentPort();
 			options.EnableProfiler = true;
+
+			var diagnostics = options.RegisterExtension(
+				"com.example.diagnostics",
+				"Sample diagnostics extension",
+				"1.0.0",
+				new[] { "build_info", "echo" });
+
+			diagnostics.MapTool(
+				"build_info",
+				"Returns sample app build information.",
+				"GET",
+				"build-info",
+				_ => Task.FromResult(HttpResponse.Json(new
+				{
+					app = AppInfo.Current.Name,
+					version = AppInfo.Current.VersionString,
+					build = AppInfo.Current.BuildString
+				})),
+				returns: JsonDocument.Parse("""
+				{
+				  "type": "object",
+				  "properties": {
+				    "app": { "type": "string" },
+				    "version": { "type": "string" },
+				    "build": { "type": "string" }
+				  }
+				}
+				""").RootElement.Clone(),
+				annotations: new ExtensionToolAnnotations
+				{
+					ReadOnly = true,
+					Idempotent = true,
+					Category = "diagnostics"
+				});
+
+			diagnostics.MapTool(
+				"echo",
+				"Echoes a JSON request body back to the caller.",
+				"POST",
+				"echo",
+				request =>
+				{
+					using var document = JsonDocument.Parse(string.IsNullOrWhiteSpace(request.Body) ? "{}" : request.Body);
+					return Task.FromResult(HttpResponse.Json(new
+					{
+						body = document.RootElement.Clone()
+					}));
+				},
+				parameters: JsonDocument.Parse("""
+				{
+				  "type": "object",
+				  "additionalProperties": true
+				}
+				""").RootElement.Clone(),
+				returns: JsonDocument.Parse("""
+				{
+				  "type": "object",
+				  "properties": {
+				    "body": { "type": "object" }
+				  }
+				}
+				""").RootElement.Clone(),
+				annotations: new ExtensionToolAnnotations
+				{
+					Idempotent = true,
+					Category = "diagnostics"
+				});
 		});
 		builder.AddMauiBlazorDevFlowTools();
 #endif

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
@@ -55,6 +55,34 @@ public class DevFlowCliCommandTests
         Assert.Contains("hello", req.Body);
     }
 
+    [Fact]
+    public async Task ExtensionsDescribe_MissingExtension_WritesStructuredError()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "extensions", "describe", "com.example.missing", "--json");
+
+        Assert.Equal(1, result.ExitCode);
+        using var document = JsonDocument.Parse(result.StdErr);
+        Assert.Equal("InvocationError", document.RootElement.GetProperty("type").GetString());
+        Assert.Contains("was not found", document.RootElement.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task ExtensionsCall_MissingTool_WritesStructuredError()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "extensions", "call", "com.example.diagnostics", "missing", "--json");
+
+        Assert.Equal(1, result.ExitCode);
+        using var document = JsonDocument.Parse(result.StdErr);
+        Assert.Equal("InvocationError", document.RootElement.GetProperty("type").GetString());
+        Assert.Contains("was not found", document.RootElement.GetProperty("error").GetString());
+    }
+
     // ========== ui status / tree / query / element / hit-test ==========
 
     [Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
@@ -19,6 +19,42 @@ public class DevFlowCliCommandTests
         return (server, cli);
     }
 
+    // ========== extensions ==========
+
+    [Fact]
+    public async Task ExtensionsList_ReturnsRegisteredExtensions()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "extensions", "list", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.True(json.GetProperty("extensions").TryGetProperty("com.example.diagnostics", out var extension));
+        Assert.Equal("1.0.0", extension.GetProperty("version").GetString());
+        Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/agent/capabilities");
+    }
+
+    [Fact]
+    public async Task ExtensionsCall_PostsToolParameters()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync(
+            "devflow", "extensions", "call",
+            "com.example.diagnostics", "echo", """{"message":"hello"}""",
+            "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var json = result.ParseJsonOutput();
+        Assert.Equal("hello", json.GetProperty("body").GetProperty("message").GetString());
+        var req = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/ext/com.example.diagnostics/echo");
+        Assert.Equal("POST", req.Method);
+        Assert.Contains("hello", req.Body);
+    }
+
     // ========== ui status / tree / query / element / hit-test ==========
 
     [Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
@@ -60,8 +60,10 @@ internal static class MockAgentResponses
             "webview": { "version": 1, "features": ["contexts", "evaluate", "source"] },
             "network": { "version": 1, "features": ["list", "detail", "clear"] },
             "logs": { "version": 1, "features": ["list", "stream"] },
-            "sensors": { "version": 1, "features": ["list", "start", "stop"] },
-            "storage": { "version": 1, "features": ["preferences", "secure-storage", "roots", "files"] },
+            "device.sensors": { "version": 1, "features": ["list", "start", "stop"] },
+            "storage.preferences": { "version": 1, "features": ["list", "get", "set", "delete", "clear"] },
+            "storage.secure": { "version": 1, "features": ["get", "set", "delete", "clear"] },
+            "storage.files": { "version": 1, "features": ["roots", "list", "download", "upload", "delete"] },
             "profiler": { "version": 1, "features": ["capabilities", "sessions", "samples"] },
             "com.example.diagnostics": { "version": 1, "features": ["build_info", "echo"] }
           },

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
@@ -38,19 +38,68 @@ internal static class MockAgentResponses
           },
           "running": true,
           "cdpReady": true,
-          "cdpWebViewCount": 1
+          "cdpWebViewCount": 1,
+          "extensions": {
+            "count": 1,
+            "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+          }
         }
         """;
 
     public const string AgentCapabilities = """
         {
-          "ui": { "supported": true, "features": ["tree", "query", "tap", "fill", "batch"] },
-          "webview": { "supported": true, "features": ["contexts", "evaluate", "source"] },
-          "network": { "supported": true, "features": ["list", "detail", "clear"] },
-          "logs": { "supported": true, "features": ["list", "stream"] },
-          "sensors": { "supported": true, "features": ["list", "start", "stop"] },
-          "storage": { "supported": true, "features": ["preferences", "secure-storage", "roots", "files"] },
-          "profiler": { "supported": true, "features": ["capabilities", "sessions", "samples"] }
+          "agent": {
+            "name": "Microsoft.Maui.DevFlow.Agent",
+            "version": "0.1.0-test",
+            "framework": "maui",
+            "frameworkVersion": "10.0.0"
+          },
+          "capabilities": {
+            "ui.tree": { "version": 1, "features": ["tree", "query"] },
+            "ui.actions": { "version": 1, "features": ["tap", "fill", "batch"] },
+            "webview": { "version": 1, "features": ["contexts", "evaluate", "source"] },
+            "network": { "version": 1, "features": ["list", "detail", "clear"] },
+            "logs": { "version": 1, "features": ["list", "stream"] },
+            "sensors": { "version": 1, "features": ["list", "start", "stop"] },
+            "storage": { "version": 1, "features": ["preferences", "secure-storage", "roots", "files"] },
+            "profiler": { "version": 1, "features": ["capabilities", "sessions", "samples"] },
+            "com.example.diagnostics": { "version": 1, "features": ["build_info", "echo"] }
+          },
+          "extensions": {
+            "com.example.diagnostics": {
+              "version": "1.0.0",
+              "description": "Sample diagnostics extension",
+              "tools": [
+                {
+                  "name": "build_info",
+                  "description": "Returns build information.",
+                  "method": "GET",
+                  "path": "/api/v1/ext/com.example.diagnostics/build-info",
+                  "returns": { "type": "object" },
+                  "annotations": {
+                    "readOnly": true,
+                    "idempotent": true,
+                    "destructive": false,
+                    "category": "diagnostics"
+                  }
+                },
+                {
+                  "name": "echo",
+                  "description": "Echoes request parameters.",
+                  "method": "POST",
+                  "path": "/api/v1/ext/com.example.diagnostics/echo",
+                  "parameters": { "type": "object" },
+                  "returns": { "type": "object" },
+                  "annotations": {
+                    "readOnly": false,
+                    "idempotent": true,
+                    "destructive": false,
+                    "category": "diagnostics"
+                  }
+                }
+              ]
+            }
+          }
         }
         """;
 

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
@@ -64,6 +64,7 @@ public sealed class MockAgentServer : IAsyncDisposable
         RegisterStorageEndpoints(_app);
         RegisterWebViewEndpoints(_app);
         RegisterNetworkEndpoints(_app);
+        RegisterExtensionEndpoints(_app);
 
         await _app.StartAsync();
         Port = _app.Urls.Select(url => new Uri(url).Port).First();
@@ -88,6 +89,18 @@ public sealed class MockAgentServer : IAsyncDisposable
     {
         app.MapGet("/api/v1/agent/status", () => Results.Content(MockAgentResponses.AgentStatus, "application/json"));
         app.MapGet("/api/v1/agent/capabilities", () => Results.Content(MockAgentResponses.AgentCapabilities, "application/json"));
+    }
+
+    private static void RegisterExtensionEndpoints(WebApplication app)
+    {
+        app.MapGet("/api/v1/ext/com.example.diagnostics/build-info", () =>
+            Results.Content("""{"app":"TestApp","version":"1.0.0","build":"42"}""", "application/json"));
+        app.MapPost("/api/v1/ext/com.example.diagnostics/echo", async (HttpContext context) =>
+        {
+            using var reader = new StreamReader(context.Request.Body, Encoding.UTF8);
+            var body = await reader.ReadToEndAsync();
+            return Results.Content($$"""{"body":{{body}}}""", "application/json");
+        });
     }
 
     private static void RegisterUiEndpoints(WebApplication app)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
@@ -26,4 +26,8 @@ namespace Microsoft.Maui.Cli.DevFlow;
 [JsonSerializable(typeof(AndroidDevFlowForwardingReport))]
 [JsonSerializable(typeof(AndroidDevFlowDevice[]))]
 [JsonSerializable(typeof(AndroidDevFlowPortForward[]))]
+[JsonSerializable(typeof(ExtensionDescriptor))]
+[JsonSerializable(typeof(ExtensionToolInfo))]
+[JsonSerializable(typeof(ExtensionToolAnnotationsInfo))]
+[JsonSerializable(typeof(Dictionary<string, ExtensionDescriptor>))]
 internal sealed partial class DevFlowCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -1541,78 +1541,114 @@ public class DevFlowCommands
 
     private static async Task ExtensionsListAsync(string host, int port, bool json)
     {
-        using var client = new AgentClient(host, port);
-        var extensions = await client.GetExtensionsAsync();
-        if (json)
+        try
         {
-            var result = new JsonObject
+            using var client = new AgentClient(host, port);
+            var extensions = await client.GetExtensionsAsync();
+            if (json)
             {
-                ["extensions"] = JsonSerializer.SerializeToNode(
-                    extensions,
-                    typeof(Dictionary<string, ExtensionDescriptor>),
-                    DevFlowCliJsonContext.Default)
-            };
-            Output.WriteResult(result, json);
-            return;
-        }
+                var result = new JsonObject
+                {
+                    ["extensions"] = JsonSerializer.SerializeToNode(
+                        extensions,
+                        typeof(Dictionary<string, ExtensionDescriptor>),
+                        DevFlowCliJsonContext.Default)
+                };
+                Output.WriteResult(result, json);
+                return;
+            }
 
-        if (extensions.Count == 0)
+            if (extensions.Count == 0)
+            {
+                Console.WriteLine("No extensions registered on the connected agent.");
+                return;
+            }
+
+            Console.WriteLine($"{"Namespace",-35} {"Version",-10} {"Tools",-5} Description");
+            Console.WriteLine(new string('-', 90));
+            foreach (var (ns, extension) in extensions.OrderBy(e => e.Key, StringComparer.Ordinal))
+                Console.WriteLine($"{ns,-35} {extension.Version,-10} {extension.Tools.Count,-5} {extension.Description}");
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or IOException or JsonException or NotSupportedException)
         {
-            Console.WriteLine("No extensions registered on the connected agent.");
-            return;
+            Output.WriteError(ex.Message, json);
+            _errorOccurred = true;
         }
-
-        Console.WriteLine($"{"Namespace",-35} {"Version",-10} {"Tools",-5} Description");
-        Console.WriteLine(new string('-', 90));
-        foreach (var (ns, extension) in extensions.OrderBy(e => e.Key, StringComparer.Ordinal))
-            Console.WriteLine($"{ns,-35} {extension.Version,-10} {extension.Tools.Count,-5} {extension.Description}");
     }
 
     private static async Task ExtensionsDescribeAsync(string host, int port, string ns, bool json)
     {
-        using var client = new AgentClient(host, port);
-        var extensions = await client.GetExtensionsAsync();
-        if (!extensions.TryGetValue(ns, out var extension))
-            throw new InvalidOperationException($"Extension '{ns}' was not found.");
-
-        if (json)
+        try
         {
-            Output.WriteResult(extension, json);
-            return;
-        }
+            using var client = new AgentClient(host, port);
+            var extensions = await client.GetExtensionsAsync();
+            if (!extensions.TryGetValue(ns, out var extension))
+            {
+                Output.WriteError($"Extension '{ns}' was not found.", json, "InvocationError");
+                _errorOccurred = true;
+                return;
+            }
 
-        Console.WriteLine($"{ns} {extension.Version}");
-        Console.WriteLine(extension.Description);
-        Console.WriteLine();
-        Console.WriteLine($"{"Tool",-24} {"Method",-7} Path");
-        Console.WriteLine(new string('-', 80));
-        foreach (var tool in extension.Tools.OrderBy(t => t.Name, StringComparer.Ordinal))
-            Console.WriteLine($"{tool.Name,-24} {tool.Method,-7} {tool.Path}");
+            if (json)
+            {
+                Output.WriteResult(extension, json);
+                return;
+            }
+
+            Console.WriteLine($"{ns} {extension.Version}");
+            Console.WriteLine(extension.Description);
+            Console.WriteLine();
+            Console.WriteLine($"{"Tool",-24} {"Method",-7} Path");
+            Console.WriteLine(new string('-', 80));
+            foreach (var tool in extension.Tools.OrderBy(t => t.Name, StringComparer.Ordinal))
+                Console.WriteLine($"{tool.Name,-24} {tool.Method,-7} {tool.Path}");
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or IOException or JsonException or NotSupportedException)
+        {
+            Output.WriteError(ex.Message, json);
+            _errorOccurred = true;
+        }
     }
 
     private static async Task ExtensionsCallAsync(string host, int port, string ns, string toolName, string? parameters, bool json)
     {
-        using var client = new AgentClient(host, port);
-        var extensions = await client.GetExtensionsAsync();
-        if (!extensions.TryGetValue(ns, out var extension))
-            throw new InvalidOperationException($"Extension '{ns}' was not found.");
-
-        var tool = extension.Tools.FirstOrDefault(t => string.Equals(t.Name, toolName, StringComparison.Ordinal));
-        if (tool == null)
-            throw new InvalidOperationException($"Tool '{toolName}' was not found in extension '{ns}'.");
-
-        JsonElement? parameterJson = null;
-        if (!string.IsNullOrWhiteSpace(parameters))
-            parameterJson = JsonSerializer.Deserialize<JsonElement>(parameters);
-
-        var result = await client.CallExtensionToolAsync(tool.Method, tool.Path, parameterJson);
-        if (json)
+        try
         {
-            Console.WriteLine(result);
-            return;
-        }
+            using var client = new AgentClient(host, port);
+            var extensions = await client.GetExtensionsAsync();
+            if (!extensions.TryGetValue(ns, out var extension))
+            {
+                Output.WriteError($"Extension '{ns}' was not found.", json, "InvocationError");
+                _errorOccurred = true;
+                return;
+            }
 
-        Console.WriteLine(TryFormatJson(result));
+            var tool = extension.Tools.FirstOrDefault(t => string.Equals(t.Name, toolName, StringComparison.Ordinal));
+            if (tool == null)
+            {
+                Output.WriteError($"Tool '{toolName}' was not found in extension '{ns}'.", json, "InvocationError");
+                _errorOccurred = true;
+                return;
+            }
+
+            JsonElement? parameterJson = null;
+            if (!string.IsNullOrWhiteSpace(parameters))
+                parameterJson = JsonSerializer.Deserialize<JsonElement>(parameters);
+
+            var result = await client.CallExtensionToolAsync(tool.Method, tool.Path, parameterJson);
+            if (json)
+            {
+                Console.WriteLine(result);
+                return;
+            }
+
+            Console.WriteLine(TryFormatJson(result));
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or IOException or JsonException or NotSupportedException)
+        {
+            Output.WriteError(ex.Message, json);
+            _errorOccurred = true;
+        }
     }
 
     private static string TryFormatJson(string value)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Cli.DevFlow.Skills;
 using Microsoft.Maui.Cli.Utils;
+using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.Cli.DevFlow;
 
@@ -1434,6 +1435,52 @@ public class DevFlowCommands
 
         devflowCommand.Add(agentCommand);
 
+        // ===== extensions command (agent extension discovery + invocation) =====
+        var extensionsCommand = new Command("extensions", "Discover and call DevFlow agent extensions");
+
+        var extListCmd = new Command("list", "List all registered extensions on the connected agent");
+        extListCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            await ExtensionsListAsync(host, port, output.ResolveJsonMode(json, noJson));
+        });
+        extensionsCommand.Add(extListCmd);
+
+        var extDescribeNamespaceArg = new Argument<string>("namespace") { Description = "Extension namespace in reverse-domain notation" };
+        var extDescribeCmd = new Command("describe", "Describe extension tools") { extDescribeNamespaceArg };
+        extDescribeCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var ns = ctx.GetValue(extDescribeNamespaceArg)!;
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            await ExtensionsDescribeAsync(host, port, ns, output.ResolveJsonMode(json, noJson));
+        });
+        extensionsCommand.Add(extDescribeCmd);
+
+        var extCallNamespaceArg = new Argument<string>("namespace") { Description = "Extension namespace in reverse-domain notation" };
+        var extToolArg = new Argument<string>("tool") { Description = "Tool name within the extension" };
+        var extParametersArg = new Argument<string?>("parameters") { Description = "Optional JSON parameters", DefaultValueFactory = _ => null };
+        var extCallCmd = new Command("call", "Call an extension tool") { extCallNamespaceArg, extToolArg, extParametersArg };
+        extCallCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var ns = ctx.GetValue(extCallNamespaceArg)!;
+            var tool = ctx.GetValue(extToolArg)!;
+            var parameters = ctx.GetValue(extParametersArg);
+            var json = ctx.GetValue(jsonOption);
+            var noJson = ctx.GetValue(noJsonOption);
+            await ExtensionsCallAsync(host, port, ns, tool, parameters, output.ResolveJsonMode(json, noJson));
+        });
+        extensionsCommand.Add(extCallCmd);
+
+        devflowCommand.Add(extensionsCommand);
+
         // ===== batch command (interactive stdin/stdout) =====
         var batchDelayOption = new Option<int>("--delay") { Description = "Delay in ms between commands", DefaultValueFactory = _ => 250 };
         var batchContinueOption = new Option<bool>("--continue-on-error") { Description = "Continue executing after a command fails", DefaultValueFactory = _ => false };
@@ -1490,6 +1537,98 @@ public class DevFlowCommands
         _devflowCommand = devflowCommand;
 
         return devflowCommand;
+    }
+
+    private static async Task ExtensionsListAsync(string host, int port, bool json)
+    {
+        using var client = new AgentClient(host, port);
+        var extensions = await client.GetExtensionsAsync();
+        if (json)
+        {
+            var result = new JsonObject
+            {
+                ["extensions"] = JsonSerializer.SerializeToNode(
+                    extensions,
+                    typeof(Dictionary<string, ExtensionDescriptor>),
+                    DevFlowCliJsonContext.Default)
+            };
+            Output.WriteResult(result, json);
+            return;
+        }
+
+        if (extensions.Count == 0)
+        {
+            Console.WriteLine("No extensions registered on the connected agent.");
+            return;
+        }
+
+        Console.WriteLine($"{"Namespace",-35} {"Version",-10} {"Tools",-5} Description");
+        Console.WriteLine(new string('-', 90));
+        foreach (var (ns, extension) in extensions.OrderBy(e => e.Key, StringComparer.Ordinal))
+            Console.WriteLine($"{ns,-35} {extension.Version,-10} {extension.Tools.Count,-5} {extension.Description}");
+    }
+
+    private static async Task ExtensionsDescribeAsync(string host, int port, string ns, bool json)
+    {
+        using var client = new AgentClient(host, port);
+        var extensions = await client.GetExtensionsAsync();
+        if (!extensions.TryGetValue(ns, out var extension))
+            throw new InvalidOperationException($"Extension '{ns}' was not found.");
+
+        if (json)
+        {
+            Output.WriteResult(extension, json);
+            return;
+        }
+
+        Console.WriteLine($"{ns} {extension.Version}");
+        Console.WriteLine(extension.Description);
+        Console.WriteLine();
+        Console.WriteLine($"{"Tool",-24} {"Method",-7} Path");
+        Console.WriteLine(new string('-', 80));
+        foreach (var tool in extension.Tools.OrderBy(t => t.Name, StringComparer.Ordinal))
+            Console.WriteLine($"{tool.Name,-24} {tool.Method,-7} {tool.Path}");
+    }
+
+    private static async Task ExtensionsCallAsync(string host, int port, string ns, string toolName, string? parameters, bool json)
+    {
+        using var client = new AgentClient(host, port);
+        var extensions = await client.GetExtensionsAsync();
+        if (!extensions.TryGetValue(ns, out var extension))
+            throw new InvalidOperationException($"Extension '{ns}' was not found.");
+
+        var tool = extension.Tools.FirstOrDefault(t => string.Equals(t.Name, toolName, StringComparison.Ordinal));
+        if (tool == null)
+            throw new InvalidOperationException($"Tool '{toolName}' was not found in extension '{ns}'.");
+
+        JsonElement? parameterJson = null;
+        if (!string.IsNullOrWhiteSpace(parameters))
+            parameterJson = JsonSerializer.Deserialize<JsonElement>(parameters);
+
+        var result = await client.CallExtensionToolAsync(tool.Method, tool.Path, parameterJson);
+        if (json)
+        {
+            Console.WriteLine(result);
+            return;
+        }
+
+        Console.WriteLine(TryFormatJson(result));
+    }
+
+    private static string TryFormatJson(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "{}";
+
+        try
+        {
+            using var doc = JsonDocument.Parse(value);
+            return JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (JsonException)
+        {
+            return value;
+        }
     }
     
     // ===== CDP Helper: Send command via AgentClient =====

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -1633,7 +1633,7 @@ public class DevFlowCommands
 
             JsonElement? parameterJson = null;
             if (!string.IsNullOrWhiteSpace(parameters))
-                parameterJson = JsonSerializer.Deserialize<JsonElement>(parameters);
+                parameterJson = CliJson.ParseElement(parameters);
 
             var result = await client.CallExtensionToolAsync(tool.Method, tool.Path, parameterJson);
             if (json)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -47,7 +47,8 @@ public static class McpServerHost
 			.WithTools<JobTools>()
 			.WithTools<FileTools>()
 			.WithTools<BatchTools>()
-			.WithTools<InvokeTools>();
+			.WithTools<InvokeTools>()
+			.WithTools<ExtensionTools>();
 
 		await builder.Build().RunAsync();
 	}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ExtensionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ExtensionTools.cs
@@ -8,13 +8,6 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class ExtensionTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-        WriteIndented = false
-    };
-
     [McpServerTool(Name = "maui_extension_list"), Description("List all extensions registered on the connected DevFlow agent.")]
     public static async Task<string> ListExtensions(
         McpAgentSession session,
@@ -22,7 +15,7 @@ public sealed class ExtensionTools
     {
         using var client = await session.GetAgentClientAsync(agentPort);
         var extensions = await client.GetExtensionsAsync();
-        return JsonSerializer.Serialize(extensions, JsonOptions);
+        return CliJson.SerializeUntyped(extensions, indented: false);
     }
 
     [McpServerTool(Name = "maui_extension_call"), Description("Call an extension tool on the connected DevFlow agent.")]
@@ -44,7 +37,7 @@ public sealed class ExtensionTools
 
         JsonElement? parameterJson = null;
         if (!string.IsNullOrWhiteSpace(parameters))
-            parameterJson = JsonSerializer.Deserialize<JsonElement>(parameters);
+            parameterJson = CliJson.ParseElement(parameters);
 
         return await client.CallExtensionToolAsync(tool.Method, tool.Path, parameterJson);
     }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ExtensionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ExtensionTools.cs
@@ -15,7 +15,7 @@ public sealed class ExtensionTools
         WriteIndented = false
     };
 
-    [McpServerTool(Name = "extension_list"), Description("List all extensions registered on the connected DevFlow agent.")]
+    [McpServerTool(Name = "maui_extension_list"), Description("List all extensions registered on the connected DevFlow agent.")]
     public static async Task<string> ListExtensions(
         McpAgentSession session,
         [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
@@ -25,7 +25,7 @@ public sealed class ExtensionTools
         return JsonSerializer.Serialize(extensions, JsonOptions);
     }
 
-    [McpServerTool(Name = "extension_call"), Description("Call an extension tool on the connected DevFlow agent.")]
+    [McpServerTool(Name = "maui_extension_call"), Description("Call an extension tool on the connected DevFlow agent.")]
     public static async Task<string> CallExtension(
         McpAgentSession session,
         [Description("Extension namespace, e.g. com.example.diagnostics")] string extensionNamespace,

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ExtensionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ExtensionTools.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Microsoft.Maui.Cli.DevFlow.Mcp;
+
+namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class ExtensionTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    [McpServerTool(Name = "extension_list"), Description("List all extensions registered on the connected DevFlow agent.")]
+    public static async Task<string> ListExtensions(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        using var client = await session.GetAgentClientAsync(agentPort);
+        var extensions = await client.GetExtensionsAsync();
+        return JsonSerializer.Serialize(extensions, JsonOptions);
+    }
+
+    [McpServerTool(Name = "extension_call"), Description("Call an extension tool on the connected DevFlow agent.")]
+    public static async Task<string> CallExtension(
+        McpAgentSession session,
+        [Description("Extension namespace, e.g. com.example.diagnostics")] string extensionNamespace,
+        [Description("Tool name within the extension")] string toolName,
+        [Description("Optional JSON parameters for the tool")] string? parameters = null,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        using var client = await session.GetAgentClientAsync(agentPort);
+        var extensions = await client.GetExtensionsAsync();
+        if (!extensions.TryGetValue(extensionNamespace, out var extension))
+            return $"Extension '{extensionNamespace}' not found.";
+
+        var tool = extension.Tools.FirstOrDefault(t => string.Equals(t.Name, toolName, StringComparison.Ordinal));
+        if (tool == null)
+            return $"Tool '{toolName}' not found in extension '{extensionNamespace}'.";
+
+        JsonElement? parameterJson = null;
+        if (!string.IsNullOrWhiteSpace(parameters))
+            parameterJson = JsonSerializer.Deserialize<JsonElement>(parameters);
+
+        return await client.CallExtensionToolAsync(tool.Method, tool.Path, parameterJson);
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentExtension.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentExtension.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Maui.DevFlow.Agent.Core;
+
+public sealed class AgentExtension
+{
+    private static readonly Regex NamespacePattern = new("^[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private readonly List<AgentExtensionRoute> _routes = new();
+    private readonly List<ExtensionToolDescriptor> _tools = new();
+
+    public string Namespace { get; }
+    public string Description { get; }
+    public string Version { get; }
+    public IReadOnlyList<string> Features { get; }
+    internal IReadOnlyList<AgentExtensionRoute> Routes => _routes;
+    internal IReadOnlyList<ExtensionToolDescriptor> Tools => _tools;
+
+    public AgentExtension(string @namespace, string description, int version = 1, IEnumerable<string>? features = null)
+        : this(@namespace, description, $"{version}.0.0", features)
+    {
+    }
+
+    public AgentExtension(string @namespace, string description, string version, IEnumerable<string>? features = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
+
+        Namespace = @namespace.Trim();
+        if (!NamespacePattern.IsMatch(Namespace))
+            throw new ArgumentException("Extension namespace must use reverse-domain notation, e.g. 'com.example.tool'.", nameof(@namespace));
+
+        Description = description?.Trim() ?? string.Empty;
+        Version = string.IsNullOrWhiteSpace(version) ? "1.0.0" : version.Trim();
+        Features = (features ?? Array.Empty<string>())
+            .Where(f => !string.IsNullOrWhiteSpace(f))
+            .Select(f => f.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public void MapGet(string path, Func<HttpRequest, Task<HttpResponse>> handler)
+        => AddRoute("GET", path, handler);
+
+    public void MapPost(string path, Func<HttpRequest, Task<HttpResponse>> handler)
+        => AddRoute("POST", path, handler);
+
+    public void MapPut(string path, Func<HttpRequest, Task<HttpResponse>> handler)
+        => AddRoute("PUT", path, handler);
+
+    public void MapDelete(string path, Func<HttpRequest, Task<HttpResponse>> handler)
+        => AddRoute("DELETE", path, handler);
+
+    public void MapTool(
+        string name,
+        string description,
+        string method,
+        string path,
+        Func<HttpRequest, Task<HttpResponse>> handler,
+        JsonElement? parameters = null,
+        JsonElement? returns = null,
+        ExtensionToolAnnotations? annotations = null)
+        => AddRoute(method, path, handler, name, description, parameters, returns, annotations);
+
+    private void AddRoute(
+        string method,
+        string path,
+        Func<HttpRequest, Task<HttpResponse>> handler,
+        string? name = null,
+        string? description = null,
+        JsonElement? parameters = null,
+        JsonElement? returns = null,
+        ExtensionToolAnnotations? annotations = null)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var normalizedMethod = method.Trim().ToUpperInvariant();
+        var normalizedPath = NormalizePath(path);
+        var fullPath = $"/api/v1/ext/{Namespace}{normalizedPath}";
+        _routes.Add(new AgentExtensionRoute(normalizedMethod, fullPath, handler));
+        _tools.Add(new ExtensionToolDescriptor
+        {
+            Name = string.IsNullOrWhiteSpace(name) ? BuildToolName(normalizedMethod, normalizedPath) : name.Trim(),
+            Description = string.IsNullOrWhiteSpace(description) ? $"{normalizedMethod} {fullPath}" : description.Trim(),
+            Method = normalizedMethod,
+            Path = fullPath,
+            Parameters = parameters,
+            Returns = returns,
+            Annotations = annotations
+        });
+    }
+
+    private static string NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || path == "/")
+            return string.Empty;
+
+        var trimmed = path.Trim();
+        return trimmed.StartsWith('/') ? trimmed : $"/{trimmed}";
+    }
+
+    private static string BuildToolName(string method, string path)
+    {
+        var source = string.IsNullOrWhiteSpace(path) || path == "/" ? "root" : path.Trim('/');
+        var sanitized = Regex.Replace(source.ToLowerInvariant(), "[^a-z0-9]+", "_").Trim('_');
+        return string.IsNullOrWhiteSpace(sanitized) ? method.ToLowerInvariant() : sanitized;
+    }
+}
+
+internal sealed class AgentExtensionRoute
+{
+    public AgentExtensionRoute(string method, string path, Func<HttpRequest, Task<HttpResponse>> handler)
+    {
+        Method = method;
+        Path = path;
+        Handler = handler;
+    }
+
+    public string Method { get; }
+    public string Path { get; }
+    public Func<HttpRequest, Task<HttpResponse>> Handler { get; }
+}
+
+public sealed class ExtensionToolDescriptor
+{
+    public required string Name { get; init; }
+    public required string Description { get; init; }
+    public required string Method { get; init; }
+    public required string Path { get; init; }
+    public JsonElement? Parameters { get; init; }
+    public JsonElement? Returns { get; init; }
+    public ExtensionToolAnnotations? Annotations { get; init; }
+}
+
+public sealed class ExtensionToolAnnotations
+{
+    public bool ReadOnly { get; init; }
+    public bool Idempotent { get; init; }
+    public bool Destructive { get; init; }
+    public string? Category { get; init; }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentExtension.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentExtension.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.DevFlow.Agent.Core;
 public sealed class AgentExtension
 {
     private static readonly Regex NamespacePattern = new("^[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex SemanticVersionPattern = new("^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private readonly List<AgentExtensionRoute> _routes = new();
     private readonly List<ExtensionToolDescriptor> _tools = new();
 
@@ -31,6 +32,9 @@ public sealed class AgentExtension
 
         Description = description?.Trim() ?? string.Empty;
         Version = string.IsNullOrWhiteSpace(version) ? "1.0.0" : version.Trim();
+        if (!SemanticVersionPattern.IsMatch(Version))
+            throw new ArgumentException("Extension version must be a semantic version, e.g. '1.0.0'.", nameof(version));
+
         Features = (features ?? Array.Empty<string>())
             .Where(f => !string.IsNullOrWhiteSpace(f))
             .Select(f => f.Trim())
@@ -76,10 +80,14 @@ public sealed class AgentExtension
         var normalizedMethod = method.Trim().ToUpperInvariant();
         var normalizedPath = NormalizePath(path);
         var fullPath = $"/api/v1/ext/{Namespace}{normalizedPath}";
+        var toolName = string.IsNullOrWhiteSpace(name) ? BuildToolName(normalizedMethod, normalizedPath) : name.Trim();
+        if (_tools.Any(tool => string.Equals(tool.Name, toolName, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Duplicate extension tool name registration: {toolName}");
+
         _routes.Add(new AgentExtensionRoute(normalizedMethod, fullPath, handler));
         _tools.Add(new ExtensionToolDescriptor
         {
-            Name = string.IsNullOrWhiteSpace(name) ? BuildToolName(normalizedMethod, normalizedPath) : name.Trim(),
+            Name = toolName,
             Description = string.IsNullOrWhiteSpace(description) ? $"{normalizedMethod} {fullPath}" : description.Trim(),
             Method = normalizedMethod,
             Path = fullPath,
@@ -102,7 +110,9 @@ public sealed class AgentExtension
     {
         var source = string.IsNullOrWhiteSpace(path) || path == "/" ? "root" : path.Trim('/');
         var sanitized = Regex.Replace(source.ToLowerInvariant(), "[^a-z0-9]+", "_").Trim('_');
-        return string.IsNullOrWhiteSpace(sanitized) ? method.ToLowerInvariant() : sanitized;
+        return string.IsNullOrWhiteSpace(sanitized)
+            ? method.ToLowerInvariant()
+            : $"{method.ToLowerInvariant()}_{sanitized}";
     }
 }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentOptions.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentOptions.cs
@@ -115,4 +115,27 @@ public class AgentOptions
     /// Default: false to avoid broad attachment overhead.
     /// </summary>
     public bool EnableDetailedUiHooks { get; set; } = false;
+
+    /// <summary>
+    /// Custom routes registered under /api/v1/ext/{namespace}/...
+    /// </summary>
+    public IList<AgentExtension> Extensions { get; } = new List<AgentExtension>();
+
+    public AgentExtension RegisterExtension(
+        string @namespace,
+        string description,
+        int version = 1,
+        IEnumerable<string>? features = null)
+        => RegisterExtension(@namespace, description, $"{version}.0.0", features);
+
+    public AgentExtension RegisterExtension(
+        string @namespace,
+        string description,
+        string version,
+        IEnumerable<string>? features = null)
+    {
+        var extension = new AgentExtension(@namespace, description, version, features);
+        Extensions.Add(extension);
+        return extension;
+    }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -3,6 +3,8 @@ using System.Text.RegularExpressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Maui;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
@@ -544,6 +546,44 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         // Invoke / reflection
         _server.MapGet("/api/v1/invoke/actions", HandleListActions);
         _server.MapPost("/api/v1/invoke/actions/{name}", HandleInvokeAction);
+
+        RegisterExtensionRoutes();
+    }
+
+    private void RegisterExtensionRoutes()
+    {
+        var namespaces = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var extension in _options.Extensions)
+        {
+            if (!namespaces.Add(extension.Namespace))
+                throw new InvalidOperationException($"Duplicate extension namespace registration: {extension.Namespace}");
+
+            foreach (var route in extension.Routes)
+            {
+                var key = $"{route.Method} {route.Path}";
+                if (!seen.Add(key))
+                    throw new InvalidOperationException($"Duplicate extension route registration: {key}");
+
+                switch (route.Method)
+                {
+                    case "GET":
+                        _server.MapGet(route.Path, route.Handler);
+                        break;
+                    case "POST":
+                        _server.MapPost(route.Path, route.Handler);
+                        break;
+                    case "PUT":
+                        _server.MapPut(route.Path, route.Handler);
+                        break;
+                    case "DELETE":
+                        _server.MapDelete(route.Path, route.Handler);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unsupported extension route method: {route.Method}");
+                }
+            }
+        }
     }
 
     private async Task<HttpResponse> HandleStatus(HttpRequest request)
@@ -614,7 +654,8 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                 cdpReady = _cdpWebViews.Any(v => v.IsReady),
                 cdpWebViewCount = _cdpWebViews.Count,
                 profiler = BuildProfilerCapabilitiesPayload(),
-                profilerSession = _profilerSessions.CurrentSession
+                profilerSession = _profilerSessions.CurrentSession,
+                extensions = BuildExtensionsMarker()
             };
         });
 
@@ -639,62 +680,143 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private Task<HttpResponse> HandleCapabilities(HttpRequest request)
     {
-        var result = new
+        var version = typeof(DevFlowAgentService).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+
+        var capabilities = new Dictionary<string, object>();
+
+        capabilities["ui.tree"] = new { version = 1, features = new[] { "css-selector", "type", "text", "accessibility-id" } };
+        capabilities["ui.actions"] = new { version = 1, features = new[] { "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "properties" } };
+        capabilities["ui.screenshot"] = new { version = 1, features = new[] { "element", "fullscreen", "selector" } };
+
+        if (_cdpWebViews.Count > 0)
+            capabilities["webview"] = new { version = 1, features = new[] { "evaluate", "contexts", "source", "dom", "dom-query", "network", "console", "screenshot" } };
+
+        capabilities["profiler"] = new { version = 1, features = BuildProfilerFeatureList() };
+        capabilities["network"] = new { version = 1, features = new[] { "list", "detail", "clear", "stream" } };
+        capabilities["logs"] = new { version = 1, features = new[] { "list", "stream" } };
+        capabilities["device.info"] = new { version = 1, features = new[] { "app", "device", "display", "battery", "connectivity" } };
+        capabilities["device.sensors"] = new { version = 1, features = new[] { "list", "start", "stop", "stream" } };
+        capabilities["device.jobs"] = new
         {
-            ui = new
+            version = 1,
+            features = IsJobsSupported
+                ? IsJobRunSupported ? new[] { "list", "run" } : new[] { "list" }
+                : Array.Empty<string>(),
+            supported = IsJobsSupported
+        };
+        capabilities["device.ble"] = new { version = 1, features = Ble.SupportedFeatures, supported = Ble.SupportedFeatures.Count > 0 };
+        capabilities["storage.preferences"] = new { version = 1, features = new[] { "list", "get", "set", "delete", "clear" } };
+        capabilities["storage.secure"] = new { version = 1, features = new[] { "get", "set", "delete", "clear" } };
+        capabilities["storage.files"] = new { version = 1, features = new[] { "roots", "list", "download", "upload", "delete" } };
+        capabilities["invoke"] = new { version = 1, features = new[] { "actions" } };
+
+        var result = new Dictionary<string, object?>
+        {
+            ["agent"] = new
             {
-                supported = true,
-                features = new[] { "tree", "query", "hit-test", "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "properties", "screenshot" }
+                name = "Microsoft.Maui.DevFlow.Agent",
+                version,
+                framework = "maui",
+                frameworkVersion = typeof(Microsoft.Maui.Controls.Application).Assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown"
             },
-            webview = new
-            {
-                supported = _cdpWebViews.Any(v => v.IsReady),
-                features = _cdpWebViews.Any(v => v.IsReady)
-                    ? new[] { "evaluate", "contexts", "source", "dom", "dom-query", "network", "console", "screenshot" }
-                    : Array.Empty<string>()
-            },
-            network = new
-            {
-                supported = true,
-                features = new[] { "list", "detail", "clear", "stream" }
-            },
-            logs = new
-            {
-                supported = true,
-                features = new[] { "list", "stream" }
-            },
-            sensors = new
-            {
-                supported = true,
-                features = new[] { "list", "start", "stop", "stream" }
-            },
-            storage = new
-            {
-                supported = true,
-                features = new[] { "preferences", "secure-storage", "roots", "files" }
-            },
-            profiler = new
-            {
-                supported = IsProfilerFeatureAvailable,
-                features = IsProfilerFeatureAvailable
-                    ? new[] { "capabilities", "sessions", "samples", "markers", "spans", "hotspots" }
-                    : Array.Empty<string>()
-            },
-            jobs = new
-            {
-                supported = IsJobsSupported,
-                features = IsJobsSupported
-                    ? IsJobRunSupported ? new[] { "list", "run" } : new[] { "list" }
-                    : Array.Empty<string>()
-            },
-            invoke = new
-            {
-                supported = true,
-                features = new[] { "actions" }
-            }
+            ["capabilities"] = capabilities
         };
 
+        if (_options.Extensions.Count > 0)
+        {
+            var extensions = BuildExtensionMetadata();
+            foreach (var extension in _options.Extensions)
+            {
+                capabilities[extension.Namespace] = new
+                {
+                    version = GetCapabilityVersion(extension.Version),
+                    features = extension.Features.Count > 0
+                        ? extension.Features
+                        : extension.Tools.Select(tool => tool.Name).ToArray()
+                };
+            }
+
+            result["extensions"] = extensions;
+        }
+
         return Task.FromResult(HttpResponse.Json(result));
+    }
+
+    private object BuildExtensionsMarker()
+    {
+        var metadata = BuildExtensionMetadata();
+        return new
+        {
+            count = metadata.Count,
+            hash = ComputeExtensionHash(metadata)
+        };
+    }
+
+    private Dictionary<string, object> BuildExtensionMetadata()
+    {
+        var extensions = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        foreach (var extension in _options.Extensions.OrderBy(e => e.Namespace, StringComparer.Ordinal))
+        {
+            extensions[extension.Namespace] = new
+            {
+                version = extension.Version,
+                description = extension.Description,
+                tools = extension.Tools.Select(tool => new
+                {
+                    name = tool.Name,
+                    description = tool.Description,
+                    method = tool.Method,
+                    path = tool.Path,
+                    parameters = tool.Parameters,
+                    returns = tool.Returns,
+                    annotations = tool.Annotations is null ? null : new
+                    {
+                        readOnly = tool.Annotations.ReadOnly,
+                        idempotent = tool.Annotations.Idempotent,
+                        destructive = tool.Annotations.Destructive,
+                        category = tool.Annotations.Category
+                    }
+                }).ToArray()
+            };
+        }
+
+        return extensions;
+    }
+
+    private static string ComputeExtensionHash(Dictionary<string, object> metadata)
+    {
+        var json = JsonSerializer.Serialize(metadata);
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    private static int GetCapabilityVersion(string version)
+    {
+        var dot = version.IndexOf('.');
+        var major = dot >= 0 ? version[..dot] : version;
+        return int.TryParse(major, out var parsed) && parsed > 0 ? parsed : 1;
+    }
+
+    private string[] BuildProfilerFeatureList()
+    {
+        if (!IsProfilerFeatureAvailable)
+            return Array.Empty<string>();
+
+        var features = new List<string> { "capabilities", "sessions", "samples", "markers", "spans", "hotspots" };
+        var capabilities = _profilerCollector.GetCapabilities();
+        if (capabilities.ManagedMemorySupported)
+            features.Add("managed-memory");
+        if (capabilities.NativeMemorySupported)
+            features.Add("native-memory");
+        if (capabilities.CpuPercentSupported)
+            features.Add("cpu");
+        if (capabilities.FpsSupported)
+            features.Add("fps");
+
+        return features.ToArray();
     }
 
     private async Task<HttpResponse> HandleTree(HttpRequest request)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -705,7 +705,6 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                 : Array.Empty<string>(),
             supported = IsJobsSupported
         };
-        capabilities["device.ble"] = new { version = 1, features = Ble.SupportedFeatures, supported = Ble.SupportedFeatures.Count > 0 };
         capabilities["storage.preferences"] = new { version = 1, features = new[] { "list", "get", "set", "delete", "clear" } };
         capabilities["storage.secure"] = new { version = 1, features = new[] { "get", "set", "delete", "clear" } };
         capabilities["storage.files"] = new { version = 1, features = new[] { "roots", "list", "download", "upload", "delete" } };

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/AgentMetadataTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/AgentMetadataTests.cs
@@ -92,6 +92,6 @@ public class AgentMetadataTests : IntegrationTestBase
         Assert.NotNull(status!.Capabilities);
         Assert.Equal(
             status.Capabilities!.Jobs,
-            capabilities.GetProperty("jobs").GetProperty("supported").GetBoolean());
+            capabilities.GetProperty("capabilities").GetProperty("device.jobs").GetProperty("supported").GetBoolean());
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -80,8 +80,7 @@ public class AgentClient : IDisposable
 
     public async Task<Dictionary<string, ExtensionDescriptor>> GetExtensionsAsync()
     {
-        var json = await _http.GetStringAsync($"{_baseUrl}{AgentApi}/capabilities");
-        var capabilities = DriverJson.Deserialize<AgentCapabilitiesResponse>(json);
+        var capabilities = await GetAsync<AgentCapabilitiesResponse>($"{AgentApi}/capabilities");
         return capabilities?.Extensions ?? new Dictionary<string, ExtensionDescriptor>();
     }
 
@@ -90,16 +89,22 @@ public class AgentClient : IDisposable
         if (string.IsNullOrWhiteSpace(path) || !path.StartsWith('/'))
             throw new ArgumentException("Extension tool path must be an absolute agent path.", nameof(path));
 
-        using var request = new HttpRequestMessage(new HttpMethod(method), $"{_baseUrl}{path}");
-        if (parameters.HasValue && !string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase))
+        var httpMethod = new HttpMethod(method);
+        using var response = await SendWithTransientRetriesAsync(httpMethod, () => SendExtensionToolRequestAsync(httpMethod, path, parameters));
+        var body = await response.Content.ReadAsStringAsync();
+        response.EnsureSuccessStatusCode();
+        return body;
+    }
+
+    private async Task<HttpResponseMessage> SendExtensionToolRequestAsync(HttpMethod method, string path, JsonElement? parameters)
+    {
+        using var request = new HttpRequestMessage(method, $"{_baseUrl}{path}");
+        if (parameters.HasValue && method != HttpMethod.Get)
             request.Content = new StringContent(parameters.Value.GetRawText(), Encoding.UTF8, "application/json");
         else if (parameters.HasValue && parameters.Value.ValueKind == JsonValueKind.Object)
             request.RequestUri = new Uri($"{_baseUrl}{path}{BuildQueryString(parameters.Value)}");
 
-        using var response = await _http.SendAsync(request);
-        var body = await response.Content.ReadAsStringAsync();
-        response.EnsureSuccessStatusCode();
-        return body;
+        return await _http.SendAsync(request);
     }
 
     private static string BuildQueryString(JsonElement parameters)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -78,6 +78,47 @@ public class AgentClient : IDisposable
     public Task<JsonElement> GetCapabilitiesAsync()
         => GetJsonAsync($"{AgentApi}/capabilities");
 
+    public async Task<Dictionary<string, ExtensionDescriptor>> GetExtensionsAsync()
+    {
+        var json = await _http.GetStringAsync($"{_baseUrl}{AgentApi}/capabilities");
+        var capabilities = DriverJson.Deserialize<AgentCapabilitiesResponse>(json);
+        return capabilities?.Extensions ?? new Dictionary<string, ExtensionDescriptor>();
+    }
+
+    public async Task<string> CallExtensionToolAsync(string method, string path, JsonElement? parameters = null)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !path.StartsWith('/'))
+            throw new ArgumentException("Extension tool path must be an absolute agent path.", nameof(path));
+
+        using var request = new HttpRequestMessage(new HttpMethod(method), $"{_baseUrl}{path}");
+        if (parameters.HasValue && !string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase))
+            request.Content = new StringContent(parameters.Value.GetRawText(), Encoding.UTF8, "application/json");
+        else if (parameters.HasValue && parameters.Value.ValueKind == JsonValueKind.Object)
+            request.RequestUri = new Uri($"{_baseUrl}{path}{BuildQueryString(parameters.Value)}");
+
+        using var response = await _http.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+        response.EnsureSuccessStatusCode();
+        return body;
+    }
+
+    private static string BuildQueryString(JsonElement parameters)
+    {
+        var query = parameters.EnumerateObject()
+            .Select(property => $"{Uri.EscapeDataString(property.Name)}={Uri.EscapeDataString(FormatQueryValue(property.Value))}")
+            .ToArray();
+        return query.Length == 0 ? string.Empty : "?" + string.Join("&", query);
+    }
+
+    private static string FormatQueryValue(JsonElement value)
+        => value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? string.Empty,
+            JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => value.ToString(),
+            JsonValueKind.Null => string.Empty,
+            _ => value.GetRawText()
+        };
+
     /// <summary>
     /// Get the visual tree from the running app.
     /// </summary>
@@ -978,6 +1019,8 @@ public class AgentStatus
     public AppDescriptor? App { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("capabilities")]
     public AgentCapabilities? Capabilities { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("extensions")]
+    public ExtensionsMarker? Extensions { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("timestamp")]
     public string? Timestamp { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("running")]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/DevFlowDriverJson.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/DevFlowDriverJson.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Maui.DevFlow.Driver;
 [JsonSerializable(typeof(AgentClient.ProfilerSessionEnvelope))]
 [JsonSerializable(typeof(AgentClient.ActionResponse))]
 [JsonSerializable(typeof(InvokeResult))]
+[JsonSerializable(typeof(AgentCapabilitiesResponse))]
+[JsonSerializable(typeof(ExtensionDescriptor))]
+[JsonSerializable(typeof(ExtensionToolInfo))]
+[JsonSerializable(typeof(ExtensionToolAnnotationsInfo))]
+[JsonSerializable(typeof(Dictionary<string, ExtensionDescriptor>))]
 internal sealed partial class DevFlowDriverJsonContext : JsonSerializerContext;
 
 internal static class DriverJson

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ExtensionModels.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ExtensionModels.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.DevFlow.Driver;
+
+public sealed class ExtensionDescriptor
+{
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "";
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = "";
+
+    [JsonPropertyName("tools")]
+    public List<ExtensionToolInfo> Tools { get; set; } = [];
+}
+
+public sealed class ExtensionToolInfo
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = "";
+
+    [JsonPropertyName("method")]
+    public string Method { get; set; } = "GET";
+
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = "";
+
+    [JsonPropertyName("parameters")]
+    public JsonElement? Parameters { get; set; }
+
+    [JsonPropertyName("returns")]
+    public JsonElement? Returns { get; set; }
+
+    [JsonPropertyName("annotations")]
+    public ExtensionToolAnnotationsInfo? Annotations { get; set; }
+}
+
+public sealed class ExtensionToolAnnotationsInfo
+{
+    [JsonPropertyName("readOnly")]
+    public bool ReadOnly { get; set; }
+
+    [JsonPropertyName("idempotent")]
+    public bool Idempotent { get; set; }
+
+    [JsonPropertyName("destructive")]
+    public bool Destructive { get; set; }
+
+    [JsonPropertyName("category")]
+    public string? Category { get; set; }
+}
+
+public sealed class ExtensionsMarker
+{
+    [JsonPropertyName("count")]
+    public int Count { get; set; }
+
+    [JsonPropertyName("hash")]
+    public string Hash { get; set; } = "";
+}
+
+public sealed class AgentCapabilitiesResponse
+{
+    [JsonPropertyName("extensions")]
+    public Dictionary<string, ExtensionDescriptor>? Extensions { get; set; }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
@@ -296,9 +296,12 @@ public class AgentHttpServerTests : IDisposable
 
             var body = """
             {
-              "ui": { "supported": true, "features": ["tree", "tap", "batch"] },
-              "webview": { "supported": true, "features": ["contexts", "evaluate"] },
-              "network": { "supported": true, "features": ["list", "clear"] }
+              "agent": { "name": "Microsoft.Maui.DevFlow.Agent", "version": "1.0.0", "framework": "maui", "frameworkVersion": "10.0.0" },
+              "capabilities": {
+                "ui.actions": { "version": 1, "features": ["tap", "batch"] },
+                "webview": { "version": 1, "features": ["contexts", "evaluate"] },
+                "network": { "version": 1, "features": ["list", "clear"] }
+              }
             }
             """;
             var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
@@ -308,8 +311,8 @@ public class AgentHttpServerTests : IDisposable
         using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
         var capabilities = await agentClient.GetCapabilitiesAsync();
 
-        Assert.True(capabilities.GetProperty("ui").GetProperty("supported").GetBoolean());
-        Assert.Contains("batch", capabilities.GetProperty("ui").GetProperty("features").EnumerateArray().Select(x => x.GetString()));
+        Assert.Equal("maui", capabilities.GetProperty("agent").GetProperty("framework").GetString());
+        Assert.Contains("batch", capabilities.GetProperty("capabilities").GetProperty("ui.actions").GetProperty("features").EnumerateArray().Select(x => x.GetString()));
 
         await acceptTask;
         listener.Stop();

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/DevFlowAgentServiceLifecycleTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/DevFlowAgentServiceLifecycleTests.cs
@@ -169,6 +169,35 @@ public class DevFlowAgentServiceLifecycleTests
     }
 
     [Fact]
+    public void RegisterExtension_RejectsInvalidVersion()
+    {
+        var options = new AgentOptions();
+
+        Assert.Throws<ArgumentException>(() => options.RegisterExtension("com.example.diagnostics", "Diagnostics", "beta"));
+    }
+
+    [Fact]
+    public async Task Extensions_WithSamePathAndDifferentMethods_GenerateUniqueToolNames()
+    {
+        var port = GetFreePort();
+        var options = new AgentOptions { Port = port };
+        var extension = options.RegisterExtension("com.example.diagnostics", "Diagnostics");
+        extension.MapGet("echo", _ => Task.FromResult(HttpResponse.Json(new { method = "GET" })));
+        extension.MapPost("echo", _ => Task.FromResult(HttpResponse.Json(new { method = "POST" })));
+
+        using var service = new DevFlowAgentService(options);
+        using var client = new AgentClient("localhost", port);
+
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        var extensions = await client.GetExtensionsAsync();
+        var descriptor = Assert.Single(extensions);
+        var toolNames = descriptor.Value.Tools.Select(tool => tool.Name).OrderBy(name => name, StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(new[] { "get_echo", "post_echo" }, toolNames);
+    }
+
+    [Fact]
     public void StartServerOnly_RejectsDuplicateExtensionNamespace()
     {
         var options = new AgentOptions { Port = GetFreePort() };

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/DevFlowAgentServiceLifecycleTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/DevFlowAgentServiceLifecycleTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Text.Json;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.DevFlow.Agent.Core;
 using Microsoft.Maui.DevFlow.Driver;
@@ -45,10 +46,14 @@ public class DevFlowAgentServiceLifecycleTests
         Assert.NotNull(status);
         Assert.NotNull(status!.Capabilities);
         Assert.False(status.Capabilities!.Jobs);
+        Assert.NotNull(status.Extensions);
+        Assert.Equal(0, status.Extensions!.Count);
+        Assert.Matches("^[a-f0-9]{64}$", status.Extensions.Hash);
 
         var capabilities = await client.GetCapabilitiesAsync();
-        Assert.False(capabilities.GetProperty("jobs").GetProperty("supported").GetBoolean());
-        Assert.Empty(capabilities.GetProperty("jobs").GetProperty("features").EnumerateArray());
+        var jobsCapabilities = capabilities.GetProperty("capabilities").GetProperty("device.jobs");
+        Assert.False(jobsCapabilities.GetProperty("supported").GetBoolean());
+        Assert.Empty(jobsCapabilities.GetProperty("features").EnumerateArray());
 
         var jobs = await client.GetJobsAsync();
         Assert.False(jobs.GetProperty("supported").GetBoolean());
@@ -74,7 +79,7 @@ public class DevFlowAgentServiceLifecycleTests
         Assert.True(status.Capabilities!.Jobs);
 
         var capabilities = await client.GetCapabilitiesAsync();
-        var jobsCapabilities = capabilities.GetProperty("jobs");
+        var jobsCapabilities = capabilities.GetProperty("capabilities").GetProperty("device.jobs");
         Assert.True(jobsCapabilities.GetProperty("supported").GetBoolean());
 
         var features = jobsCapabilities.GetProperty("features").EnumerateArray().Select(feature => feature.GetString()).ToArray();
@@ -105,6 +110,72 @@ public class DevFlowAgentServiceLifecycleTests
 
         Assert.Equal("main-thread", result);
         Assert.Equal(1, service.MainThreadFallbackCallCount);
+    }
+
+    [Fact]
+    public async Task Extensions_AreDiscoverableAndCallable()
+    {
+        var port = GetFreePort();
+        var options = new AgentOptions { Port = port };
+        var extension = options.RegisterExtension(
+            "com.example.diagnostics",
+            "Diagnostics extension",
+            "1.2.3",
+            new[] { "build_info" });
+        extension.MapTool(
+            "build_info",
+            "Returns build information.",
+            "GET",
+            "build-info",
+            _ => Task.FromResult(HttpResponse.Json(new { version = "1.0.0" })),
+            returns: JsonDocument.Parse("""{"type":"object","properties":{"version":{"type":"string"}}}""").RootElement.Clone(),
+            annotations: new ExtensionToolAnnotations
+            {
+                ReadOnly = true,
+                Idempotent = true,
+                Category = "diagnostics"
+            });
+
+        using var service = new DevFlowAgentService(options);
+        using var client = new AgentClient("localhost", port);
+
+        service.StartServerOnly(new ImmediateDispatcher());
+
+        var status = await WaitForStatusAsync(client);
+        Assert.NotNull(status?.Extensions);
+        Assert.Equal(1, status!.Extensions!.Count);
+        Assert.Matches("^[a-f0-9]{64}$", status.Extensions.Hash);
+
+        var extensions = await client.GetExtensionsAsync();
+        var descriptor = Assert.Single(extensions);
+        Assert.Equal("com.example.diagnostics", descriptor.Key);
+        Assert.Equal("1.2.3", descriptor.Value.Version);
+        var tool = Assert.Single(descriptor.Value.Tools);
+        Assert.Equal("build_info", tool.Name);
+        Assert.Equal("/api/v1/ext/com.example.diagnostics/build-info", tool.Path);
+        Assert.True(tool.Annotations!.ReadOnly);
+
+        var result = await client.CallExtensionToolAsync(tool.Method, tool.Path);
+        using var resultJson = JsonDocument.Parse(result);
+        Assert.Equal("1.0.0", resultJson.RootElement.GetProperty("version").GetString());
+    }
+
+    [Fact]
+    public void RegisterExtension_RejectsInvalidNamespace()
+    {
+        var options = new AgentOptions();
+
+        Assert.Throws<ArgumentException>(() => options.RegisterExtension("diagnostics", "Invalid namespace"));
+    }
+
+    [Fact]
+    public void StartServerOnly_RejectsDuplicateExtensionNamespace()
+    {
+        var options = new AgentOptions { Port = GetFreePort() };
+        options.RegisterExtension("com.example.diagnostics", "First");
+        options.RegisterExtension("com.example.diagnostics", "Second");
+
+        Assert.Throws<InvalidOperationException>(() => new DevFlowAgentService(options));
     }
 
     private static async Task<AgentStatus?> WaitForStatusAsync(AgentClient client)

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -113,6 +113,7 @@ The same value can also be supplied via the `MAUI_DEVFLOW_SESSION_ID` environmen
 - **Device Introspection** — battery, connectivity, geolocation, display, permissions, and sensor data
 - **Dialog Handling** — detect and dismiss alerts/action sheets programmatically
 - **Batch Operations** — execute command sequences from stdin for scripting
+- **Agent Extensions** — expose app-specific diagnostic tools under `/api/v1/ext/{namespace}/...` with self-describing metadata for CLI and MCP discovery
 - **Multi-Platform** — iOS, Android, Mac Catalyst, Windows, Linux/GTK
 
 ## CLI Commands
@@ -128,6 +129,7 @@ All DevFlow commands are available under `maui devflow`. Run `maui devflow <comm
 | `network` | Monitor and inspect HTTP requests |
 | `storage` | Read/write app preferences, secure storage, discover file storage roots, and manage sandboxed app files |
 | `agent` | Discover and inspect connected agents (status, list, wait, diagnose) |
+| `extensions` | List, describe, and call app-specific DevFlow extension tools |
 | `broker` | Manage the agent broker (start, stop, status, log) |
 | `batch` | Execute command sequences from stdin |
 | `commands` | List all available commands (schema discovery) |


### PR DESCRIPTION
Adds self-describing DevFlow extension descriptors so MAUI apps can advertise app-specific tools with stable metadata, JSON Schema inputs/outputs, and annotations. This lets DevFlow clients discover available app tools and invoke them through a consistent protocol surface.

## What changed

- Updates the DevFlow protocol schemas and OpenAPI docs with descriptor-based extension discovery, extension proxy operations, and an extension status marker for cache invalidation.
- Adds a MAUI agent extension registration model with namespace validation, explicit tool descriptors, route helpers, duplicate route checks, capabilities metadata, and status hashing.
- Wires extension discovery and invocation through the driver, CLI commands, and stable MCP tools.
- Adds a neutral sample diagnostics extension plus unit test coverage for capabilities, status markers, CLI list/call flows, and duplicate namespace handling.

## Notes

Dynamic per-extension MCP tool registration is intentionally deferred. This change adds stable discovery and invocation tools first so clients can consume extension metadata without requiring server-side dynamic tool registration.

## Validation

- `dotnet build /Users/redth/code/maui-labs/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/Microsoft.Maui.DevFlow.Agent.Core.csproj --nologo`
- `dotnet build /Users/redth/code/maui-labs/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Microsoft.Maui.DevFlow.Driver.csproj --nologo`
- `dotnet build /Users/redth/code/maui-labs/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj --nologo`
- `dotnet test /Users/redth/code/maui-labs/src/DevFlow/Microsoft.Maui.DevFlow.Tests/Microsoft.Maui.DevFlow.Tests.csproj --nologo --no-restore`
- `dotnet test /Users/redth/code/maui-labs/src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj --nologo --no-restore`
- `dotnet build /Users/redth/code/maui-labs/samples/DevFlow.Sample/DevFlow.Sample.csproj --nologo --no-restore`