### PR TITLE
feat: Docs-check workflow creates draft PRs instead of issues

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,5 +1,10 @@
 {
   "entries": {
+    "actions/github-script@v8": {
+      "repo": "actions/github-script",
+      "version": "v8",
+      "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
+    },
     "actions/github-script@v9": {
       "repo": "actions/github-script",
       "version": "v9",
@@ -15,67 +20,15 @@
       "version": "v0.68.3",
       "sha": "ba90f2186d7ad780ec640f364005fa24e797b360"
     },
+    "github/gh-aw/actions/setup@v0.53.5": {
+      "repo": "github/gh-aw/actions/setup",
+      "version": "v0.53.5",
+      "sha": "ffb8573262a0892a8117694ac8c0738e96e846d0"
+    },
     "github/gh-aw/actions/setup@v0.69.3": {
       "repo": "github/gh-aw/actions/setup",
       "version": "v0.69.3",
       "sha": "6abd7107cebd8b300f4d64013201ad2d8e0a994f"
-    }
-  },
-  "containers": {
-    "ghcr.io/github/gh-aw-firewall/agent:0.23.0": {
-      "image": "ghcr.io/github/gh-aw-firewall/agent:0.23.0",
-      "digest": "sha256:5a1d66eafd57942d4955069bc5144416d2bcc1c0999f3e9f1b66bcb515fe2ee6",
-      "pinned_image": "ghcr.io/github/gh-aw-firewall/agent:0.23.0@sha256:5a1d66eafd57942d4955069bc5144416d2bcc1c0999f3e9f1b66bcb515fe2ee6"
-    },
-    "ghcr.io/github/gh-aw-firewall/agent:0.24.3": {
-      "image": "ghcr.io/github/gh-aw-firewall/agent:0.24.3",
-      "digest": "sha256:8512b97bc79cb5fcb4d463e4ac8336182d5cb382e7f594649b8d66cdebb174f0",
-      "pinned_image": "ghcr.io/github/gh-aw-firewall/agent:0.24.3@sha256:8512b97bc79cb5fcb4d463e4ac8336182d5cb382e7f594649b8d66cdebb174f0"
-    },
-    "ghcr.io/github/gh-aw-firewall/api-proxy:0.23.0": {
-      "image": "ghcr.io/github/gh-aw-firewall/api-proxy:0.23.0",
-      "digest": "sha256:90662a2988d944892290827a5b8be4585ef8fe5001838b884e69211960049a5b",
-      "pinned_image": "ghcr.io/github/gh-aw-firewall/api-proxy:0.23.0@sha256:90662a2988d944892290827a5b8be4585ef8fe5001838b884e69211960049a5b"
-    },
-    "ghcr.io/github/gh-aw-firewall/api-proxy:0.24.3": {
-      "image": "ghcr.io/github/gh-aw-firewall/api-proxy:0.24.3",
-      "digest": "sha256:b36073e20ae2fed8f6a78a01475bdda155eb6271f07c551613603b1aac19b71d",
-      "pinned_image": "ghcr.io/github/gh-aw-firewall/api-proxy:0.24.3@sha256:b36073e20ae2fed8f6a78a01475bdda155eb6271f07c551613603b1aac19b71d"
-    },
-    "ghcr.io/github/gh-aw-firewall/squid:0.23.0": {
-      "image": "ghcr.io/github/gh-aw-firewall/squid:0.23.0",
-      "digest": "sha256:14937495d20d14353e37980ad419acf7a127bcd47886988d57db3d4903d826e6",
-      "pinned_image": "ghcr.io/github/gh-aw-firewall/squid:0.23.0@sha256:14937495d20d14353e37980ad419acf7a127bcd47886988d57db3d4903d826e6"
-    },
-    "ghcr.io/github/gh-aw-firewall/squid:0.24.3": {
-      "image": "ghcr.io/github/gh-aw-firewall/squid:0.24.3",
-      "digest": "sha256:5668f16716d1579508997779265e72d9dfcbd6f5437a8cb6a28deac78e8446ab",
-      "pinned_image": "ghcr.io/github/gh-aw-firewall/squid:0.24.3@sha256:5668f16716d1579508997779265e72d9dfcbd6f5437a8cb6a28deac78e8446ab"
-    },
-    "ghcr.io/github/gh-aw-mcpg:v0.1.19": {
-      "image": "ghcr.io/github/gh-aw-mcpg:v0.1.19",
-      "digest": "sha256:c0ea41e38e0fe415bf74f50aab30dce8fe88df366b3511e8abbc14ad2e05e1f2",
-      "pinned_image": "ghcr.io/github/gh-aw-mcpg:v0.1.19@sha256:c0ea41e38e0fe415bf74f50aab30dce8fe88df366b3511e8abbc14ad2e05e1f2"
-    },
-    "ghcr.io/github/gh-aw-mcpg:v0.1.8": {
-      "image": "ghcr.io/github/gh-aw-mcpg:v0.1.8",
-      "digest": "sha256:d6799280a9864d801b8dcc346b36a34093e421f1b23af2733c2007282d13a7c3",
-      "pinned_image": "ghcr.io/github/gh-aw-mcpg:v0.1.8@sha256:d6799280a9864d801b8dcc346b36a34093e421f1b23af2733c2007282d13a7c3"
-    },
-    "ghcr.io/github/github-mcp-server:v0.31.0": {
-      "image": "ghcr.io/github/github-mcp-server:v0.31.0",
-      "digest": "sha256:7b1384cdd6d025c09256af2fb6cb79bc5e87aedc957c8826b5e50d8cb82f0be3",
-      "pinned_image": "ghcr.io/github/github-mcp-server:v0.31.0@sha256:7b1384cdd6d025c09256af2fb6cb79bc5e87aedc957c8826b5e50d8cb82f0be3"
-    },
-    "ghcr.io/github/github-mcp-server:v0.32.0": {
-      "image": "ghcr.io/github/github-mcp-server:v0.32.0",
-      "digest": "sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28",
-      "pinned_image": "ghcr.io/github/github-mcp-server:v0.32.0@sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28"
-    },
-    "node:lts-alpine": {
-      "image": "node:lts-alpine",
-      "digest": "sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f",
-      "pinned_image": "node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"
     }
   }
 }

