### PR TITLE
bump: Xamarin.Apple.Tools.MaciOS 1.0.0-preview.1.26255.1 + simulator app lifecycle commands

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -32,9 +32,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>73b3b5ac0e4a5658c7a0555b67d91a22ad39de4b</Sha>
     </Dependency>
-    <Dependency Name="Xamarin.Apple.Tools.MaciOS" Version="1.0.0-preview.1.26230.1">
+    <Dependency Name="Xamarin.Apple.Tools.MaciOS" Version="1.0.0-preview.1.26255.1">
       <Uri>https://github.com/dotnet/macios-devtools</Uri>
-      <Sha>11fad7fe464a7de7dd809542e4bb352310236052</Sha>
+      <Sha>87eb6abbc8d317b0b4c530b084ee3794b7f04c95</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">
-    <XamarinAppleToolsMaciOSVersion>1.0.0-preview.1.26230.1</XamarinAppleToolsMaciOSVersion>
+    <XamarinAppleToolsMaciOSVersion>1.0.0-preview.1.26255.1</XamarinAppleToolsMaciOSVersion>
   </PropertyGroup>
   <PropertyGroup Label="Platform Extensions">
     <PlatformMauiLinuxGtk4Version>0.6.0</PlatformMauiLinuxGtk4Version>

--- a/eng/smoke-tests/apple-cli-smoke-test.sh
+++ b/eng/smoke-tests/apple-cli-smoke-test.sh
@@ -159,6 +159,31 @@ else
     fail "Install --platform all dry-run" "No status in JSON output"
 fi
 
+# --- Test 8: Simulator app lifecycle commands (invalid UDID = validates error handling) ---
+echo "Test 8: maui apple simulator install (invalid UDID, expects E2204)"
+SIM_INSTALL_OUTPUT=$($MAUI apple simulator install "INVALID-UDID" "/tmp/Fake.app" --json 2>&1) || true
+if echo "$SIM_INSTALL_OUTPUT" | grep -q 'E2204'; then
+    pass "Simulator install correctly returns E2204 for invalid UDID"
+else
+    fail "Simulator install error handling" "Expected E2204 in output"
+fi
+
+echo "Test 9: maui apple simulator launch (invalid UDID, expects E2204)"
+SIM_LAUNCH_OUTPUT=$($MAUI apple simulator launch "INVALID-UDID" "com.fake.app" --json 2>&1) || true
+if echo "$SIM_LAUNCH_OUTPUT" | grep -q 'E2204'; then
+    pass "Simulator launch correctly returns E2204 for invalid UDID"
+else
+    fail "Simulator launch error handling" "Expected E2204 in output"
+fi
+
+echo "Test 10: maui apple simulator get-app-container (invalid UDID, expects E2204)"
+SIM_CONTAINER_OUTPUT=$($MAUI apple simulator get-app-container "INVALID-UDID" "com.fake.app" --json 2>&1) || true
+if echo "$SIM_CONTAINER_OUTPUT" | grep -q 'E2204'; then
+    pass "Simulator get-app-container correctly returns E2204 for invalid UDID"
+else
+    fail "Simulator get-app-container error handling" "Expected E2204 in output"
+fi
+
 # --- Summary ---
 echo ""
 echo "========================================"

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AppleSimulatorCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AppleSimulatorCommandsTests.cs
@@ -1,16 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using Microsoft.Maui.Cli.Commands;
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Output;
+using Microsoft.Maui.Cli.Providers.Apple;
 using Microsoft.Maui.Cli.UnitTests.Fakes;
 using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
 
