### PR TITLE
Add MAUI DevFlow session review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This repository is also a marketplace for distributable agent skills for .NET MA
 
 | Plugin | Description |
 |--------|-------------|
-| [`dotnet-maui`](plugins/dotnet-maui/) | MAUI development: DevFlow automation, profiling, accessibility, platform bindings, diagnostics |
+| [`dotnet-maui`](plugins/dotnet-maui/) | MAUI development: DevFlow automation, profiling, accessibility, platform bindings, diagnostics, session review |
 
 ```bash
 # Install via Copilot CLI

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,7 +2,7 @@
 
 Distributable agent skills for .NET MAUI development. Installable via the Copilot CLI, Claude Code, or VS Code plugin system.
 
-DevFlow runtime skills (`maui-devflow-onboard`, `maui-devflow-debug`) are bundled with the `maui` CLI from `plugins/dotnet-maui/skills/`, installed with `maui devflow init`, and exposed through the plugin manifest.
+DevFlow runtime skills (`maui-devflow-onboard`, `maui-devflow-debug`, `maui-devflow-session-review`) are bundled with the `maui` CLI from `plugins/dotnet-maui/skills/`, installed with `maui devflow init`, and exposed through the plugin manifest.
 
 ## Plugin
 
@@ -10,6 +10,7 @@ DevFlow runtime skills (`maui-devflow-onboard`, `maui-devflow-debug`) are bundle
 |--------|-------|-------------|
 | [dotnet-maui](dotnet-maui/) | [maui-devflow-onboard](dotnet-maui/skills/maui-devflow-onboard/) | Add MAUI DevFlow packages and app registration to a project. |
 | | [maui-devflow-debug](dotnet-maui/skills/maui-devflow-debug/) | Run MAUI DevFlow build, deploy, connection recovery, inspect, and fix loops. |
+| | [maui-devflow-session-review](dotnet-maui/skills/maui-devflow-session-review/) | Review opt-in MAUI DevFlow sessions for friction, retries, workarounds, and product feedback. |
 | | [devflow-connect](dotnet-maui/skills/devflow-connect/) | Diagnose and fix DevFlow agent connectivity issues between the `maui` CLI and running .NET MAUI apps. |
 | | [maui-ai-debugging](dotnet-maui/skills/maui-ai-debugging/) | Legacy compatibility skill for older DevFlow clients. |
 | | [android-slim-bindings](dotnet-maui/skills/android-slim-bindings/) | Create Android slim bindings using the Native Library Interop approach. |

--- a/plugins/dotnet-maui/plugin.json
+++ b/plugins/dotnet-maui/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-maui",
   "version": "0.2.0",
-  "description": "Skills for .NET MAUI development: DevFlow automation, platform bindings, workload diagnostics, profiling, and accessibility. Some skills require the maui CLI tool.",
+  "description": "Skills for .NET MAUI development: DevFlow automation, session review, platform bindings, workload diagnostics, profiling, and accessibility. Some skills require the maui CLI tool.",
   "skills": ["./skills/"]
 }

--- a/plugins/dotnet-maui/skills/devflow-automation/SKILL.md
+++ b/plugins/dotnet-maui/skills/devflow-automation/SKILL.md
@@ -16,6 +16,13 @@ DevFlow Actions are named shortcuts that a .NET MAUI app explicitly exposes for 
 
 Actions are opt-in. DevFlow does not expose arbitrary reflection invoke; if you need a new shortcut, add an attributed method in app debug/test code, let Hot Reload apply it, then list and invoke the action.
 
+## Optional Session Feedback Nudge
+
+If action discovery or invocation exposed repeated DevFlow friction, missing
+observability, or several workarounds to reach app state, ask whether the user
+wants to run `maui-devflow-session-review` to summarize product feedback. Do not
+run it automatically.
+
 ## Start by Listing Actions
 
 Always check for available actions early in a DevFlow session:

--- a/plugins/dotnet-maui/skills/devflow-connect/SKILL.md
+++ b/plugins/dotnet-maui/skills/devflow-connect/SKILL.md
@@ -28,6 +28,13 @@ Diagnose and resolve connectivity between the `maui` CLI and running .NET MAUI a
 - Visual tree queries after connection works
 - CDP/Blazor WebView debugging
 
+## Optional Session Feedback Nudge
+
+If connectivity recovery required repeated broker/list/wait/status attempts,
+Android forwarding detours, direct port fallback, or other workarounds, ask
+whether the user wants to run `maui-devflow-session-review` to summarize friction
+for MAUI DevFlow product feedback. Do not run it automatically.
+
 ## Prerequisites
 
 - The `maui` CLI tool installed (`dotnet tool install -g Microsoft.Maui.Cli`)

--- a/plugins/dotnet-maui/skills/maui-ai-debugging/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ai-debugging/SKILL.md
@@ -32,6 +32,13 @@ Keep DevFlow skills up to date with `maui devflow skills update`. The hidden
 `maui devflow update-skill` compatibility command runs the same bundled updater
 and may remove this legacy skill after installing current replacements.
 
+## Optional Session Feedback Nudge
+
+If this legacy workflow involved repeated DevFlow retries, unclear workarounds,
+or a long debugging session, ask whether the user wants to run
+`maui-devflow-session-review` to summarize friction for MAUI DevFlow product
+feedback. Do not run it automatically.
+
 ## Integrating MauiDevFlow into a MAUI App
 
 For complete setup instructions, see [references/setup.md](references/setup.md).

--- a/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-debug/SKILL.md
@@ -32,6 +32,13 @@ packages and `builder.AddMauiDevFlowAgent()` registered.
 - If DevFlow packages or `MauiProgram.cs` registration are missing, use `maui-devflow-onboard`.
 - If the failure is a generic build or SDK issue with no DevFlow angle, use normal .NET/MAUI diagnostics.
 
+## Optional Session Feedback Nudge
+
+If you have retried the same MAUI DevFlow workflow several times, tried multiple
+workarounds, or are ending a long DevFlow-assisted debugging session, ask
+whether the user wants to run `maui-devflow-session-review` to summarize friction
+for MAUI DevFlow product feedback. Do not run it automatically.
+
 ## Core Loop
 
 1. Confirm the app is already integrated:

--- a/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-onboard/SKILL.md
@@ -28,6 +28,13 @@ Use this skill to add MAUI DevFlow to a project after `maui devflow init` has in
 - If package references and `AddMauiDevFlowAgent()` are already present but the CLI cannot connect, use `maui-devflow-debug`.
 - If an agent is reachable and the user wants to inspect, tap, screenshot, or debug UI, use `maui-devflow-debug`.
 
+## Optional Session Feedback Nudge
+
+If onboarding required repeated DevFlow attempts, unclear package/version
+workarounds, or a long setup session, ask whether the user wants to run
+`maui-devflow-session-review` to summarize friction for MAUI DevFlow product
+feedback. Do not run it automatically.
+
 ## Workflow
 
 1. Optionally run `maui devflow skills check` and update bundled skills before editing if it reports `update-available-from-current-cli`.

--- a/plugins/dotnet-maui/skills/maui-devflow-session-review/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-session-review/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: maui-devflow-session-review
+description: >-
+  Review previous AI sessions that used MAUI DevFlow to identify opt-in product
+  feedback, friction, repeated attempts, failed advertised features, and
+  workarounds. USE FOR: MAUI DevFlow session review, stuck maui devflow debugging
+  sessions, reviewing CLI/MCP behavior for friction, markdown feedback reports,
+  filing dotnet/maui-labs GitHub issues. DO NOT USE FOR: fixing discovered bugs,
+  adding DevFlow to apps (use maui-devflow-onboard), iterative app debugging
+  (use maui-devflow-debug), or generic memory search. INVOKES: session
+  history/search tools, gh CLI, and maui devflow CLI.
+---
+
+# MAUI DevFlow Session Review
+
+Use this skill to turn prior MAUI DevFlow-assisted AI sessions into opt-in
+product feedback. The goal is not to fix bugs during the review; the goal is to
+identify where DevFlow caused friction, what workarounds were tried, and what
+outcome the agent eventually reached.
+
+## When to Use
+
+Use this skill when:
+
+- reviewing previous AI sessions that used `maui devflow`
+- summarizing a long or stuck MAUI DevFlow debugging session
+- finding repeated failed attempts, retries, or workarounds around DevFlow tools
+- checking whether an advertised DevFlow feature did not work in practice
+- preparing a markdown feedback report for MAUI DevFlow maintainers
+- filing GitHub issues in `dotnet/maui-labs` from session evidence
+- another DevFlow skill suggested an optional post-session feedback review
+
+## When to Stop
+
+- The top actionable friction points are summarized with evidence, environment
+  metadata, attempts, workaround, and final outcome.
+- The markdown report is written or the requested GitHub issues are filed after
+  a PII scrub.
+- Remaining evidence would require scanning outside the user-approved scope.
+- The finding is too ambiguous to classify without more context; label it
+  unknown instead of continuing to mine private history.
+
+## Workflow
+
+### 1. Confirm opt-in scope
+
+Identify what the user wants reviewed:
+
+- current session
+- recent sessions matching MAUI DevFlow keywords
+- a date range, target platform, feature, command family, or app framework
+- sessions related to setup, connectivity, UI inspection, CDP, recording, logs,
+  network, storage, profiler, or DevFlow Actions
+
+Do not scan unrelated session history. This skill is opt-in telemetry: the user
+controls the scope and the output destination.
+
+Do not ask the user for session IDs, transcript paths, log paths, artifact
+paths, or other local identifiers. If a tool requires an internal handle to
+inspect a session, use it only transiently and never include it in saved or
+shared output.
+
+If another DevFlow skill suggested this review, preserve the trigger context:
+what challenge was stuck, which workarounds had already been tried, and whether
+the user wants markdown-only output or GitHub issue filing.
+
+### 2. Find DevFlow-specific sessions
+
+Use [references/session-sources.md](references/session-sources.md) to choose the
+available data source. Good candidate signals include:
+
+- `maui devflow`, `maui-devflow-onboard`, `maui-devflow-debug`, or this skill
+- CLI commands such as `maui devflow wait`, `maui devflow list`,
+  `maui devflow agent status`, `maui devflow ui tree`,
+  `maui devflow ui query`, `maui devflow recording`, `maui devflow logs`,
+  `maui devflow network`, `maui devflow diagnose`, or `maui devflow mcp`
+- MCP tools such as `maui_wait`, `maui_list_agents`, `maui_status`,
+  `maui_tree`, `maui_query`, `maui_tap`, `maui_recording_start`,
+  `maui_recording_stop`, `maui_logs`, `maui_network`, `maui_cdp_*`,
+  or `maui_invoke_action`
+- package and API names such as `Microsoft.Maui.DevFlow.Agent`,
+  `Microsoft.Maui.DevFlow.Blazor`, `Microsoft.Maui.DevFlow.Agent.Gtk`,
+  `Microsoft.Maui.DevFlow.Driver`, `builder.AddMauiDevFlowAgent()`,
+  or `AddMauiBlazorDevFlowTools()`
+- broker or port evidence such as `19223`, `9223`, `adb reverse`,
+  `adb forward`, agent registration, or direct port fallback
+
+Start narrow and widen only when the first search does not find enough evidence.
+
+### 3. Build the environment fingerprint
+
+For every report and issue, collect the metadata in
+[references/environment-fingerprint.md](references/environment-fingerprint.md):
+
+- host platform and OS version
+- AI tool or host, if detectable
+- model name and reasoning effort, if detectable
+- MAUI, .NET SDK, and MAUI DevFlow package versions, if available
+- target app platforms, such as Android, iOS, Mac Catalyst, macOS, Windows,
+  Linux/GTK, or Blazor WebView runtime
+- `maui` CLI version and invocation mode
+- embedded DevFlow package/reference versions in the app
+
+Unknown metadata is acceptable. Mark it as `Unknown` rather than guessing.
+
+### 4. Classify friction
+
+Use [references/friction-rubric.md](references/friction-rubric.md). Prioritize:
+
+- advertised DevFlow features that failed or were unavailable
+- repeated attempts at the same command, selector, connection, or setup step
+- workaround chains that eventually succeeded
+- broker discovery, direct agent port, or Android forwarding loops
+- platform-specific setup, package, entitlement, or version mismatches
+- missing stable `AutomationId`s or missing observability that made DevFlow less
+  useful
+- AI-host or model behavior that misused DevFlow guidance
+
+Separate confirmed DevFlow issues from app bugs, environment setup problems, and
+unknown causes.
+
+### 5. Capture attempts, workarounds, and outcome
+
+For each finding, record:
+
+- symptom
+- sanitized evidence summary with no session IDs, file paths, usernames, machine
+  names, emails, private URLs, or other PII
+- attempts and retries, especially repeated or contradictory actions
+- workarounds tried
+- final outcome: unresolved, worked around, solved, or unknown
+- confidence level and why
+
+Paraphrase private transcript content. Before sending, saving, or filing any
+report, scrub PII and identifiers including names, emails, usernames, session
+IDs, local file paths, machine names, private URLs, secrets, credentials, request
+bodies, screenshots, and user-specific text.
+
+### 6. Report or file issues
+
+Use [references/reporting.md](references/reporting.md). Default to a markdown
+report. File GitHub issues only when the user asks and repository access works.
+
+For GitHub issues, prefer one issue per actionable MAUI DevFlow product problem.
+Merge near-duplicate session evidence into the same issue body instead of
+opening many low-signal issues.
+
+Before saving markdown or filing issues, do a final privacy pass. If a useful
+finding cannot be explained without PII or local identifiers, omit it or replace
+the details with a generic description.
+
+## Optional Feedback Nudge
+
+Other MAUI DevFlow skills may suggest this review when an agent has retried the
+same DevFlow workflow several times, tried multiple workarounds, or finishes a
+long DevFlow-assisted debugging session. That nudge should ask the user whether
+they want an opt-in review; it should not run this skill automatically.
+
+## Critical Anti-Patterns
+
+| Do not | Do instead |
+| --- | --- |
+| Auto-scan all past sessions | Ask for scope and stay inside it |
+| Ask for session IDs, transcript paths, log paths, or artifact paths | Ask for a high-level scope such as time range, platform, feature, or current session |
+| Treat one ambiguous failure as a confirmed DevFlow bug | Label confidence and separate app/environment/unknown causes |
+| Include raw private transcript excerpts, screenshots, tokens, file paths, session IDs, or request bodies | Paraphrase safe evidence and scrub PII before output |
+| Fix the discovered issues during the review | Produce feedback unless the user separately asks for implementation |
+| File GitHub issues without user approval and repo access | Produce markdown first, then file only on request |
+| Hide successful workarounds | Capture the final working path and the failed attempts that led to it |
+
+## References
+
+- **Session sources**:
+  [references/session-sources.md](references/session-sources.md)
+- **Friction rubric**:
+  [references/friction-rubric.md](references/friction-rubric.md)
+- **Environment fingerprint**:
+  [references/environment-fingerprint.md](references/environment-fingerprint.md)
+- **Reporting and GitHub issues**:
+  [references/reporting.md](references/reporting.md)

--- a/plugins/dotnet-maui/skills/maui-devflow-session-review/references/environment-fingerprint.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-session-review/references/environment-fingerprint.md
@@ -1,0 +1,107 @@
+# Environment fingerprint
+
+Every report or GitHub issue should include the best available environment
+fingerprint. Unknown values are acceptable; guessing is not.
+
+## Required fields
+
+```markdown
+## Environment
+
+- Host OS/platform: {macOS/Windows/Linux + version, if known}
+- AI tool/host: {Copilot CLI, VS Code Copilot Chat, Claude Code, other, Unknown}
+- Model: {model and reasoning effort if known, otherwise Unknown}
+- MAUI CLI: {Microsoft.Maui.Cli version and invocation mode, otherwise Unknown}
+- App framework(s): {.NET MAUI/MAUI Blazor Hybrid/GTK/WPF/macOS AppKit + versions}
+- Target platform(s): {Android/iOS/Mac Catalyst/macOS/Windows/Linux/GTK/WebView/etc.}
+- MAUI DevFlow package/reference versions: {package names and versions}
+- Review scope: {current session/recent sessions/date range/platform/feature}
+```
+
+## Host platform
+
+Use explicit session metadata when available. Otherwise collect it from safe
+local commands or project outputs, such as OS name/version or architecture. Do
+not include usernames, home paths, machine identifiers, local file paths, or
+hostnames.
+
+## AI tool and model
+
+Prefer observable metadata:
+
+- session metadata such as agent name, model ID, or usage model
+- transcript headers or host-specific run metadata
+- user-provided information
+- visible model strings in assistant/system context
+
+Common tool names to normalize:
+
+- Copilot CLI
+- VS Code GitHub Copilot Chat
+- Claude Code
+- GitHub Copilot coding agent
+- Other
+- Unknown
+
+If the model or reasoning effort cannot be detected, write `Unknown`. Do not
+infer a model from writing style.
+
+## MAUI CLI version
+
+Use the first reliable source available:
+
+- `maui --version`
+- `maui version`
+- `maui devflow diagnose`
+- JSON output from `maui devflow skills doctor`
+- local tool manifest or package version when the CLI binary is unavailable
+- command output captured in the session, after removing local identifiers
+
+Record whether the session used CLI commands, MCP tools, or both.
+
+## App frameworks and versions
+
+Collect framework versions from project files and lockfiles inside the scoped
+workspace:
+
+- `.csproj`, `Directory.Packages.props`, target frameworks, and
+  `PackageReference` entries
+- `global.json`, `.config/dotnet-tools.json`, and solution filters when relevant
+- MAUI platform package references for GTK, WPF, macOS AppKit, or Blazor WebView
+
+Only collect the versions needed to explain the finding.
+
+## Target platforms
+
+Infer targets from observable signals:
+
+- .NET target frameworks such as `net*-android`, `net*-ios`,
+  `net*-maccatalyst`, `net*-windows`, `net*-macos`, or GTK-specific head
+  projects
+- simulator, emulator, device, or desktop launch commands
+- `maui devflow device` and `maui devflow diagnose` output
+- user-provided platform context
+
+## MAUI DevFlow packages
+
+Look for package/reference names such as:
+
+- `Microsoft.Maui.Cli`
+- `Microsoft.Maui.DevFlow.Agent`
+- `Microsoft.Maui.DevFlow.Agent.Core`
+- `Microsoft.Maui.DevFlow.Agent.Gtk`
+- `Microsoft.Maui.DevFlow.Blazor`
+- `Microsoft.Maui.DevFlow.Blazor.Gtk`
+- `Microsoft.Maui.DevFlow.Driver`
+- `Microsoft.Maui.DevFlow.Logging`
+
+Include versions and whether the package came from a project reference, package
+reference, central package management entry, or local source checkout.
+
+## PII scrub
+
+Before sending, saving, or filing the environment fingerprint, remove names,
+usernames, emails, session IDs, local file paths, machine names, private server
+URLs, request bodies, user profile text, screenshots, credentials, and tokens.
+Prefer generic source types such as "project manifest" or "CLI output" over
+paths or identifiers.

--- a/plugins/dotnet-maui/skills/maui-devflow-session-review/references/friction-rubric.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-session-review/references/friction-rubric.md
@@ -1,0 +1,91 @@
+# Friction rubric
+
+Classify friction by product impact, repeatability, and confidence. The goal is
+to explain what slowed the AI/user loop and what MAUI DevFlow could improve.
+
+## Severity
+
+| Severity | Signal |
+| --- | --- |
+| High | Advertised MAUI DevFlow feature failed, was missing, or contradicted docs; no reasonable workaround; repeated sessions hit the same issue |
+| Medium | Workflow eventually worked but required retries, hidden prerequisites, stale guidance, manual fallback, or platform-specific knowledge |
+| Low | Minor confusion, unclear output, noisy guidance, or a one-off workaround with low repeatability |
+| Unknown | Evidence shows friction but not enough to attribute cause |
+
+## Common friction patterns
+
+### Advertised feature did not work
+
+Look for cases where the agent expected a `maui devflow` command, MCP tool, or
+skill workflow to exist or behave a certain way, but it failed. Capture the
+advertised expectation, actual behavior, and whether docs or skill guidance
+caused the expectation.
+
+### Repeated command or tool loop
+
+Count repeated attempts at the same underlying task, not just identical command
+strings. Three or more failed attempts at connection, selection, query, action,
+recording, logging, WebView/CDP, or setup are usually worth reporting.
+
+### Workaround chain
+
+Record the failed approaches before the workaround. A useful report explains why
+the successful approach was not obvious:
+
+- broker discovery failed, direct `--agent-port` worked
+- Android registration failed until `adb reverse tcp:19223 tcp:19223`
+- Android CLI-to-agent traffic failed until `adb forward tcp:<port> tcp:<port>`
+- targeted query failed, shallow tree plus manual element selection worked
+- platform setup docs missed a package, entitlement, or debug-only guard
+- a recording or screenshot was needed because structured state was unavailable
+
+### Broker, discovery, and port confusion
+
+High-signal evidence includes repeated switching between broker discovery,
+`localhost:9223`, `19223`, `maui devflow list`, `maui devflow wait`,
+`maui devflow agent status`, and explicit host/port overrides without clear
+success criteria.
+
+### Platform package or version mismatch
+
+Look for mismatch between `Microsoft.Maui.Cli`, embedded DevFlow package
+versions, target app framework versions, or runtime platform. Examples: missing
+GTK package, missing Blazor package, Mac Catalyst entitlement gaps, old direct
+port configuration, or package names that changed.
+
+### Missing stable identifiers or observability
+
+Report when DevFlow could connect but the workflow became brittle because the
+app had no stable `AutomationId`, route, DevFlow Action, log, network entry,
+storage root, profiler data, or assertion point.
+
+### AI-host or model/tool mismatch
+
+Capture when the AI host did not expose the expected session history, MCP tools,
+model metadata, or filesystem access. This may not be a DevFlow bug, but it is
+useful product feedback if DevFlow guidance assumes capabilities that are not
+available in common hosts.
+
+## Confidence
+
+| Confidence | Use when |
+| --- | --- |
+| Confirmed | Multiple evidence points agree, or the same DevFlow failure reproduced in-session |
+| Likely | Session evidence strongly suggests DevFlow friction but one variable is missing |
+| Possible | DevFlow was involved, but app code, environment, or AI host could also explain the issue |
+| Unknown | Evidence is insufficient; include as a question or omit from issue filing |
+
+## Outcome labels
+
+- **Solved**: the session reached the intended DevFlow-assisted result.
+- **Worked around**: the original DevFlow path failed, but another path
+  succeeded.
+- **Unresolved**: the session stopped before success.
+- **Unknown**: the transcript does not show the final state.
+
+## Stop signals
+
+- You have identified the top actionable friction points.
+- Additional candidates repeat the same pattern without adding new evidence.
+- The issue is likely app-specific and not useful MAUI DevFlow product feedback.
+- Confidence remains unknown after checking the approved evidence.

--- a/plugins/dotnet-maui/skills/maui-devflow-session-review/references/reporting.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-session-review/references/reporting.md
@@ -1,0 +1,119 @@
+# Reporting and GitHub issues
+
+Default to a markdown report. File GitHub issues only when the user asks and the
+agent has access to `dotnet/maui-labs`.
+
+Before sending, saving, or filing any output, perform a PII scrub. Reports and
+issues must not contain session IDs, transcript IDs, local file paths, artifact
+paths, names, usernames, emails, machine names, private URLs, credentials,
+tokens, request bodies, screenshots, or user-specific private text.
+
+## Markdown report template
+
+```markdown
+# MAUI DevFlow session review
+
+## Summary
+
+{One paragraph with scope, session count, and top findings.}
+
+## Environment
+
+- Host OS/platform: {value}
+- AI tool/host: {value}
+- Model: {value}
+- MAUI CLI: {value}
+- App framework(s): {value}
+- Target platform(s): {value}
+- MAUI DevFlow package/reference versions: {value}
+- Review scope: {current session/recent sessions/date range/platform/feature}
+
+## Findings
+
+### 1. {short title}
+
+- Severity: {High/Medium/Low/Unknown}
+- Confidence: {Confirmed/Likely/Possible/Unknown}
+- Outcome: {Solved/Worked around/Unresolved/Unknown}
+- Symptom: {what happened}
+- Evidence: {sanitized behavior summary, no identifiers or paths}
+- Attempts: {failed attempts, retries, detours}
+- Workaround or success route: {final working approach, if any}
+- Product feedback: {what MAUI DevFlow could improve}
+
+## Suggested GitHub issues
+
+{List issue titles or say "None requested".}
+```
+
+## GitHub issue template
+
+Use this shape when the user asks to file issues:
+
+```markdown
+## Summary
+
+{A concise product-facing description of the friction.}
+
+## Environment
+
+- Host OS/platform: {value}
+- AI tool/host: {value}
+- Model: {value}
+- MAUI CLI: {value}
+- App framework(s): {value}
+- Target platform(s): {value}
+- MAUI DevFlow package/reference versions: {value}
+
+## What happened
+
+{Observed symptom and user/agent goal.}
+
+## Attempts and workarounds
+
+1. {attempt}
+2. {attempt}
+3. {workaround or final state}
+
+## Expected behavior
+
+{What MAUI DevFlow advertised or should reasonably do.}
+
+## Actual behavior
+
+{What happened instead.}
+
+## Outcome
+
+{Solved, worked around, unresolved, or unknown. Include workaround if present.}
+
+## Scope
+
+{High-level review scope only, with no session IDs or file paths.}
+```
+
+## Filing guidance
+
+- Ask before filing. Markdown-only is the default.
+- Check that `gh` is authenticated and has access to `dotnet/maui-labs`.
+- Prefer one issue per distinct MAUI DevFlow product problem.
+- Merge repeated evidence into one issue when multiple sessions hit the same
+  symptom.
+- Do not include private transcript excerpts, secrets, screenshots, request
+  bodies, session IDs, file paths, or user-specific data.
+- If access fails, keep the issue body in the markdown report for manual filing.
+
+## Title patterns
+
+Good issue titles are product-facing and specific:
+
+- `Broker discovery loop when agent is registered but maui devflow wait times out`
+- `Android agent registration guidance missed adb reverse for broker port`
+- `maui_query failure required full tree workaround for stable AutomationId`
+- `Blazor WebView CDP guidance lacked fallback when webview list was empty`
+
+Avoid titles that blame the AI host without evidence:
+
+- `Copilot failed`
+- `Session was bad`
+- `DevFlow is broken`

--- a/plugins/dotnet-maui/skills/maui-devflow-session-review/references/session-sources.md
+++ b/plugins/dotnet-maui/skills/maui-devflow-session-review/references/session-sources.md
@@ -1,0 +1,104 @@
+# Session sources
+
+Use the narrowest source that can answer the user's request. The review is
+opt-in; do not broaden from the approved scope to unrelated history without
+asking.
+
+## Source order
+
+1. **User-approved scope**: current session, recent sessions, date range, target
+   platform, feature, command family, or DevFlow workflow.
+2. **Current session context**: useful when the review is prompted because the
+   current DevFlow workflow was stuck.
+3. **Session history tools**: use when available to search recent sessions by
+   MAUI DevFlow-specific signals.
+4. **Already-provided sanitized material**: use only if the user has already
+   supplied it. Do not ask for session IDs, transcript paths, log paths, artifact
+   paths, or local file names.
+
+Do not recursively scan a home directory or cloud-synced folder just because it
+might contain session logs.
+
+## Session history query strategy
+
+When a session-store query tool is available:
+
+- Start with a time bound and `LIMIT`.
+- Search for DevFlow-specific terms first: `maui devflow`,
+  `Microsoft.Maui.DevFlow`, `AddMauiDevFlowAgent`, `maui_wait`, `maui_tree`,
+  `maui_query`, `maui devflow wait`, `maui devflow ui tree`, `recording`,
+  `broker`, `9223`, or `19223`.
+- Prefer finding candidate sessions within the scoped search, then inspect only
+  those sessions. If a tool exposes internal handles, use them only
+  transiently; never ask the user for them or include them in output.
+- Include exact filters such as agent/tool fields when available.
+- Widen the time window only if the first query finds too little evidence.
+
+Example intent, not a required exact query:
+
+```sql
+-- Find recent candidate sessions with MAUI DevFlow-specific text.
+SELECT timestamp, user_message, assistant_response
+FROM turns
+WHERE timestamp > now() - INTERVAL '14 days'
+  AND (
+    COALESCE(user_message, '') ILIKE '%maui devflow%'
+    OR COALESCE(assistant_response, '') ILIKE '%maui devflow%'
+    OR COALESCE(assistant_response, '') ILIKE '%Microsoft.Maui.DevFlow%'
+    OR COALESCE(assistant_response, '') ILIKE '%maui_wait%'
+    OR COALESCE(assistant_response, '') ILIKE '%maui_tree%'
+    OR COALESCE(assistant_response, '') ILIKE '%AddMauiDevFlowAgent%'
+  )
+LIMIT 50
+```
+
+After selecting candidate sessions, look for retry patterns and outcomes in the
+same session rather than scanning every historical turn.
+
+## Provided material fallback
+
+If no session-store tool is available, work from the current conversation or
+material the user already provided. Do not ask for local paths or identifiers.
+Collect only non-PII facts:
+
+- relevant time window, turn number, or command family
+- command/tool attempts and results
+- final answer or stopping point
+
+If the user provides a transcript that includes private material, summarize the
+safe pattern and avoid quoting sensitive text.
+
+## Evidence to preserve
+
+For each finding, preserve the smallest useful evidence set:
+
+- sanitized evidence summary
+- turn/time range or command sequence without local identifiers
+- observed failure or repeated attempt
+- workaround attempts
+- final successful command or unresolved blocker
+- environment metadata source type, such as CLI output or package manifest,
+  without local file paths
+
+Do not preserve session IDs, file paths, full transcripts, screenshots, tokens,
+request bodies, private URLs, usernames, emails, machine names, or private user
+text in the report.
+
+## Output scrub
+
+Before sending, saving, or filing anything, scan the summary for PII and local
+identifiers. Remove or generalize:
+
+- names, usernames, emails, handles, or account IDs
+- session IDs, transcript IDs, file paths, artifact paths, machine names, and
+  home-directory fragments
+- private hostnames, internal URLs, tokens, credentials, request bodies, or
+  screenshots
+- user-authored private text copied from a transcript
+
+## Stop signals
+
+- You have enough evidence to explain the top actionable findings.
+- Candidate sessions are unrelated to MAUI DevFlow after a quick scan.
+- Further investigation would require private or out-of-scope history.
+- The output would become a transcript dump instead of product feedback.

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowSkillManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowSkillManagerTests.cs
@@ -21,6 +21,8 @@ public sealed class DevFlowSkillManagerTests
         Assert.Equal("install", result["action"]?.GetValue<string>());
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-onboard", "SKILL.md")));
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-debug", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-session-review", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-session-review", "references", "friction-rubric.md")));
         Assert.False(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-connect", "SKILL.md")));
         Assert.False(File.Exists(Path.Combine(workspace.Path, ".maui", "devflow-skills.lock.json")));
 
@@ -373,6 +375,7 @@ public sealed class DevFlowSkillManagerTests
         Assert.False(Directory.Exists(legacyDirectory));
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-onboard", "SKILL.md")));
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-debug", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-session-review", "SKILL.md")));
         var results = Assert.IsType<JsonArray>(result["results"]);
         var legacyResult = results.OfType<JsonObject>().Single(item => item["skillId"]?.GetValue<string>() == "maui-ai-debugging");
         Assert.Equal("removed", legacyResult["action"]?.GetValue<string>());
@@ -389,6 +392,7 @@ public sealed class DevFlowSkillManagerTests
         Assert.Equal("update", result["action"]?.GetValue<string>());
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-onboard", "SKILL.md")));
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-debug", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, ".claude", "skills", "maui-devflow-session-review", "SKILL.md")));
         var results = Assert.IsType<JsonArray>(result["results"]);
         Assert.Contains(results.OfType<JsonObject>(), item =>
             item["skillId"]?.GetValue<string>() == "maui-devflow-onboard" &&
@@ -396,6 +400,10 @@ public sealed class DevFlowSkillManagerTests
             item["message"]?.GetValue<string>() == "Installed missing skill files from the current CLI bundle.");
         Assert.Contains(results.OfType<JsonObject>(), item =>
             item["skillId"]?.GetValue<string>() == "maui-devflow-debug" &&
+            item["action"]?.GetValue<string>() == "written" &&
+            item["message"]?.GetValue<string>() == "Installed missing skill files from the current CLI bundle.");
+        Assert.Contains(results.OfType<JsonObject>(), item =>
+            item["skillId"]?.GetValue<string>() == "maui-devflow-session-review" &&
             item["action"]?.GetValue<string>() == "written" &&
             item["message"]?.GetValue<string>() == "Installed missing skill files from the current CLI bundle.");
     }
@@ -416,6 +424,7 @@ public sealed class DevFlowSkillManagerTests
 
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".agent", "skills", "maui-devflow-onboard", "SKILL.md")));
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".agent", "skills", "maui-devflow-debug", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, ".agent", "skills", "maui-devflow-session-review", "SKILL.md")));
         Assert.False(Directory.Exists(Path.Combine(workspace.Path, ".claude")));
         var statePath = GetStatePathFromResults(result);
         Assert.StartsWith(Path.Combine(workspace.StateRoot, "workspaces"), statePath, StringComparison.Ordinal);
@@ -438,6 +447,7 @@ public sealed class DevFlowSkillManagerTests
 
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".agents", "skills", "maui-devflow-onboard", "SKILL.md")));
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".agents", "skills", "maui-devflow-debug", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, ".agents", "skills", "maui-devflow-session-review", "SKILL.md")));
         Assert.False(Directory.Exists(Path.Combine(workspace.Path, ".claude")));
 
         var results = Assert.IsType<JsonArray>(result["results"]);
@@ -454,6 +464,7 @@ public sealed class DevFlowSkillManagerTests
 
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".agent", "skills", "maui-devflow-onboard", "SKILL.md")));
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".agent", "skills", "maui-devflow-debug", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, ".agent", "skills", "maui-devflow-session-review", "SKILL.md")));
         Assert.False(Directory.Exists(Path.Combine(workspace.Path, ".claude")));
     }
 
@@ -466,6 +477,7 @@ public sealed class DevFlowSkillManagerTests
 
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".github", "skills", "maui-devflow-onboard", "SKILL.md")));
         Assert.True(File.Exists(Path.Combine(workspace.Path, ".github", "skills", "maui-devflow-debug", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, ".github", "skills", "maui-devflow-session-review", "SKILL.md")));
         Assert.False(Directory.Exists(Path.Combine(workspace.Path, ".claude")));
     }
 
@@ -616,6 +628,7 @@ public sealed class DevFlowSkillManagerTests
         Assert.StartsWith(Path.Combine(workspace.StateRoot, "workspaces"), projectStatePath, StringComparison.Ordinal);
         Assert.Equal(Path.Combine(workspace.StateRoot, "user", "skills", "claude.json"), userStatePath);
         Assert.True(File.Exists(Path.Combine(workspace.UserRoot, ".claude", "skills", "maui-devflow-onboard", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.UserRoot, ".claude", "skills", "maui-devflow-session-review", "SKILL.md")));
     }
 
     [Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowSkillOutputTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowSkillOutputTests.cs
@@ -33,6 +33,7 @@ public sealed class DevFlowSkillOutputTests
         Assert.Contains("Next prompt for your AI agent", output);
         Assert.Contains("maui-devflow-onboard", output);
         Assert.Contains("maui-devflow-debug", output);
+        Assert.Contains("maui-devflow-session-review", output);
         Assert.Contains("maui devflow ui tree --depth 1", output);
         Assert.DoesNotContain("[yellow]", output);
         Assert.DoesNotContain("[/]", output);

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Skills/DevFlowSkillCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Skills/DevFlowSkillCommands.cs
@@ -270,6 +270,7 @@ internal static class DevFlowSkillCommands
         console.Write(new Rule("[yellow]Next prompt for your AI agent[/]").LeftJustified());
         console.MarkupLine("  Use the [bold cyan]maui-devflow-onboard[/] skill to add MAUI DevFlow to this project.");
         console.MarkupLine("  Use [bold cyan]maui-devflow-debug[/] after the app is running for build/deploy/inspect/fix loops.");
+        console.MarkupLine("  Use [bold cyan]maui-devflow-session-review[/] to turn long or stuck DevFlow sessions into opt-in product feedback.");
         console.WriteLine();
 
         console.MarkupLine("[yellow]Manual fallback:[/]");

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Skills/DevFlowSkillManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Skills/DevFlowSkillManager.cs
@@ -22,7 +22,8 @@ internal static class DevFlowSkillManager
     static readonly DevFlowSkillDefinition[] s_skills =
     [
         new("maui-devflow-onboard", "MAUI DevFlow Onboard", "Guides first-time MAUI DevFlow project integration.", Recommended: true),
-        new("maui-devflow-debug", "MAUI DevFlow Debug", "Guides build, deploy, connection recovery, inspect, and debug loops with MAUI DevFlow.", Recommended: true)
+        new("maui-devflow-debug", "MAUI DevFlow Debug", "Guides build, deploy, connection recovery, inspect, and debug loops with MAUI DevFlow.", Recommended: true),
+        new("maui-devflow-session-review", "MAUI DevFlow Session Review", "Guides opt-in review of MAUI DevFlow-assisted AI sessions for friction, workarounds, and product feedback.", Recommended: true)
     ];
 
     static readonly string[] s_legacySkillIds =

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -78,6 +78,9 @@
     <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-debug\**\*" LogicalName="devflow.skills/maui-devflow-debug/%(RecursiveDir)%(Filename)%(Extension)">
       <WithCulture>false</WithCulture>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-session-review\**\*" LogicalName="devflow.skills/maui-devflow-session-review/%(RecursiveDir)%(Filename)%(Extension)">
+      <WithCulture>false</WithCulture>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/tests/dotnet-maui/maui-devflow-session-review/eval.yaml
+++ b/tests/dotnet-maui/maui-devflow-session-review/eval.yaml
@@ -1,0 +1,79 @@
+scenarios:
+  - name: "Review repeated broker and agent wait failures"
+    prompt: |
+      I had a MAUI DevFlow debugging session where the agent tried
+      `maui devflow list`, `maui devflow wait`, and `maui devflow ui tree`
+      several times. On Android it also tried direct localhost access, then
+      switched between broker discovery and port forwarding before the workflow
+      finally worked. I do not want to fix the app right now; I want a concise
+      product-feedback report for the DevFlow maintainers.
+    assertions:
+      - type: "output_matches"
+        pattern: "maui devflow (list|wait|ui tree)"
+      - type: "output_matches"
+        pattern: "19223|9223|adb (reverse|forward)|broker"
+      - type: "output_matches"
+        pattern: "(?i)PII|scrub|sanitize"
+      - type: "output_matches"
+        pattern: "(?i)severity|confidence|outcome"
+    rubric:
+      - "Treats the task as a session review/report, not as an app fix"
+      - "Identifies repeated broker/wait/tree attempts as DevFlow friction"
+      - "Calls out Android broker/agent port forwarding as relevant evidence"
+      - "Includes privacy scrubbing and avoids local identifiers"
+      - "Classifies findings with severity, confidence, and outcome"
+    timeout: 240
+
+  - name: "Create markdown report for long Blazor WebView debugging session"
+    prompt: |
+      Please summarize this long MAUI Blazor Hybrid DevFlow session into a
+      markdown-only feedback report. The repeated friction was around
+      `maui_cdp_webviews`, `maui_cdp_source`, `maui devflow ui tree`, and a
+      fallback to screenshots because the WebView list kept coming back empty.
+      Do not file an issue yet.
+    assertions:
+      - type: "output_contains"
+        value: "markdown"
+      - type: "output_contains"
+        value: "## Environment"
+      - type: "output_contains"
+        value: "## Findings"
+      - type: "output_matches"
+        pattern: "maui_cdp_webviews|maui_cdp_source|WebView"
+      - type: "output_not_matches"
+        pattern: "gh issue create"
+    rubric:
+      - "Defaults to markdown output and does not file an issue"
+      - "Uses the report shape with Environment and Findings sections"
+      - "Recognizes CDP/WebView and screenshot fallback as DevFlow-specific friction"
+      - "Captures attempts, workaround, and final outcome"
+      - "Keeps unknown environment fields explicit rather than guessing"
+    timeout: 240
+
+  - name: "Draft scrubbed GitHub issue for dotnet/maui-labs"
+    prompt: |
+      I want to file a GitHub issue from a DevFlow session review. The raw notes
+      mention `/Users/alex/src/MyCustomerApp`, `alex@example.com`, and a private
+      staging URL. The useful product signal is that `maui_query --automationId`
+      failed three times, then the agent dumped the full tree and manually found
+      the element. Draft the issue body and show how you would file it.
+    assertions:
+      - type: "output_contains"
+        value: "dotnet/maui-labs"
+      - type: "output_matches"
+        pattern: "gh issue create|GitHub issue"
+      - type: "output_matches"
+        pattern: "(?i)scrub|remove|sanitize|redact"
+      - type: "output_matches"
+        pattern: "maui_query|AutomationId|full tree"
+      - type: "output_not_contains"
+        value: "/Users/alex/src/MyCustomerApp"
+      - type: "output_not_contains"
+        value: "alex@example.com"
+    rubric:
+      - "Routes issue filing to dotnet/maui-labs"
+      - "Scrubs local paths, email addresses, and private URLs before output"
+      - "Summarizes the product problem as targeted query failure requiring full tree workaround"
+      - "Includes expected behavior, actual behavior, attempts/workarounds, and outcome"
+      - "Mentions filing only after user approval/access rather than silently posting"
+    timeout: 240


### PR DESCRIPTION
## Summary

- Add `maui-devflow-session-review`, an opt-in skill for turning long or stuck MAUI DevFlow AI sessions into privacy-scrubbed product feedback.
- Bundle the new skill with `maui devflow init` / `maui devflow skills update` and update CLI output/tests.
- Add optional nudges from existing DevFlow skills plus eval coverage for retry loops, markdown reports, and scrubbed issue filing.

## Validation

- `git diff --check`
- `dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj --filter "FullyQualifiedName~DevFlowSkill" --nologo --verbosity minimal`
- `dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj --nologo --verbosity minimal`

Note: local `skill-validator` was not installed; the repository `skill-check` workflow covers static skill validation.
