### PR TITLE
fix: Docs-check  reliable issues, no noise

### DIFF
--- a/.github/workflows/pr-docs-check.lock.yml
+++ b/.github/workflows/pr-docs-check.lock.yml
@@ -23,11 +23,10 @@
 #
 # Analyzes merged pull requests for documentation needs. When a PR is merged,
 # this workflow reviews the changes and determines if documentation updates are
-# needed on dotnet/docs-maui. If updates are needed, it creates a draft PR on
-# docs-maui with the actual documentation changes. If not, it comments on the
-# source PR explaining why.
+# needed on dotnet/docs-maui. If updates are needed, it opens an issue on
+# docs-maui with a detailed description of the changes needed.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"b03e406e037b8b4fce1d6f330ae269ae0ff23ab54d27bdf5de9512ee8fbdfd19","compiler_version":"v0.53.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"aca99a0b965d805fd31b7246144fe3fa51596ecb5e64db1077df66c625d62c8a","compiler_version":"v0.53.5"}
 
 name: "PR Documentation Check"
 "on":
@@ -172,10 +171,7 @@ jobs:
           cat "/opt/gh-aw/prompts/safe_outputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
-          Tools: add_comment, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_EOF
-          cat "/opt/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_EOF'
+          Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -203,9 +199,6 @@ jobs:
           {{#if __GH_AW_GITHUB_RUN_ID__ }}
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
-          - **checkouts**: The following repositories have been checked out and are available in the workspace:
-            - `$GITHUB_WORKSPACE` → `dotnet/docs-maui` (cwd) (**current** - this is the repository you are working on; use this as the target for all GitHub operations unless otherwise specified) [shallow clone, fetch-depth=1 (default)]
-            - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
           GH_AW_PROMPT_EOF
@@ -320,11 +313,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Checkout dotnet/docs-maui
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          repository: dotnet/docs-maui
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Configure Git credentials
@@ -376,25 +364,32 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1,"target-repo":"dotnet/maui-labs"},"create_pull_request":{"draft":true,"fallback_as_issue":true,"max":1,"target-repo":"dotnet/docs-maui","title_prefix":"[maui-labs docs] "},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"create_issue":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Add a comment to an existing GitHub issue, pull request, or discussion. Use this to provide feedback, answer questions, or add information to an existing conversation. For creating new items, use create_issue, create_discussion, or create_pull_request instead. IMPORTANT: Comments are subject to validation constraints enforced by the MCP server - maximum 65536 characters for the complete comment (including footer which is added automatically), 10 mentions (@username), and 50 links. Exceeding these limits will result in an immediate error with specific guidance. NOTE: By default, this tool requires discussions:write permission. If your GitHub App lacks Discussions permission, set 'discussions: false' in the workflow's safe-outputs.add-comment configuration to exclude this permission. CONSTRAINTS: Maximum 1 comment(s) can be added. Comments will be added in repository \"dotnet/maui-labs\".",
+              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[maui-labs docs] \". Labels [\"docs-from-code\"] will be automatically added. Issues will be created in repository \"dotnet/docs-maui\".",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
                   "body": {
-                    "description": "The comment text in Markdown format. This is the 'body' field - do not use 'comment_body' or other variations. Provide helpful, relevant information that adds value to the conversation. CONSTRAINTS: The complete comment (your body text + automatically added footer) must not exceed 65536 characters total. Maximum 10 mentions (@username), maximum 50 links (http/https URLs). A footer (~200-500 characters) is automatically appended with workflow attribution, so leave adequate space. If these limits are exceeded, the tool call will fail with a detailed error message indicating which constraint was violated.",
+                    "description": "Detailed issue description in Markdown. Do NOT repeat the title as a heading since it already appears as the issue's h1. Include context, reproduction steps, or acceptance criteria as appropriate.",
                     "type": "string"
                   },
                   "integrity": {
                     "description": "Trustworthiness level of the message source (e.g., \"low\", \"medium\", \"high\").",
                     "type": "string"
                   },
-                  "item_number": {
-                    "description": "The issue, pull request, or discussion number to comment on. This is the numeric ID from the GitHub URL (e.g., 123 in github.com/owner/repo/issues/123). Can also be a temporary_id (e.g., 'aw_abc123') from a previously created issue in the same workflow run. If omitted, the tool auto-targets the issue, PR, or discussion that triggered this workflow. Auto-targeting only works for issue, pull_request, discussion, and comment event triggers — it does NOT work for schedule, workflow_dispatch, push, or workflow_run triggers. For those trigger types, always provide item_number explicitly, or the tool call will fail with an error.",
+                  "labels": {
+                    "description": "Labels to categorize the issue (e.g., 'bug', 'enhancement'). Labels must exist in the repository.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "parent": {
+                    "description": "Parent issue number for creating sub-issues. This is the numeric ID from the GitHub URL (e.g., 42 in github.com/owner/repo/issues/42). Can also be a temporary_id (e.g., 'aw_abc123', 'aw_Test123') from a previously created issue in the same workflow run.",
                     "type": [
                       "number",
                       "string"
@@ -405,56 +400,12 @@ jobs:
                     "type": "string"
                   },
                   "temporary_id": {
-                    "description": "Unique temporary identifier for this comment. Format: 'aw_' followed by 3 to 12 alphanumeric characters (e.g., 'aw_abc1', 'aw_Test123'). Auto-generated if not provided. The temporary ID is returned in the tool response so you can reference this comment later.",
+                    "description": "Unique temporary identifier for referencing this issue before it's created. Format: 'aw_' followed by 3 to 12 alphanumeric characters (e.g., 'aw_abc1', 'aw_Test123'). Use '#aw_ID' in body text to reference other issues by their temporary_id; these are replaced with actual issue numbers after creation.",
                     "pattern": "^aw_[A-Za-z0-9]{3,12}$",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "body"
-                ],
-                "type": "object"
-              },
-              "name": "add_comment"
-            },
-            {
-              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[maui-labs docs] \". Labels [\"docs-from-code\"] will be automatically added. PRs will be created as drafts.",
-              "inputSchema": {
-                "additionalProperties": false,
-                "properties": {
-                  "body": {
-                    "description": "Detailed PR description in Markdown. Include what changes were made, why, testing notes, and any breaking changes. Do NOT repeat the title as a heading.",
-                    "type": "string"
-                  },
-                  "branch": {
-                    "description": "Source branch name containing the changes. If omitted, uses the current working branch.",
-                    "type": "string"
-                  },
-                  "draft": {
-                    "description": "Whether to create the PR as a draft. Draft PRs cannot be merged until marked as ready for review. Use mark_pull_request_as_ready_for_review to convert a draft PR. Default: true.",
-                    "type": "boolean"
-                  },
-                  "integrity": {
-                    "description": "Trustworthiness level of the message source (e.g., \"low\", \"medium\", \"high\").",
-                    "type": "string"
-                  },
-                  "labels": {
-                    "description": "Labels to categorize the PR (e.g., 'enhancement', 'bugfix'). Labels must exist in the repository.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "repo": {
-                    "description": "Target repository in 'owner/repo' format. For multi-repo workflows where the target repo differs from the workflow repo, this must match a repo in the allowed-repos list or the configured target-repo. If omitted, defaults to the configured target-repo (from safe-outputs config), NOT the workflow repository. In most cases, you should omit this parameter and let the system use the configured default.",
-                    "type": "string"
-                  },
-                  "secrecy": {
-                    "description": "Confidentiality level of the message content (e.g., \"public\", \"internal\", \"private\").",
                     "type": "string"
                   },
                   "title": {
-                    "description": "Concise PR title describing the changes. Follow repository conventions (e.g., conventional commits). The title appears as the main heading.",
+                    "description": "Concise issue title summarizing the bug, feature, or task. The title appears as the main heading, so keep it brief and descriptive.",
                     "type": "string"
                   }
                 },
@@ -464,7 +415,7 @@ jobs:
                 ],
                 "type": "object"
               },
-              "name": "create_pull_request"
+              "name": "create_issue"
             },
             {
               "description": "Report that a tool or capability needed to complete the task is not available, or share any information you deem important about missing functionality or limitations. Use this when you cannot accomplish what was requested because the required functionality is missing or access is restricted.",
@@ -563,7 +514,7 @@ jobs:
           GH_AW_SAFE_OUTPUTS_TOOLS_EOF
           cat > /opt/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_EOF'
           {
-            "add_comment": {
+            "create_issue": {
               "defaultMax": 1,
               "fields": {
                 "body": {
@@ -571,33 +522,6 @@ jobs:
                   "type": "string",
                   "sanitize": true,
                   "maxLength": 65000
-                },
-                "item_number": {
-                  "issueOrPRNumber": true
-                },
-                "repo": {
-                  "type": "string",
-                  "maxLength": 256
-                }
-              }
-            },
-            "create_pull_request": {
-              "defaultMax": 1,
-              "fields": {
-                "body": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 65000
-                },
-                "branch": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 256
-                },
-                "draft": {
-                  "type": "boolean"
                 },
                 "labels": {
                   "type": "array",
@@ -605,9 +529,15 @@ jobs:
                   "itemSanitize": true,
                   "itemMaxLength": 128
                 },
+                "parent": {
+                  "issueOrPRNumber": true
+                },
                 "repo": {
                   "type": "string",
                   "maxLength": 256
+                },
+                "temporary_id": {
+                  "type": "string"
                 },
                 "title": {
                   "required": true,
@@ -780,7 +710,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 20
+        timeout-minutes: 15
         run: |
           set -o pipefail
           # shellcheck disable=SC1003
@@ -943,7 +873,6 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
-            /tmp/gh-aw/aw-*.patch
           if-no-files-found: ignore
       # --- Threat Detection (inline) ---
       - name: Check if detection needed
@@ -982,7 +911,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           WORKFLOW_NAME: "PR Documentation Check"
-          WORKFLOW_DESCRIPTION: "Analyzes merged pull requests for documentation needs. When a PR is merged,\nthis workflow reviews the changes and determines if documentation updates are\nneeded on dotnet/docs-maui. If updates are needed, it creates a draft PR on\ndocs-maui with the actual documentation changes. If not, it comments on the\nsource PR explaining why."
+          WORKFLOW_DESCRIPTION: "Analyzes merged pull requests for documentation needs. When a PR is merged,\nthis workflow reviews the changes and determines if documentation updates are\nneeded on dotnet/docs-maui. If updates are needed, it opens an issue on\ndocs-maui with a detailed description of the changes needed."
           HAS_PATCH: ${{ steps.collect_output.outputs.has_patch }}
         with:
           script: |
@@ -1070,10 +999,8 @@ jobs:
     if: (always()) && (needs.agent.result != 'skipped')
     runs-on: ubuntu-slim
     permissions:
-      contents: write
-      discussions: write
+      contents: read
       issues: write
-      pull-requests: write
     concurrency:
       group: "gh-aw-conclusion-pr-docs-check"
       cancel-in-progress: false
@@ -1138,10 +1065,8 @@ jobs:
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
-          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
-          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_TIMEOUT_MINUTES: "20"
+          GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.MAUI_BOT_TOKEN }}
           script: |
@@ -1165,20 +1090,6 @@ jobs:
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/handle_noop_message.cjs');
-            await main();
-      - name: Handle Create Pull Request Error
-        id: handle_create_pr_error
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "PR Documentation Check"
-          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          github-token: ${{ secrets.MAUI_BOT_TOKEN }}
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/handle_create_pr_error.cjs');
             await main();
 
   pre_activation:
@@ -1208,16 +1119,12 @@ jobs:
             await main();
 
   safe_outputs:
-    needs:
-      - activation
-      - agent
+    needs: agent
     if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.agent.outputs.detection_success == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: write
-      discussions: write
+      contents: read
       issues: write
-      pull-requests: write
     timeout-minutes: 15
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/pr-docs-check"
@@ -1227,12 +1134,10 @@ jobs:
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
-      comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
-      comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
-      created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
-      created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
+      created_issue_number: ${{ steps.process_safe_outputs.outputs.created_issue_number }}
+      created_issue_url: ${{ steps.process_safe_outputs.outputs.created_issue_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
@@ -1253,35 +1158,6 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs/
           find "/tmp/gh-aw/safeoutputs/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
-      - name: Download patch artifact
-        continue-on-error: true
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
-        with:
-          name: agent-artifacts
-          path: /tmp/gh-aw/
-      - name: Checkout repository
-        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: dotnet/docs-maui
-          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
-          token: ${{ secrets.MAUI_BOT_TOKEN }}
-          persist-credentials: false
-          fetch-depth: 1
-      - name: Configure Git credentials
-        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
-        env:
-          REPO_NAME: "dotnet/docs-maui"
-          SERVER_URL: ${{ github.server_url }}
-          GIT_TOKEN: ${{ secrets.MAUI_BOT_TOKEN }}
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git config --global am.keepcr true
-          # Re-authenticate git with GitHub token
-          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
-          echo "Git configured with standard GitHub Actions identity"
       - name: Process Safe Outputs
         id: process_safe_outputs
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -1290,8 +1166,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target-repo\":\"dotnet/maui-labs\"},\"create_pull_request\":{\"draft\":true,\"fallback_as_issue\":true,\"labels\":[\"docs-from-code\"],\"max\":1,\"max_patch_size\":1024,\"target-repo\":\"dotnet/docs-maui\",\"title_prefix\":\"[maui-labs docs] \"},\"missing_data\":{},\"missing_tool\":{}}"
-          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"docs-from-code\"],\"max\":1,\"target-repo\":\"dotnet/docs-maui\",\"title_prefix\":\"[maui-labs docs] \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.MAUI_BOT_TOKEN }}
           script: |

--- a/.github/workflows/pr-docs-check.md
+++ b/.github/workflows/pr-docs-check.md
@@ -2,9 +2,8 @@
 description: |
   Analyzes merged pull requests for documentation needs. When a PR is merged,
   this workflow reviews the changes and determines if documentation updates are
-  needed on dotnet/docs-maui. If updates are needed, it creates a draft PR on
-  docs-maui with the actual documentation changes. If not, it comments on the
-  source PR explaining why.
+  needed on dotnet/docs-maui. If updates are needed, it opens an issue on
+  docs-maui with a detailed description of the changes needed.
 
 on:
   pull_request:
@@ -39,10 +38,6 @@ if: >-
   (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
   && github.repository_owner == 'dotnet'
 
-checkout:
-  - repository: dotnet/docs-maui
-    current: true
-
 permissions:
   contents: read
   pull-requests: read
@@ -60,34 +55,25 @@ tools:
 
 safe-outputs:
   github-token: ${{ secrets.MAUI_BOT_TOKEN }}
-  create-pull-request:
+  create-issue:
     title-prefix: "[maui-labs docs] "
     labels: [docs-from-code]
-    draft: true
     target-repo: "dotnet/docs-maui"
-    fallback-as-issue: true
-  add-comment:
-    target-repo: "dotnet/maui-labs"
-    hide-older-comments: true
 
-timeout-minutes: 20
+timeout-minutes: 15
 ---
 
 # PR Documentation Check
 
 Analyze a merged pull request in `dotnet/maui-labs` and determine whether
 documentation updates are needed on the `dotnet/docs-maui` documentation site.
-If updates are needed, write the actual documentation changes and create a draft PR.
+If updates are needed, open an issue on docs-maui. If not, do nothing.
 
 ## Context
 
 - **Source repository**: `dotnet/maui-labs`
 - **PR Number**: `${{ github.event.pull_request.number || github.event.inputs.pr_number }}`
 - **PR Title**: `${{ github.event.pull_request.title }}`
-
-> [!NOTE]
-> The agent runs with `dotnet/docs-maui` as the current workspace. Use GitHub
-> tools to read the source `dotnet/maui-labs` PR details and diff.
 
 ## Step 1: Gather PR Information
 
@@ -96,10 +82,8 @@ for the PR number above, including the title, description, author, labels, base
 branch, and the full diff of changes.
 
 If this was triggered via `workflow_dispatch`, use the `pr_number` input to look up
-the PR details. If the PR number is invalid or the PR cannot be found, stop and
-comment on the workflow run that the input was invalid. If the PR was not merged
-(still open or closed without merging), comment that no documentation updates are
-needed because the PR was not merged, then **stop**.
+the PR details. If the PR number is invalid or the PR cannot be found, stop.
+If the PR was not merged (still open or closed without merging), stop.
 
 ## Step 2: Quick Filter — Skip Obviously Non-Doc PRs
 
@@ -114,8 +98,7 @@ Before doing a deep analysis, check if this PR can be **skipped entirely**:
 - ALL changed files are CI/build infrastructure only (`eng/`, `.github/`,
   `*.yml`, `*.yaml`, `*.props`, `*.targets`)
 
-If the PR is skipped, comment on the PR with a brief one-line message confirming
-no documentation updates are needed and why, then **stop**.
+If the PR is skipped, **stop silently** — do not create any issues or comments.
 
 **Always proceed with analysis if:**
 - Any file in `src/Cli/Microsoft.Maui.Cli/DevFlow/` was changed (CLI DevFlow commands)
@@ -127,7 +110,7 @@ no documentation updates are needed and why, then **stop**.
 
 Review the PR diff for user-facing changes that affect documentation.
 
-**PROCEED with a docs PR if the change includes any of:**
+**PROCEED if the change includes any of:**
 - New or changed CLI commands, flags, or options
 - New or changed MCP tools (new tools, renamed tools, changed parameters)
 - New public APIs in user-facing packages (AgentClient, DevFlow CLI, etc.)
@@ -137,7 +120,7 @@ Review the PR diff for user-facing changes that affect documentation.
 - New NuGet packages
 - Behavioral changes users will notice (e.g., a CLI flag works differently)
 
-**SKIP (no docs PR needed) if the change is only:**
+**SKIP if the change is only:**
 - Internal refactoring with no public API or behavior change
 - Test-only changes
 - Bug fixes that don't change documented behavior
@@ -146,78 +129,44 @@ Review the PR diff for user-facing changes that affect documentation.
 - Performance improvements that don't change usage patterns
 - Help text or error message fixes (these are self-documenting)
 
-**When uncertain, PROCEED.** Draft PRs are cheap; missing docs are expensive.
+If no documentation is needed, **stop silently** — do not create any issues or comments.
 
-## Step 4: If Documentation IS Needed
+**When uncertain, PROCEED.** Issues are cheap; missing docs are expensive.
 
-### 4a: Read Existing Documentation
+## Step 4: Open an Issue on docs-maui
 
-Browse the checked-out `dotnet/docs-maui` workspace to understand the current
-documentation structure. The developer-tools documentation lives under
-`docs/developer-tools/` with this structure:
+If documentation updates ARE needed, create an issue on `dotnet/docs-maui` with
+a clear, actionable description. The issue will be picked up by an agentic
+workflow on the docs-maui side that creates a draft PR from it.
 
-**CLI documentation** (`docs/developer-tools/cli/`):
-- `index.md` — .NET MAUI CLI overview
-- `environment-diagnostics.md` — Environment diagnostics with `maui doctor`
-- `android-management.md` — Android SDK and emulator management
-- `device-management.md` — Device management
+The issue body MUST include all of the following sections:
 
-**DevFlow documentation** (`docs/developer-tools/devflow/`):
-- `index.md` — DevFlow overview
-- `visual-tree-screenshots.md` — Visual tree inspection and screenshots
-- `element-interaction.md` — Element interaction and automation
-- `blazor-cdp.md` — Blazor WebView debugging with CDP
-- `mcp-server.md` — MCP server for AI agents
-- `network-profiling.md` — Network monitoring and profiling
-- `broker.md` — DevFlow broker architecture
-- `setup-windows.md` — DevFlow Windows setup
-- `setup-android.md` — DevFlow Android setup
-- `setup-apple.md` — DevFlow Apple platforms setup
+### Source PR
+Link to the source PR with full URL:
+`https://github.com/dotnet/maui-labs/pull/<number>`
 
-Also check:
-- `docs/developer-tools/index.md` — Landing page for the developer-tools section
-- `docs/TOC.yml` — Table of contents (update if adding new pages)
+Include the PR title, author, and merge date.
 
-### 4b: Write Documentation Changes
+### Summary of Changes
+A concise summary of the user-facing changes. Focus on what changed from a
+documentation perspective, not implementation details.
 
-Based on your analysis, make the actual file changes in the workspace:
+### Documentation Pages Affected
+List which existing pages need updating. Reference the file paths in the docs repo:
 
-- **For updates to existing pages**: Edit the relevant `.md` files in place
-- **For new pages**: Create new `.md` files in the appropriate directory
+- CLI docs: `docs/developer-tools/cli/`
+- DevFlow docs: `docs/developer-tools/devflow/`
+- Landing page: `docs/developer-tools/index.md`
+- TOC: `docs/TOC.yml`
 
-Follow these MS Learn documentation conventions:
-- **Frontmatter**: Every page needs `title`, `description`, and `ms.date` (format: `MM/DD/YYYY`)
-- **Headings**: Use `#` for the page title (must match frontmatter `title`), `##` for sections
-- **Code blocks**: Use triple backticks with language identifier (e.g., ````csharp`, ````bash`)
-- **Notes/warnings**: Use `> [!NOTE]`, `> [!IMPORTANT]`, `> [!WARNING]`
-- **Cross-references**: Use relative paths for internal links (e.g., `[DevFlow overview](../devflow/index.md)`)
-- **TOC.yml**: If adding new pages, add an entry under the appropriate section
+### Suggested Changes
+Provide the specific text, code blocks, table rows, or sections to add or modify.
+Be detailed enough that a docs author (or an agent) can apply the changes without
+reading the full source PR diff. Include:
 
-### 4c: Create Draft PR
+- Exact headings, parameter tables, code examples
+- Where in the existing page the content should be inserted
+- If a new page is needed, suggest the filename and TOC.yml placement
 
-Create a draft pull request on `dotnet/docs-maui` with:
-
-**Title**: A clear, concise title describing the documentation work
-(the `[maui-labs docs]` prefix will be added automatically)
-
-**Description** that includes:
-- A link to the source PR: `Documents changes from dotnet/maui-labs#<number>`
-- The PR author mention: `@<author>`
-- A summary of what documentation was added or changed
-- A list of files modified or created
-
-### 4d: Comment on Source PR
-
-After the draft PR is created, comment on the original PR in `dotnet/maui-labs` with:
-- A message indicating documentation updates have been drafted
-- A link to the newly created draft PR on `dotnet/docs-maui`
-- A brief summary of what documentation changes were made
-- A note that the draft PR needs human review before merging
-
-## Step 5: If Documentation is NOT Needed
-
-Comment on the PR in `dotnet/maui-labs` with a brief one-line message confirming
-no documentation updates are required and a short reason (e.g., "internal
-refactoring only", "test changes only", "bug fix with no behavioral change").
-
-Keep the comment concise — one or two sentences maximum.
+The issue body should be **self-contained** — everything needed to make the
+documentation update should be in the issue itself.


### PR DESCRIPTION
Simplifies the pr-docs-check workflow:workflow 
- Issue-only output (no cross-repo push needed)
- Silent skip when no docs needed (no 'no docs needed' comments)
- Self-contained issue body for downstream agentic workflow on docs-maui
- No labels (avoids permission issues)