+[Collection("CLI")]
 public class AppleSimulatorCommandsTests
 {
 	[Fact]
@@ -347,5 +352,109 @@ public class AppleSimulatorCommandsTests
 		var error = ErrorResult.FromException(ex);
 		Assert.Equal("E2213", error.Code);
 		Assert.Equal("platform", error.Category);
+	}
+
+	// --- Handler-level tests (require macOS, exercise CLI argument parsing) ---
+
+	static async Task<(int ExitCode, string StdOut, string StdErr, FakeAppleProvider Fake)> InvokeSimulatorCommandAsync(
+		Action<FakeAppleProvider>? configure = null,
+		params string[] args)
+	{
+		var fake = new FakeAppleProvider();
+		configure?.Invoke(fake);
+
+		var testProvider = ServiceConfiguration.CreateTestServiceProvider(appleProvider: fake);
+		var originalServices = Program.Services;
+		var stdOut = new StringWriter();
+		var stdErr = new StringWriter();
+		var originalOut = Console.Out;
+		var originalErr = Console.Error;
+		try
+		{
+			Program.Services = testProvider;
+			Console.SetOut(stdOut);
+			Console.SetError(stdErr);
+
+			var rootCommand = Program.BuildRootCommand();
+			var parseResult = rootCommand.Parse(args);
+			var exitCode = await parseResult.InvokeAsync();
+			return (exitCode, stdOut.ToString(), stdErr.ToString(), fake);
+		}
+		finally
+		{
+			Console.SetOut(originalOut);
+			Console.SetError(originalErr);
+			Program.ResetServices();
+		}
+	}
+
+	[Fact]
+	public async Task LaunchCommand_ForwardsArgsToProvider()
+	{
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			return;
+
+		var (exitCode, stdout, _, fake) = await InvokeSimulatorCommandAsync(
+			f =>
+			{
+				f.Simulators.Add(new SimulatorInfo { Name = "iPhone 15", Udid = "AAAA-BBBB", IsAvailable = true });
+				f.LaunchAppResult = true;
+			},
+			"apple", "simulator", "launch", "AAAA-BBBB", "com.test.app", "--args", "--debug", "--wait-for-debugger", "--json");
+
+		Assert.Equal(0, exitCode);
+		Assert.Single(fake.LaunchedApps);
+		Assert.Equal("AAAA-BBBB", fake.LaunchedApps[0].Udid);
+		Assert.Equal("com.test.app", fake.LaunchedApps[0].BundleId);
+		Assert.Equal(new[] { "--debug", "--wait-for-debugger" }, fake.LaunchedApps[0].Args);
+	}
+
+	[Fact]
+	public async Task InstallCommand_InvalidUdid_ReturnsSimulatorNotFound()
+	{
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			return;
+
+		// Create a temporary .app directory so we pass path validation and hit the UDID check
+		var tempApp = Path.Combine(Path.GetTempPath(), $"FakeTest_{Guid.NewGuid():N}.app");
+		Directory.CreateDirectory(tempApp);
+		try
+		{
+			var (exitCode, stdout, _, fake) = await InvokeSimulatorCommandAsync(
+				f =>
+				{
+					// No simulators — any UDID will be "not found"
+					f.InstallAppResult = true;
+				},
+				"apple", "simulator", "install", "BAD-UDID", tempApp, "--json");
+
+			Assert.Equal(1, exitCode);
+			Assert.Contains("E2204", stdout);
+			Assert.Empty(fake.InstalledApps); // never reached the provider
+		}
+		finally
+		{
+			Directory.Delete(tempApp, recursive: true);
+		}
+	}
+
+	[Fact]
+	public async Task UninstallCommand_ValidUdid_CallsProvider()
+	{
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			return;
+
+		var (exitCode, stdout, _, fake) = await InvokeSimulatorCommandAsync(
+			f =>
+			{
+				f.Simulators.Add(new SimulatorInfo { Name = "iPhone 16", Udid = "SIM-1234", IsAvailable = true });
+				f.UninstallAppResult = true;
+			},
+			"apple", "simulator", "uninstall", "SIM-1234", "com.example.myapp", "--json");
+
+		Assert.Equal(0, exitCode);
+		Assert.Single(fake.UninstalledApps);
+		Assert.Equal(("SIM-1234", "com.example.myapp"), fake.UninstalledApps[0]);
+		Assert.Contains("uninstalled", stdout);
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AppleSimulatorCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AppleSimulatorCommandsTests.cs
@@ -159,4 +159,193 @@ public class AppleSimulatorCommandsTests
 		Assert.Equal("E2208", error.Code);
 		Assert.Equal("platform", error.Category);
 	}
