### PR TITLE
Bump Xamarin.Android.Tools.AndroidSdk to 1.0.155-preview.137

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.) -->
-    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.143-preview.10">
-      <Uri>https://github.com/dotnet/android-tools</Uri>
-      <Sha>d222cfe45c30c4158211760b0f6df31c064165f5</Sha>
+    <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.)
+         The package is built by dotnet/android which includes android-tools as a submodule. -->
+    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.155-preview.137">
+      <Uri>https://github.com/dotnet/android</Uri>
+      <Sha>e8fb4bc8f779fd0d27c5c0ed04637a5dd25c083b</Sha>
     </Dependency>
     <!-- dotnet/maui -->
     <Dependency Name="Microsoft.Maui.Controls" Version="10.0.41">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,7 +51,7 @@
   </PropertyGroup>
   <!-- Android platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Android Tools">
-    <XamarinAndroidToolsAndroidSdkVersion>1.0.143-preview.10</XamarinAndroidToolsAndroidSdkVersion>
+    <XamarinAndroidToolsAndroidSdkVersion>1.0.155-preview.137</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">


### PR DESCRIPTION
## Summary

Bumps `Xamarin.Android.Tools.AndroidSdk` from `1.0.143-preview.10` to `1.0.155-preview.137` — a signed build from the standard `dotnet11` feed.

Updates android-tools from `d222cfe` → `2fd1240b` (7 upstream commits).

## Upstream Improvements Included

| PR | Description |
|----|-------------|
| [#337](https://github.com/dotnet/android-tools/pull/337) | **JdkInfo: Fix `StringBuilder` concurrency crash** in `GetJavaProperties()` — adds `lock(output)` to prevent race between stdout/stderr callbacks |
| [#341](https://github.com/dotnet/android-tools/pull/341) | JdkInfo: Remove dead code (`GetLibJvmJdks`, `GetLibJvmJdkPaths`) |
| [#342](https://github.com/dotnet/android-tools/pull/342) | BaseTasks: Fix NRE in `DeleteFile` catch block |
| [#335](https://github.com/dotnet/android-tools/pull/335), [#338](https://github.com/dotnet/android-tools/pull/338) | BaseTasks: Improve hash implementation in `Files` class (Crc64 → XxHash64 → System.IO.Hashing.Crc64) |
| [#334](https://github.com/dotnet/android-tools/pull/334) | Tests: Add BenchmarkDotNet project for `Files` hash APIs |
| [#333](https://github.com/dotnet/android-tools/pull/333) | Tests: Rename test cases to `relative.txt` |

## Also Fixed

- **Version.Details.xml**: Updated `<Uri>` from `dotnet/android-tools` to `dotnet/android` (the repo that actually builds and publishes the package) and clarified the relationship in the XML comment.

## Changes

| File | Change |
|------|--------|
| `eng/Versions.props` | `1.0.143-preview.10` → `1.0.155-preview.137` |
| `eng/Version.Details.xml` | SHA `d222cfe` → `e8fb4bc8f7`, URI fix, comment clarification |

## Testing

- ✅ Build: 0 warnings, 0 errors
- ✅ Tests: 504/504 pass
- ✅ Restore: clean from `dotnet11` feed (signed package, no NU3027 warnings)