### PR TITLE
Improve Android DevFlow port forwarding

### DIFF
--- a/docs/DevFlow/broker.md
+++ b/docs/DevFlow/broker.md
@@ -277,10 +277,13 @@ The HTTP server stays up throughout reconnection attempts — only broker discov
 | Windows        | `localhost:19223` direct     | `localhost:{port}` direct |
 | Linux/GTK      | `localhost:19223` direct     | `localhost:{port}` direct |
 | iOS Simulator  | Shares host network, direct  | `localhost:{port}` direct |
-| Android Emu    | `adb reverse tcp:19223 tcp:19223` | `adb reverse tcp:{port} tcp:{port}` |
+| Android Emu    | `adb reverse tcp:19223 tcp:19223` | `adb forward tcp:{port} tcp:{port}` |
 
-For Android, you need `adb reverse` for both the broker port (always 19223) and the
-agent's assigned port. The broker port only needs to be set up once per emulator session.
+For Android, the two directions are different: the app reaches the host broker through
+`adb reverse tcp:19223 tcp:19223`, while the host CLI reaches the in-emulator agent
+through `adb forward tcp:{port} tcp:{port}`. The CLI prepares these mappings
+automatically when it can select a single online Android device. If multiple devices are
+online, pass `--android-device <serial>` or set `ANDROID_SERIAL` so it does not guess.
 
 ## File Locations
 
@@ -331,9 +334,13 @@ The broker exposes a simple HTTP API on port 19223 for CLI and diagnostic use:
 - **Broker running?** Run `maui devflow broker status` to check.
 - **App actually started?** The agent registers during app startup. Verify the
   app launched successfully.
-- **Firewall?** On Android, ensure `adb reverse tcp:19223 tcp:19223` is set up.
+- **Firewall?** On Android, run `maui devflow diagnose` and check the `android`
+  forwarding section. If multiple devices are online, retry with
+  `--android-device <serial>`.
 - **Custom port in code?** If `AddMicrosoft.Maui.DevFlowAgent(o => o.Port = XXXX)` sets a
-  non-default port, the agent skips broker registration and uses the hardcoded port.
+  non-default port, the agent includes that `currentPort` during broker registration so
+  the broker reuses the hardcoded port. If broker registration is unavailable, the CLI
+  direct fallback still uses the configured port.
 
 ### CLI can't connect to agent
 
@@ -341,8 +348,10 @@ The broker exposes a simple HTTP API on port 19223 for CLI and diagnostic use:
   Run `maui devflow list` to see actual port assignments.
 - **Agent crashed after registration?** The broker may show the agent briefly
   before detecting the disconnect. Wait a moment and check again.
-- **Android?** You need `adb reverse` for **both** port 19223 (broker) and the
-  agent's assigned port.
+- **Android?** `maui devflow list`, `maui devflow wait`, auto-resolved agent commands,
+  and `maui devflow diagnose` check/repair ADB forwarding when possible. Manually, use
+  `adb reverse tcp:19223 tcp:19223` for broker registration and
+  `adb forward tcp:{port} tcp:{port}` for the CLI-to-agent HTTP path.
 
 ### Broker exits unexpectedly
 

--- a/docs/DevFlow/broker.md
+++ b/docs/DevFlow/broker.md
@@ -283,7 +283,7 @@ For Android, the two directions are different: the app reaches the host broker t
 `adb reverse tcp:19223 tcp:19223`, while the host CLI reaches the in-emulator agent
 through `adb forward tcp:{port} tcp:{port}`. The CLI prepares these mappings
 automatically when it can select a single online Android device. If multiple devices are
-online, pass `--android-device <serial>` or set `ANDROID_SERIAL` so it does not guess.
+online, pass `--device <serial>` or set `ANDROID_SERIAL` so it does not guess.
 
 ## File Locations
 
@@ -336,7 +336,7 @@ The broker exposes a simple HTTP API on port 19223 for CLI and diagnostic use:
   app launched successfully.
 - **Firewall?** On Android, run `maui devflow diagnose` and check the `android`
   forwarding section. If multiple devices are online, retry with
-  `--android-device <serial>`.
+  `--device <serial>`.
 - **Custom port in code?** If `AddMicrosoft.Maui.DevFlowAgent(o => o.Port = XXXX)` sets a
   non-default port, the agent includes that `currentPort` during broker registration so
   the broker reuses the hardcoded port. If broker registration is unavailable, the CLI

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -48,11 +48,19 @@ Use this when a project already has DevFlow package references and `builder.AddM
 Android emulators run in a separate network namespace. Broker registration and CLI-to-agent traffic need opposite forwarding directions:
 
 ```bash
-maui devflow list                 # note the assigned agent port
+maui devflow diagnose             # reports Android forwarding state
+maui devflow list                 # checks/repairs forwarding when one device is online
 adb reverse tcp:19223 tcp:19223   # app in emulator -> host broker
 adb forward tcp:<port> tcp:<port> # host CLI -> app agent
 adb reverse --list
 adb forward --list
+```
+
+When multiple Android devices/emulators are connected, use the same serial selection the CLI supports:
+
+```bash
+maui devflow diagnose --android-device <serial>
+maui devflow list --android-device <serial>
 ```
 
 If no broker is available and the app uses a direct `.mauidevflow` port, forward that port instead:
@@ -104,8 +112,8 @@ pgrep -f "YourApp"
 | Symptom | Fix |
 |---------|-----|
 | `maui devflow list` shows no agents | Verify app is running in Debug, package references exist, and `AddMauiDevFlowAgent()` executes |
-| Android agent never registers | Run `adb reverse tcp:19223 tcp:19223` for broker registration |
-| Android connection refused after registration | Run `adb forward tcp:<port> tcp:<port>` using the port from `maui devflow list` |
+| Android agent never registers | Run `maui devflow diagnose --android-device <serial>` or manually set `adb reverse tcp:19223 tcp:19223` for broker registration |
+| Android connection refused after registration | Run `maui devflow diagnose --android-device <serial>` or manually set `adb forward tcp:<port> tcp:<port>` using the port from `maui devflow list` |
 | Android broker list is empty but app is running | Forward the direct `.mauidevflow` port and run `maui devflow agent status --agent-host localhost --agent-port <port>` |
 | Broker unavailable | `maui devflow broker start`; retry the command |
 | Port already in use | Identify the owner with `lsof -i :<port>` before killing a PID |

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/references/connectivity.md
@@ -59,8 +59,8 @@ adb forward --list
 When multiple Android devices/emulators are connected, use the same serial selection the CLI supports:
 
 ```bash
