### PR TITLE
Pin DevFlow integration workload versions

### DIFF
--- a/.github/workflows/devflow-integration.yml
+++ b/.github/workflows/devflow-integration.yml
@@ -49,6 +49,7 @@ concurrency:
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
+  DOTNET_WORKLOAD_VERSION: 10.0.203
   TEST_PROJECT: src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Microsoft.Maui.DevFlow.Agent.IntegrationTests.csproj
 
 jobs:
@@ -119,7 +120,7 @@ jobs:
           global-json-file: global.json
 
       - name: Install Android MAUI workload
-        run: dotnet workload install maui-android
+        run: dotnet workload install maui-android --version ${{ env.DOTNET_WORKLOAD_VERSION }}
 
       - name: Cache AVD
         uses: actions/cache@v4
@@ -182,7 +183,7 @@ jobs:
 
       - name: Select Xcode
         run: |
-          # .NET 10's Apple workloads currently require Xcode 26.3 on hosted runners.
+          # Keep Xcode aligned with DOTNET_WORKLOAD_VERSION; newer Apple workloads can require newer Xcode.
           COMPATIBLE="${COMPATIBLE:-}"
           for candidate in /Applications/Xcode_26.3.app /Applications/Xcode_26.3.0.app; do
             if [[ -d "$candidate" ]]; then
@@ -215,7 +216,7 @@ jobs:
           global-json-file: global.json
 
       - name: Install Apple MAUI workloads
-        run: dotnet workload install maui ios macos
+        run: dotnet workload install maui ios macos --version ${{ env.DOTNET_WORKLOAD_VERSION }}
 
       - name: List available iOS simulators
         run: xcrun simctl list devices available
@@ -248,7 +249,7 @@ jobs:
 
       - name: Select Xcode
         run: |
-          # .NET 10's Apple workloads currently require Xcode 26.3 on hosted runners.
+          # Keep Xcode aligned with DOTNET_WORKLOAD_VERSION; newer Apple workloads can require newer Xcode.
           COMPATIBLE="${COMPATIBLE:-}"
           for candidate in /Applications/Xcode_26.3.app /Applications/Xcode_26.3.0.app; do
             if [[ -d "$candidate" ]]; then
@@ -281,7 +282,7 @@ jobs:
           global-json-file: global.json
 
       - name: Install Apple MAUI workloads
-        run: dotnet workload install maui maccatalyst macos
+        run: dotnet workload install maui maccatalyst macos --version ${{ env.DOTNET_WORKLOAD_VERSION }}
 
       - name: Run DevFlow integration tests (maccatalyst)
         run: >
@@ -315,7 +316,7 @@ jobs:
           global-json-file: global.json
 
       - name: Install MAUI workloads
-        run: dotnet workload install maui
+        run: dotnet workload install maui --version ${{ env.DOTNET_WORKLOAD_VERSION }}
 
       - name: Run DevFlow integration tests (windows)
         shell: pwsh


### PR DESCRIPTION
DevFlow integration jobs select Xcode 26.3 on hosted macOS runners, but unpinned workload installs can pull newer Apple SDK packs that require a newer Xcode. That caused the iOS and MacCatalyst jobs to fail during sample app build before the integration tests could run.

This adds a shared `DOTNET_WORKLOAD_VERSION` for the DevFlow integration workflow and uses it for Android, iOS, MacCatalyst, and Windows workload installs. Keeping those jobs on the existing `10.0.203` workload set aligns the Apple SDK packs with the selected Xcode and makes the workflow behavior consistent across platforms.

Testing:
- Parsed `.github/workflows/devflow-integration.yml` as YAML
- Ran `git diff --check` for the workflow change