### PR TITLE
Fix EssentialsAI tool call logging tests for M.E.AI 10.4

### DIFF
--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ToolCallLoggingTests/InformationalOnlyToolCallLoggingTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ToolCallLoggingTests/InformationalOnlyToolCallLoggingTests.cs
@@ -89,14 +89,20 @@ public class InformationalOnlyToolCallLoggingTests
 		var logs = new LogCollector(LogLevel.Trace);
 		var loggerFactory = new SingleLoggerFactory(logs);
 
-		var mockClient = new MockToolCallClient(informationalOnly: true);
-		mockClient.AddFunctionCallContent("GetWeather", "call-1",
-			new Dictionary<string, object?> { ["location"] = "NYC" });
-		mockClient.AddFunctionCallContent("GetTime", "call-2",
-			new Dictionary<string, object?> { ["timezone"] = "EST" });
-		mockClient.AddFunctionResultContent("call-1", "Cloudy");
-		mockClient.AddFunctionResultContent("call-2", "3:00 PM");
-		mockClient.AddTextContent("Done.");
+		var mockClient = new MockToolCallClient();
+		// Explicitly mark as InformationalOnly — this simulates an on-device model (e.g. Apple
+		// Intelligence) that invokes tools itself and returns call+result together. Do not rely
+		// on M.E.AI's auto-detection of paired call+result, which is an internal behaviour that
+		// could change across versions.
+		mockClient.AddFirstRoundContent(
+			new FunctionCallContent("call-1", "GetWeather",
+				new Dictionary<string, object?> { ["location"] = "NYC" }) { InformationalOnly = true });
+		mockClient.AddFirstRoundContent(
+			new FunctionCallContent("call-2", "GetTime",
+				new Dictionary<string, object?> { ["timezone"] = "EST" }) { InformationalOnly = true });
+		mockClient.AddFirstRoundContent(new FunctionResultContent("call-1", "Cloudy"));
+		mockClient.AddFirstRoundContent(new FunctionResultContent("call-2", "3:00 PM"));
+		mockClient.AddFirstRoundContent(new TextContent("Done."));
 
 		using var pipeline = new ChatClientBuilder(mockClient)
 			.UseFunctionInvocation(loggerFactory)
@@ -117,7 +123,7 @@ public class InformationalOnlyToolCallLoggingTests
 	{
 		var logs = new LogCollector(LogLevel.Trace);
 		var loggerFactory = new SingleLoggerFactory(logs);
-		var mockClient = new MockToolCallClient(informationalOnly: true);
+		var mockClient = new MockToolCallClient();
 		mockClient.AddTextContent("Hello there!");
 
 		using var pipeline = new ChatClientBuilder(mockClient)

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ToolCallLoggingTests/InvocableToolCallLoggingTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ToolCallLoggingTests/InvocableToolCallLoggingTests.cs
@@ -21,7 +21,7 @@ public class InvocableToolCallLoggingTests
 	{
 		var (pipeline, logs, options) = BuildPipeline(LogLevel.Trace, informationalOnly: false);
 
-		await pipeline.GetResponseAsync([new ChatMessage(ChatRole.User, "weather?")], options);
+		var response = await pipeline.GetResponseAsync([new ChatMessage(ChatRole.User, "weather?")], options);
 
 		var allLogs = CombineLogs(logs);
 
@@ -31,6 +31,9 @@ public class InvocableToolCallLoggingTests
 		// FICC logs "GetWeather invocation completed. Duration: ..." at Debug (captured at Trace min)
 		Assert.Contains("invocation completed", allLogs, StringComparison.Ordinal);
 		Assert.Contains("Duration", allLogs, StringComparison.Ordinal);
+
+		// FICC invoked the tool, re-called the model, and the Round 2 text is in the final response
+		Assert.Contains("The weather is sunny.", response.Text ?? string.Empty, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -38,7 +41,7 @@ public class InvocableToolCallLoggingTests
 	{
 		var (pipeline, logs, options) = BuildPipeline(LogLevel.Debug, informationalOnly: false);
 
-		await pipeline.GetResponseAsync([new ChatMessage(ChatRole.User, "weather?")], options);
+		var response = await pipeline.GetResponseAsync([new ChatMessage(ChatRole.User, "weather?")], options);
 
 		var debugMessages = logs.Entries.Where(e => e.Level == LogLevel.Debug).Select(e => e.Message).ToList();
 
@@ -49,6 +52,9 @@ public class InvocableToolCallLoggingTests
 
 		// LoggingChatClient lifecycle still present
 		Assert.Contains(debugMessages, m => m.Contains("GetResponseAsync invoked", StringComparison.Ordinal));
+
+		// Tool was invoked and Round 2 model response is present
+		Assert.Contains("The weather is sunny.", response.Text ?? string.Empty, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -56,11 +62,17 @@ public class InvocableToolCallLoggingTests
 	{
 		var (pipeline, logs, options) = BuildPipeline(LogLevel.Trace, informationalOnly: false);
 
-		await foreach (var _ in pipeline.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "weather?")], options))
+		var responseText = new System.Text.StringBuilder();
+		await foreach (var update in pipeline.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "weather?")], options))
 		{
+			if (update.Text is not null)
+				responseText.Append(update.Text);
 		}
 
 		var allLogs = CombineLogs(logs);
 		Assert.Contains("Invoking GetWeather", allLogs, StringComparison.Ordinal);