-maui devflow diagnose --android-device <serial>
-maui devflow list --android-device <serial>
+maui devflow diagnose --device <serial>
+maui devflow list --device <serial>
 ```
 
 If no broker is available and the app uses a direct `.mauidevflow` port, forward that port instead:
@@ -112,8 +112,8 @@ pgrep -f "YourApp"
 | Symptom | Fix |
 |---------|-----|
 | `maui devflow list` shows no agents | Verify app is running in Debug, package references exist, and `AddMauiDevFlowAgent()` executes |
-| Android agent never registers | Run `maui devflow diagnose --android-device <serial>` or manually set `adb reverse tcp:19223 tcp:19223` for broker registration |
-| Android connection refused after registration | Run `maui devflow diagnose --android-device <serial>` or manually set `adb forward tcp:<port> tcp:<port>` using the port from `maui devflow list` |
+| Android agent never registers | Run `maui devflow diagnose --device <serial>` or manually set `adb reverse tcp:19223 tcp:19223` for broker registration |
+| Android connection refused after registration | Run `maui devflow diagnose --device <serial>` or manually set `adb forward tcp:<port> tcp:<port>` using the port from `maui devflow list` |
 | Android broker list is empty but app is running | Forward the direct `.mauidevflow` port and run `maui devflow agent status --agent-host localhost --agent-port <port>` |
 | Broker unavailable | `maui devflow broker start`; retry the command |
 | Port already in use | Identify the owner with `lsof -i :<port>` before killing a PID |

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
@@ -173,6 +173,28 @@ public class AndroidDevFlowPortForwarderTests
 		Assert.Contains("adb -s emulator-5554 reverse tcp:19225 tcp:19225", report.Suggestions);
 	}
 
+	[Fact]
+	public async Task EnsureAsync_WithoutBrokerReverseRequest_DoesNotCheckOrReportReverse()
+	{
+		var provider = CreateProvider(Device("emulator-5554"));
+		var forwardRules = new HashSet<int> { 9223 };
+		var reverseRules = new HashSet<int> { 19223 };
+		var commands = new List<string>();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules, commands));
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
+		{
+			AgentPorts = [9223],
+			EnsureBrokerReverse = false,
+			Repair = true
+		});
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.Ok, report.Status);
+		Assert.False(report.BrokerReverseChecked);
+		Assert.False(report.BrokerReversePresent);
+		Assert.DoesNotContain("-s emulator-5554 reverse --list", commands);
+	}
+
 	static FakeAndroidProvider CreateProvider(params Device[] devices)
 		=> new()
 		{

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
@@ -1,0 +1,204 @@
+using Microsoft.Maui.Cli.DevFlow.Android;
+using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.UnitTests.Fakes;
+using Microsoft.Maui.Cli.Utils;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class AndroidDevFlowPortForwarderTests
+{
+	[Fact]
+	public async Task EnsureAsync_WithoutSdkPath_ReportsNoAdb()
+	{
+		var provider = new FakeAndroidProvider();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, null, (_, _, _) => throw new InvalidOperationException("adb should not run"));
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest { AgentPorts = [9223] });
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.AdbNotFound, report.Status);
+		Assert.False(report.AdbAvailable);
+		Assert.Equal("ADB was not found. Install Android platform-tools or set ANDROID_HOME.", report.Message);
+	}
+
+	[Fact]
+	public async Task EnsureAsync_WithMultipleOnlineDevices_ReportsMultipleDevices()
+	{
+		var provider = CreateProvider(
+			Device("emulator-5554"),
+			Device("RZ8T123456A", isEmulator: false));
+		var commands = new List<string>();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", (_, args, _) =>
+		{
+			commands.Add(string.Join(' ', args));
+			return Task.FromResult(new ProcessResult { ExitCode = 0 });
+		});
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest { AgentPorts = [9223] });
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.MultipleDevices, report.Status);
+		Assert.Null(report.SelectedSerial);
+		Assert.Equal("Multiple online Android devices or emulators were found. Specify --android-device or ANDROID_SERIAL.", report.Message);
+		Assert.Empty(commands);
+	}
+
+	[Fact]
+	public async Task EnsureAsync_WithExplicitSerial_SelectsMatchingDevice()
+	{
+		var provider = CreateProvider(
+			Device("emulator-5554"),
+			Device("RZ8T123456A", isEmulator: false));
+		var forwardRules = new HashSet<int> { 9223 };
+		var reverseRules = new HashSet<int> { 19223 };
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules));
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
+		{
+			DeviceSerial = "RZ8T123456A",
+			AgentPorts = [9223],
+			EnsureBrokerReverse = true
+		});
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.Ok, report.Status);
+		Assert.Equal("RZ8T123456A", report.SelectedSerial);
+		Assert.True(report.BrokerReversePresent);
+		Assert.True(report.AgentForwards.Single(f => f.Port == 9223).PresentAfter);
+	}
+
+	[Fact]
+	public async Task EnsureAsync_WhenMappingsAlreadyExist_DoesNotRepair()
+	{
+		var provider = CreateProvider(Device("emulator-5554"));
+		var forwardRules = new HashSet<int> { 9223 };
+		var reverseRules = new HashSet<int> { 19223 };
+		var commands = new List<string>();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules, commands));
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
+		{
+			AgentPorts = [9223],
+			EnsureBrokerReverse = true,
+			Repair = true
+		});
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.Ok, report.Status);
+		Assert.False(report.BrokerReverseAdded);
+		Assert.DoesNotContain("-s emulator-5554 reverse tcp:19223 tcp:19223", commands);
+		Assert.DoesNotContain("-s emulator-5554 forward tcp:9223 tcp:9223", commands);
+	}
+
+	[Fact]
+	public async Task EnsureAsync_WithRepair_AddsMissingReverseAndForward()
+	{
+		var provider = CreateProvider(Device("emulator-5554"));
+		var forwardRules = new HashSet<int>();
+		var reverseRules = new HashSet<int>();
+		var commands = new List<string>();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules, commands));
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
+		{
+			AgentPorts = [9223],
+			EnsureBrokerReverse = true,
+			Repair = true
+		});
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.Repaired, report.Status);
+		Assert.True(report.BrokerReversePresent);
+		Assert.True(report.BrokerReverseAdded);
+		Assert.True(report.AgentForwards.Single(f => f.Port == 9223).PresentAfter);
+		Assert.Contains("-s emulator-5554 reverse tcp:19223 tcp:19223", commands);
+		Assert.Contains("-s emulator-5554 forward tcp:9223 tcp:9223", commands);
+	}
+
+	[Fact]
+	public async Task EnsureAsync_WithoutRepair_ReportsMissingMappings()
+	{
+		var provider = CreateProvider(Device("emulator-5554"));
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner([], []));
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
+		{
+			AgentPorts = [9223],
+			EnsureBrokerReverse = true,
+			Repair = false
+		});
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.Missing, report.Status);
+		Assert.False(report.BrokerReversePresent);
+		Assert.False(report.AgentForwards.Single(f => f.Port == 9223).PresentAfter);
+		Assert.Contains("adb -s emulator-5554 reverse tcp:19223 tcp:19223", report.Suggestions);
+		Assert.Contains("adb -s emulator-5554 forward tcp:9223 tcp:9223", report.Suggestions);
+	}
+
+	static FakeAndroidProvider CreateProvider(params Device[] devices)
+		=> new()
+		{
+			SdkPath = "/android-sdk",
+			IsSdkInstalled = true,
+			Devices = devices.ToList()
+		};
+
+	static Device Device(string serial, bool isEmulator = true)
+		=> new()
+		{
+			Id = serial,
+			Name = serial,
+			Platforms = ["android"],
+			Type = isEmulator ? DeviceType.Emulator : DeviceType.Physical,
+			State = DeviceState.Connected,
+			IsEmulator = isEmulator,
+			IsRunning = true
+		};
+
+	static Func<string, string[], CancellationToken, Task<ProcessResult>> CreateAdbRunner(
+		HashSet<int> forwardRules,
+		HashSet<int> reverseRules,
+		List<string>? commands = null)
+		=> (_, args, _) =>
+		{
+			commands?.Add(string.Join(' ', args));
+
+			if (args is ["-s", var forwardListSerial, "forward", "--list"])
+			{
+				var output = string.Join(Environment.NewLine, forwardRules.Select(port => $"{forwardListSerial} tcp:{port} tcp:{port}"));
+				return Task.FromResult(new ProcessResult { ExitCode = 0, StandardOutput = output });
+			}
+
+			if (args is ["-s", var reverseListSerial, "reverse", "--list"])
+			{
+				var output = string.Join(Environment.NewLine, reverseRules.Select(port => $"{reverseListSerial} tcp:{port} tcp:{port}"));
+				return Task.FromResult(new ProcessResult { ExitCode = 0, StandardOutput = output });
+			}
+
+			if (args is ["-s", _, "forward", var forwardLocal, var forwardRemote] &&
+				TryParseTcpPort(forwardLocal, out var forwardLocalPort) &&
+				TryParseTcpPort(forwardRemote, out var forwardRemotePort) &&
+				forwardLocalPort == forwardRemotePort)
+			{
+				forwardRules.Add(forwardLocalPort);
+				return Task.FromResult(new ProcessResult { ExitCode = 0 });
+			}
+
+			if (args is ["-s", _, "reverse", var reverseLocal, var reverseRemote] &&
+				TryParseTcpPort(reverseLocal, out var reverseLocalPort) &&
+				TryParseTcpPort(reverseRemote, out var reverseRemotePort) &&
+				reverseLocalPort == reverseRemotePort)
+			{
+				reverseRules.Add(reverseLocalPort);
+				return Task.FromResult(new ProcessResult { ExitCode = 0 });
+			}
+
+			return Task.FromResult(new ProcessResult { ExitCode = 1, StandardError = $"Unexpected adb command: {string.Join(' ', args)}" });
+		};
+
+	static bool TryParseTcpPort(string value, out int port)
+	{
+		const string Prefix = "tcp:";
+		if (value.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
+			return int.TryParse(value[Prefix.Length..], out port);
+
+		port = 0;
+		return false;
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
@@ -38,7 +38,7 @@ public class AndroidDevFlowPortForwarderTests
 
 		Assert.Equal(AndroidDevFlowForwardingStatus.MultipleDevices, report.Status);
 		Assert.Null(report.SelectedSerial);
-		Assert.Equal("Multiple online Android devices or emulators were found. Specify --android-device or ANDROID_SERIAL.", report.Message);
+		Assert.Equal("Multiple online Android devices or emulators were found. Specify --device or ANDROID_SERIAL.", report.Message);
 		Assert.Empty(commands);
 	}
 

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
@@ -131,6 +131,48 @@ public class AndroidDevFlowPortForwarderTests
 		Assert.Contains("adb -s emulator-5554 forward tcp:9223 tcp:9223", report.Suggestions);
 	}
 
+	[Fact]
+	public async Task EnsureAsync_WithCustomBrokerPort_UsesProvidedPortForReverse()
+	{
+		var provider = CreateProvider(Device("emulator-5554"));
+		var forwardRules = new HashSet<int>();
+		var reverseRules = new HashSet<int>();
+		var commands = new List<string>();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules, commands));
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
+		{
+			AgentPorts = [9223],
+			EnsureBrokerReverse = true,
+			BrokerPort = 19225,
+			Repair = true
+		});
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.Repaired, report.Status);
+		Assert.Equal(19225, report.BrokerPort);
+		Assert.True(report.BrokerReversePresent);
+		Assert.Contains("-s emulator-5554 reverse tcp:19225 tcp:19225", commands);
+		Assert.DoesNotContain("-s emulator-5554 reverse tcp:19223 tcp:19223", commands);
+	}
+
+	[Fact]
+	public async Task EnsureAsync_WithCustomBrokerPortAndMissingReverse_SuggestsCustomPort()
+	{
+		var provider = CreateProvider(Device("emulator-5554"));
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner([], []));
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
+		{
+			AgentPorts = [9223],
+			EnsureBrokerReverse = true,
+			BrokerPort = 19225,
+			Repair = false
+		});
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.Missing, report.Status);
+		Assert.Contains("adb -s emulator-5554 reverse tcp:19225 tcp:19225", report.Suggestions);
+	}
+
 	static FakeAndroidProvider CreateProvider(params Device[] devices)
 		=> new()
 		{

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -214,6 +214,7 @@ public class DevFlowCliIntegrationTests
                 ConnectedAt = DateTime.UnixEpoch
             }
         ]);
+        DevFlowCommands.IsAndroidAdbLikelyAvailable = () => true;
         DevFlowCommands.CreateAndroidPortForwarder = () =>
         {
             var provider = new FakeAndroidProvider
@@ -302,6 +303,7 @@ public class DevFlowCliIntegrationTests
                 }
             ]);
         };
+        DevFlowCommands.IsAndroidAdbLikelyAvailable = () => true;
         DevFlowCommands.CreateAndroidPortForwarder = () =>
         {
             var provider = new FakeAndroidProvider

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -1,8 +1,12 @@
 using System.Text;
 using System.Text.Json;
 using Microsoft.Maui.Cli.DevFlow;
+using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Maui.Cli.DevFlow.Broker;
+using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.UnitTests.Fixtures;
+using Microsoft.Maui.Cli.UnitTests.Fakes;
+using Microsoft.Maui.Cli.Utils;
 using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
@@ -178,6 +182,91 @@ public class DevFlowCliIntegrationTests
             Assert.Equal("SampleApp", agent.GetProperty("appName").GetString());
             Assert.Equal(JsonValueKind.Array, json.GetProperty("projects").ValueKind);
             Assert.Empty(json.GetProperty("projects").EnumerateArray());
+        }
+        finally
+        {
+            DevFlowCommands.ResetBrokerClientForTests();
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DiagnoseJson_WhenAndroidAgentIsRegistered_ReportsForwardingState()
+    {
+        var cli = new CliTestHarness(mockAgentPort: 9223);
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-diagnose-");
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+        var commands = new List<string>();
+
+        DevFlowCommands.ResolveRunningBrokerPortAsync = () => Task.FromResult<int?>(19223);
+        DevFlowCommands.ListBrokerAgentsAsync = _ => Task.FromResult<AgentRegistration[]?>(
+        [
+            new AgentRegistration
+            {
+                Id = "android-agent",
+                Project = "/src/App.csproj",
+                Tfm = "net10.0-android",
+                Platform = "Android",
+                AppName = "SampleApp",
+                Port = 9223,
+                Version = "0.1.0-preview",
+                ConnectedAt = DateTime.UnixEpoch
+            }
+        ]);
+        DevFlowCommands.CreateAndroidPortForwarder = () =>
+        {
+            var provider = new FakeAndroidProvider
+            {
+                SdkPath = "/android-sdk",
+                IsSdkInstalled = true,
+                Devices =
+                [
+                    new Device
+                    {
+                        Id = "emulator-5554",
+                        Name = "Pixel",
+                        Platforms = ["android"],
+                        Type = DeviceType.Emulator,
+                        State = DeviceState.Connected,
+                        IsEmulator = true,
+                        IsRunning = true
+                    }
+                ]
+            };
+
+            return new AndroidDevFlowPortForwarder(
+                provider,
+                "/android-sdk/platform-tools/adb",
+                (_, args, _) =>
+                {
+                    commands.Add(string.Join(' ', args));
+                    var output = args[2] switch
+                    {
+                        "reverse" => "emulator-5554 tcp:19223 tcp:19223",
+                        "forward" => "emulator-5554 tcp:9223 tcp:9223",
+                        _ => ""
+                    };
+                    return Task.FromResult(new ProcessResult { ExitCode = 0, StandardOutput = output });
+                });
+        };
+
+        try
+        {
+            Directory.SetCurrentDirectory(tempDir.FullName);
+
+            var result = await cli.InvokeRawAsync("devflow", "diagnose", "--json", "--android-device", "emulator-5554");
+
+            Assert.Equal(0, result.ExitCode);
+            var json = result.ParseJsonOutput();
+            var android = json.GetProperty("android");
+            Assert.Equal("emulator-5554", android.GetProperty("selected_serial").GetString());
+            Assert.True(android.GetProperty("broker_reverse_present").GetBoolean());
+            var forward = Assert.Single(android.GetProperty("agent_forwards").EnumerateArray());
+            Assert.Equal(9223, forward.GetProperty("port").GetInt32());
+            Assert.True(forward.GetProperty("present_after").GetBoolean());
+            Assert.Contains("-s emulator-5554 reverse --list", commands);
+            Assert.Contains("-s emulator-5554 forward --list", commands);
         }
         finally
         {

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -154,8 +154,8 @@ public class DevFlowCliIntegrationTests
                 {
                     Id = "agent-1",
                     Project = "/src/App.csproj",
-                    Tfm = "net10.0-android",
-                    Platform = "Android",
+                    Tfm = "net10.0-windows10.0.19041.0",
+                    Platform = "Windows",
                     AppName = "SampleApp",
                     Port = 9223,
                     Version = "0.1.0-preview",

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -258,7 +258,7 @@ public class DevFlowCliIntegrationTests
         {
             Directory.SetCurrentDirectory(tempDir.FullName);
 
-            var result = await cli.InvokeRawAsync("devflow", "diagnose", "--json", "--android-device", "emulator-5554");
+            var result = await cli.InvokeRawAsync("devflow", "diagnose", "--json", "--device", "emulator-5554");
 
             Assert.Equal(0, result.ExitCode);
             var json = result.ParseJsonOutput();
@@ -346,7 +346,7 @@ public class DevFlowCliIntegrationTests
         {
             Directory.SetCurrentDirectory(tempDir.FullName);
 
-            var result = await cli.InvokeRawAsync("devflow", "diagnose", "--no-json", "--android-device", "emulator-5554");
+            var result = await cli.InvokeRawAsync("devflow", "diagnose", "--no-json", "--device", "emulator-5554");
 
             Assert.Equal(0, result.ExitCode);
             Assert.Contains("Broker reverse:   ready (tcp:19225)", result.StdOut);

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -163,6 +163,8 @@ public class DevFlowCliIntegrationTests
                 }
             ]);
         };
+        DevFlowCommands.IsAndroidAdbLikelyAvailable = () => throw new InvalidOperationException("Non-Android diagnostics must not probe adb.");
+        DevFlowCommands.CreateAndroidPortForwarder = () => throw new InvalidOperationException("Non-Android diagnostics must not create an Android port forwarder.");
 
         try
         {

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -277,6 +277,86 @@ public class DevFlowCliIntegrationTests
     }
 
     [Fact]
+    public async Task DiagnoseHuman_WhenBrokerUsesCustomPort_ReportsCustomBrokerReversePort()
+    {
+        var cli = new CliTestHarness(mockAgentPort: 9223);
+        var tempDir = Directory.CreateTempSubdirectory("maui-devflow-diagnose-");
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+
+        DevFlowCommands.ResolveRunningBrokerPortAsync = () => Task.FromResult<int?>(19225);
+        DevFlowCommands.ListBrokerAgentsAsync = brokerPort =>
+        {
+            Assert.Equal(19225, brokerPort);
+            return Task.FromResult<AgentRegistration[]?>(
+            [
+                new AgentRegistration
+                {
+                    Id = "android-agent",
+                    Project = "/src/App.csproj",
+                    Tfm = "net10.0-android",
+                    Platform = "Android",
+                    AppName = "SampleApp",
+                    Port = 9223,
+                    Version = "0.1.0-preview",
+                    ConnectedAt = DateTime.UnixEpoch
+                }
+            ]);
+        };
+        DevFlowCommands.CreateAndroidPortForwarder = () =>
+        {
+            var provider = new FakeAndroidProvider
+            {
+                SdkPath = "/android-sdk",
+                IsSdkInstalled = true,
+                Devices =
+                [
+                    new Device
+                    {
+                        Id = "emulator-5554",
+                        Name = "Pixel",
+                        Platforms = ["android"],
+                        Type = DeviceType.Emulator,
+                        State = DeviceState.Connected,
+                        IsEmulator = true,
+                        IsRunning = true
+                    }
+                ]
+            };
+
+            return new AndroidDevFlowPortForwarder(
+                provider,
+                "/android-sdk/platform-tools/adb",
+                (_, args, _) =>
+                {
+                    var output = args[2] switch
+                    {
+                        "reverse" => "emulator-5554 tcp:19225 tcp:19225",
+                        "forward" => "emulator-5554 tcp:9223 tcp:9223",
+                        _ => ""
+                    };
+                    return Task.FromResult(new ProcessResult { ExitCode = 0, StandardOutput = output });
+                });
+        };
+
+        try
+        {
+            Directory.SetCurrentDirectory(tempDir.FullName);
+
+            var result = await cli.InvokeRawAsync("devflow", "diagnose", "--no-json", "--android-device", "emulator-5554");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("Broker reverse:   ready (tcp:19225)", result.StdOut);
+            Assert.DoesNotContain("Broker reverse:   ready (tcp:19223)", result.StdOut);
+        }
+        finally
+        {
+            DevFlowCommands.ResetBrokerClientForTests();
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task StoragePreferencesSet_UsesPutV1Route()
     {
         var (server, cli) = await CreateFixturesAsync();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/CliCollection.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/CliCollection.cs
@@ -1,5 +1,7 @@
 using Xunit;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
 namespace Microsoft.Maui.Cli.UnitTests.Fixtures;
 
 [CollectionDefinition("CLI", DisableParallelization = true)]

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
@@ -127,9 +127,13 @@ internal sealed class AndroidDevFlowPortForwarder
 
         report = report with { SelectedSerial = selected.Device!.Serial };
 
-        var reverseBefore = await ListMappingsAsync(report.SelectedSerial, reverse: true, cancellationToken);
-        if (!reverseBefore.Success)
-            return report with { Status = AndroidDevFlowForwardingStatus.Error, Message = reverseBefore.Error, Suggestions = ["adb reverse --list"] };
+        var reverseBefore = AndroidPortMappingList.Ok([]);
+        if (request.EnsureBrokerReverse)
+        {
+            reverseBefore = await ListMappingsAsync(report.SelectedSerial, reverse: true, cancellationToken);
+            if (!reverseBefore.Success)
+                return report with { Status = AndroidDevFlowForwardingStatus.Error, Message = reverseBefore.Error, Suggestions = ["adb reverse --list"] };
+        }
 
         var forwardBefore = await ListMappingsAsync(report.SelectedSerial, reverse: false, cancellationToken);
         if (!forwardBefore.Success)
@@ -171,9 +175,16 @@ internal sealed class AndroidDevFlowPortForwarder
             });
         }
 
-        var reverseAfter = await ListMappingsAsync(report.SelectedSerial, reverse: true, cancellationToken);
-        if (!reverseAfter.Success)
-            errors.Add(reverseAfter.Error ?? "Failed to verify adb reverse mappings.");
+        var reverseAfter = AndroidPortMappingList.Ok([]);
+        var brokerReverseChecked = false;
+        if (request.EnsureBrokerReverse)
+        {
+            reverseAfter = await ListMappingsAsync(report.SelectedSerial, reverse: true, cancellationToken);
+            if (reverseAfter.Success)
+                brokerReverseChecked = true;
+            else
+                errors.Add(reverseAfter.Error ?? "Failed to verify adb reverse mappings.");
+        }
 
         var forwardAfter = await ListMappingsAsync(report.SelectedSerial, reverse: false, cancellationToken);
         if (!forwardAfter.Success)
@@ -200,6 +211,7 @@ internal sealed class AndroidDevFlowPortForwarder
             return report with
             {
                 Status = AndroidDevFlowForwardingStatus.Error,
+                BrokerReverseChecked = brokerReverseChecked,
                 BrokerReversePresent = brokerReversePresent,
                 BrokerReverseAdded = brokerReverseAdded,
                 AgentForwards = agentForwards.ToArray(),
@@ -209,9 +221,10 @@ internal sealed class AndroidDevFlowPortForwarder
         }
 
         var repaired = brokerReverseAdded || agentForwards.Any(static f => f.Added);
-        var missing = (!request.EnsureBrokerReverse || brokerReversePresent) && missingPorts.Length == 0
+        var brokerReverseMissing = request.EnsureBrokerReverse && !brokerReversePresent;
+        var missing = !brokerReverseMissing && missingPorts.Length == 0
             ? Array.Empty<string>()
-            : BuildMappingSuggestions(report.SelectedSerial, request.EnsureBrokerReverse && !brokerReversePresent, brokerPort, missingPorts);
+            : BuildMappingSuggestions(report.SelectedSerial, brokerReverseMissing, brokerPort, missingPorts);
 
         var status = missing.Length > 0
             ? AndroidDevFlowForwardingStatus.Missing
@@ -222,7 +235,8 @@ internal sealed class AndroidDevFlowPortForwarder
         return report with
         {
             Status = status,
-            BrokerReversePresent = !request.EnsureBrokerReverse || brokerReversePresent,
+            BrokerReverseChecked = brokerReverseChecked,
+            BrokerReversePresent = brokerReversePresent,
             BrokerReverseAdded = brokerReverseAdded,
             AgentForwards = agentForwards.ToArray(),
             Message = status switch
@@ -416,6 +430,9 @@ internal sealed record AndroidDevFlowForwardingReport
 
     [JsonPropertyName("broker_reverse_present")]
     public bool BrokerReversePresent { get; init; }
+
+    [JsonPropertyName("broker_reverse_checked")]
+    public bool BrokerReverseChecked { get; init; }
 
     [JsonPropertyName("broker_reverse_added")]
     public bool BrokerReverseAdded { get; init; }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
@@ -1,0 +1,467 @@
+using System.Text.Json.Serialization;
+using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.Providers.Android;
+using Microsoft.Maui.Cli.Utils;
+
+namespace Microsoft.Maui.Cli.DevFlow.Android;
+
+internal sealed class AndroidDevFlowPortForwarder
+{
+    public const int DefaultBrokerPort = 19223;
+
+    readonly IAndroidProvider _androidProvider;
+    readonly string? _adbPath;
+    readonly Func<string, string[], CancellationToken, Task<ProcessResult>> _runAdbAsync;
+
+    public AndroidDevFlowPortForwarder(
+        IAndroidProvider androidProvider,
+        string? adbPath,
+        Func<string, string[], CancellationToken, Task<ProcessResult>> runAdbAsync)
+    {
+        _androidProvider = androidProvider;
+        _adbPath = adbPath;
+        _runAdbAsync = runAdbAsync;
+    }
+
+    public static AndroidDevFlowPortForwarder CreateDefault()
+    {
+        var provider = Program.AndroidProvider;
+        var environment = AndroidEnvironment.BuildEnvironmentVariables(provider.SdkPath, provider.JdkPath);
+        var adb = new Adb(() => provider.SdkPath, environment);
+
+        return new AndroidDevFlowPortForwarder(
+            provider,
+            adb.AdbPath,
+            (adbPath, args, cancellationToken) => ProcessRunner.RunAsync(
+                adbPath,
+                args,
+                environmentVariables: environment,
+                timeout: TimeSpan.FromSeconds(15),
+                cancellationToken: cancellationToken));
+    }
+
+    public async Task<AndroidDevFlowForwardingReport> EnsureAsync(
+        AndroidDevFlowForwardingRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var report = new AndroidDevFlowForwardingReport
+        {
+            AdbAvailable = !string.IsNullOrWhiteSpace(_adbPath),
+            AdbPath = _adbPath,
+            RequestedSerial = request.DeviceSerial ?? Environment.GetEnvironmentVariable("ANDROID_SERIAL"),
+            BrokerPort = DefaultBrokerPort,
+            AgentPorts = request.AgentPorts.Distinct().OrderBy(static port => port).ToArray(),
+            RepairRequested = request.Repair
+        };
+
+        if (string.IsNullOrWhiteSpace(_adbPath))
+        {
+            return report with
+            {
+                Status = AndroidDevFlowForwardingStatus.AdbNotFound,
+                Message = "ADB was not found. Install Android platform-tools or set ANDROID_HOME.",
+                Suggestions = ["maui android sdk install platform-tools"]
+            };
+        }
+
+        List<Device> devices;
+        try
+        {
+            devices = await _androidProvider.GetDevicesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return report with
+            {
+                Status = AndroidDevFlowForwardingStatus.Error,
+                Message = $"Failed to list Android devices: {ex.Message}",
+                Suggestions = ["adb devices"]
+            };
+        }
+
+        report = report with
+        {
+            Devices = devices
+                .Where(IsAndroidDevice)
+                .Select(AndroidDevFlowDevice.FromDevice)
+                .ToArray()
+        };
+
+        var onlineDevices = report.Devices
+            .Where(static d => d.IsOnline)
+            .ToArray();
+
+        var selected = SelectDevice(onlineDevices, report.RequestedSerial);
+        if (selected.Status != AndroidDevFlowForwardingStatus.Ok)
+        {
+            return report with
+            {
+                Status = selected.Status,
+                Message = selected.Message,
+                Suggestions = selected.Suggestions
+            };
+        }
+
+        report = report with { SelectedSerial = selected.Device!.Serial };
+
+        var reverseBefore = await ListMappingsAsync(report.SelectedSerial, reverse: true, cancellationToken);
+        if (!reverseBefore.Success)
+            return report with { Status = AndroidDevFlowForwardingStatus.Error, Message = reverseBefore.Error, Suggestions = ["adb reverse --list"] };
+
+        var forwardBefore = await ListMappingsAsync(report.SelectedSerial, reverse: false, cancellationToken);
+        if (!forwardBefore.Success)
+            return report with { Status = AndroidDevFlowForwardingStatus.Error, Message = forwardBefore.Error, Suggestions = ["adb forward --list"] };
+
+        var errors = new List<string>();
+        var brokerReverseBefore = request.EnsureBrokerReverse
+            && ContainsMapping(reverseBefore.Mappings, report.SelectedSerial, DefaultBrokerPort);
+        var brokerReverseAdded = false;
+
+        if (request.EnsureBrokerReverse && !brokerReverseBefore && request.Repair)
+        {
+            var result = await RunAdbAsync(report.SelectedSerial, ["reverse", $"tcp:{DefaultBrokerPort}", $"tcp:{DefaultBrokerPort}"], cancellationToken);
+            if (result.Success)
+                brokerReverseAdded = true;
+            else
+                errors.Add($"adb reverse tcp:{DefaultBrokerPort} tcp:{DefaultBrokerPort} failed: {GetProcessError(result)}");
+        }
+
+        var agentForwards = new List<AndroidDevFlowPortForward>();
+        foreach (var port in report.AgentPorts)
+        {
+            var presentBefore = ContainsMapping(forwardBefore.Mappings, report.SelectedSerial, port);
+            var added = false;
+            if (!presentBefore && request.Repair)
+            {
+                var result = await RunAdbAsync(report.SelectedSerial, ["forward", $"tcp:{port}", $"tcp:{port}"], cancellationToken);
+                if (result.Success)
+                    added = true;
+                else
+                    errors.Add($"adb forward tcp:{port} tcp:{port} failed: {GetProcessError(result)}");
+            }
+
+            agentForwards.Add(new AndroidDevFlowPortForward
+            {
+                Port = port,
+                PresentBefore = presentBefore,
+                Added = added
+            });
+        }
+
+        var reverseAfter = await ListMappingsAsync(report.SelectedSerial, reverse: true, cancellationToken);
+        if (!reverseAfter.Success)
+            errors.Add(reverseAfter.Error ?? "Failed to verify adb reverse mappings.");
+
+        var forwardAfter = await ListMappingsAsync(report.SelectedSerial, reverse: false, cancellationToken);
+        if (!forwardAfter.Success)
+            errors.Add(forwardAfter.Error ?? "Failed to verify adb forward mappings.");
+
+        var brokerReversePresent = request.EnsureBrokerReverse
+            && reverseAfter.Success
+            && ContainsMapping(reverseAfter.Mappings, report.SelectedSerial, DefaultBrokerPort);
+
+        agentForwards = agentForwards
+            .Select(f => f with
+            {
+                PresentAfter = forwardAfter.Success && ContainsMapping(forwardAfter.Mappings, report.SelectedSerial, f.Port)
+            })
+            .ToList();
+
+        var missingPorts = agentForwards
+            .Where(static f => !f.PresentAfter)
+            .Select(static f => f.Port)
+            .ToArray();
+
+        if (errors.Count > 0)
+        {
+            return report with
+            {
+                Status = AndroidDevFlowForwardingStatus.Error,
+                BrokerReversePresent = brokerReversePresent,
+                BrokerReverseAdded = brokerReverseAdded,
+                AgentForwards = agentForwards.ToArray(),
+                Message = string.Join(Environment.NewLine, errors),
+                Suggestions = BuildMappingSuggestions(report.SelectedSerial, request.EnsureBrokerReverse && !brokerReversePresent, missingPorts)
+            };
+        }
+
+        var repaired = brokerReverseAdded || agentForwards.Any(static f => f.Added);
+        var missing = (!request.EnsureBrokerReverse || brokerReversePresent) && missingPorts.Length == 0
+            ? Array.Empty<string>()
+            : BuildMappingSuggestions(report.SelectedSerial, request.EnsureBrokerReverse && !brokerReversePresent, missingPorts);
+
+        var status = missing.Length > 0
+            ? AndroidDevFlowForwardingStatus.Missing
+            : repaired
+                ? AndroidDevFlowForwardingStatus.Repaired
+                : AndroidDevFlowForwardingStatus.Ok;
+
+        return report with
+        {
+            Status = status,
+            BrokerReversePresent = !request.EnsureBrokerReverse || brokerReversePresent,
+            BrokerReverseAdded = brokerReverseAdded,
+            AgentForwards = agentForwards.ToArray(),
+            Message = status switch
+            {
+                AndroidDevFlowForwardingStatus.Repaired => "Android DevFlow ADB forwarding was repaired.",
+                AndroidDevFlowForwardingStatus.Missing => "Android DevFlow ADB forwarding is incomplete.",
+                _ => "Android DevFlow ADB forwarding is ready."
+            },
+            Suggestions = missing
+        };
+    }
+
+    static bool IsAndroidDevice(Device device)
+        => device.Platforms.Any(static p => p.Equals("android", StringComparison.OrdinalIgnoreCase));
+
+    static AndroidDeviceSelection SelectDevice(AndroidDevFlowDevice[] onlineDevices, string? requestedSerial)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedSerial))
+        {
+            var match = onlineDevices.FirstOrDefault(d => d.Serial.Equals(requestedSerial, StringComparison.OrdinalIgnoreCase));
+            return match is not null
+                ? AndroidDeviceSelection.Ok(match)
+                : AndroidDeviceSelection.Failed(
+                    AndroidDevFlowForwardingStatus.DeviceNotFound,
+                    $"Android device '{requestedSerial}' is not connected and online.",
+                    ["adb devices"]);
+        }
+
+        return onlineDevices.Length switch
+        {
+            0 => AndroidDeviceSelection.Failed(
+                AndroidDevFlowForwardingStatus.NoDevice,
+                "No online Android devices or emulators were found.",
+                ["adb devices"]),
+            1 => AndroidDeviceSelection.Ok(onlineDevices[0]),
+            _ => AndroidDeviceSelection.Failed(
+                AndroidDevFlowForwardingStatus.MultipleDevices,
+                "Multiple online Android devices or emulators were found. Specify --android-device or ANDROID_SERIAL.",
+                onlineDevices.Select(static d => $"--android-device {d.Serial}").ToArray())
+        };
+    }
+
+    async Task<AndroidPortMappingList> ListMappingsAsync(string serial, bool reverse, CancellationToken cancellationToken)
+    {
+        var result = await RunAdbAsync(serial, [reverse ? "reverse" : "forward", "--list"], cancellationToken);
+        if (!result.Success)
+        {
+            var command = reverse ? "adb reverse --list" : "adb forward --list";
+            return AndroidPortMappingList.Failed($"{command} failed: {GetProcessError(result)}");
+        }
+
+        return AndroidPortMappingList.Ok(ParsePortMappings(result.StandardOutput));
+    }
+
+    Task<ProcessResult> RunAdbAsync(string serial, string[] args, CancellationToken cancellationToken)
+    {
+        var fullArgs = new List<string> { "-s", serial };
+        fullArgs.AddRange(args);
+        return _runAdbAsync(_adbPath!, fullArgs.ToArray(), cancellationToken);
+    }
+
+    internal static AndroidDevFlowPortMapping[] ParsePortMappings(string output)
+    {
+        var mappings = new List<AndroidDevFlowPortMapping>();
+        foreach (var rawLine in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = rawLine.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 3)
+            {
+                mappings.Add(new AndroidDevFlowPortMapping
+                {
+                    Serial = parts[0],
+                    Local = parts[1],
+                    Remote = parts[2]
+                });
+            }
+            else if (parts.Length == 2)
+            {
+                mappings.Add(new AndroidDevFlowPortMapping
+                {
+                    Local = parts[0],
+                    Remote = parts[1]
+                });
+            }
+        }
+
+        return mappings.ToArray();
+    }
+
+    static bool ContainsMapping(IEnumerable<AndroidDevFlowPortMapping> mappings, string serial, int port)
+    {
+        var endpoint = $"tcp:{port}";
+        return mappings.Any(m =>
+            (string.IsNullOrWhiteSpace(m.Serial) || m.Serial.Equals(serial, StringComparison.OrdinalIgnoreCase)) &&
+            m.Local.Equals(endpoint, StringComparison.OrdinalIgnoreCase) &&
+            m.Remote.Equals(endpoint, StringComparison.OrdinalIgnoreCase));
+    }
+
+    static string GetProcessError(ProcessResult result)
+    {
+        var error = !string.IsNullOrWhiteSpace(result.StandardError)
+            ? result.StandardError.Trim()
+            : result.StandardOutput.Trim();
+
+        return string.IsNullOrWhiteSpace(error) ? $"exit code {result.ExitCode}" : error;
+    }
+
+    static string[] BuildMappingSuggestions(string serial, bool brokerReverseMissing, int[] missingAgentForwards)
+    {
+        var suggestions = new List<string>();
+        if (brokerReverseMissing)
+            suggestions.Add($"adb -s {serial} reverse tcp:{DefaultBrokerPort} tcp:{DefaultBrokerPort}");
+        foreach (var port in missingAgentForwards)
+            suggestions.Add($"adb -s {serial} forward tcp:{port} tcp:{port}");
+        return suggestions.ToArray();
+    }
+
+    sealed record AndroidDeviceSelection(AndroidDevFlowForwardingStatus Status, AndroidDevFlowDevice? Device, string? Message, string[] Suggestions)
+    {
+        public static AndroidDeviceSelection Ok(AndroidDevFlowDevice device) => new(AndroidDevFlowForwardingStatus.Ok, device, null, []);
+
+        public static AndroidDeviceSelection Failed(AndroidDevFlowForwardingStatus status, string message, string[] suggestions)
+            => new(status, null, message, suggestions);
+    }
+
+    sealed record AndroidPortMappingList(bool Success, AndroidDevFlowPortMapping[] Mappings, string? Error)
+    {
+        public static AndroidPortMappingList Ok(AndroidDevFlowPortMapping[] mappings) => new(true, mappings, null);
+
+        public static AndroidPortMappingList Failed(string error) => new(false, [], error);
+    }
+}
+
+internal sealed record AndroidDevFlowForwardingRequest
+{
+    public int[] AgentPorts { get; init; } = [];
+
+    public bool EnsureBrokerReverse { get; init; }
+
+    public bool Repair { get; init; }
+
+    public string? DeviceSerial { get; init; }
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<AndroidDevFlowForwardingStatus>))]
+internal enum AndroidDevFlowForwardingStatus
+{
+    Ok,
+    Repaired,
+    Missing,
+    AdbNotFound,
+    NoDevice,
+    MultipleDevices,
+    DeviceNotFound,
+    Error
+}
+
+internal sealed record AndroidDevFlowForwardingReport
+{
+    [JsonPropertyName("status")]
+    public AndroidDevFlowForwardingStatus Status { get; init; } = AndroidDevFlowForwardingStatus.Ok;
+
+    [JsonPropertyName("adb_available")]
+    public bool AdbAvailable { get; init; }
+
+    [JsonPropertyName("adb_path")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AdbPath { get; init; }
+
+    [JsonPropertyName("requested_serial")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RequestedSerial { get; init; }
+
+    [JsonPropertyName("selected_serial")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SelectedSerial { get; init; }
+
+    [JsonPropertyName("devices")]
+    public AndroidDevFlowDevice[] Devices { get; init; } = [];
+
+    [JsonPropertyName("broker_port")]
+    public int BrokerPort { get; init; }
+
+    [JsonPropertyName("broker_reverse_present")]
+    public bool BrokerReversePresent { get; init; }
+
+    [JsonPropertyName("broker_reverse_added")]
+    public bool BrokerReverseAdded { get; init; }
+
+    [JsonPropertyName("agent_ports")]
+    public int[] AgentPorts { get; init; } = [];
+
+    [JsonPropertyName("agent_forwards")]
+    public AndroidDevFlowPortForward[] AgentForwards { get; init; } = [];
+
+    [JsonPropertyName("repair_requested")]
+    public bool RepairRequested { get; init; }
+
+    [JsonPropertyName("message")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Message { get; init; }
+
+    [JsonPropertyName("suggestions")]
+    public string[] Suggestions { get; init; } = [];
+
+    [JsonIgnore]
+    public bool IsReady => Status is AndroidDevFlowForwardingStatus.Ok or AndroidDevFlowForwardingStatus.Repaired;
+}
+
+internal sealed record AndroidDevFlowDevice
+{
+    [JsonPropertyName("serial")]
+    public required string Serial { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("state")]
+    [JsonConverter(typeof(JsonStringEnumConverter<DeviceState>))]
+    public DeviceState State { get; init; }
+
+    [JsonPropertyName("is_emulator")]
+    public bool IsEmulator { get; init; }
+
+    [JsonPropertyName("is_online")]
+    public bool IsOnline { get; init; }
+
+    public static AndroidDevFlowDevice FromDevice(Device device)
+        => new()
+        {
+            Serial = device.Id,
+            Name = device.Name,
+            State = device.State,
+            IsEmulator = device.IsEmulator,
+            IsOnline = device.State is DeviceState.Connected or DeviceState.Booted
+        };
+}
+
+internal sealed record AndroidDevFlowPortMapping
+{
+    [JsonPropertyName("serial")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Serial { get; init; }
+
+    [JsonPropertyName("local")]
+    public string Local { get; init; } = "";
+
+    [JsonPropertyName("remote")]
+    public string Remote { get; init; } = "";
+}
+
+internal sealed record AndroidDevFlowPortForward
+{
+    [JsonPropertyName("port")]
+    public int Port { get; init; }
+
+    [JsonPropertyName("present_before")]
+    public bool PresentBefore { get; init; }
+
+    [JsonPropertyName("added")]
+    public bool Added { get; init; }
+
+    [JsonPropertyName("present_after")]
+    public bool PresentAfter { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
@@ -274,8 +274,8 @@ internal sealed class AndroidDevFlowPortForwarder
             1 => AndroidDeviceSelection.Ok(onlineDevices[0]),
             _ => AndroidDeviceSelection.Failed(
                 AndroidDevFlowForwardingStatus.MultipleDevices,
-                "Multiple online Android devices or emulators were found. Specify --android-device or ANDROID_SERIAL.",
-                onlineDevices.Select(static d => $"--android-device {d.Serial}").ToArray())
+                "Multiple online Android devices or emulators were found. Specify --device or ANDROID_SERIAL.",
+                onlineDevices.Select(static d => $"--device {d.Serial}").ToArray())
         };
     }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Microsoft.Maui.Cli.DevFlow.Broker;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.Utils;
@@ -7,7 +8,7 @@ namespace Microsoft.Maui.Cli.DevFlow.Android;
 
 internal sealed class AndroidDevFlowPortForwarder
 {
-    public const int DefaultBrokerPort = 19223;
+    public const int DefaultBrokerPort = BrokerServer.DefaultPort;
 
     readonly IAndroidProvider _androidProvider;
     readonly string? _adbPath;
@@ -40,16 +41,38 @@ internal sealed class AndroidDevFlowPortForwarder
                 cancellationToken: cancellationToken));
     }
 
+    /// <summary>
+    /// Cheap, side-effect-free probe: returns true only when the Android SDK paths
+    /// resolve to an existing <c>adb</c> binary. Used to short-circuit forwarding work
+    /// on machines that do not have the Android SDK installed.
+    /// </summary>
+    public static bool IsAdbLikelyAvailable()
+    {
+        try
+        {
+            var provider = Program.AndroidProvider;
+            var environment = AndroidEnvironment.BuildEnvironmentVariables(provider.SdkPath, provider.JdkPath);
+            var adb = new Adb(() => provider.SdkPath, environment);
+            return !string.IsNullOrWhiteSpace(adb.AdbPath) && File.Exists(adb.AdbPath);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public async Task<AndroidDevFlowForwardingReport> EnsureAsync(
         AndroidDevFlowForwardingRequest request,
         CancellationToken cancellationToken = default)
     {
+        var brokerPort = request.BrokerPort > 0 ? request.BrokerPort : DefaultBrokerPort;
+
         var report = new AndroidDevFlowForwardingReport
         {
             AdbAvailable = !string.IsNullOrWhiteSpace(_adbPath),
             AdbPath = _adbPath,
             RequestedSerial = request.DeviceSerial ?? Environment.GetEnvironmentVariable("ANDROID_SERIAL"),
-            BrokerPort = DefaultBrokerPort,
+            BrokerPort = brokerPort,
             AgentPorts = request.AgentPorts.Distinct().OrderBy(static port => port).ToArray(),
             RepairRequested = request.Repair
         };
@@ -114,16 +137,16 @@ internal sealed class AndroidDevFlowPortForwarder
 
         var errors = new List<string>();
         var brokerReverseBefore = request.EnsureBrokerReverse
-            && ContainsMapping(reverseBefore.Mappings, report.SelectedSerial, DefaultBrokerPort);
+            && ContainsMapping(reverseBefore.Mappings, report.SelectedSerial, brokerPort);
         var brokerReverseAdded = false;
 
         if (request.EnsureBrokerReverse && !brokerReverseBefore && request.Repair)
         {
-            var result = await RunAdbAsync(report.SelectedSerial, ["reverse", $"tcp:{DefaultBrokerPort}", $"tcp:{DefaultBrokerPort}"], cancellationToken);
+            var result = await RunAdbAsync(report.SelectedSerial, ["reverse", $"tcp:{brokerPort}", $"tcp:{brokerPort}"], cancellationToken);
             if (result.Success)
                 brokerReverseAdded = true;
             else
-                errors.Add($"adb reverse tcp:{DefaultBrokerPort} tcp:{DefaultBrokerPort} failed: {GetProcessError(result)}");
+                errors.Add($"adb reverse tcp:{brokerPort} tcp:{brokerPort} failed: {GetProcessError(result)}");
         }
 
         var agentForwards = new List<AndroidDevFlowPortForward>();
@@ -158,7 +181,7 @@ internal sealed class AndroidDevFlowPortForwarder
 
         var brokerReversePresent = request.EnsureBrokerReverse
             && reverseAfter.Success
-            && ContainsMapping(reverseAfter.Mappings, report.SelectedSerial, DefaultBrokerPort);
+            && ContainsMapping(reverseAfter.Mappings, report.SelectedSerial, brokerPort);
 
         agentForwards = agentForwards
             .Select(f => f with
@@ -181,14 +204,14 @@ internal sealed class AndroidDevFlowPortForwarder
                 BrokerReverseAdded = brokerReverseAdded,
                 AgentForwards = agentForwards.ToArray(),
                 Message = string.Join(Environment.NewLine, errors),
-                Suggestions = BuildMappingSuggestions(report.SelectedSerial, request.EnsureBrokerReverse && !brokerReversePresent, missingPorts)
+                Suggestions = BuildMappingSuggestions(report.SelectedSerial, request.EnsureBrokerReverse && !brokerReversePresent, brokerPort, missingPorts)
             };
         }
 
         var repaired = brokerReverseAdded || agentForwards.Any(static f => f.Added);
         var missing = (!request.EnsureBrokerReverse || brokerReversePresent) && missingPorts.Length == 0
             ? Array.Empty<string>()
-            : BuildMappingSuggestions(report.SelectedSerial, request.EnsureBrokerReverse && !brokerReversePresent, missingPorts);
+            : BuildMappingSuggestions(report.SelectedSerial, request.EnsureBrokerReverse && !brokerReversePresent, brokerPort, missingPorts);
 
         var status = missing.Length > 0
             ? AndroidDevFlowForwardingStatus.Missing
@@ -307,11 +330,11 @@ internal sealed class AndroidDevFlowPortForwarder
         return string.IsNullOrWhiteSpace(error) ? $"exit code {result.ExitCode}" : error;
     }
 
-    static string[] BuildMappingSuggestions(string serial, bool brokerReverseMissing, int[] missingAgentForwards)
+    static string[] BuildMappingSuggestions(string serial, bool brokerReverseMissing, int brokerPort, int[] missingAgentForwards)
     {
         var suggestions = new List<string>();
         if (brokerReverseMissing)
-            suggestions.Add($"adb -s {serial} reverse tcp:{DefaultBrokerPort} tcp:{DefaultBrokerPort}");
+            suggestions.Add($"adb -s {serial} reverse tcp:{brokerPort} tcp:{brokerPort}");
         foreach (var port in missingAgentForwards)
             suggestions.Add($"adb -s {serial} forward tcp:{port} tcp:{port}");
         return suggestions.ToArray();
@@ -338,6 +361,14 @@ internal sealed record AndroidDevFlowForwardingRequest
     public int[] AgentPorts { get; init; } = [];
 
     public bool EnsureBrokerReverse { get; init; }
+
+    /// <summary>
+    /// Broker port that the agent inside the emulator should reach via <c>adb reverse</c>.
+    /// Defaults to <see cref="BrokerServer.DefaultPort"/> when zero, so callers that know
+    /// the resolved broker port (for example via <c>BrokerClient.ReadBrokerPortPublic()</c>)
+    /// can override it for non-default broker deployments.
+    /// </summary>
+    public int BrokerPort { get; init; }
 
     public bool Repair { get; init; }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
@@ -41,6 +42,12 @@ public static class BrokerClient
         return await IsBrokerAliveAsync(port) ? port : null;
     }
 
+    internal static int? GetRunningBrokerPort()
+    {
+        var port = ReadBrokerPort() ?? BrokerServer.DefaultPort;
+        return IsBrokerAlive(port) ? port : null;
+    }
+
     /// <summary>
     /// Lists all agents registered with the broker.
     /// </summary>
@@ -49,6 +56,19 @@ public static class BrokerClient
         try
         {
             var response = await _http.GetStringAsync($"http://localhost:{brokerPort}/api/agents");
+            return CliJson.Deserialize<AgentRegistration[]>(response);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static AgentRegistration[]? ListAgents(int brokerPort)
+    {
+        try
+        {
+            var response = GetString($"http://localhost:{brokerPort}/api/agents");
             return CliJson.Deserialize<AgentRegistration[]>(response);
         }
         catch
@@ -85,6 +105,19 @@ public static class BrokerClient
         var agents = await ListAgentsAsync(brokerPort);
         if (agents == null || agents.Length == 0) return null;
 
+        return ResolveAgent(agents, projectPath, tfm);
+    }
+
+    public static AgentRegistration? ResolveAgent(int brokerPort, string? projectPath = null, string? tfm = null)
+    {
+        var agents = ListAgents(brokerPort);
+        if (agents == null || agents.Length == 0) return null;
+
+        return ResolveAgent(agents, projectPath, tfm);
+    }
+
+    static AgentRegistration? ResolveAgent(AgentRegistration[] agents, string? projectPath = null, string? tfm = null)
+    {
         // If project+TFM provided, look for exact match
         if (projectPath != null && tfm != null)
         {
@@ -143,6 +176,54 @@ public static class BrokerClient
         {
             return false;
         }
+    }
+
+    private static bool IsBrokerAlive(int port)
+    {
+        try
+        {
+            return TryConnect(IPAddress.Loopback, port) || TryConnect(IPAddress.IPv6Loopback, port);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryConnect(IPAddress address, int port)
+    {
+        using var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+        {
+            Blocking = false
+        };
+
+        try
+        {
+            socket.Connect(new IPEndPoint(address, port));
+            return true;
+        }
+        catch (SocketException ex) when (ex.SocketErrorCode is SocketError.WouldBlock or SocketError.InProgress or SocketError.AlreadyInProgress)
+        {
+            if (!socket.Poll(500_000, SelectMode.SelectWrite))
+                return false;
+
+            var error = (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Error)!;
+            return error == 0;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+    }
+
+    private static string GetString(string url)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        using var response = _http.Send(request);
+        response.EnsureSuccessStatusCode();
+        using var stream = response.Content.ReadAsStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
     }
 
     private static int? ReadBrokerPort()

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
@@ -91,12 +91,17 @@ public static class BrokerClient
             var id = AgentRegistration.ComputeId(projectPath, tfm);
             var match = agents.FirstOrDefault(a => a.Id == id);
             if (match != null) return match;
+
+            var tfmMatches = agents
+                .Where(a => AgentMatchesProject(a, projectPath) && a.Tfm.Equals(tfm, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            if (tfmMatches.Length == 1) return tfmMatches[0];
         }
 
         // If project provided (no TFM), match by project path
         if (projectPath != null)
         {
-            var matches = agents.Where(a => a.Project == projectPath).ToArray();
+            var matches = agents.Where(a => AgentMatchesProject(a, projectPath)).ToArray();
             if (matches.Length == 1) return matches[0];
         }
 
@@ -105,6 +110,9 @@ public static class BrokerClient
 
         return null;
     }
+
+    static bool AgentMatchesProject(AgentRegistration agent, string projectPath)
+        => agent.Project.Equals(projectPath, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Sends a shutdown request to the broker.

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerClient.cs
@@ -74,6 +74,13 @@ public static class BrokerClient
     /// Tries: broker lookup by project hash → single agent auto-select → null.
     /// </summary>
     public static async Task<int?> ResolveAgentPortAsync(int brokerPort, string? projectPath = null, string? tfm = null)
+        => (await ResolveAgentAsync(brokerPort, projectPath, tfm))?.Port;
+
+    /// <summary>
+    /// Resolves the agent registration for the current project context.
+    /// Tries: broker lookup by project hash → single agent auto-select → null.
+    /// </summary>
+    public static async Task<AgentRegistration?> ResolveAgentAsync(int brokerPort, string? projectPath = null, string? tfm = null)
     {
         var agents = await ListAgentsAsync(brokerPort);
         if (agents == null || agents.Length == 0) return null;
@@ -83,18 +90,18 @@ public static class BrokerClient
         {
             var id = AgentRegistration.ComputeId(projectPath, tfm);
             var match = agents.FirstOrDefault(a => a.Id == id);
-            if (match != null) return match.Port;
+            if (match != null) return match;
         }
 
         // If project provided (no TFM), match by project path
         if (projectPath != null)
         {
             var matches = agents.Where(a => a.Project == projectPath).ToArray();
-            if (matches.Length == 1) return matches[0].Port;
+            if (matches.Length == 1) return matches[0];
         }
 
         // If only one agent, auto-select
-        if (agents.Length == 1) return agents[0].Port;
+        if (agents.Length == 1) return agents[0];
 
         return null;
     }
@@ -171,13 +178,46 @@ public static class BrokerClient
         var csproj = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.csproj").FirstOrDefault();
         if (csproj is not null)
         {
-            var port = await ResolveAgentPortAsync(brokerPort, Path.GetFullPath(csproj));
-            if (port.HasValue) return port.Value;
+            var agent = await ResolveAgentAsync(brokerPort, Path.GetFullPath(csproj));
+            if (agent is not null) return agent.Port;
         }
 
         // Try auto-select (single agent)
-        var autoPort = await ResolveAgentPortAsync(brokerPort);
-        if (autoPort.HasValue) return autoPort.Value;
+        var autoAgent = await ResolveAgentAsync(brokerPort);
+        if (autoAgent is not null) return autoAgent.Port;
+
+        // No single match — return null so callers can handle multi-agent case
+        return null;
+    }
+
+    /// <summary>
+    /// High-level agent resolution: ensure broker running → resolve by project → auto-select → null.
+    /// Returns the resolved broker registration when one can be selected unambiguously.
+    /// </summary>
+    public static async Task<AgentRegistration?> ResolveAgentForProjectAsync()
+    {
+        var brokerPort = ReadBrokerPort() ?? BrokerServer.DefaultPort;
+
+        if (!await IsBrokerAliveAsync(brokerPort))
+        {
+            var started = await EnsureBrokerRunningAsync();
+            if (started.HasValue)
+                brokerPort = started.Value;
+            else
+                return null;
+        }
+
+        // Try project-specific resolution
+        var csproj = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.csproj").FirstOrDefault();
+        if (csproj is not null)
+        {
+            var agent = await ResolveAgentAsync(brokerPort, Path.GetFullPath(csproj));
+            if (agent is not null) return agent;
+        }
+
+        // Try auto-select (single agent)
+        var autoAgent = await ResolveAgentAsync(brokerPort);
+        if (autoAgent is not null) return autoAgent;
 
         // No single match — return null so callers can handle multi-agent case
         return null;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Maui.Cli.DevFlow.Broker;
 using Microsoft.Maui.DevFlow.Driver;
 
@@ -22,4 +23,7 @@ namespace Microsoft.Maui.Cli.DevFlow;
 [JsonSerializable(typeof(AgentRegistration[]))]
 [JsonSerializable(typeof(BrokerState))]
 [JsonSerializable(typeof(RegistrationMessage))]
+[JsonSerializable(typeof(AndroidDevFlowForwardingReport))]
+[JsonSerializable(typeof(AndroidDevFlowDevice[]))]
+[JsonSerializable(typeof(AndroidDevFlowPortForward[]))]
 internal sealed partial class DevFlowCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -51,7 +51,7 @@ public class DevFlowCommands
         // Global agent connection options (available on all subcommands)
         var agentPortOption = new Option<int>("--agent-port", "-ap") { Description = "Agent HTTP port (auto-discovered via broker, .mauidevflow, or default 9223)", DefaultValueFactory = _ => ResolveAgentPort() };
         var agentHostOption = new Option<string>("--agent-host", "-ah") { Description = "Agent HTTP host", DefaultValueFactory = _ => "localhost" };
-        var androidDeviceOption = new Option<string?>("--android-device") { Description = "Android device/emulator serial for DevFlow ADB forwarding (defaults to ANDROID_SERIAL or the only online Android device)" };
+        var deviceOption = new Option<string?>("--device") { Description = "Device/emulator/simulator identifier for platform-specific DevFlow setup (currently used as an Android serial for ADB forwarding)" };
         var platformOption = new Option<string>("--platform", "-p") { Description = "Target platform (maccatalyst, android, ios, windows)", DefaultValueFactory = _ => "maccatalyst" };
         var noJsonOption = new Option<bool>("--no-json") { Description = "Force human-readable output even when piped", DefaultValueFactory = _ => false };
 
@@ -60,8 +60,8 @@ public class DevFlowCommands
         devflowCommand.Add(agentPortOption);
         agentHostOption.Recursive = true;
         devflowCommand.Add(agentHostOption);
-        androidDeviceOption.Recursive = true;
-        devflowCommand.Add(androidDeviceOption);
+        deviceOption.Recursive = true;
+        devflowCommand.Add(deviceOption);
         platformOption.Recursive = true;
         devflowCommand.Add(platformOption);
         noJsonOption.Recursive = true;
@@ -1341,8 +1341,8 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            var androidDevice = ctx.GetValue(androidDeviceOption);
-            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson), androidDevice, ct);
+            var deviceId = ctx.GetValue(deviceOption);
+            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson), deviceId, ct);
         });
         devflowCommand.Add(listCmd);
 
@@ -1352,8 +1352,8 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            var androidDevice = ctx.GetValue(androidDeviceOption);
-            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson), androidDevice, ct);
+            var deviceId = ctx.GetValue(deviceOption);
+            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson), deviceId, ct);
         });
         devflowCommand.Add(diagnoseCmd);
 
@@ -1372,8 +1372,8 @@ public class DevFlowCommands
             var waitPlatform = ctx.GetValue(waitPlatformOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            var androidDevice = ctx.GetValue(androidDeviceOption);
-            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson), androidDevice, ct);
+            var deviceId = ctx.GetValue(deviceOption);
+            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson), deviceId, ct);
         });
         devflowCommand.Add(waitCmd);
 
@@ -1398,8 +1398,8 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            var androidDevice = ctx.GetValue(androidDeviceOption);
-            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson), androidDevice, ct);
+            var deviceId = ctx.GetValue(deviceOption);
+            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson), deviceId, ct);
         });
         agentCommand.Add(agentListCmd);
 
@@ -1417,8 +1417,8 @@ public class DevFlowCommands
             var waitPlatform = ctx.GetValue(agentWaitPlatformOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            var androidDevice = ctx.GetValue(androidDeviceOption);
-            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson), androidDevice, ct);
+            var deviceId = ctx.GetValue(deviceOption);
+            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson), deviceId, ct);
         });
         agentCommand.Add(agentWaitCmd);
 
@@ -1427,8 +1427,8 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            var androidDevice = ctx.GetValue(androidDeviceOption);
-            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson), androidDevice, ct);
+            var deviceId = ctx.GetValue(deviceOption);
+            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson), deviceId, ct);
         });
         agentCommand.Add(agentDiagnoseCmd);
 
@@ -1504,7 +1504,7 @@ public class DevFlowCommands
                 var agents = await ListBrokerAgentsAsync(brokerPort.Value);
                 var agent = agents?.FirstOrDefault(a => a.Port == port);
                 if (agent is not null && IsAndroidAgent(agent))
-                    await EnsureAndroidForwardingForAgentsAsync([agent], androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None, brokerPort: brokerPort.Value);
+                    await EnsureAndroidForwardingForAgentsAsync([agent], deviceId: null, repair: true, emitWarnings: false, CancellationToken.None, brokerPort: brokerPort.Value);
             }
         }
 
@@ -3872,7 +3872,7 @@ public class DevFlowCommands
 
     private static async Task<AndroidDevFlowForwardingReport?> EnsureAndroidForwardingForAgentsAsync(
         IEnumerable<Broker.AgentRegistration> agents,
-        string? androidDevice,
+        string? deviceId,
         bool repair,
         bool emitWarnings,
         CancellationToken cancellationToken,
@@ -3890,7 +3890,7 @@ public class DevFlowCommands
         return await EnsureAndroidForwardingForPortsAsync(
             androidPorts,
             ensureBrokerReverse: true,
-            androidDevice,
+            deviceId,
             repair,
             emitWarnings,
             cancellationToken,
@@ -3900,7 +3900,7 @@ public class DevFlowCommands
     private static async Task<AndroidDevFlowForwardingReport?> EnsureAndroidForwardingForPortsAsync(
         int[] agentPorts,
         bool ensureBrokerReverse,
-        string? androidDevice,
+        string? deviceId,
         bool repair,
         bool emitWarnings,
         CancellationToken cancellationToken,
@@ -3920,7 +3920,7 @@ public class DevFlowCommands
                 EnsureBrokerReverse = ensureBrokerReverse,
                 BrokerPort = brokerPort ?? Broker.BrokerClient.ReadBrokerPortPublic() ?? Broker.BrokerServer.DefaultPort,
                 Repair = repair,
-                DeviceSerial = androidDevice
+                DeviceSerial = deviceId
             }, cancellationToken);
 
             if (emitWarnings)
@@ -4093,7 +4093,7 @@ public class DevFlowCommands
             Console.WriteLine(lines[i]);
     }
 
-    private static async Task ListAgentsCommandAsync(bool json, string? androidDevice, CancellationToken cancellationToken)
+    private static async Task ListAgentsCommandAsync(bool json, string? deviceId, CancellationToken cancellationToken)
     {
         await WriteSkillFreshnessHintAsync(json, cancellationToken);
 
@@ -4148,7 +4148,7 @@ public class DevFlowCommands
             return;
         }
 
-        await EnsureAndroidForwardingForAgentsAsync(agents, androidDevice, repair: true, emitWarnings: !json, cancellationToken, brokerPort: port.Value);
+        await EnsureAndroidForwardingForAgentsAsync(agents, deviceId, repair: true, emitWarnings: !json, cancellationToken, brokerPort: port.Value);
 
         if (json)
         {
@@ -4170,7 +4170,7 @@ public class DevFlowCommands
         }
     }
 
-    private static async Task DiagnoseCommandAsync(bool json, string? androidDevice, CancellationToken cancellationToken)
+    private static async Task DiagnoseCommandAsync(bool json, string? deviceId, CancellationToken cancellationToken)
     {
         await WriteSkillFreshnessHintAsync(json, cancellationToken);
 
@@ -4200,12 +4200,12 @@ public class DevFlowCommands
             .Distinct()
             .ToArray() ?? [];
         AndroidDevFlowForwardingReport? androidForwarding = null;
-        if (androidAgentPorts.Length > 0 || !string.IsNullOrWhiteSpace(androidDevice))
+        if (androidAgentPorts.Length > 0 || !string.IsNullOrWhiteSpace(deviceId))
         {
             androidForwarding = await EnsureAndroidForwardingForPortsAsync(
                 androidAgentPorts,
                 ensureBrokerReverse: true,
-                androidDevice,
+                deviceId,
                 repair: false,
                 emitWarnings: false,
                 cancellationToken,
@@ -4297,7 +4297,7 @@ public class DevFlowCommands
         }
     }
 
-    private static async Task WaitForAgentCommandAsync(int timeoutSeconds, string? projectFilter, string? platformFilter, bool json, string? androidDevice, CancellationToken cancellationToken)
+    private static async Task WaitForAgentCommandAsync(int timeoutSeconds, string? projectFilter, string? platformFilter, bool json, string? deviceId, CancellationToken cancellationToken)
     {
         await WriteSkillFreshnessHintAsync(json, cancellationToken);
 
@@ -4310,7 +4310,7 @@ public class DevFlowCommands
         }
 
         if (ShouldPrepareAndroidBrokerReverse(platformFilter))
-            await EnsureAndroidForwardingForPortsAsync([], ensureBrokerReverse: true, androidDevice, repair: true, emitWarnings: !json, cancellationToken, brokerPort: brokerPort.Value);
+            await EnsureAndroidForwardingForPortsAsync([], ensureBrokerReverse: true, deviceId, repair: true, emitWarnings: !json, cancellationToken, brokerPort: brokerPort.Value);
 
         // Resolve project filter to full path for matching
         string? resolvedProject = null;
@@ -4344,7 +4344,7 @@ public class DevFlowCommands
         }
 
         if (IsAndroidAgent(matched))
-            await EnsureAndroidForwardingForAgentsAsync([matched], androidDevice, repair: true, emitWarnings: !json, cancellationToken, brokerPort: brokerPort.Value);
+            await EnsureAndroidForwardingForAgentsAsync([matched], deviceId, repair: true, emitWarnings: !json, cancellationToken, brokerPort: brokerPort.Value);
 
         if (json)
         {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -3894,12 +3894,19 @@ public class DevFlowCommands
         bool emitWarnings,
         CancellationToken cancellationToken)
     {
+        // Short-circuit on machines without an Android SDK so we don't pay the
+        // cost of instantiating AndroidProvider / building env vars on every
+        // devflow list/wait/diagnose invocation on desktop-only dev boxes.
+        if (!AndroidDevFlowPortForwarder.IsAdbLikelyAvailable())
+            return null;
+
         try
         {
             var report = await CreateAndroidPortForwarder().EnsureAsync(new AndroidDevFlowForwardingRequest
             {
                 AgentPorts = agentPorts,
                 EnsureBrokerReverse = ensureBrokerReverse,
+                BrokerPort = Broker.BrokerClient.ReadBrokerPortPublic() ?? Broker.BrokerServer.DefaultPort,
                 Repair = repair,
                 DeviceSerial = androidDevice
             }, cancellationToken);

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -3825,12 +3825,7 @@ public class DevFlowCommands
             // No single match — check config file fallback
             var configPort = Broker.BrokerClient.ReadConfigPort();
             if (configPort.HasValue)
-            {
-                EnsureAndroidForwardingForPortsAsync([configPort.Value], ensureBrokerReverse: true, androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None)
-                    .GetAwaiter()
-                    .GetResult();
                 return configPort.Value;
-            }
 
             // Multiple agents, can't disambiguate — show them so the caller
             // (human or AI agent) can re-run with --agent-port
@@ -3838,7 +3833,7 @@ public class DevFlowCommands
             var agents = Broker.BrokerClient.ListAgentsAsync(brokerPort).GetAwaiter().GetResult();
             if (agents != null && agents.Length > 1)
             {
-                EnsureAndroidForwardingForAgentsAsync(agents, androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None)
+                EnsureAndroidForwardingForAgentsAsync(agents, androidDevice: null, repair: true, emitWarnings: false, cancellationToken: CancellationToken.None, brokerPort: brokerPort)
                     .GetAwaiter()
                     .GetResult();
 
@@ -3854,11 +3849,7 @@ public class DevFlowCommands
         }
         catch { /* broker unavailable, fall through */ }
 
-        var fallbackPort = Broker.BrokerClient.ReadConfigPort() ?? 9223;
-        EnsureAndroidForwardingForPortsAsync([fallbackPort], ensureBrokerReverse: true, androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None)
-            .GetAwaiter()
-            .GetResult();
-        return fallbackPort;
+        return Broker.BrokerClient.ReadConfigPort() ?? 9223;
     }
 
     private static async Task<AndroidDevFlowForwardingReport?> EnsureAndroidForwardingForAgentsAsync(
@@ -3866,7 +3857,8 @@ public class DevFlowCommands
         string? androidDevice,
         bool repair,
         bool emitWarnings,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int? brokerPort = null)
     {
         var androidPorts = agents
             .Where(IsAndroidAgent)
@@ -3883,7 +3875,8 @@ public class DevFlowCommands
             androidDevice,
             repair,
             emitWarnings,
-            cancellationToken);
+            cancellationToken,
+            brokerPort: brokerPort);
     }
 
     private static async Task<AndroidDevFlowForwardingReport?> EnsureAndroidForwardingForPortsAsync(
@@ -3892,7 +3885,8 @@ public class DevFlowCommands
         string? androidDevice,
         bool repair,
         bool emitWarnings,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int? brokerPort = null)
     {
         // Short-circuit on machines without an Android SDK so we don't pay the
         // cost of instantiating AndroidProvider / building env vars on every
@@ -3906,7 +3900,7 @@ public class DevFlowCommands
             {
                 AgentPorts = agentPorts,
                 EnsureBrokerReverse = ensureBrokerReverse,
-                BrokerPort = Broker.BrokerClient.ReadBrokerPortPublic() ?? Broker.BrokerServer.DefaultPort,
+                BrokerPort = brokerPort ?? Broker.BrokerClient.ReadBrokerPortPublic() ?? Broker.BrokerServer.DefaultPort,
                 Repair = repair,
                 DeviceSerial = androidDevice
             }, cancellationToken);
@@ -3948,7 +3942,10 @@ public class DevFlowCommands
         else
             Console.WriteLine("   Devices:          none online");
 
-        Console.WriteLine($"   Broker reverse:   {(report.BrokerReversePresent ? "ready" : "missing")} (tcp:{AndroidDevFlowPortForwarder.DefaultBrokerPort})");
+        var brokerReverseStatus = report.BrokerReverseChecked
+            ? (report.BrokerReversePresent ? "ready" : "missing")
+            : "not checked";
+        Console.WriteLine($"   Broker reverse:   {brokerReverseStatus} (tcp:{report.BrokerPort})");
 
         if (report.AgentForwards.Length > 0)
         {
@@ -4094,8 +4091,6 @@ public class DevFlowCommands
             return;
         }
 
-        await EnsureAndroidForwardingForPortsAsync([], ensureBrokerReverse: true, androidDevice, repair: true, emitWarnings: !json, cancellationToken);
-
         var agents = await Broker.BrokerClient.ListAgentsAsync(port.Value);
         if (agents == null || agents.Length == 0)
         {
@@ -4135,7 +4130,7 @@ public class DevFlowCommands
             return;
         }
 
-        await EnsureAndroidForwardingForAgentsAsync(agents, androidDevice, repair: true, emitWarnings: !json, cancellationToken);
+        await EnsureAndroidForwardingForAgentsAsync(agents, androidDevice, repair: true, emitWarnings: !json, cancellationToken, brokerPort: port.Value);
 
         if (json)
         {
@@ -4192,7 +4187,8 @@ public class DevFlowCommands
             androidDevice,
             repair: false,
             emitWarnings: false,
-            cancellationToken);
+            cancellationToken,
+            brokerPort: brokerPort);
         
         // Scan for devflow-enabled projects
         var projects = ScanForDevFlowProjects();
@@ -4292,7 +4288,7 @@ public class DevFlowCommands
         }
 
         if (ShouldPrepareAndroidBrokerReverse(platformFilter))
-            await EnsureAndroidForwardingForPortsAsync([], ensureBrokerReverse: true, androidDevice, repair: true, emitWarnings: !json, cancellationToken);
+            await EnsureAndroidForwardingForPortsAsync([], ensureBrokerReverse: true, androidDevice, repair: true, emitWarnings: !json, cancellationToken, brokerPort: brokerPort.Value);
 
         // Resolve project filter to full path for matching
         string? resolvedProject = null;
@@ -4326,7 +4322,7 @@ public class DevFlowCommands
         }
 
         if (IsAndroidAgent(matched))
-            await EnsureAndroidForwardingForAgentsAsync([matched], androidDevice, repair: true, emitWarnings: !json, cancellationToken);
+            await EnsureAndroidForwardingForAgentsAsync([matched], androidDevice, repair: true, emitWarnings: !json, cancellationToken, brokerPort: brokerPort.Value);
 
         if (json)
         {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -3813,39 +3813,47 @@ public class DevFlowCommands
     {
         try
         {
-            var agent = Broker.BrokerClient.ResolveAgentForProjectAsync().GetAwaiter().GetResult();
-            if (agent is not null)
+            var brokerPort = Broker.BrokerClient.GetRunningBrokerPortAsync().GetAwaiter().GetResult();
+            if (brokerPort.HasValue)
             {
-                EnsureAndroidForwardingForAgentsAsync([agent], androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None)
-                    .GetAwaiter()
-                    .GetResult();
-                return agent.Port;
+                Broker.AgentRegistration? agent = null;
+                var csproj = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.csproj").FirstOrDefault();
+                if (csproj is not null)
+                    agent = Broker.BrokerClient.ResolveAgentAsync(brokerPort.Value, Path.GetFullPath(csproj)).GetAwaiter().GetResult();
+
+                agent ??= Broker.BrokerClient.ResolveAgentAsync(brokerPort.Value).GetAwaiter().GetResult();
+                if (agent is not null)
+                {
+                    EnsureAndroidForwardingForAgentsAsync([agent], androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None, brokerPort: brokerPort.Value)
+                        .GetAwaiter()
+                        .GetResult();
+                    return agent.Port;
+                }
+
+                // Multiple agents, can't disambiguate — show them so the caller
+                // (human or AI agent) can re-run with --agent-port
+                var agents = Broker.BrokerClient.ListAgentsAsync(brokerPort.Value).GetAwaiter().GetResult();
+                if (agents != null && agents.Length > 1)
+                {
+                    EnsureAndroidForwardingForAgentsAsync(agents, androidDevice: null, repair: true, emitWarnings: false, cancellationToken: CancellationToken.None, brokerPort: brokerPort.Value)
+                        .GetAwaiter()
+                        .GetResult();
+
+                    Console.Error.WriteLine("Multiple agents connected. Use --agent-port to specify which one:");
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine($"{"ID",-15}{"App",-20}{"Platform",-15}{"TFM",-25}{"Port",-7}");
+                    Console.Error.WriteLine(new string('-', 82));
+                    foreach (var a in agents)
+                        Console.Error.WriteLine($"{a.Id,-15}{a.AppName,-20}{a.Platform,-15}{a.Tfm,-25}{a.Port,-7}");
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine("Example: maui devflow ui status --agent-port <port>");
+                }
             }
 
             // No single match — check config file fallback
             var configPort = Broker.BrokerClient.ReadConfigPort();
             if (configPort.HasValue)
                 return configPort.Value;
-
-            // Multiple agents, can't disambiguate — show them so the caller
-            // (human or AI agent) can re-run with --agent-port
-            var brokerPort = Broker.BrokerClient.ReadBrokerPortPublic() ?? Broker.BrokerServer.DefaultPort;
-            var agents = Broker.BrokerClient.ListAgentsAsync(brokerPort).GetAwaiter().GetResult();
-            if (agents != null && agents.Length > 1)
-            {
-                EnsureAndroidForwardingForAgentsAsync(agents, androidDevice: null, repair: true, emitWarnings: false, cancellationToken: CancellationToken.None, brokerPort: brokerPort)
-                    .GetAwaiter()
-                    .GetResult();
-
-                Console.Error.WriteLine("Multiple agents connected. Use --agent-port to specify which one:");
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"{"ID",-15}{"App",-20}{"Platform",-15}{"TFM",-25}{"Port",-7}");
-                Console.Error.WriteLine(new string('-', 82));
-                foreach (var a in agents)
-                    Console.Error.WriteLine($"{a.Id,-15}{a.AppName,-20}{a.Platform,-15}{a.Tfm,-25}{a.Port,-7}");
-                Console.Error.WriteLine();
-                Console.Error.WriteLine("Example: maui devflow ui status --agent-port <port>");
-            }
         }
         catch { /* broker unavailable, fall through */ }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -23,6 +23,7 @@ public class DevFlowCommands
     internal static Func<Task<int?>> ResolveRunningBrokerPortAsync { get; set; } = Broker.BrokerClient.GetRunningBrokerPortAsync;
     internal static Func<int, Task<Broker.AgentRegistration[]?>> ListBrokerAgentsAsync { get; set; } = Broker.BrokerClient.ListAgentsAsync;
     internal static Func<AndroidDevFlowPortForwarder> CreateAndroidPortForwarder { get; set; } = AndroidDevFlowPortForwarder.CreateDefault;
+    internal static Func<bool> IsAndroidAdbLikelyAvailable { get; set; } = AndroidDevFlowPortForwarder.IsAdbLikelyAvailable;
 
     private static IDevFlowOutputWriter Output => s_output ?? throw new InvalidOperationException("DevFlowCommands not initialized. Call CreateDevFlowCommand first.");
 
@@ -31,6 +32,7 @@ public class DevFlowCommands
         ResolveRunningBrokerPortAsync = Broker.BrokerClient.GetRunningBrokerPortAsync;
         ListBrokerAgentsAsync = Broker.BrokerClient.ListAgentsAsync;
         CreateAndroidPortForwarder = AndroidDevFlowPortForwarder.CreateDefault;
+        IsAndroidAdbLikelyAvailable = AndroidDevFlowPortForwarder.IsAdbLikelyAvailable;
     }
 
     /// <summary>
@@ -3899,7 +3901,7 @@ public class DevFlowCommands
         // Short-circuit on machines without an Android SDK so we don't pay the
         // cost of instantiating AndroidProvider / building env vars on every
         // devflow list/wait/diagnose invocation on desktop-only dev boxes.
-        if (!AndroidDevFlowPortForwarder.IsAdbLikelyAvailable())
+        if (!IsAndroidAdbLikelyAvailable())
             return null;
 
         try

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -1494,9 +1494,26 @@ public class DevFlowCommands
     
     // ===== CDP Helper: Send command via AgentClient =====
 
+    private static async Task<Microsoft.Maui.DevFlow.Driver.AgentClient> CreateAgentClientAsync(string host, int port)
+    {
+        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            var brokerPort = await ResolveRunningBrokerPortAsync();
+            if (brokerPort.HasValue)
+            {
+                var agents = await ListBrokerAgentsAsync(brokerPort.Value);
+                var agent = agents?.FirstOrDefault(a => a.Port == port);
+                if (agent is not null && IsAndroidAgent(agent))
+                    await EnsureAndroidForwardingForAgentsAsync([agent], androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None, brokerPort: brokerPort.Value);
+            }
+        }
+
+        return new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+    }
+
     private static async Task<JsonElement?> SendCdpCommandAsync(string host, int port, string method, JsonNode? parameters = null, string? webview = null)
     {
-        using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+        using var client = await CreateAgentClientAsync(host, port);
         var result = await client.SendCdpCommandAsync(method, parameters, webview);
         return result;
     }
@@ -1758,7 +1775,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var result = await client.GetCdpWebViewsAsync();
             var body = result.ToString();
 
@@ -1799,7 +1816,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var source = await client.GetCdpSourceAsync(webview);
             Console.WriteLine(source);
         }
@@ -2173,7 +2190,7 @@ public class DevFlowCommands
 
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var results = await client.QueryAsync(type, automationId, text);
 
             if (results.Count == 0)
@@ -2256,7 +2273,7 @@ public class DevFlowCommands
             var resolvedId = await ResolveElementIdAsync(host, port, json, elementId, automationId, null, null, 0);
             if (resolvedId == null) return;
 
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var actualValue = await client.GetPropertyAsync(resolvedId, propertyName);
 
             var passed = string.Equals(actualValue, expectedValue, StringComparison.Ordinal);
@@ -2382,7 +2399,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var status = await client.GetStatusAsync(window);
             if (status == null)
             {
@@ -2405,7 +2422,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var tree = await client.GetTreeAsync(depth, window);
             if (json)
             {
@@ -2424,7 +2441,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
 
             if (!string.IsNullOrWhiteSpace(waitUntil))
             {
@@ -2506,7 +2523,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var result = await client.HitTestAsync(x, y, window);
             if (json)
                 Console.WriteLine(result);
@@ -2520,7 +2537,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var success = await client.TapAsync(elementId);
             Output.WriteActionResult(success, "Tapped", elementId, json,
                 success ? $"Tapped: {elementId}" : $"Failed to tap: {elementId}");
@@ -2533,7 +2550,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var success = await client.FillAsync(elementId, text);
             Output.WriteActionResult(success, "Filled", elementId, json,
                 success ? $"Filled: {elementId}" : $"Failed to fill: {elementId}");
@@ -2546,7 +2563,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var success = await client.ClearAsync(elementId);
             Output.WriteActionResult(success, "Cleared", elementId, json,
                 success ? $"Cleared: {elementId}" : $"Failed to clear: {elementId}");
@@ -2570,7 +2587,7 @@ public class DevFlowCommands
             byte[]? data = null;
             bool fromSimctl = false;
 
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
 
             // For full-screen captures (no element scoping), try simctl io screenshot first
             // when connected to an iOS simulator. This captures everything on the simulator
@@ -2768,7 +2785,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var value = await client.GetPropertyAsync(elementId, propertyName);
             if (json)
             {
@@ -2790,7 +2807,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var success = await client.SetPropertyAsync(elementId, propertyName, value);
             if (success)
             {
@@ -2810,7 +2827,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var el = await client.GetElementAsync(elementId);
             if (el == null)
             {
@@ -2828,7 +2845,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var success = await client.NavigateAsync(route);
             Output.WriteActionResult(success, "Navigated", route, json,
                 success ? $"Navigated to: {route}" : $"Failed to navigate to: {route}");
@@ -2841,7 +2858,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var success = await client.ScrollAsync(elementId, dx, dy, animated, window, itemIndex, groupIndex, scrollToPosition);
             if (json)
             {
@@ -2865,7 +2882,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var success = await client.FocusAsync(elementId);
             Output.WriteActionResult(success, "Focused", elementId, json,
                 success ? $"Focused: {elementId}" : $"Failed to focus: {elementId}");
@@ -2878,7 +2895,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var success = await client.ResizeAsync(width, height, window);
             if (json)
                 Output.WriteActionResult(success, "Resized", $"{width}x{height}", json);
@@ -2893,7 +2910,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var body = await client.GetLogsAsync(limit, skip, source);
 
             if (json)
@@ -3156,7 +3173,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var requests = await client.GetNetworkRequestsAsync(limit, filterHost, filterMethod);
 
             if (json)
@@ -3189,7 +3206,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var req = await client.GetNetworkRequestDetailAsync(id);
 
             if (req == null)
@@ -3246,7 +3263,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var result = await client.ClearNetworkRequestsAsync();
             Output.WriteActionResult(result, "NetworkCleared", null, json,
                 result ? "Network request buffer cleared." : "Failed to clear.");
@@ -3511,7 +3528,7 @@ public class DevFlowCommands
         // Auto-detect from connected agent
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var status = await client.GetStatusAsync();
             if (status?.Platform != null)
             {
@@ -3568,7 +3585,7 @@ public class DevFlowCommands
         // Try to find the PID by checking what's listening on the agent port
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var status = await client.GetStatusAsync();
             var appName = status?.App?.Name ?? status?.AppName;
             if (!string.IsNullOrWhiteSpace(appName))
@@ -3591,7 +3608,7 @@ public class DevFlowCommands
 
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
             var status = await client.GetStatusAsync();
             var appName = status?.App?.Name ?? status?.AppName;
             if (!string.IsNullOrWhiteSpace(appName))
@@ -3815,32 +3832,23 @@ public class DevFlowCommands
     {
         try
         {
-            var brokerPort = Broker.BrokerClient.GetRunningBrokerPortAsync().GetAwaiter().GetResult();
+            var brokerPort = Broker.BrokerClient.GetRunningBrokerPort();
             if (brokerPort.HasValue)
             {
                 Broker.AgentRegistration? agent = null;
                 var csproj = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.csproj").FirstOrDefault();
                 if (csproj is not null)
-                    agent = Broker.BrokerClient.ResolveAgentAsync(brokerPort.Value, Path.GetFullPath(csproj)).GetAwaiter().GetResult();
+                    agent = Broker.BrokerClient.ResolveAgent(brokerPort.Value, Path.GetFullPath(csproj));
 
-                agent ??= Broker.BrokerClient.ResolveAgentAsync(brokerPort.Value).GetAwaiter().GetResult();
+                agent ??= Broker.BrokerClient.ResolveAgent(brokerPort.Value);
                 if (agent is not null)
-                {
-                    EnsureAndroidForwardingForAgentsAsync([agent], androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None, brokerPort: brokerPort.Value)
-                        .GetAwaiter()
-                        .GetResult();
                     return agent.Port;
-                }
 
                 // Multiple agents, can't disambiguate — show them so the caller
                 // (human or AI agent) can re-run with --agent-port
-                var agents = Broker.BrokerClient.ListAgentsAsync(brokerPort.Value).GetAwaiter().GetResult();
+                var agents = Broker.BrokerClient.ListAgents(brokerPort.Value);
                 if (agents != null && agents.Length > 1)
                 {
-                    EnsureAndroidForwardingForAgentsAsync(agents, androidDevice: null, repair: true, emitWarnings: false, cancellationToken: CancellationToken.None, brokerPort: brokerPort.Value)
-                        .GetAwaiter()
-                        .GetResult();
-
                     Console.Error.WriteLine("Multiple agents connected. Use --agent-port to specify which one:");
                     Console.Error.WriteLine();
                     Console.Error.WriteLine($"{"ID",-15}{"App",-20}{"Platform",-15}{"TFM",-25}{"Port",-7}");

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Cli.DevFlow.Skills;
 using Microsoft.Maui.Cli.Utils;
@@ -21,6 +22,7 @@ public class DevFlowCommands
     private static IDevFlowOutputWriter? s_output;
     internal static Func<Task<int?>> ResolveRunningBrokerPortAsync { get; set; } = Broker.BrokerClient.GetRunningBrokerPortAsync;
     internal static Func<int, Task<Broker.AgentRegistration[]?>> ListBrokerAgentsAsync { get; set; } = Broker.BrokerClient.ListAgentsAsync;
+    internal static Func<AndroidDevFlowPortForwarder> CreateAndroidPortForwarder { get; set; } = AndroidDevFlowPortForwarder.CreateDefault;
 
     private static IDevFlowOutputWriter Output => s_output ?? throw new InvalidOperationException("DevFlowCommands not initialized. Call CreateDevFlowCommand first.");
 
@@ -28,6 +30,7 @@ public class DevFlowCommands
     {
         ResolveRunningBrokerPortAsync = Broker.BrokerClient.GetRunningBrokerPortAsync;
         ListBrokerAgentsAsync = Broker.BrokerClient.ListAgentsAsync;
+        CreateAndroidPortForwarder = AndroidDevFlowPortForwarder.CreateDefault;
     }
 
     /// <summary>
@@ -46,6 +49,7 @@ public class DevFlowCommands
         // Global agent connection options (available on all subcommands)
         var agentPortOption = new Option<int>("--agent-port", "-ap") { Description = "Agent HTTP port (auto-discovered via broker, .mauidevflow, or default 9223)", DefaultValueFactory = _ => ResolveAgentPort() };
         var agentHostOption = new Option<string>("--agent-host", "-ah") { Description = "Agent HTTP host", DefaultValueFactory = _ => "localhost" };
+        var androidDeviceOption = new Option<string?>("--android-device") { Description = "Android device/emulator serial for DevFlow ADB forwarding (defaults to ANDROID_SERIAL or the only online Android device)" };
         var platformOption = new Option<string>("--platform", "-p") { Description = "Target platform (maccatalyst, android, ios, windows)", DefaultValueFactory = _ => "maccatalyst" };
         var noJsonOption = new Option<bool>("--no-json") { Description = "Force human-readable output even when piped", DefaultValueFactory = _ => false };
 
@@ -54,6 +58,8 @@ public class DevFlowCommands
         devflowCommand.Add(agentPortOption);
         agentHostOption.Recursive = true;
         devflowCommand.Add(agentHostOption);
+        androidDeviceOption.Recursive = true;
+        devflowCommand.Add(androidDeviceOption);
         platformOption.Recursive = true;
         devflowCommand.Add(platformOption);
         noJsonOption.Recursive = true;
@@ -1333,7 +1339,8 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson), ct);
+            var androidDevice = ctx.GetValue(androidDeviceOption);
+            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson), androidDevice, ct);
         });
         devflowCommand.Add(listCmd);
 
@@ -1343,7 +1350,8 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson), ct);
+            var androidDevice = ctx.GetValue(androidDeviceOption);
+            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson), androidDevice, ct);
         });
         devflowCommand.Add(diagnoseCmd);
 
@@ -1362,7 +1370,8 @@ public class DevFlowCommands
             var waitPlatform = ctx.GetValue(waitPlatformOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson), ct);
+            var androidDevice = ctx.GetValue(androidDeviceOption);
+            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson), androidDevice, ct);
         });
         devflowCommand.Add(waitCmd);
 
@@ -1387,7 +1396,8 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson), ct);
+            var androidDevice = ctx.GetValue(androidDeviceOption);
+            await ListAgentsCommandAsync(output.ResolveJsonMode(json, noJson), androidDevice, ct);
         });
         agentCommand.Add(agentListCmd);
 
@@ -1405,7 +1415,8 @@ public class DevFlowCommands
             var waitPlatform = ctx.GetValue(agentWaitPlatformOption);
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson), ct);
+            var androidDevice = ctx.GetValue(androidDeviceOption);
+            await WaitForAgentCommandAsync(timeout, project, waitPlatform, output.ResolveJsonMode(json, noJson), androidDevice, ct);
         });
         agentCommand.Add(agentWaitCmd);
 
@@ -1414,7 +1425,8 @@ public class DevFlowCommands
         {
             var json = ctx.GetValue(jsonOption);
             var noJson = ctx.GetValue(noJsonOption);
-            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson), ct);
+            var androidDevice = ctx.GetValue(androidDeviceOption);
+            await DiagnoseCommandAsync(output.ResolveJsonMode(json, noJson), androidDevice, ct);
         });
         agentCommand.Add(agentDiagnoseCmd);
 
@@ -3801,12 +3813,24 @@ public class DevFlowCommands
     {
         try
         {
-            var port = Broker.BrokerClient.ResolveAgentPortForProjectAsync().GetAwaiter().GetResult();
-            if (port.HasValue) return port.Value;
+            var agent = Broker.BrokerClient.ResolveAgentForProjectAsync().GetAwaiter().GetResult();
+            if (agent is not null)
+            {
+                EnsureAndroidForwardingForAgentsAsync([agent], androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+                return agent.Port;
+            }
 
             // No single match — check config file fallback
             var configPort = Broker.BrokerClient.ReadConfigPort();
-            if (configPort.HasValue) return configPort.Value;
+            if (configPort.HasValue)
+            {
+                EnsureAndroidForwardingForPortsAsync([configPort.Value], ensureBrokerReverse: true, androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+                return configPort.Value;
+            }
 
             // Multiple agents, can't disambiguate — show them so the caller
             // (human or AI agent) can re-run with --agent-port
@@ -3814,6 +3838,10 @@ public class DevFlowCommands
             var agents = Broker.BrokerClient.ListAgentsAsync(brokerPort).GetAwaiter().GetResult();
             if (agents != null && agents.Length > 1)
             {
+                EnsureAndroidForwardingForAgentsAsync(agents, androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+
                 Console.Error.WriteLine("Multiple agents connected. Use --agent-port to specify which one:");
                 Console.Error.WriteLine();
                 Console.Error.WriteLine($"{"ID",-15}{"App",-20}{"Platform",-15}{"TFM",-25}{"Port",-7}");
@@ -3826,8 +3854,111 @@ public class DevFlowCommands
         }
         catch { /* broker unavailable, fall through */ }
 
-        return Broker.BrokerClient.ReadConfigPort() ?? 9223;
+        var fallbackPort = Broker.BrokerClient.ReadConfigPort() ?? 9223;
+        EnsureAndroidForwardingForPortsAsync([fallbackPort], ensureBrokerReverse: true, androidDevice: null, repair: true, emitWarnings: false, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+        return fallbackPort;
     }
+
+    private static async Task<AndroidDevFlowForwardingReport?> EnsureAndroidForwardingForAgentsAsync(
+        IEnumerable<Broker.AgentRegistration> agents,
+        string? androidDevice,
+        bool repair,
+        bool emitWarnings,
+        CancellationToken cancellationToken)
+    {
+        var androidPorts = agents
+            .Where(IsAndroidAgent)
+            .Select(static a => a.Port)
+            .Distinct()
+            .ToArray();
+
+        if (androidPorts.Length == 0)
+            return null;
+
+        return await EnsureAndroidForwardingForPortsAsync(
+            androidPorts,
+            ensureBrokerReverse: true,
+            androidDevice,
+            repair,
+            emitWarnings,
+            cancellationToken);
+    }
+
+    private static async Task<AndroidDevFlowForwardingReport?> EnsureAndroidForwardingForPortsAsync(
+        int[] agentPorts,
+        bool ensureBrokerReverse,
+        string? androidDevice,
+        bool repair,
+        bool emitWarnings,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var report = await CreateAndroidPortForwarder().EnsureAsync(new AndroidDevFlowForwardingRequest
+            {
+                AgentPorts = agentPorts,
+                EnsureBrokerReverse = ensureBrokerReverse,
+                Repair = repair,
+                DeviceSerial = androidDevice
+            }, cancellationToken);
+
+            if (emitWarnings)
+                WriteAndroidForwardingWarning(report);
+
+            return report;
+        }
+        catch (Exception ex)
+        {
+            if (emitWarnings)
+                Console.Error.WriteLine($"Android DevFlow forwarding check failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static void WriteAndroidForwardingWarning(AndroidDevFlowForwardingReport report)
+    {
+        if (report.IsReady || report.Status is AndroidDevFlowForwardingStatus.NoDevice or AndroidDevFlowForwardingStatus.AdbNotFound)
+            return;
+
+        Console.Error.WriteLine($"Android DevFlow forwarding: {report.Message ?? report.Status.ToString()}");
+        foreach (var suggestion in report.Suggestions)
+            Console.Error.WriteLine($"  {suggestion}");
+    }
+
+    private static void PrintAndroidForwardingDiagnostics(AndroidDevFlowForwardingReport? report)
+    {
+        if (report is null)
+            return;
+
+        Console.WriteLine("Android forwarding:");
+        Console.WriteLine($"   ADB:              {(report.AdbAvailable ? "available" : "not found")}");
+        if (!string.IsNullOrWhiteSpace(report.SelectedSerial))
+            Console.WriteLine($"   Device:           {report.SelectedSerial}");
+        else if (report.Devices.Length > 0)
+            Console.WriteLine($"   Devices:          {report.Devices.Length} Android device(s), {report.Devices.Count(static d => d.IsOnline)} online");
+        else
+            Console.WriteLine("   Devices:          none online");
+
+        Console.WriteLine($"   Broker reverse:   {(report.BrokerReversePresent ? "ready" : "missing")} (tcp:{AndroidDevFlowPortForwarder.DefaultBrokerPort})");
+
+        if (report.AgentForwards.Length > 0)
+        {
+            foreach (var forward in report.AgentForwards)
+                Console.WriteLine($"   Agent forward:    {(forward.PresentAfter ? "ready" : "missing")} (tcp:{forward.Port})");
+        }
+
+        if (!string.IsNullOrWhiteSpace(report.Message))
+            Console.WriteLine($"   Status:           {report.Message}");
+
+        foreach (var suggestion in report.Suggestions)
+            Console.WriteLine($"   Suggestion:       {suggestion}");
+    }
+
+    private static bool IsAndroidAgent(Broker.AgentRegistration agent)
+        => agent.Platform.Contains("Android", StringComparison.OrdinalIgnoreCase)
+           || agent.Tfm.Contains("-android", StringComparison.OrdinalIgnoreCase);
 
     // ===== Broker Commands =====
 
@@ -3940,7 +4071,7 @@ public class DevFlowCommands
             Console.WriteLine(lines[i]);
     }
 
-    private static async Task ListAgentsCommandAsync(bool json, CancellationToken cancellationToken)
+    private static async Task ListAgentsCommandAsync(bool json, string? androidDevice, CancellationToken cancellationToken)
     {
         await WriteSkillFreshnessHintAsync(json, cancellationToken);
 
@@ -3955,6 +4086,8 @@ public class DevFlowCommands
             _errorOccurred = true;
             return;
         }
+
+        await EnsureAndroidForwardingForPortsAsync([], ensureBrokerReverse: true, androidDevice, repair: true, emitWarnings: !json, cancellationToken);
 
         var agents = await Broker.BrokerClient.ListAgentsAsync(port.Value);
         if (agents == null || agents.Length == 0)
@@ -3995,6 +4128,8 @@ public class DevFlowCommands
             return;
         }
 
+        await EnsureAndroidForwardingForAgentsAsync(agents, androidDevice, repair: true, emitWarnings: !json, cancellationToken);
+
         if (json)
         {
             Output.WriteResult(agents, json);
@@ -4015,7 +4150,7 @@ public class DevFlowCommands
         }
     }
 
-    private static async Task DiagnoseCommandAsync(bool json, CancellationToken cancellationToken)
+    private static async Task DiagnoseCommandAsync(bool json, string? androidDevice, CancellationToken cancellationToken)
     {
         await WriteSkillFreshnessHintAsync(json, cancellationToken);
 
@@ -4038,6 +4173,19 @@ public class DevFlowCommands
             foreach (var agent in agents)
                 agentsJson.Add(CliJson.ParseNode(CliJson.SerializeUntyped(agent, indented: false)));
         }
+
+        var androidAgentPorts = agents?
+            .Where(IsAndroidAgent)
+            .Select(static a => a.Port)
+            .Distinct()
+            .ToArray() ?? [];
+        var androidForwarding = await EnsureAndroidForwardingForPortsAsync(
+            androidAgentPorts,
+            ensureBrokerReverse: true,
+            androidDevice,
+            repair: false,
+            emitWarnings: false,
+            cancellationToken);
         
         // Scan for devflow-enabled projects
         var projects = ScanForDevFlowProjects();
@@ -4056,6 +4204,8 @@ public class DevFlowCommands
             };
             if (brokerPort is not null)
                 diagnostics["broker_port"] = brokerPort;
+            if (androidForwarding is not null)
+                diagnostics["android"] = CliJson.ParseNode(CliJson.SerializeUntyped(androidForwarding, indented: false));
             Output.WriteResult(diagnostics, json);
             return;
         }
@@ -4093,9 +4243,12 @@ public class DevFlowCommands
         {
             Console.WriteLine("⚠️  No agents connected");
         }
-        
+
         Console.WriteLine();
-        
+        PrintAndroidForwardingDiagnostics(androidForwarding);
+
+        Console.WriteLine();
+
         if (projects.Length > 0)
         {
             Console.WriteLine("📦 DevFlow-enabled projects:");
@@ -4119,7 +4272,7 @@ public class DevFlowCommands
         }
     }
 
-    private static async Task WaitForAgentCommandAsync(int timeoutSeconds, string? projectFilter, string? platformFilter, bool json, CancellationToken cancellationToken)
+    private static async Task WaitForAgentCommandAsync(int timeoutSeconds, string? projectFilter, string? platformFilter, bool json, string? androidDevice, CancellationToken cancellationToken)
     {
         await WriteSkillFreshnessHintAsync(json, cancellationToken);
 
@@ -4130,6 +4283,9 @@ public class DevFlowCommands
             Environment.ExitCode = 1;
             return;
         }
+
+        if (ShouldPrepareAndroidBrokerReverse(platformFilter))
+            await EnsureAndroidForwardingForPortsAsync([], ensureBrokerReverse: true, androidDevice, repair: true, emitWarnings: !json, cancellationToken);
 
         // Resolve project filter to full path for matching
         string? resolvedProject = null;
@@ -4162,6 +4318,9 @@ public class DevFlowCommands
             return;
         }
 
+        if (IsAndroidAgent(matched))
+            await EnsureAndroidForwardingForAgentsAsync([matched], androidDevice, repair: true, emitWarnings: !json, cancellationToken);
+
         if (json)
         {
             Console.WriteLine(CliJson.SerializeUntyped(matched, indented: false));
@@ -4171,6 +4330,10 @@ public class DevFlowCommands
             Console.WriteLine(matched.Port);
         }
     }
+
+    private static bool ShouldPrepareAndroidBrokerReverse(string? platformFilter)
+        => string.IsNullOrWhiteSpace(platformFilter)
+           || platformFilter.Contains("Android", StringComparison.OrdinalIgnoreCase);
 
     private static Broker.AgentRegistration? FindMatchingAgent(Broker.AgentRegistration[] agents, string? projectFilter, string? platformFilter)
     {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -4191,14 +4191,18 @@ public class DevFlowCommands
             .Select(static a => a.Port)
             .Distinct()
             .ToArray() ?? [];
-        var androidForwarding = await EnsureAndroidForwardingForPortsAsync(
-            androidAgentPorts,
-            ensureBrokerReverse: true,
-            androidDevice,
-            repair: false,
-            emitWarnings: false,
-            cancellationToken,
-            brokerPort: brokerPort);
+        AndroidDevFlowForwardingReport? androidForwarding = null;
+        if (androidAgentPorts.Length > 0 || !string.IsNullOrWhiteSpace(androidDevice))
+        {
+            androidForwarding = await EnsureAndroidForwardingForPortsAsync(
+                androidAgentPorts,
+                ensureBrokerReverse: true,
+                androidDevice,
+                repair: false,
+                emitWarnings: false,
+                cancellationToken,
+                brokerPort: brokerPort);
+        }
         
         // Scan for devflow-enabled projects
         var projects = ScanForDevFlowProjects();

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpAgentSession.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpAgentSession.cs
@@ -6,15 +6,40 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp;
 
 public class McpAgentSession
 {
-	public int? DefaultAgentPort { get; set; }
+	int? _defaultAgentPort;
+
+	public int? DefaultAgentPort
+	{
+		get => _defaultAgentPort;
+		set
+		{
+			_defaultAgentPort = value;
+			if (DefaultAgent?.Port != value)
+				DefaultAgent = null;
+		}
+	}
 	public string DefaultAgentHost { get; set; } = "localhost";
+	AgentRegistration? DefaultAgent { get; set; }
 
 	public async Task<AgentClient> GetAgentClientAsync(int? agentPort = null)
 	{
-		var port = agentPort ?? DefaultAgentPort ?? await ResolveAgentPortAsync();
-		if (agentPort.HasValue && DefaultAgentHost.Equals("localhost", StringComparison.OrdinalIgnoreCase))
-			await TryEnsureAndroidForwardingAsync([agentPort.Value], ensureBrokerReverse: false);
+		var selectedPort = agentPort ?? DefaultAgentPort;
+		var port = selectedPort ?? await ResolveAgentPortAsync();
+		if (selectedPort.HasValue && DefaultAgentHost.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+			await TryEnsureAndroidForwardingForAgentPortAsync(port, ensureBrokerReverse: false);
 		return new AgentClient(DefaultAgentHost, port);
+	}
+
+	public void SetDefaultAgent(AgentRegistration agent)
+	{
+		DefaultAgent = agent;
+		DefaultAgentPort = agent.Port;
+	}
+
+	public async Task SetDefaultAgentPortAsync(int agentPort)
+	{
+		DefaultAgent = await FindAgentByPortAsync(agentPort);
+		DefaultAgentPort = agentPort;
 	}
 
 	public async Task<int> GetBrokerPortAsync()
@@ -40,8 +65,24 @@ public class McpAgentSession
 		}
 
 		var fallbackPort = BrokerClient.ReadConfigPort() ?? 9223;
-		await TryEnsureAndroidForwardingAsync([fallbackPort], ensureBrokerReverse: true);
 		return fallbackPort;
+	}
+
+	async Task TryEnsureAndroidForwardingForAgentPortAsync(int agentPort, bool ensureBrokerReverse)
+	{
+		var agent = DefaultAgent?.Port == agentPort
+			? DefaultAgent
+			: await FindAgentByPortAsync(agentPort);
+
+		if (agent is not null && IsAndroidAgent(agent))
+			await TryEnsureAndroidForwardingAsync([agentPort], ensureBrokerReverse);
+	}
+
+	static async Task<AgentRegistration?> FindAgentByPortAsync(int agentPort)
+	{
+		var brokerPort = BrokerClient.ReadBrokerPortPublic() ?? BrokerServer.DefaultPort;
+		var agents = await BrokerClient.ListAgentsAsync(brokerPort);
+		return agents?.FirstOrDefault(a => a.Port == agentPort);
 	}
 
 	static async Task TryEnsureAndroidForwardingAsync(int[] agentPorts, bool ensureBrokerReverse)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpAgentSession.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpAgentSession.cs
@@ -46,12 +46,16 @@ public class McpAgentSession
 
 	static async Task TryEnsureAndroidForwardingAsync(int[] agentPorts, bool ensureBrokerReverse)
 	{
+		if (!AndroidDevFlowPortForwarder.IsAdbLikelyAvailable())
+			return;
+
 		try
 		{
 			await AndroidDevFlowPortForwarder.CreateDefault().EnsureAsync(new AndroidDevFlowForwardingRequest
 			{
 				AgentPorts = agentPorts,
 				EnsureBrokerReverse = ensureBrokerReverse,
+				BrokerPort = BrokerClient.ReadBrokerPortPublic() ?? Broker.BrokerServer.DefaultPort,
 				Repair = true
 			});
 		}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpAgentSession.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpAgentSession.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Cli.DevFlow.Broker;
+using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.Cli.DevFlow.Mcp;
@@ -11,6 +12,8 @@ public class McpAgentSession
 	public async Task<AgentClient> GetAgentClientAsync(int? agentPort = null)
 	{
 		var port = agentPort ?? DefaultAgentPort ?? await ResolveAgentPortAsync();
+		if (agentPort.HasValue && DefaultAgentHost.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+			await TryEnsureAndroidForwardingAsync([agentPort.Value], ensureBrokerReverse: false);
 		return new AgentClient(DefaultAgentHost, port);
 	}
 
@@ -28,8 +31,37 @@ public class McpAgentSession
 
 	private async Task<int> ResolveAgentPortAsync()
 	{
-		return await BrokerClient.ResolveAgentPortForProjectAsync()
-			?? BrokerClient.ReadConfigPort()
-			?? 9223;
+		var agent = await BrokerClient.ResolveAgentForProjectAsync();
+		if (agent != null)
+		{
+			if (IsAndroidAgent(agent))
+				await TryEnsureAndroidForwardingAsync([agent.Port], ensureBrokerReverse: true);
+			return agent.Port;
+		}
+
+		var fallbackPort = BrokerClient.ReadConfigPort() ?? 9223;
+		await TryEnsureAndroidForwardingAsync([fallbackPort], ensureBrokerReverse: true);
+		return fallbackPort;
 	}
+
+	static async Task TryEnsureAndroidForwardingAsync(int[] agentPorts, bool ensureBrokerReverse)
+	{
+		try
+		{
+			await AndroidDevFlowPortForwarder.CreateDefault().EnsureAsync(new AndroidDevFlowForwardingRequest
+			{
+				AgentPorts = agentPorts,
+				EnsureBrokerReverse = ensureBrokerReverse,
+				Repair = true
+			});
+		}
+		catch (Exception ex)
+		{
+			Console.Error.WriteLine($"[DevFlow Android forwarding] {ex.Message}");
+		}
+	}
+
+	static bool IsAndroidAgent(AgentRegistration agent)
+		=> agent.Platform.Contains("Android", StringComparison.OrdinalIgnoreCase)
+		   || agent.Tfm.Contains("-android", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/AgentTools.cs
@@ -69,7 +69,7 @@ public sealed class AgentTools
 
                 if (match != null)
                 {
-                    session.DefaultAgentPort = match.Port;
+                    session.SetDefaultAgent(match);
                     return CliJson.SerializeUntyped(new JsonObject
                     {
                         ["id"] = match.Id,
@@ -101,11 +101,11 @@ public sealed class AgentTools
     }
 
     [McpServerTool(Name = "maui_select_agent"), Description("Set the default agent for this MCP session. Subsequent tool calls will use this agent automatically without needing agentPort.")]
-    public static string SelectAgent(
+    public static async Task<string> SelectAgent(
         McpAgentSession session,
         [Description("Agent HTTP port to use as default")] int agentPort)
     {
-        session.DefaultAgentPort = agentPort;
+        await session.SetDefaultAgentPortAsync(agentPort);
         return $"Default agent set to port {agentPort}. All subsequent commands will use this agent.";
     }
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Properties/InternalsVisibleTo.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Properties/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Maui.DevFlow.Tests")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.Cli.UnitTests")]

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
@@ -15,21 +15,29 @@ namespace Microsoft.Maui.Cli.Providers.Android;
 /// </summary>
 public class Adb
 {
-	readonly AdbRunner? _runner;
+	readonly IDictionary<string, string>? _environmentVariables;
 	readonly string? _adbPath;
+	AdbRunner? _runner;
 
 	public Adb(Func<string?> getSdkPath, IDictionary<string, string>? environmentVariables = null)
 	{
 		_adbPath = ResolveAdbPath(getSdkPath());
-		if (_adbPath != null)
-			_runner = new AdbRunner(_adbPath, environmentVariables);
+		_environmentVariables = environmentVariables;
 	}
 
 	public string? AdbPath => _adbPath;
 
-	public bool IsAvailable => _runner != null;
+	public bool IsAvailable => _adbPath != null;
 
-	internal AdbRunner? Runner => _runner;
+	internal AdbRunner? Runner => GetRunner();
+
+	AdbRunner? GetRunner()
+	{
+		if (_adbPath == null)
+			return null;
+
+		return _runner ??= new AdbRunner(_adbPath, _environmentVariables);
+	}
 
 	static string? ResolveAdbPath(string? sdkPath)
 	{
@@ -43,14 +51,15 @@ public class Adb
 
 	public async Task<List<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
 	{
-		if (_runner == null)
+		var runner = Runner;
+		if (runner == null)
 			return new List<Device>();
 
 		try
 		{
 			// AdbRunner.ListDevicesAsync already queries AVD names for online emulators
 			// via getprop ro.boot.qemu.avd_name + emu avd name fallback
-			var devices = await _runner.ListDevicesAsync(cancellationToken);
+			var devices = await runner.ListDevicesAsync(cancellationToken);
 			return devices.Select(MapToMauiDevice).ToList();
 		}
 		catch (InvalidOperationException ex)
@@ -104,7 +113,11 @@ public class Adb
 		if (!IsAvailable)
 			throw new MauiToolException(ErrorCodes.AndroidAdbNotFound, "ADB not found");
 
-		await _runner!.StopEmulatorAsync(deviceSerial, cancellationToken);
+		var runner = Runner;
+		if (runner == null)
+			throw new MauiToolException(ErrorCodes.AndroidAdbNotFound, "ADB not found");
+
+		await runner.StopEmulatorAsync(deviceSerial, cancellationToken);
 	}
 
 }


### PR DESCRIPTION
Android DevFlow connectivity depended on manual ADB setup, and the existing docs had conflicting guidance about when to use `adb reverse` versus `adb forward`. This makes the CLI prepare and diagnose the Android forwarding path as part of normal broker discovery and direct fallback behavior.

## Changes

- Add a testable Android DevFlow forwarding helper that selects a deterministic device, checks existing ADB mappings, and repairs broker reverse plus agent forwards when requested.
- Extend broker resolution to return full agent metadata so Android agents can be identified before connecting to their HTTP port.
- Wire forwarding into `maui devflow list`, `maui devflow wait`, diagnose output, auto-resolved agent commands, and MCP agent sessions.
- Add `--android-device <serial>` and `ANDROID_SERIAL` support for multi-device scenarios instead of guessing.
- Update broker docs and the bundled DevFlow debug skill to document `adb reverse tcp:19223 tcp:19223` for app-to-broker and `adb forward tcp:<port> tcp:<port>` for CLI-to-agent.

## Validation

- `dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj --no-restore --logger "console;verbosity=minimal"`