+
+	// --- Install/Uninstall/Launch/Terminate/GetAppContainer command tests ---
+
+	[Fact]
+	public void SimulatorCommand_HasInstallSubcommand()
+	{
+		var root = Program.BuildRootCommand();
+		var simulator = root.Subcommands
+			.First(c => c.Name == "apple").Subcommands
+			.First(c => c.Name == "simulator");
+		Assert.Contains(simulator.Subcommands, c => c.Name == "install");
+	}
+
+	[Fact]
+	public void SimulatorCommand_HasUninstallSubcommand()
+	{
+		var root = Program.BuildRootCommand();
+		var simulator = root.Subcommands
+			.First(c => c.Name == "apple").Subcommands
+			.First(c => c.Name == "simulator");
+		Assert.Contains(simulator.Subcommands, c => c.Name == "uninstall");
+	}
+
+	[Fact]
+	public void SimulatorCommand_HasLaunchSubcommand()
+	{
+		var root = Program.BuildRootCommand();
+		var simulator = root.Subcommands
+			.First(c => c.Name == "apple").Subcommands
+			.First(c => c.Name == "simulator");
+		Assert.Contains(simulator.Subcommands, c => c.Name == "launch");
+	}
+
+	[Fact]
+	public void SimulatorCommand_HasTerminateSubcommand()
+	{
+		var root = Program.BuildRootCommand();
+		var simulator = root.Subcommands
+			.First(c => c.Name == "apple").Subcommands
+			.First(c => c.Name == "simulator");
+		Assert.Contains(simulator.Subcommands, c => c.Name == "terminate");
+	}
+
+	[Fact]
+	public void SimulatorCommand_HasGetAppContainerSubcommand()
+	{
+		var root = Program.BuildRootCommand();
+		var simulator = root.Subcommands
+			.First(c => c.Name == "apple").Subcommands
+			.First(c => c.Name == "simulator");
+		Assert.Contains(simulator.Subcommands, c => c.Name == "get-app-container");
+	}
+
+	[Fact]
+	public void FakeAppleProvider_InstallApp_TracksCall()
+	{
+		var fake = new FakeAppleProvider { InstallAppResult = true };
+		var result = fake.InstallApp("UDID-123", "/path/to/MyApp.app");
+		Assert.True(result);
+		Assert.Single(fake.InstalledApps);
+		Assert.Equal(("UDID-123", "/path/to/MyApp.app"), fake.InstalledApps[0]);
+	}
+
+	[Fact]
+	public void FakeAppleProvider_UninstallApp_TracksCall()
+	{
+		var fake = new FakeAppleProvider { UninstallAppResult = true };
+		var result = fake.UninstallApp("UDID-123", "com.example.myapp");
+		Assert.True(result);
+		Assert.Single(fake.UninstalledApps);
+		Assert.Equal(("UDID-123", "com.example.myapp"), fake.UninstalledApps[0]);
+	}
+
+	[Fact]
+	public void FakeAppleProvider_LaunchApp_TracksCallWithArgs()
+	{
+		var fake = new FakeAppleProvider { LaunchAppResult = true };
+		var result = fake.LaunchApp("UDID-123", "com.example.myapp", "--debug", "--wait");
+		Assert.True(result);
+		Assert.Single(fake.LaunchedApps);
+		Assert.Equal("UDID-123", fake.LaunchedApps[0].Udid);
+		Assert.Equal("com.example.myapp", fake.LaunchedApps[0].BundleId);
+		Assert.Equal(new[] { "--debug", "--wait" }, fake.LaunchedApps[0].Args);
+	}
+
+	[Fact]
+	public void FakeAppleProvider_TerminateApp_TracksCall()
+	{
+		var fake = new FakeAppleProvider { TerminateAppResult = true };
+		var result = fake.TerminateApp("UDID-123", "com.example.myapp");
+		Assert.True(result);
+		Assert.Single(fake.TerminatedApps);
+		Assert.Equal(("UDID-123", "com.example.myapp"), fake.TerminatedApps[0]);
+	}
+
+	[Fact]
+	public void FakeAppleProvider_GetAppContainer_TracksCallAndReturnsPath()
+	{
+		var fake = new FakeAppleProvider { GetAppContainerResult = "/data/Containers/Data/Application/UUID" };
+		var path = fake.GetAppContainer("UDID-123", "com.example.myapp", "data");
+		Assert.Equal("/data/Containers/Data/Application/UUID", path);
+		Assert.Single(fake.GetAppContainerCalls);
+		Assert.Equal(("UDID-123", "com.example.myapp", "data"), fake.GetAppContainerCalls[0]);
+	}
+
+	[Fact]
+	public void SimulatorAppResult_SerializesToSnakeCase_WithBundleIdentifier()
+	{
+		var model = new SimulatorAppResult { Udid = "UDID-AAA", BundleIdentifier = "com.example.app", Action = "launched", Success = true };
+		var json = JsonSerializer.Serialize(model, MauiCliJsonContext.Default.SimulatorAppResult);
+		using var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+		Assert.Equal("UDID-AAA", root.GetProperty("udid").GetString());
+		Assert.Equal("com.example.app", root.GetProperty("bundle_identifier").GetString());
+		Assert.Equal("launched", root.GetProperty("action").GetString());
+		Assert.True(root.GetProperty("success").GetBoolean());
+		Assert.False(root.TryGetProperty("app_path", out _));
+	}
+
+	[Fact]
+	public void SimulatorAppResult_SerializesToSnakeCase_WithAppPath()
+	{
+		var model = new SimulatorAppResult { Udid = "UDID-BBB", AppPath = "/path/to/MyApp.app", Action = "installed", Success = true };
+		var json = JsonSerializer.Serialize(model, MauiCliJsonContext.Default.SimulatorAppResult);
+		using var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+		Assert.Equal("UDID-BBB", root.GetProperty("udid").GetString());
+		Assert.Equal("/path/to/MyApp.app", root.GetProperty("app_path").GetString());
+		Assert.Equal("installed", root.GetProperty("action").GetString());
+		Assert.True(root.GetProperty("success").GetBoolean());
+		Assert.False(root.TryGetProperty("bundle_identifier", out _));
+	}
+
+	[Fact]
+	public void SimulatorAppContainerResult_SerializesToSnakeCase()
+	{
+		var model = new SimulatorAppContainerResult { Udid = "UDID-CCC", BundleIdentifier = "com.test.app", Path = "/data/path" };
+		var json = JsonSerializer.Serialize(model, MauiCliJsonContext.Default.SimulatorAppContainerResult);
+		using var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+		Assert.Equal("UDID-CCC", root.GetProperty("udid").GetString());
+		Assert.Equal("com.test.app", root.GetProperty("bundle_identifier").GetString());
+		Assert.Equal("/data/path", root.GetProperty("path").GetString());
+	}
+
+	[Fact]
+	public void SimulatorInstallFailed_ErrorResult_HasCorrectCode()
+	{
+		var ex = new MauiToolException(ErrorCodes.AppleSimulatorInstallFailed, "Install failed");
+		var error = ErrorResult.FromException(ex);
+		Assert.Equal("E2209", error.Code);
+		Assert.Equal("platform", error.Category);
+	}
+
+	[Fact]
+	public void SimulatorUninstallFailed_ErrorResult_HasCorrectCode()
+	{
+		var ex = new MauiToolException(ErrorCodes.AppleSimulatorUninstallFailed, "Uninstall failed");
+		var error = ErrorResult.FromException(ex);
+		Assert.Equal("E2210", error.Code);
+		Assert.Equal("platform", error.Category);
+	}
+
+	[Fact]
+	public void SimulatorLaunchFailed_ErrorResult_HasCorrectCode()
+	{
+		var ex = new MauiToolException(ErrorCodes.AppleSimulatorLaunchFailed, "Launch failed");
+		var error = ErrorResult.FromException(ex);
+		Assert.Equal("E2211", error.Code);
+		Assert.Equal("platform", error.Category);
+	}
+
+	[Fact]
+	public void SimulatorTerminateFailed_ErrorResult_HasCorrectCode()
+	{
+		var ex = new MauiToolException(ErrorCodes.AppleSimulatorTerminateFailed, "Terminate failed");
+		var error = ErrorResult.FromException(ex);
+		Assert.Equal("E2212", error.Code);
+		Assert.Equal("platform", error.Category);
+	}
+
+	[Fact]
+	public void SimulatorGetAppContainerFailed_ErrorResult_HasCorrectCode()
+	{
+		var ex = new MauiToolException(ErrorCodes.AppleSimulatorGetContainerFailed, "GetAppContainer failed");
+		var error = ErrorResult.FromException(ex);
+		Assert.Equal("E2213", error.Code);
+		Assert.Equal("platform", error.Category);
+	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
@@ -30,6 +30,11 @@ public class FakeAppleProvider : IAppleProvider
 	public bool DeleteSimulatorResult { get; set; } = true;
 	public string? CreateSimulatorResult { get; set; } = "new-udid";
 	public bool EraseSimulatorResult { get; set; } = true;
+	public bool InstallAppResult { get; set; } = true;
+	public bool UninstallAppResult { get; set; } = true;
+	public bool LaunchAppResult { get; set; } = true;
+	public bool TerminateAppResult { get; set; } = true;
+	public string? GetAppContainerResult { get; set; } = "/path/to/container";
 
 	// --- Call tracking ---
 
@@ -40,6 +45,11 @@ public class FakeAppleProvider : IAppleProvider
 	public List<(string Name, string DeviceType, string? Runtime)> CreatedSimulators { get; } = new();
 	public List<(IEnumerable<string>? Platforms, bool DryRun)> InstallCalls { get; } = new();
 	public List<string> ErasedSimulators { get; } = new();
+	public List<(string Udid, string AppPath)> InstalledApps { get; } = new();
+	public List<(string Udid, string BundleId)> UninstalledApps { get; } = new();
+	public List<(string Udid, string BundleId, string[] Args)> LaunchedApps { get; } = new();
+	public List<(string Udid, string BundleId)> TerminatedApps { get; } = new();
+	public List<(string Udid, string BundleId, string? ContainerType)> GetAppContainerCalls { get; } = new();
 
 	// --- IAppleProvider implementation ---
 
@@ -100,6 +110,36 @@ public class FakeAppleProvider : IAppleProvider
 	{
 		ErasedSimulators.Add(udidOrName);
 		return EraseSimulatorResult;
+	}
+
+	public bool InstallApp(string udid, string appBundlePath)
+	{
+		InstalledApps.Add((udid, appBundlePath));
+		return InstallAppResult;
+	}
+
+	public bool UninstallApp(string udid, string bundleIdentifier)
+	{
+		UninstalledApps.Add((udid, bundleIdentifier));
+		return UninstallAppResult;
+	}
+
+	public bool LaunchApp(string udid, string bundleIdentifier, params string[] extraArgs)
+	{
+		LaunchedApps.Add((udid, bundleIdentifier, extraArgs));
+		return LaunchAppResult;
+	}
+
+	public bool TerminateApp(string udid, string bundleIdentifier)
+	{
+		TerminatedApps.Add((udid, bundleIdentifier));
+		return TerminateAppResult;
+	}
+
+	public string? GetAppContainer(string udid, string bundleIdentifier, string? containerType = null)
+	{
+		GetAppContainerCalls.Add((udid, bundleIdentifier, containerType));
+		return GetAppContainerResult;
 	}
 
 	public List<HealthCheck> CheckHealth() => HealthChecks;

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -518,9 +518,15 @@ public static class AppleCommands
 			var udid = parseResult.GetValue(udidArg)!;
 			var appPath = parseResult.GetValue(appPathArg)!;
 
+			if (!appPath.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.InvalidArgument, $"Path must point to a .app bundle directory, got: '{appPath}'."));
+				return 1;
+			}
+
 			if (!Directory.Exists(appPath))
 			{
-				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorInstallFailed, $"App bundle not found at '{appPath}'."));
+				formatter.WriteError(new MauiToolException(ErrorCodes.InvalidArgument, $"App bundle not found at '{appPath}'."));
 				return 1;
 			}
 