--- a/.github/workflows/pr-docs-check.lock.yml
+++ b/.github/workflows/pr-docs-check.lock.yml
@@ -23,11 +23,11 @@
 #
 # Analyzes merged pull requests for documentation needs. When a PR is merged,
 # this workflow reviews the changes and determines if documentation updates are
-# needed on dotnet/docs-maui. If updates are needed, it opens an issue on
-# docs-maui describing the suggested changes. If not, it comments on the source
-# PR explaining why.
+# needed on dotnet/docs-maui. If updates are needed, it creates a draft PR on
+# docs-maui with the actual documentation changes. If not, it comments on the
+# source PR explaining why.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"bccd9707220610aace0db957ab957186eb6eae9f381d044ccb5e997f112583de","compiler_version":"v0.53.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"34cc4266ed0151a2037903be77206b4bf5ffe97f7c725420f700d0cd134bd486","compiler_version":"v0.53.5"}
 
 name: "PR Documentation Check"
 "on":
@@ -172,7 +172,10 @@ jobs:
           cat "/opt/gh-aw/prompts/safe_outputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
-          Tools: add_comment, create_issue, missing_tool, missing_data, noop
+          Tools: add_comment, create_pull_request, missing_tool, missing_data, noop
+          GH_AW_PROMPT_EOF
+          cat "/opt/gh-aw/prompts/safe_outputs_create_pull_request.md"
+          cat << 'GH_AW_PROMPT_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -200,6 +203,9 @@ jobs:
           {{#if __GH_AW_GITHUB_RUN_ID__ }}
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
+          - **checkouts**: The following repositories have been checked out and are available in the workspace:
+            - `$GITHUB_WORKSPACE` → `dotnet/docs-maui` (cwd) (**current** - this is the repository you are working on; use this as the target for all GitHub operations unless otherwise specified) [shallow clone, fetch-depth=1 (default)]
+            - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
           GH_AW_PROMPT_EOF
@@ -216,7 +222,6 @@ jobs:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_EXPR_2697560F: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
-          GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -315,6 +320,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Checkout dotnet/docs-maui
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: dotnet/docs-maui
+          token: ${{ secrets.MAUI_BOT_TOKEN }}
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Configure Git credentials
@@ -366,61 +377,12 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1},"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"add_comment":{"max":1,"target-repo":"dotnet/maui-labs"},"create_pull_request":{"draft":true,"fallback_as_issue":true,"max":1,"target-repo":"dotnet/docs-maui","title_prefix":"[maui-labs docs] "},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[maui-labs docs] \". Labels [\"docs-from-code\"] will be automatically added. Issues will be created in repository \"dotnet/docs-maui\".",
-              "inputSchema": {
-                "additionalProperties": false,
-                "properties": {
-                  "body": {
-                    "description": "Detailed issue description in Markdown. Do NOT repeat the title as a heading since it already appears as the issue's h1. Include context, reproduction steps, or acceptance criteria as appropriate.",
-                    "type": "string"
-                  },
-                  "integrity": {
-                    "description": "Trustworthiness level of the message source (e.g., \"low\", \"medium\", \"high\").",
-                    "type": "string"
-                  },
-                  "labels": {
-                    "description": "Labels to categorize the issue (e.g., 'bug', 'enhancement'). Labels must exist in the repository.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "parent": {
-                    "description": "Parent issue number for creating sub-issues. This is the numeric ID from the GitHub URL (e.g., 42 in github.com/owner/repo/issues/42). Can also be a temporary_id (e.g., 'aw_abc123', 'aw_Test123') from a previously created issue in the same workflow run.",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "secrecy": {
-                    "description": "Confidentiality level of the message content (e.g., \"public\", \"internal\", \"private\").",
-                    "type": "string"
-                  },
-                  "temporary_id": {
-                    "description": "Unique temporary identifier for referencing this issue before it's created. Format: 'aw_' followed by 3 to 12 alphanumeric characters (e.g., 'aw_abc1', 'aw_Test123'). Use '#aw_ID' in body text to reference other issues by their temporary_id; these are replaced with actual issue numbers after creation.",
-                    "pattern": "^aw_[A-Za-z0-9]{3,12}$",
-                    "type": "string"
-                  },
-                  "title": {
-                    "description": "Concise issue title summarizing the bug, feature, or task. The title appears as the main heading, so keep it brief and descriptive.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "title",
-                  "body"
-                ],
-                "type": "object"
-              },
-              "name": "create_issue"
-            },
-            {
-              "description": "Add a comment to an existing GitHub issue, pull request, or discussion. Use this to provide feedback, answer questions, or add information to an existing conversation. For creating new items, use create_issue, create_discussion, or create_pull_request instead. IMPORTANT: Comments are subject to validation constraints enforced by the MCP server - maximum 65536 characters for the complete comment (including footer which is added automatically), 10 mentions (@username), and 50 links. Exceeding these limits will result in an immediate error with specific guidance. NOTE: By default, this tool requires discussions:write permission. If your GitHub App lacks Discussions permission, set 'discussions: false' in the workflow's safe-outputs.add-comment configuration to exclude this permission. CONSTRAINTS: Maximum 1 comment(s) can be added.",
+              "description": "Add a comment to an existing GitHub issue, pull request, or discussion. Use this to provide feedback, answer questions, or add information to an existing conversation. For creating new items, use create_issue, create_discussion, or create_pull_request instead. IMPORTANT: Comments are subject to validation constraints enforced by the MCP server - maximum 65536 characters for the complete comment (including footer which is added automatically), 10 mentions (@username), and 50 links. Exceeding these limits will result in an immediate error with specific guidance. NOTE: By default, this tool requires discussions:write permission. If your GitHub App lacks Discussions permission, set 'discussions: false' in the workflow's safe-outputs.add-comment configuration to exclude this permission. CONSTRAINTS: Maximum 1 comment(s) can be added. Comments will be added in repository \"dotnet/maui-labs\".",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -455,6 +417,55 @@ jobs:
                 "type": "object"
               },
               "name": "add_comment"
+            },
+            {
+              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[maui-labs docs] \". Labels [\"docs-from-code\"] will be automatically added. PRs will be created as drafts.",
+              "inputSchema": {
+                "additionalProperties": false,
+                "properties": {
+                  "body": {
+                    "description": "Detailed PR description in Markdown. Include what changes were made, why, testing notes, and any breaking changes. Do NOT repeat the title as a heading.",
+                    "type": "string"
+                  },
+                  "branch": {
+                    "description": "Source branch name containing the changes. If omitted, uses the current working branch.",
+                    "type": "string"
+                  },
+                  "draft": {
+                    "description": "Whether to create the PR as a draft. Draft PRs cannot be merged until marked as ready for review. Use mark_pull_request_as_ready_for_review to convert a draft PR. Default: true.",
+                    "type": "boolean"
+                  },
+                  "integrity": {
+                    "description": "Trustworthiness level of the message source (e.g., \"low\", \"medium\", \"high\").",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "description": "Labels to categorize the PR (e.g., 'enhancement', 'bugfix'). Labels must exist in the repository.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "repo": {
+                    "description": "Target repository in 'owner/repo' format. For multi-repo workflows where the target repo differs from the workflow repo, this must match a repo in the allowed-repos list or the configured target-repo. If omitted, defaults to the configured target-repo (from safe-outputs config), NOT the workflow repository. In most cases, you should omit this parameter and let the system use the configured default.",
+                    "type": "string"
+                  },
+                  "secrecy": {
+                    "description": "Confidentiality level of the message content (e.g., \"public\", \"internal\", \"private\").",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Concise PR title describing the changes. Follow repository conventions (e.g., conventional commits). The title appears as the main heading.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ],
+                "type": "object"
+              },
+              "name": "create_pull_request"
             },
             {
               "description": "Report that a tool or capability needed to complete the task is not available, or share any information you deem important about missing functionality or limitations. Use this when you cannot accomplish what was requested because the required functionality is missing or access is restricted.",
@@ -571,7 +582,7 @@ jobs:
                 }
               }
             },