+
+		// Round 2 model text is present in the streamed response
+		Assert.Contains("The weather is sunny.", responseText.ToString(), StringComparison.Ordinal);
 	}
 }

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ToolCallLoggingTests/ToolCallLoggingHelpers.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ToolCallLoggingTests/ToolCallLoggingHelpers.cs
@@ -21,18 +21,37 @@ internal static class ToolCallLoggingHelpers
 		var logs = new LogCollector(level);
 		var loggerFactory = new SingleLoggerFactory(logs);
 
-		var mockClient = new MockToolCallClient(informationalOnly);
-		mockClient.AddFunctionCallContent("GetWeather", "call-1",
-			new Dictionary<string, object?> { ["location"] = "Seattle" });
-		mockClient.AddFunctionResultContent("call-1", "Sunny, 72°F");
-		mockClient.AddTextContent("The weather is sunny.");
+		var mockClient = new MockToolCallClient();
+
+		if (informationalOnly)
+		{
+			// Informational-only scenario: the model (e.g. Apple Intelligence on-device)
+			// invoked the tool itself and returns call + result + summary in one response.
+			// FICC sees InformationalOnly=true and skips local invocation.
+			mockClient.AddFirstRoundContent(
+				new FunctionCallContent("call-1", "GetWeather",
+					new Dictionary<string, object?> { ["location"] = "Seattle" }) { InformationalOnly = true });
+			mockClient.AddFirstRoundContent(new FunctionResultContent("call-1", "Sunny, 72°F"));
+			mockClient.AddFirstRoundContent(new TextContent("The weather is sunny."));
+		}
+		else
+		{
+			// Invocable scenario: the model asks FICC to call the tool.
+			// Round 1 — LLM returns only the function call; it has no result yet.
+			mockClient.AddFirstRoundContent(
+				new FunctionCallContent("call-1", "GetWeather",
+					new Dictionary<string, object?> { ["location"] = "Seattle" }));
+
+			// Round 2 — after FICC invokes the tool and appends the result to history,
+			// the LLM gets called again and now produces the final text summary.
+			mockClient.AddSecondRoundContent(new TextContent("The weather is sunny."));
+		}
 
 		var pipeline = new ChatClientBuilder(mockClient)
 			.UseFunctionInvocation(loggerFactory)
 			.UseLogging(loggerFactory)
 			.Build();
 
-		// For invocable tools, register the tool in ChatOptions so FICC can find it
 		var options = new ChatOptions();
 		if (!informationalOnly)
 		{
@@ -86,78 +105,80 @@ internal class SingleLoggerFactory : ILoggerFactory
 }
 
 /// <summary>