@@ -534,7 +540,7 @@ public static class AppleCommands
 
 			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 			if (useJson)
-				formatter.Write(new SimulatorAppResult { Udid = udid, BundleIdentifier = Path.GetFileNameWithoutExtension(appPath), Action = "installed", Success = true });
+				formatter.Write(new SimulatorAppResult { Udid = udid, AppPath = appPath, Action = "installed", Success = true });
 			else
 				formatter.WriteSuccess($"App installed on simulator '{udid}'.");
 			return 0;

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -347,6 +347,11 @@ public static class AppleCommands
 		simCommand.Add(deleteCommand);
 		simCommand.Add(CreateSimulatorCreateCommand());
 		simCommand.Add(CreateSimulatorEraseCommand());
+		simCommand.Add(CreateSimulatorInstallCommand());
+		simCommand.Add(CreateSimulatorUninstallCommand());
+		simCommand.Add(CreateSimulatorLaunchCommand());
+		simCommand.Add(CreateSimulatorTerminateCommand());
+		simCommand.Add(CreateSimulatorGetAppContainerCommand());
 		return simCommand;
 	}
 
@@ -491,5 +496,210 @@ public static class AppleCommands
 		});
 
 		return eraseCommand;
+	}
+
+	static Command CreateSimulatorInstallCommand()
+	{
+		var udidArg = new Argument<string>("udid") { Description = "Simulator UDID" };
+		var appPathArg = new Argument<string>("app-bundle-path") { Description = "Path to the .app bundle to install" };
+
+		var installCommand = new Command("install", "Install an app bundle on a simulator") { udidArg, appPathArg };
+		installCommand.SetAction((ParseResult parseResult) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.PlatformNotSupported, "Simulators are only available on macOS."));
+				return 1;
+			}
+
+			var appleProvider = Program.AppleProvider;
+			var udid = parseResult.GetValue(udidArg)!;
+			var appPath = parseResult.GetValue(appPathArg)!;
+
+			if (!Directory.Exists(appPath))
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorInstallFailed, $"App bundle not found at '{appPath}'."));
+				return 1;
+			}
+
+			var success = appleProvider.InstallApp(udid, appPath);
+
+			if (!success)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorInstallFailed, $"Failed to install app on simulator '{udid}'. Ensure the simulator is booted."));
+				return 1;
+			}
+
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			if (useJson)
+				formatter.Write(new SimulatorAppResult { Udid = udid, BundleIdentifier = Path.GetFileNameWithoutExtension(appPath), Action = "installed", Success = true });
+			else
+				formatter.WriteSuccess($"App installed on simulator '{udid}'.");
+			return 0;
+		});
+
+		return installCommand;
+	}
+
+	static Command CreateSimulatorUninstallCommand()
+	{
+		var udidArg = new Argument<string>("udid") { Description = "Simulator UDID" };
+		var bundleIdArg = new Argument<string>("bundle-identifier") { Description = "App bundle identifier (e.g. com.example.MyApp)" };
+
+		var uninstallCommand = new Command("uninstall", "Uninstall an app from a simulator") { udidArg, bundleIdArg };
+		uninstallCommand.SetAction((ParseResult parseResult) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.PlatformNotSupported, "Simulators are only available on macOS."));
+				return 1;
+			}
+
+			var appleProvider = Program.AppleProvider;
+			var udid = parseResult.GetValue(udidArg)!;
+			var bundleId = parseResult.GetValue(bundleIdArg)!;
+
+			var success = appleProvider.UninstallApp(udid, bundleId);
+
+			if (!success)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorUninstallFailed, $"Failed to uninstall '{bundleId}' from simulator '{udid}'."));
+				return 1;
+			}
+
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			if (useJson)
+				formatter.Write(new SimulatorAppResult { Udid = udid, BundleIdentifier = bundleId, Action = "uninstalled", Success = true });
+			else
+				formatter.WriteSuccess($"App '{bundleId}' uninstalled from simulator '{udid}'.");
+			return 0;
+		});
+
+		return uninstallCommand;
+	}
+
+	static Command CreateSimulatorLaunchCommand()
+	{
+		var udidArg = new Argument<string>("udid") { Description = "Simulator UDID" };
+		var bundleIdArg = new Argument<string>("bundle-identifier") { Description = "App bundle identifier (e.g. com.example.MyApp)" };
+		var extraArgsOption = new Option<string[]>("--args") { Description = "Extra arguments to pass to the app", AllowMultipleArgumentsPerToken = true };
+
+		var launchCommand = new Command("launch", "Launch an app on a simulator") { udidArg, bundleIdArg, extraArgsOption };
+		launchCommand.SetAction((ParseResult parseResult) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.PlatformNotSupported, "Simulators are only available on macOS."));
+				return 1;
+			}
+
+			var appleProvider = Program.AppleProvider;
+			var udid = parseResult.GetValue(udidArg)!;
+			var bundleId = parseResult.GetValue(bundleIdArg)!;
+			var extraArgs = parseResult.GetValue(extraArgsOption) ?? Array.Empty<string>();
+
+			var success = appleProvider.LaunchApp(udid, bundleId, extraArgs);
+
+			if (!success)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorLaunchFailed, $"Failed to launch '{bundleId}' on simulator '{udid}'. Ensure the app is installed and the simulator is booted."));
+				return 1;
+			}
+
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			if (useJson)
+				formatter.Write(new SimulatorAppResult { Udid = udid, BundleIdentifier = bundleId, Action = "launched", Success = true });
+			else
+				formatter.WriteSuccess($"App '{bundleId}' launched on simulator '{udid}'.");
+			return 0;
+		});
+
+		return launchCommand;
+	}
+
+	static Command CreateSimulatorTerminateCommand()
+	{
+		var udidArg = new Argument<string>("udid") { Description = "Simulator UDID" };
+		var bundleIdArg = new Argument<string>("bundle-identifier") { Description = "App bundle identifier (e.g. com.example.MyApp)" };
+
+		var terminateCommand = new Command("terminate", "Terminate a running app on a simulator") { udidArg, bundleIdArg };
+		terminateCommand.SetAction((ParseResult parseResult) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.PlatformNotSupported, "Simulators are only available on macOS."));
+				return 1;
+			}
+
+			var appleProvider = Program.AppleProvider;
+			var udid = parseResult.GetValue(udidArg)!;
+			var bundleId = parseResult.GetValue(bundleIdArg)!;
+
+			var success = appleProvider.TerminateApp(udid, bundleId);
+
+			if (!success)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorTerminateFailed, $"Failed to terminate '{bundleId}' on simulator '{udid}'."));
+				return 1;
+			}
+
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			if (useJson)
+				formatter.Write(new SimulatorAppResult { Udid = udid, BundleIdentifier = bundleId, Action = "terminated", Success = true });
+			else
+				formatter.WriteSuccess($"App '{bundleId}' terminated on simulator '{udid}'.");
+			return 0;
+		});
+
+		return terminateCommand;
+	}
+
+	static Command CreateSimulatorGetAppContainerCommand()
+	{
+		var udidArg = new Argument<string>("udid") { Description = "Simulator UDID" };
+		var bundleIdArg = new Argument<string>("bundle-identifier") { Description = "App bundle identifier (e.g. com.example.MyApp)" };
+		var containerTypeOption = new Option<string?>("--type") { Description = "Container type: 'app' (default), 'data', 'groups', or a specific group identifier" };
+
+		var containerCommand = new Command("get-app-container", "Get the container path for an installed app") { udidArg, bundleIdArg, containerTypeOption };
+		containerCommand.SetAction((ParseResult parseResult) =>
+		{
+			var formatter = Program.GetFormatter(parseResult);
+
+			if (!PlatformDetector.IsMacOS)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.PlatformNotSupported, "Simulators are only available on macOS."));
+				return 1;
+			}
+
+			var appleProvider = Program.AppleProvider;
+			var udid = parseResult.GetValue(udidArg)!;
+			var bundleId = parseResult.GetValue(bundleIdArg)!;
+			var containerType = parseResult.GetValue(containerTypeOption);
+
+			var path = appleProvider.GetAppContainer(udid, bundleId, containerType);
+
+			if (path is null)
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorGetContainerFailed, $"Failed to get container for '{bundleId}' on simulator '{udid}'. Ensure the app is installed."));
+				return 1;
+			}
+
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			if (useJson)
+				formatter.Write(new SimulatorAppContainerResult { Udid = udid, BundleIdentifier = bundleId, ContainerType = containerType, Path = path });
+			else
+				formatter.WriteSuccess(path);
+			return 0;
+		});
+
+		return containerCommand;
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AppleCommands.cs
@@ -530,6 +530,12 @@ public static class AppleCommands
 				return 1;
 			}
 
