### PR TITLE
Add Xcode 26.3 selection to macOS AppKit AzDO job + update pipeline instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -295,9 +295,11 @@ The official pipeline is **`eng/pipelines/devflow-official.yml`**. It handles Ar
               displayName: Build and Test {Product}
 ```
 
-> **Workload versioning:** Always pin workload installs with `--version 10.0.203` (or the current pinned version from `_build.yml`). Unpinned installs cause version drift between CI and official builds.
+> **SDK versioning:** Use `UseDotNet@2` with an explicit `version:` matching the repo-root `global.json` SDK version, **not** `useGlobalJson: true` — the latter scans the entire checkout and can find nested `global.json` files (e.g. Comet's .NET 11 preview) that break non-Comet jobs.
 >
-> **macOS builds:** Products targeting `net10.0-macos` must build on macOS. Use `pool: { name: Azure Pipelines, vmImage: macos-latest-internal, os: macOS }` with a `templateContext:` block (even if `outputs: []`). The internal `NetCore1ESPool-Internal` pool does not have macOS agents. See the `EssentialsAI_macOS` job for the full pattern.
+> **Workload versioning:** Always pin workload installs with `--version <pinned>`. Check `_build.yml` for the current pinned version. Unpinned installs cause version drift between CI and official builds.
+>
+> **macOS builds:** Products targeting `net10.0-macos` must build on macOS. Use `pool: { name: Azure Pipelines, vmImage: macos-latest-internal, os: macOS }` with a `templateContext:` block (even if `outputs: []`). Add a `sudo xcode-select` step before workload install — the required Xcode version depends on the workload version. Check by running `dotnet workload install maui --version <pinned>` locally and reading the error message, or consult https://aka.ms/xcode-requirement. See the `EssentialsAI_macOS` job for the full pattern.
 
 #### c) Conditional publish stage (at the bottom, after the other `publish_*_nuget` stages)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ Each product requires source setup **and** CI/CD configuration across two system
 ### CI/CD Setup
 
 7. **GitHub Actions**: Create `.github/workflows/ci-{newproduct}.yml` calling the reusable `_build.yml` workflow. Must include `pull_request.types: [opened, synchronize, reopened, edited]` and path filters scoped to the product source plus shared build files.
-8. **Azure DevOps**: Edit `eng/pipelines/devflow-official.yml` — add a publish parameter, a build job in the `build` stage, and a conditional publish stage for NuGet.org. Pin workload installs with `--version 10.0.203` (match `_build.yml`). macOS-only products must use `pool: { name: Azure Pipelines, vmImage: macos-15, os: macOS }` with a `templateContext:` block.
+8. **Azure DevOps**: Edit `eng/pipelines/devflow-official.yml` — add a publish parameter, a build job in the `build` stage, and a conditional publish stage for NuGet.org. Use `UseDotNet@2` with an explicit `version:` matching `global.json` (not `useGlobalJson: true`). Pin workloads with `--version` matching `_build.yml`. macOS products must use `pool: { name: Azure Pipelines, vmImage: macos-latest-internal, os: macOS }` with `templateContext:`, and select the Xcode version required by the pinned workload (check https://aka.ms/xcode-requirement).
 
 > **Complete copy-paste templates** for both the GitHub Actions workflow and all three Azure DevOps blocks (parameter, build job, publish stage) are in `.github/copilot-instructions.md` under **"CI/CD — New Product Checklist"**.
 

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -356,6 +356,8 @@ extends:
               displayName: Install .NET SDK
               inputs:
                 version: 10.0.105
+            - script: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+              displayName: Select Xcode 26.3
             - script: dotnet workload install maui macos --version 10.0.203
               displayName: Install MAUI and macOS workloads
             - script: ./eng/common/cibuild.sh


### PR DESCRIPTION
## Problem

macOS AppKit AzDO build fails:
```
This version of .NET for macOS (26.2.10233) requires Xcode 26.3.
The current version of Xcode is 16.4.
```

The EssentialsAI macOS job already selects Xcode 26.3; the AppKit job was missing this step.

## Changes

1. **Pipeline  add `sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer` to the macOS AppKit job, before workload installfix** 

2. **AGENTS.md + copilot-instructions. consolidated all AzDO pipeline learnings from this session:md** 
   - Use `version: 10.0.105` not `useGlobalJson: true` (avoids nested global.json conflicts)
   - Pin workloads with `--version 10.0.203`
   - Select Xcode 26.3 on macOS jobs
   - Use `macos-latest-internal` image with `templateContext`