-/// Mock chat client that returns predefined content.
-/// When informationalOnly=false, FunctionCallContent is invocable by FICC,
-/// and a matching tool is registered in ChatOptions.
+/// Mock chat client that simulates two-round LLM function-calling behaviour.
+/// Round 1: returns <see cref="AddFirstRoundContent"/> items (the initial LLM response).
+/// Round 2: when the conversation history contains a Tool message (i.e. FICC has already
+///           invoked a function and appended its result), returns <see cref="AddSecondRoundContent"/> items.
+/// This mirrors how real models work: the LLM never produces a text summary until it
+/// actually receives the function result back from the caller.
 /// </summary>
 internal class MockToolCallClient : IChatClient
 {
-	private readonly bool _informationalOnly;
-	private readonly List<AIContent> _content = [];
-
-	public MockToolCallClient(bool informationalOnly) => _informationalOnly = informationalOnly;
+	private readonly List<AIContent> _firstRound = [];
+	private readonly List<AIContent> _secondRound = [];
 
 	public ChatClientMetadata Metadata => new("MockToolCallClient");
 
-	public void AddTextContent(string text) =>
-		_content.Add(new TextContent(text));
+	public void AddFirstRoundContent(AIContent content) => _firstRound.Add(content);
+	public void AddSecondRoundContent(AIContent content) => _secondRound.Add(content);
 
+	// Keep these helpers for tests that build their own MockToolCallClient directly
+	// (e.g. MultipleFunctionCalls_AllLoggedAtTrace).
+	public void AddTextContent(string text) => _firstRound.Add(new TextContent(text));
 	public void AddFunctionCallContent(string name, string callId, Dictionary<string, object?>? arguments = null) =>
-		_content.Add(new FunctionCallContent(callId, name, arguments) { InformationalOnly = _informationalOnly });
-
+		_firstRound.Add(new FunctionCallContent(callId, name, arguments));
 	public void AddFunctionResultContent(string callId, object? result) =>
-		_content.Add(new FunctionResultContent(callId, result));
+		_firstRound.Add(new FunctionResultContent(callId, result));
 
 	public Task<ChatResponse> GetResponseAsync(
 		IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
 	{
-		// When FICC invokes tools and re-calls us, return just the text
-		if (messages.Any(m => m.Role == ChatRole.Tool))
-			return Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "Weather result processed.")]));
-
-		var responseMessages = new List<ChatMessage>();
-		var currentContents = new List<AIContent>();
-
-		foreach (var content in _content)
-		{
-			if (content is FunctionResultContent)
-			{
-				if (currentContents.Count > 0)
-				{
-					responseMessages.Add(new ChatMessage(ChatRole.Assistant, [.. currentContents]));
-					currentContents.Clear();
-				}
-				responseMessages.Add(new ChatMessage(ChatRole.Tool, [content]));
-			}
-			else
-			{
-				currentContents.Add(content);
-			}
-		}
-
-		if (currentContents.Count > 0)
-			responseMessages.Add(new ChatMessage(ChatRole.Assistant, [.. currentContents]));
-
-		return Task.FromResult(new ChatResponse(responseMessages));
+		var content = messages.Any(m => m.Role == ChatRole.Tool) ? _secondRound : _firstRound;
+		return Task.FromResult(new ChatResponse(BuildMessages(content)));
 	}
 
 	public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
 		IEnumerable<ChatMessage> messages, ChatOptions? options = null,
 		[EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
-		// When FICC re-calls after invocation, return processed text
-		if (messages.Any(m => m.Role == ChatRole.Tool))
-		{
-			yield return new ChatResponseUpdate { Role = ChatRole.Assistant, Contents = [new TextContent("Weather result processed.")] };
-			yield break;
-		}
-
-		foreach (var content in _content)
+		var content = messages.Any(m => m.Role == ChatRole.Tool) ? _secondRound : _firstRound;
+		foreach (var item in content)
 		{
 			await Task.Yield();
-			var role = content is FunctionResultContent ? ChatRole.Tool : ChatRole.Assistant;
-			yield return new ChatResponseUpdate { Role = role, Contents = [content] };
+			yield return new ChatResponseUpdate
+			{
+				Role = item is FunctionResultContent ? ChatRole.Tool : ChatRole.Assistant,
+				Contents = [item]
+			};
 		}
+	}
+
+	private static List<ChatMessage> BuildMessages(List<AIContent> content)
+	{
+		var messages = new List<ChatMessage>();
+		var assistantBuffer = new List<AIContent>();
+
+		foreach (var item in content)
+		{
+			if (item is FunctionResultContent)
+			{
+				if (assistantBuffer.Count > 0)
+				{
+					messages.Add(new ChatMessage(ChatRole.Assistant, [.. assistantBuffer]));
+					assistantBuffer.Clear();
+				}
+				messages.Add(new ChatMessage(ChatRole.Tool, [item]));
+			}
+			else
+			{
+				assistantBuffer.Add(item);
+			}
+		}
+
+		if (assistantBuffer.Count > 0)
+			messages.Add(new ChatMessage(ChatRole.Assistant, [.. assistantBuffer]));
+
+		return messages;
 	}
 
 	public object? GetService(Type serviceType, object? serviceKey = null) => null;


### PR DESCRIPTION
## Problem

In M.E.AI 10.4, `FunctionInvokingChatClient` (FICC) auto-marks `FunctionCallContent` as `InformationalOnly` when the same response already contains a matching `FunctionResultContent` with the same `CallId`. This skips local tool invocation, so no "Invoking ..." log appears.

The deeper issue was that `MockToolCallClient` used a single content list for all responses, placing `TextContent` in Round 1 — before FICC even invokes the tool. A real LLM cannot summarise tool results it doesn't have yet.

### Failing tests
- `Trace_FICCLogsInvocationWithArguments`
- `Debug_FICCLogsInvocationWithDuration`
- `Streaming_Trace_FICCLogsInvocation`

## Fix

Restructure `MockToolCallClient` to separate two conversation rounds, matching real-world LLM function-calling behaviour:

- **Round 1** — the initial LLM response (before any tool is invoked)
- **Round 2** — the LLM response after FICC has invoked the tool and appended the result to history

`BuildPipeline` now configures each scenario explicitly:

| Scenario | Model example | Round 1 | Round 2 |
|---|---|---|---|
| `informationalOnly: true` | Apple Intelligence | `FunctionCallContent(InformationalOnly=true)` + `FunctionResultContent` + `TextContent` | *(none — model handles everything)* |
| `informationalOnly: false` | Phi Silica | `FunctionCallContent` only | `TextContent` after tool result in history |

Also:
- Invocable tests now assert on **final response text** (not just logs), proving the full round-trip works end-to-end.
- `MultipleFunctionCalls_AllLoggedAtTrace` now explicitly sets `InformationalOnly = true` on each `FunctionCallContent` instead of relying on M.E.AI's internal auto-detection heuristic.

## Verification

All 333 EssentialsAI unit tests pass on macOS and Windows.