+			if (!SimulatorExists(appleProvider, udid))
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorNotFound, $"No simulator found with UDID '{udid}'. List simulators with 'maui apple simulator list'."));
+				return 1;
+			}
+
 			var success = appleProvider.InstallApp(udid, appPath);
 
 			if (!success)
@@ -568,6 +574,12 @@ public static class AppleCommands
 			var appleProvider = Program.AppleProvider;
 			var udid = parseResult.GetValue(udidArg)!;
 			var bundleId = parseResult.GetValue(bundleIdArg)!;
+
+			if (!SimulatorExists(appleProvider, udid))
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorNotFound, $"No simulator found with UDID '{udid}'. List simulators with 'maui apple simulator list'."));
+				return 1;
+			}
 
 			var success = appleProvider.UninstallApp(udid, bundleId);
 
@@ -610,6 +622,12 @@ public static class AppleCommands
 			var bundleId = parseResult.GetValue(bundleIdArg)!;
 			var extraArgs = parseResult.GetValue(extraArgsOption) ?? Array.Empty<string>();
 
+			if (!SimulatorExists(appleProvider, udid))
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorNotFound, $"No simulator found with UDID '{udid}'. List simulators with 'maui apple simulator list'."));
+				return 1;
+			}
+
 			var success = appleProvider.LaunchApp(udid, bundleId, extraArgs);
 
 			if (!success)