-            "create_issue": {
+            "create_pull_request": {
               "defaultMax": 1,
               "fields": {
                 "body": {
@@ -580,21 +591,24 @@ jobs:
                   "sanitize": true,
                   "maxLength": 65000
                 },
+                "branch": {
+                  "required": true,
+                  "type": "string",
+                  "sanitize": true,
+                  "maxLength": 256
+                },
+                "draft": {
+                  "type": "boolean"
+                },
                 "labels": {
                   "type": "array",
                   "itemType": "string",
                   "itemSanitize": true,
                   "itemMaxLength": 128
                 },
-                "parent": {
-                  "issueOrPRNumber": true
-                },
                 "repo": {
                   "type": "string",
                   "maxLength": 256
-                },
-                "temporary_id": {
-                  "type": "string"
                 },
                 "title": {
                   "required": true,
@@ -767,7 +781,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: |
           set -o pipefail
           # shellcheck disable=SC1003
@@ -930,6 +944,7 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
+            /tmp/gh-aw/aw-*.patch
           if-no-files-found: ignore
       # --- Threat Detection (inline) ---
       - name: Check if detection needed
@@ -968,7 +983,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           WORKFLOW_NAME: "PR Documentation Check"
-          WORKFLOW_DESCRIPTION: "Analyzes merged pull requests for documentation needs. When a PR is merged,\nthis workflow reviews the changes and determines if documentation updates are\nneeded on dotnet/docs-maui. If updates are needed, it opens an issue on\ndocs-maui describing the suggested changes. If not, it comments on the source\nPR explaining why."
+          WORKFLOW_DESCRIPTION: "Analyzes merged pull requests for documentation needs. When a PR is merged,\nthis workflow reviews the changes and determines if documentation updates are\nneeded on dotnet/docs-maui. If updates are needed, it creates a draft PR on\ndocs-maui with the actual documentation changes. If not, it comments on the\nsource PR explaining why."
           HAS_PATCH: ${{ steps.collect_output.outputs.has_patch }}
         with:
           script: |
@@ -1056,7 +1071,7 @@ jobs:
     if: (always()) && (needs.agent.result != 'skipped')
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
       discussions: write
       issues: write
       pull-requests: write
@@ -1124,8 +1139,10 @@ jobs:
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
+          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
+          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_TIMEOUT_MINUTES: "15"
+          GH_AW_TIMEOUT_MINUTES: "20"
         with:
           github-token: ${{ secrets.MAUI_BOT_TOKEN }}
           script: |
@@ -1149,6 +1166,20 @@ jobs:
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/handle_noop_message.cjs');
+            await main();
+      - name: Handle Create Pull Request Error
+        id: handle_create_pr_error
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
+          GH_AW_WORKFLOW_NAME: "PR Documentation Check"
+          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ secrets.MAUI_BOT_TOKEN }}
+          script: |
+            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('/opt/gh-aw/actions/handle_create_pr_error.cjs');
             await main();
 
   pre_activation:
@@ -1178,11 +1209,13 @@ jobs:
             await main();
 
   safe_outputs:
-    needs: agent
+    needs:
+      - activation
+      - agent
     if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.agent.outputs.detection_success == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
       discussions: write
       issues: write
       pull-requests: write
@@ -1199,8 +1232,8 @@ jobs:
       comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
-      created_issue_number: ${{ steps.process_safe_outputs.outputs.created_issue_number }}
-      created_issue_url: ${{ steps.process_safe_outputs.outputs.created_issue_url }}
+      created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
+      created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
@@ -1221,6 +1254,35 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs/
           find "/tmp/gh-aw/safeoutputs/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
+      - name: Download patch artifact
+        continue-on-error: true
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        with:
+          name: agent-artifacts
+          path: /tmp/gh-aw/
+      - name: Checkout repository
+        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: dotnet/docs-maui
+          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
+          token: ${{ secrets.MAUI_BOT_TOKEN }}
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Configure Git credentials
+        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+        env:
+          REPO_NAME: "dotnet/docs-maui"
+          SERVER_URL: ${{ github.server_url }}
+          GIT_TOKEN: ${{ secrets.MAUI_BOT_TOKEN }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global am.keepcr true
+          # Re-authenticate git with GitHub token
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Process Safe Outputs
         id: process_safe_outputs
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -1229,7 +1291,8 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"create_issue\":{\"labels\":[\"docs-from-code\"],\"max\":1,\"target-repo\":\"dotnet/docs-maui\",\"title_prefix\":\"[maui-labs docs] \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target-repo\":\"dotnet/maui-labs\"},\"create_pull_request\":{\"draft\":true,\"fallback_as_issue\":true,\"labels\":[\"docs-from-code\"],\"max\":1,\"max_patch_size\":1024,\"target-repo\":\"dotnet/docs-maui\",\"title_prefix\":\"[maui-labs docs] \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.MAUI_BOT_TOKEN }}
           script: |

--- a/.github/workflows/pr-docs-check.md
+++ b/.github/workflows/pr-docs-check.md
@@ -2,9 +2,9 @@
 description: |
   Analyzes merged pull requests for documentation needs. When a PR is merged,
   this workflow reviews the changes and determines if documentation updates are
-  needed on dotnet/docs-maui. If updates are needed, it opens an issue on
-  docs-maui describing the suggested changes. If not, it comments on the source
-  PR explaining why.
+  needed on dotnet/docs-maui. If updates are needed, it creates a draft PR on
+  docs-maui with the actual documentation changes. If not, it comments on the
+  source PR explaining why.
 
 on:
   pull_request:
@@ -39,6 +39,11 @@ if: >-
   (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
   && github.repository_owner == 'dotnet'
 
+checkout:
+  - repository: dotnet/docs-maui
+    github-token: ${{ secrets.MAUI_BOT_TOKEN }}
+    current: true
+
 permissions:
   contents: read
   pull-requests: read
@@ -56,31 +61,40 @@ tools:
 
 safe-outputs:
   github-token: ${{ secrets.MAUI_BOT_TOKEN }}
-  create-issue:
+  create-pull-request:
     title-prefix: "[maui-labs docs] "
     labels: [docs-from-code]
+    draft: true
     target-repo: "dotnet/docs-maui"
+    fallback-as-issue: true
   add-comment:
+    target-repo: "dotnet/maui-labs"
     hide-older-comments: true
 
-timeout-minutes: 15
+timeout-minutes: 20
 ---
 
 # PR Documentation Check
 
 Analyze a merged pull request in `dotnet/maui-labs` and determine whether
 documentation updates are needed on the `dotnet/docs-maui` documentation site.
+If updates are needed, write the actual documentation changes and create a draft PR.
 
 ## Context
 
-- **Repository**: `${{ github.repository }}`
+- **Source repository**: `dotnet/maui-labs`
 - **PR Number**: `${{ github.event.pull_request.number || github.event.inputs.pr_number }}`
 - **PR Title**: `${{ github.event.pull_request.title }}`
 
+> [!NOTE]
+> The agent runs with `dotnet/docs-maui` as the current workspace. Use GitHub
+> tools to read the source `dotnet/maui-labs` PR details and diff.
+
 ## Step 1: Gather PR Information
 
-Use the GitHub tools to read the full pull request details for the PR number above,
-including the title, description, author, labels, base branch, and the full diff of changes.
+Use the GitHub tools to read the full pull request details from `dotnet/maui-labs`
+for the PR number above, including the title, description, author, labels, base
+branch, and the full diff of changes.
 
 If this was triggered via `workflow_dispatch`, use the `pr_number` input to look up
 the PR details. If the PR number is invalid or the PR cannot be found, stop and
@@ -137,10 +151,11 @@ Review the PR diff for user-facing changes that affect documentation.
 
 ## Step 4: If Documentation IS Needed
 
-### 4a: Check Existing Documentation
+### 4a: Read Existing Documentation
 
-Use the GitHub tools to read the current documentation in `dotnet/docs-maui`.
-The developer-tools documentation lives under `docs/developer-tools/` with this structure:
+Browse the checked-out `dotnet/docs-maui` workspace to understand the current
+documentation structure. The developer-tools documentation lives under
+`docs/developer-tools/` with this structure:
 
 **CLI documentation** (`docs/developer-tools/cli/`):
 - `index.md` — .NET MAUI CLI overview
@@ -164,25 +179,41 @@ Also check:
 - `docs/developer-tools/index.md` — Landing page for the developer-tools section
 - `docs/TOC.yml` — Table of contents (update if adding new pages)
 
-### 4b: Open an Issue on docs-maui
+### 4b: Write Documentation Changes
 
-Create an issue on `dotnet/docs-maui` describing the documentation updates needed.
-The issue should include:
+Based on your analysis, make the actual file changes in the workspace:
 
-- **Which pages** need updating (reference the file paths above)
-- **What changed** — summarize the user-facing changes from the PR
-- **Suggested content** — provide the specific text, code blocks, or table rows
-  to add or modify so a docs author can apply the changes directly
-- If a new page is needed, suggest the filename and where it fits in `docs/TOC.yml`
+- **For updates to existing pages**: Edit the relevant `.md` files in place
+- **For new pages**: Create new `.md` files in the appropriate directory
 
-The issue body should be self-contained — a docs author should be able to make
-the update without reading the full source PR diff.
+Follow these MS Learn documentation conventions:
+- **Frontmatter**: Every page needs `title`, `description`, and `ms.date` (format: `MM/DD/YYYY`)
+- **Headings**: Use `#` for the page title (must match frontmatter `title`), `##` for sections
+- **Code blocks**: Use triple backticks with language identifier (e.g., ````csharp`, ````bash`)
+- **Notes/warnings**: Use `> [!NOTE]`, `> [!IMPORTANT]`, `> [!WARNING]`
+- **Cross-references**: Use relative paths for internal links (e.g., `[DevFlow overview](../devflow/index.md)`)
+- **TOC.yml**: If adding new pages, add an entry under the appropriate section
 
-### 4c: Comment on the Source PR
+### 4c: Create Draft PR
 
-Comment on the original PR in `dotnet/maui-labs` with:
-- A summary of the documentation changes suggested
-- A link to the issue opened on `dotnet/docs-maui`
+Create a draft pull request on `dotnet/docs-maui` with:
+
+**Title**: A clear, concise title describing the documentation work
+(the `[maui-labs docs]` prefix will be added automatically)
+
+**Description** that includes:
+- A link to the source PR: `Documents changes from dotnet/maui-labs#<number>`
+- The PR author mention: `@<author>`
+- A summary of what documentation was added or changed
+- A list of files modified or created
+
+### 4d: Comment on Source PR
+
+After the draft PR is created, comment on the original PR in `dotnet/maui-labs` with:
+- A message indicating documentation updates have been drafted
+- A link to the newly created draft PR on `dotnet/docs-maui`
+- A brief summary of what documentation changes were made
+- A note that the draft PR needs human review before merging
 
 ## Step 5: If Documentation is NOT Needed
 


### PR DESCRIPTION
Upgrades the pr-docs-check agentic workflow to create draft PRs on dotnet/docs-maui with actual documentation changes (like Aspire does), instead of just opening issues.

Falls back to issues if the token lacks push  zero risk of regression.access 

Key changes:
- Checks out `dotnet/docs-maui` as workspace
- `create-pull-request` with `fallback-as-issue: true`
- Agent writes actual docs following MS Learn conventions
- Comments on source PR with link to draft docs PR