### PR TITLE
Fix MacOS-libs.slnf: use backslashes in project paths

### DIFF
--- a/platforms/MacOS/MacOS-libs.slnf
+++ b/platforms/MacOS/MacOS-libs.slnf
@@ -2,9 +2,9 @@
   "solution": {
     "path": "MacOS.slnx",
     "projects": [
-      "src/MacOS/MacOS.csproj",
-      "src/MacOS.Essentials/MacOS.Essentials.csproj",
-      "src/MacOS.BlazorWebView/MacOS.BlazorWebView.csproj"
+      "src\\MacOS\\MacOS.csproj",
+      "src\\MacOS.Essentials\\MacOS.Essentials.csproj",
+      "src\\MacOS.BlazorWebView\\MacOS.BlazorWebView.csproj"
     ]
   }
 }


### PR DESCRIPTION
The macOS AppKit official build fails with:
```
MacOS-libs.slnf(1,1): error MSB4025: Data at the root level is invalid. Line 1, position 1.
```

`.slnf` files require **backslash** path separators on Windows. The file was created with forward slashes (`src/MacOS/MacOS.csproj`) which MSBuild on Windows cannot parse.

Fixed to use `src\\MacOS\\MacOS.csproj` matching the pattern used by all other `.slnf` files in the repo (`Cli.slnf`, `DevFlow.slnf`, etc.).