@@ -648,6 +666,12 @@ public static class AppleCommands
 			var appleProvider = Program.AppleProvider;
 			var udid = parseResult.GetValue(udidArg)!;
 			var bundleId = parseResult.GetValue(bundleIdArg)!;
+
+			if (!SimulatorExists(appleProvider, udid))
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorNotFound, $"No simulator found with UDID '{udid}'. List simulators with 'maui apple simulator list'."));
+				return 1;
+			}
 
 			var success = appleProvider.TerminateApp(udid, bundleId);
 
@@ -690,6 +714,12 @@ public static class AppleCommands
 			var bundleId = parseResult.GetValue(bundleIdArg)!;
 			var containerType = parseResult.GetValue(containerTypeOption);
 
+			if (!SimulatorExists(appleProvider, udid))
+			{
+				formatter.WriteError(new MauiToolException(ErrorCodes.AppleSimulatorNotFound, $"No simulator found with UDID '{udid}'. List simulators with 'maui apple simulator list'."));
+				return 1;
+			}
+
 			var path = appleProvider.GetAppContainer(udid, bundleId, containerType);
 
 			if (path is null)
@@ -707,5 +737,11 @@ public static class AppleCommands
 		});
 
 		return containerCommand;
+	}
+
+	static bool SimulatorExists(IAppleProvider appleProvider, string udid)
+	{
+		var sims = appleProvider.GetSimulators();
+		return sims.Any(s => string.Equals(s.Udid, udid, StringComparison.OrdinalIgnoreCase));
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodes.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Errors/ErrorCodes.cs
@@ -46,6 +46,11 @@ public static class ErrorCodes
 	public const string AppleSetupFailed = "E2206";
 	public const string AppleSimulatorCreateFailed = "E2207";
 	public const string AppleSimulatorEraseFailed = "E2208";
+	public const string AppleSimulatorInstallFailed = "E2209";
+	public const string AppleSimulatorUninstallFailed = "E2210";
+	public const string AppleSimulatorLaunchFailed = "E2211";
+	public const string AppleSimulatorTerminateFailed = "E2212";
+	public const string AppleSimulatorGetContainerFailed = "E2213";
 
 	// Platform/SDK errors - Windows (E23xx)
 	public const string WindowsSdkNotFound = "E2301";

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
@@ -124,3 +124,34 @@ internal sealed record SimulatorEraseResult
 	[JsonPropertyName("erased")]
 	public bool Erased { get; init; }
 }
