### PR TITLE
fix: Add contents:write to Comet CI for release asset uploads

### DIFF
--- a/.github/workflows/ci-comet.yml
+++ b/.github/workflows/ci-comet.yml
@@ -52,6 +52,8 @@ jobs:
   package:
     needs: build
     runs-on: windows-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: src/Comet


### PR DESCRIPTION
Release asset uploads fail with 403 because the workflow lacks `contents: write` permission.