+
+internal sealed record SimulatorAppResult
+{
+	[JsonPropertyName("udid")]
+	public required string Udid { get; init; }
+
+	[JsonPropertyName("bundle_identifier")]
+	public required string BundleIdentifier { get; init; }
+
+	[JsonPropertyName("action")]
+	public required string Action { get; init; }
+
+	[JsonPropertyName("success")]
+	public bool Success { get; init; }
+}
+
+internal sealed record SimulatorAppContainerResult
+{
+	[JsonPropertyName("udid")]
+	public required string Udid { get; init; }
+
+	[JsonPropertyName("bundle_identifier")]
+	public required string BundleIdentifier { get; init; }
+
+	[JsonPropertyName("container_type")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? ContainerType { get; init; }
+
+	[JsonPropertyName("path")]
+	public required string Path { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/JsonOutputModels.cs
@@ -131,7 +131,12 @@ internal sealed record SimulatorAppResult
 	public required string Udid { get; init; }
 
 	[JsonPropertyName("bundle_identifier")]
-	public required string BundleIdentifier { get; init; }
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? BundleIdentifier { get; init; }
+
+	[JsonPropertyName("app_path")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? AppPath { get; init; }
 
 	[JsonPropertyName("action")]
 	public required string Action { get; init; }

--- a/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
@@ -48,4 +48,6 @@ namespace Microsoft.Maui.Cli.Output;
 [JsonSerializable(typeof(CliCommandResult))]
 [JsonSerializable(typeof(SimulatorCreateResult))]
 [JsonSerializable(typeof(SimulatorEraseResult))]
+[JsonSerializable(typeof(SimulatorAppResult))]
+[JsonSerializable(typeof(SimulatorAppContainerResult))]
 internal sealed partial class MauiCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
@@ -164,6 +164,31 @@ public class AppleProvider : IAppleProvider
 		return _simulatorService?.Erase(udidOrName) ?? false;
 	}
 
+	public bool InstallApp(string udid, string appBundlePath)
+	{
+		return _simulatorService?.Install(udid, appBundlePath) ?? false;
+	}
+
+	public bool UninstallApp(string udid, string bundleIdentifier)
+	{
+		return _simulatorService?.Uninstall(udid, bundleIdentifier) ?? false;
+	}
+
+	public bool LaunchApp(string udid, string bundleIdentifier, params string[] extraArgs)
+	{
+		return _simulatorService?.Launch(udid, bundleIdentifier, extraArgs) ?? false;
+	}
+
+	public bool TerminateApp(string udid, string bundleIdentifier)
+	{
+		return _simulatorService?.Terminate(udid, bundleIdentifier) ?? false;
+	}
+
+	public string? GetAppContainer(string udid, string bundleIdentifier, string? containerType = null)
+	{
+		return _simulatorService?.GetAppContainer(udid, bundleIdentifier, containerType);
+	}
+
 	public List<HealthCheck> CheckHealth()
 	{
 		var checks = new List<HealthCheck>();

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
@@ -72,6 +72,34 @@ public interface IAppleProvider
 	bool EraseSimulator(string udidOrName);
 
 	/// <summary>
+	/// Installs an app bundle on a simulator.
+	/// </summary>
+	bool InstallApp(string udid, string appBundlePath);
+
+	/// <summary>
+	/// Uninstalls an app from a simulator by bundle identifier.
+	/// </summary>
+	bool UninstallApp(string udid, string bundleIdentifier);
+
+	/// <summary>
+	/// Launches an app on a simulator.
+	/// </summary>
+	bool LaunchApp(string udid, string bundleIdentifier, params string[] extraArgs);
+
+	/// <summary>
+	/// Terminates a running app on a simulator.
+	/// </summary>
+	bool TerminateApp(string udid, string bundleIdentifier);
+
+	/// <summary>
+	/// Gets the container path for an installed app on a simulator.
+	/// </summary>
+	/// <param name="udid">Simulator UDID.</param>
+	/// <param name="bundleIdentifier">App bundle identifier.</param>
+	/// <param name="containerType">Container type (e.g., "app", "data", "groups"). Null for default (app).</param>
+	string? GetAppContainer(string udid, string bundleIdentifier, string? containerType = null);
+
+	/// <summary>
 	/// Gets the health status of Apple tooling (Xcode, CLT, simulators).
 	/// </summary>
 	List<HealthCheck> CheckHealth();


### PR DESCRIPTION
## Summary

Bumps `Xamarin.Apple.Tools.MaciOS` from `1.0.0-preview.1.26230.1` to `1.0.0-preview.1.26255.1` and wires up the new simulator app lifecycle APIs from [dotnet/macios-devtools#176](https://github.com/dotnet/macios-devtools/pull/176).

## Upstream changes

| PR | Description |
|----|-------------|
| [#172](https://github.com/dotnet/macios-devtools/pull/172) | `PDictionary.OpenFile` and `TryOpenFile` convenience methods |
| [#176](https://github.com/dotnet/macios-devtools/pull/176) | Simulator app lifecycle APIs (install/uninstall/launch/terminate/get_app_container) |

## New CLI commands

| Command | Description |
|---------|-------------|
| `maui apple simulator install <udid> <app-bundle-path>` | Install .app bundle on a simulator |
| `maui apple simulator uninstall <udid> <bundle-id>` | Uninstall app by bundle identifier |
| `maui apple simulator launch <udid> <bundle-id> [--args ...]` | Launch app (with optional extra args) |
| `maui apple simulator terminate <udid> <bundle-id>` | Terminate a running app |
| `maui apple simulator get-app-container <udid> <bundle-id> [--type]` | Get container path (app/data/groups) |

All commands support `--json` output mode and emit structured error codes (E2209–E2213).

## Changes

- `eng/Version.Details.xml` / `eng/Versions.props` — version + SHA bump
- `IAppleProvider` — 5 new interface methods
- `AppleProvider` — implementations delegating to `SimulatorService`
- `AppleCommands.cs` — 5 new subcommands under `maui apple simulator`
- `ErrorCodes.cs` — E2209–E2213
- `JsonOutputModels.cs` / `MauiCliJsonContext.cs` — result DTOs
- `FakeAppleProvider.cs` — test fake updated

## Testing

- 433 CLI unit tests pass ✅
- Smoke tests require macOS with Xcode (CI will validate)