### PR TITLE
Harden Android DevFlow integration tests

### DIFF
--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
@@ -196,22 +196,69 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
         if (string.IsNullOrWhiteSpace(_serialNumber))
             return;
 
-        var (output, _, exitCode) = await RunProcessAsync(
-            AdbPath(),
-            "forward --list",
-            timeoutSeconds: 5);
-
-        var expectedForward = $"tcp:{AgentPort} tcp:{AgentPort}";
-        var hasForward = exitCode == 0 && output
-            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Any(line => line.StartsWith(_serialNumber, StringComparison.OrdinalIgnoreCase)
-                && line.Contains(expectedForward, StringComparison.Ordinal));
-
-        if (hasForward)
+        if (await IsAgentForwardEstablishedAsync())
             return;
 
-        Console.WriteLine($"[AndroidFixture] Re-establishing missing ADB forward {expectedForward}.");
+        Console.WriteLine($"[AndroidFixture] Re-establishing missing ADB forward tcp:{AgentPort} tcp:{AgentPort}.");
+
+        // Best-effort remove first so a stale or partial mapping (e.g. left
+        // behind by a previous adb-server crash) doesn't block the re-add.
+        try { await AdbAsync($"forward --remove tcp:{AgentPort}", timeoutSeconds: 5); } catch { }
+
         await AdbCheckedAsync($"forward tcp:{AgentPort} tcp:{AgentPort}", timeoutSeconds: 15);
+
+        // Verify the mapping actually landed - `adb forward` can return 0 while
+        // the daemon is in an inconsistent state, and silently failing here
+        // amplifies into a slow, opaque retry storm in the agent client.
+        if (!await IsAgentForwardEstablishedAsync())
+        {
+            throw new InvalidOperationException(
+                $"adb forward tcp:{AgentPort} tcp:{AgentPort} reported success on '{_serialNumber}' " +
+                "but the mapping is not visible in `adb forward --list`.");
+        }
+    }
+
+    async Task<bool> IsAgentForwardEstablishedAsync()
+    {
+        // Scope the listing to this device so we get the 2-column
+        // `<local> <remote>` form regardless of how many devices are attached.
+        var (output, _, exitCode) = await AdbAsync("forward --list", timeoutSeconds: 5);
+        if (exitCode != 0)
+            return false;
+
+        var expectedLocal = $"tcp:{AgentPort}";
+        var expectedRemote = $"tcp:{AgentPort}";
+
+        foreach (var rawLine in output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = rawLine.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+            // Tolerate both `<serial> <local> <remote>` and `<local> <remote>`
+            // shapes - older `adb` releases emit the 3-column form even with `-s`.
+            string? local;
+            string? remote;
+            if (parts.Length >= 3)
+            {
+                local = parts[1];
+                remote = parts[2];
+            }
+            else if (parts.Length == 2)
+            {
+                local = parts[0];
+                remote = parts[1];
+            }
+            else
+            {
+                continue;
+            }
+
+            if (string.Equals(local, expectedLocal, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(remote, expectedRemote, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     async Task<string?> TryGetAppPidAsync(int timeoutSeconds = 5)
@@ -333,13 +380,26 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
         {
             var (stdout, stderr, _) = await RunProcessAsync(
                 AdbPath(),
-                "forward --list",
+                $"-s {_serialNumber} forward --list",
                 timeoutSeconds: 10);
             await File.WriteAllTextAsync($"{prefix}.forward-list.txt", $"{stdout}{Environment.NewLine}{Environment.NewLine}STDERR:{Environment.NewLine}{stderr}");
         }
         catch (Exception ex)
         {
             await File.WriteAllTextAsync($"{prefix}.forward-list.error.txt", ex.ToString());
+        }
+
+        try
+        {
+            var (stdout, stderr, _) = await RunProcessAsync(
+                AdbPath(),
+                $"-s {_serialNumber} reverse --list",
+                timeoutSeconds: 10);
+            await File.WriteAllTextAsync($"{prefix}.reverse-list.txt", $"{stdout}{Environment.NewLine}{Environment.NewLine}STDERR:{Environment.NewLine}{stderr}");
+        }
+        catch (Exception ex)
+        {
+            await File.WriteAllTextAsync($"{prefix}.reverse-list.error.txt", ex.ToString());
         }
 
         try

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
@@ -31,7 +31,14 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
         _apiLevel = GetTargetApiLevel();
         var avdName = GetTargetAvdName(_apiLevel);
 
-        await EnsureAvdExistsAsync(avdName, _apiLevel);
+        // If the caller pinned a non-emulator (i.e. physical) device that is already
+        // online, skip AVD provisioning entirely so the physical-device path works
+        // even when cmdline-tools / system-images aren't installed locally.
+        var skipAvdSetup = await IsPhysicalDeviceReadyAsync();
+
+        if (!skipAvdSetup)
+            await EnsureAvdExistsAsync(avdName, _apiLevel);
+
         _serialNumber = await EnsureEmulatorRunningAsync(avdName);
 
         await WithBuildLockAsync(async () =>
@@ -253,9 +260,11 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
                 continue;
             }
 
-            var pid = columns.FirstOrDefault(column => int.TryParse(column, out _));
-            if (!string.IsNullOrWhiteSpace(pid))
-                return pid;
+            // Standard `ps -A` output is `USER PID PPID VSZ RSS ...`, so the PID is
+            // always column index 1. Avoid scanning for the first integer-parseable
+            // column because some ROMs use numeric UIDs in the USER column.
+            if (int.TryParse(columns[1], out _))
+                return columns[1];
         }
 
         return null;
@@ -420,6 +429,31 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
     static string GetTargetAvdName(int apiLevel) =>
         Environment.GetEnvironmentVariable("DEVFLOW_TEST_ANDROID_AVD")
         ?? $"devflow-tests-api{apiLevel}";
+
+    async Task<bool> IsPhysicalDeviceReadyAsync()
+    {
+        var requestedSerial = Environment.GetEnvironmentVariable("DEVFLOW_TEST_ANDROID_SERIAL");
+        if (string.IsNullOrWhiteSpace(requestedSerial))
+            return false;
+
+        if (requestedSerial.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        try
+        {
+            var (stateOutput, _, stateExitCode) = await RunProcessAsync(
+                AdbPath(),
+                $"-s {requestedSerial} get-state",
+                timeoutSeconds: 10);
+
+            return stateExitCode == 0
+                && stateOutput.Trim().Equals("device", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     async Task EnsureAvdExistsAsync(string avdName, int apiLevel)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
@@ -238,6 +238,13 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
             string? remote;
             if (parts.Length >= 3)
             {
+                // Defensive: even though `AdbAsync` already scopes the listing to
+                // this device via `-s {_serialNumber}`, older adb releases can emit
+                // 3-column output. Skip rows whose serial does not match so we
+                // never accept a forward belonging to a different attached device.
+                if (!string.Equals(parts[0], _serialNumber, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 local = parts[1];
                 remote = parts[2];
             }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
@@ -137,21 +137,35 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
 
     async Task MonitorAppProcessAsync(CancellationToken cancellationToken)
     {
+        var missingProcessChecks = 0;
+
         while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
+                await EnsureAgentPortForwardAsync();
+
                 var pid = await TryGetAppPidAsync();
                 if (!string.IsNullOrWhiteSpace(pid))
                 {
                     _appSeenRunning = true;
                     _lastKnownPid = pid.Trim();
+                    missingProcessChecks = 0;
                 }
                 else if (_appSeenRunning)
                 {
-                    _appSeenRunning = false;
-                    var reason = $"App process '{PackageId}' disappeared. Last known pid: {_lastKnownPid ?? "<unknown>"}";
-                    await CaptureCrashDiagnosticsAsync(reason);
+                    missingProcessChecks++;
+                    Console.WriteLine(
+                        $"[AndroidFixture] App process probe missed '{PackageId}' " +
+                        $"({missingProcessChecks}/3). Last known pid: {_lastKnownPid ?? "<unknown>"}");
+
+                    if (missingProcessChecks >= 3)
+                    {
+                        _appSeenRunning = false;
+                        missingProcessChecks = 0;
+                        var reason = $"App process '{PackageId}' disappeared after repeated probes. Last known pid: {_lastKnownPid ?? "<unknown>"}";
+                        await CaptureCrashDiagnosticsAsync(reason);
+                    }
                 }
             }
             catch (Exception ex)
@@ -170,6 +184,29 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
         }
     }
 
+    async Task EnsureAgentPortForwardAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_serialNumber))
+            return;
+
+        var (output, _, exitCode) = await RunProcessAsync(
+            AdbPath(),
+            "forward --list",
+            timeoutSeconds: 5);
+
+        var expectedForward = $"tcp:{AgentPort} tcp:{AgentPort}";
+        var hasForward = exitCode == 0 && output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Any(line => line.StartsWith(_serialNumber, StringComparison.OrdinalIgnoreCase)
+                && line.Contains(expectedForward, StringComparison.Ordinal));
+
+        if (hasForward)
+            return;
+
+        Console.WriteLine($"[AndroidFixture] Re-establishing missing ADB forward {expectedForward}.");
+        await AdbCheckedAsync($"forward tcp:{AgentPort} tcp:{AgentPort}", timeoutSeconds: 15);
+    }
+
     async Task<string?> TryGetAppPidAsync(int timeoutSeconds = 5)
     {
         if (string.IsNullOrWhiteSpace(_serialNumber))
@@ -180,11 +217,48 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
             $"-s {_serialNumber} shell pidof {PackageId}",
             timeoutSeconds: timeoutSeconds);
 
+        if (exitCode == 0)
+        {
+            var pid = output.Trim();
+            if (!string.IsNullOrWhiteSpace(pid))
+                return pid;
+        }
+
+        return await TryGetAppPidFromPsAsync(timeoutSeconds);
+    }
+
+    async Task<string?> TryGetAppPidFromPsAsync(int timeoutSeconds)
+    {
+        if (string.IsNullOrWhiteSpace(_serialNumber))
+            return null;
+
+        var (output, _, exitCode) = await RunProcessAsync(
+            AdbPath(),
+            $"-s {_serialNumber} shell ps -A",
+            timeoutSeconds: timeoutSeconds);
+
         if (exitCode != 0)
             return null;
 
-        var pid = output.Trim();
-        return string.IsNullOrWhiteSpace(pid) ? null : pid;
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var columns = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (columns.Length < 2)
+                continue;
+
+            var processName = columns[^1];
+            if (!processName.Equals(PackageId, StringComparison.Ordinal)
+                && !line.EndsWith($" {PackageId}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var pid = columns.FirstOrDefault(column => int.TryParse(column, out _));
+            if (!string.IsNullOrWhiteSpace(pid))
+                return pid;
+        }
+
+        return null;
     }
 
     async Task CaptureCrashDiagnosticsAsync(string reason)
@@ -244,6 +318,30 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
         catch (Exception ex)
         {
             await File.WriteAllTextAsync($"{prefix}.activity-top.error.txt", ex.ToString());
+        }
+
+        try
+        {
+            var (stdout, stderr, _) = await RunProcessAsync(
+                AdbPath(),
+                "forward --list",
+                timeoutSeconds: 10);
+            await File.WriteAllTextAsync($"{prefix}.forward-list.txt", $"{stdout}{Environment.NewLine}{Environment.NewLine}STDERR:{Environment.NewLine}{stderr}");
+        }
+        catch (Exception ex)
+        {
+            await File.WriteAllTextAsync($"{prefix}.forward-list.error.txt", ex.ToString());
+        }
+
+        try
+        {
+            using var response = await Http.GetAsync("/api/v1/agent/status");
+            var body = await response.Content.ReadAsStringAsync();
+            await File.WriteAllTextAsync($"{prefix}.agent-status.txt", $"HTTP {(int)response.StatusCode}{Environment.NewLine}{body}");
+        }
+        catch (Exception ex)
+        {
+            await File.WriteAllTextAsync($"{prefix}.agent-status.error.txt", ex.ToString());
         }
 
         Console.WriteLine($"[AndroidFixture] Captured app-loss diagnostics at '{prefix}.*'");
@@ -370,6 +468,18 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
             {
                 _weStartedEmulator = false;
                 return requestedSerial;
+            }
+
+            if (!requestedSerial.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase))
+            {
+                var (stateOutput, _, stateExitCode) = await RunProcessAsync(adb,
+                    $"-s {requestedSerial} get-state", timeoutSeconds: 10);
+
+                if (stateExitCode == 0 && stateOutput.Trim().Equals("device", StringComparison.OrdinalIgnoreCase))
+                {
+                    _weStartedEmulator = false;
+                    return requestedSerial;
+                }
             }
 
             throw new InvalidOperationException(

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureBase.cs
@@ -70,7 +70,11 @@ public abstract class AppFixtureBase : IAppFixture
             BaseAddress = new Uri(AgentBaseUrl),
             Timeout = TimeSpan.FromSeconds(60)
         };
-        Client = new AgentClient("localhost", AgentPort);
+        Client = new AgentClient("localhost", AgentPort)
+        {
+            TransientFailureRetryCount = Platform == "android" ? 8 : 0,
+            TransientFailureRetryDelay = TimeSpan.FromMilliseconds(250),
+        };
     }
 
     protected async Task<bool> IsAgentReadyAsync()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IntegrationTestBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IntegrationTestBase.cs
@@ -32,20 +32,22 @@ public abstract class IntegrationTestBase
 
     protected async Task<JsonElement> GetJsonAsync(string path)
     {
-        var response = await Http.GetAsync(path);
+        using var response = await SendHttpWithTransportRetryAsync(() => Http.GetAsync(path));
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<JsonElement>(body, JsonOptions);
     }
 
-    protected Task<HttpResponseMessage> GetRawAsync(string path) => Http.GetAsync(path);
+    protected Task<HttpResponseMessage> GetRawAsync(string path)
+        => SendHttpWithTransportRetryAsync(() => Http.GetAsync(path));
 
     protected async Task<JsonElement> PostJsonAsync(string path, object? body = null)
     {
-        var content = body != null
-            ? new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json")
-            : null;
-        var response = await Http.PostAsync(path, content);
+        using var response = await SendHttpWithTransportRetryAsync(async () =>
+        {
+            using var content = CreateJsonContent(body);
+            return await Http.PostAsync(path, content);
+        });
         response.EnsureSuccessStatusCode();
         var responseBody = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<JsonElement>(responseBody, JsonOptions);
@@ -53,32 +55,61 @@ public abstract class IntegrationTestBase
 
     protected Task<HttpResponseMessage> PostRawAsync(string path, object? body = null)
     {
-        var content = body != null
-            ? new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json")
-            : null;
-        return Http.PostAsync(path, content);
+        return SendHttpWithTransportRetryAsync(async () =>
+        {
+            using var content = CreateJsonContent(body);
+            return await Http.PostAsync(path, content);
+        });
     }
 
     protected async Task<JsonElement> PutJsonAsync(string path, object? body = null)
     {
-        var content = body != null
-            ? new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json")
-            : null;
-        var response = await Http.PutAsync(path, content);
+        using var response = await SendHttpWithTransportRetryAsync(async () =>
+        {
+            using var content = CreateJsonContent(body);
+            return await Http.PutAsync(path, content);
+        });
         response.EnsureSuccessStatusCode();
         var responseBody = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<JsonElement>(responseBody, JsonOptions);
     }
 
-    protected Task<HttpResponseMessage> DeleteRawAsync(string path) => Http.DeleteAsync(path);
+    protected Task<HttpResponseMessage> DeleteRawAsync(string path)
+        => SendHttpWithTransportRetryAsync(() => Http.DeleteAsync(path));
 
     protected async Task<JsonElement> DeleteJsonAsync(string path)
     {
-        var response = await Http.DeleteAsync(path);
+        using var response = await SendHttpWithTransportRetryAsync(() => Http.DeleteAsync(path));
         response.EnsureSuccessStatusCode();
         var responseBody = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<JsonElement>(responseBody, JsonOptions);
     }
+
+    static StringContent? CreateJsonContent(object? body)
+        => body != null
+            ? new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json")
+            : null;
+
+    async Task<T> SendHttpWithTransportRetryAsync<T>(Func<Task<T>> send)
+    {
+        var retryCount = Platform == "android" ? 8 : 0;
+
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                return await send();
+            }
+            catch (Exception ex) when (IsTransientTransportException(ex) && attempt < retryCount)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(250 * Math.Min(attempt + 1, 5)));
+            }
+        }
+    }
+
+    static bool IsTransientTransportException(Exception ex)
+        => ex is HttpRequestException or TaskCanceledException or IOException
+            || (ex.InnerException is not null && IsTransientTransportException(ex.InnerException));
 
     protected async Task<ElementInfo> FindElementAsync(string automationId, int timeoutMs = 5000)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IntegrationTestBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IntegrationTestBase.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -108,8 +109,13 @@ public abstract class IntegrationTestBase
     }
 
     static bool IsTransientTransportException(Exception ex)
-        => ex is HttpRequestException or TaskCanceledException or IOException
-            || (ex.InnerException is not null && IsTransientTransportException(ex.InnerException));
+        => ex switch
+        {
+            HttpRequestException { InnerException: SocketException } => true,
+            IOException => true,
+            TaskCanceledException tce when tce.InnerException is not TimeoutException => true,
+            _ => ex.InnerException is not null && IsTransientTransportException(ex.InnerException),
+        };
 
     protected async Task<ElementInfo> FindElementAsync(string automationId, int timeoutMs = 5000)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IntegrationTestBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IntegrationTestBase.cs
@@ -113,7 +113,7 @@ public abstract class IntegrationTestBase
         {
             HttpRequestException { InnerException: SocketException } => true,
             IOException => true,
-            TaskCanceledException tce when tce.InnerException is not TimeoutException => true,
+            TaskCanceledException tce when tce.InnerException is not null and not TimeoutException => true,
             _ => ex.InnerException is not null && IsTransientTransportException(ex.InnerException),
         };
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -23,6 +23,17 @@ public class AgentClient : IDisposable
 
     public string BaseUrl => _baseUrl;
 
+    /// <summary>
+    /// Additional attempts for transient transport failures such as a dropped ADB port
+    /// forward. Defaults to 0 so normal client calls keep their current fail-fast behavior.
+    /// </summary>
+    public int TransientFailureRetryCount { get; set; }
+
+    /// <summary>
+    /// Base delay between transient transport retries.
+    /// </summary>
+    public TimeSpan TransientFailureRetryDelay { get; set; } = TimeSpan.FromMilliseconds(250);
+
     public AgentClient(string host = "localhost", int port = 9223)
     {
         _baseUrl = $"http://{host}:{port}";
@@ -84,7 +95,7 @@ public class AgentClient : IDisposable
     public async Task<List<ElementInfo>> QueryCssAsync(string selector)
     {
         var url = $"{_baseUrl}{UiApi}/elements?selector={Uri.EscapeDataString(selector)}";
-        var response = await _http.GetAsync(url);
+        using var response = await SendWithTransientRetriesAsync(() => _http.GetAsync(url));
         var body = await response.Content.ReadAsStringAsync();
         var json = DriverJson.ParseElement(body);
         if (json.ValueKind == JsonValueKind.Object &&
@@ -194,8 +205,11 @@ public class AgentClient : IDisposable
             ["actions"] = items
         };
 
-        using var content = DriverJson.CreateJsonContent(body);
-        var response = await _http.PostAsync($"{_baseUrl}{UiApi}/actions/batch", content);
+        using var response = await SendWithTransientRetriesAsync(async () =>
+        {
+            using var content = DriverJson.CreateJsonContent(body);
+            return await _http.PostAsync($"{_baseUrl}{UiApi}/actions/batch", content);
+        });
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
@@ -256,11 +270,11 @@ public class AgentClient : IDisposable
                 ? $"{_baseUrl}{UiApi}/screenshot?{string.Join("&", queryParams)}"
                 : $"{_baseUrl}{UiApi}/screenshot";
 
-            var response = await _http.GetAsync(url);
+            using var response = await SendWithTransientRetriesAsync(() => _http.GetAsync(url));
             if (!response.IsSuccessStatusCode) return null;
             return await response.Content.ReadAsByteArrayAsync();
         }
-        catch { return null; }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return null; }
     }
 
     /// <summary>
@@ -281,14 +295,17 @@ public class AgentClient : IDisposable
     {
         try
         {
-            using var content = DriverJson.CreateJsonContent(new JsonObject
+            using var response = await SendWithTransientRetriesAsync(async () =>
             {
-                ["value"] = value
+                using var content = DriverJson.CreateJsonContent(new JsonObject
+                {
+                    ["value"] = value
+                });
+                return await _http.PutAsync($"{_baseUrl}{UiApi}/elements/{elementId}/properties/{propertyName}", content);
             });
-            var response = await _http.PutAsync($"{_baseUrl}{UiApi}/elements/{elementId}/properties/{propertyName}", content);
             return response.IsSuccessStatusCode;
         }
-        catch { return false; }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return false; }
     }
 
     /// <summary>
@@ -299,7 +316,7 @@ public class AgentClient : IDisposable
         var path = $"{ApiV1}/logs?limit={limit}&skip={skip}";
         if (!string.IsNullOrEmpty(source) && source != "all")
             path += $"&source={Uri.EscapeDataString(source)}";
-        return await _http.GetStringAsync($"{_baseUrl}{path}");
+        return await GetStringWithTransientRetriesAsync($"{_baseUrl}{path}");
     }
 
     /// <summary>
@@ -318,8 +335,11 @@ public class AgentClient : IDisposable
         if (@params != null)
             body["params"] = @params.DeepClone();
 
-        using var content = DriverJson.CreateJsonContent(body);
-        var response = await _http.PostAsync($"{_baseUrl}{path}", content);
+        using var response = await SendWithTransientRetriesAsync(async () =>
+        {
+            using var content = DriverJson.CreateJsonContent(body);
+            return await _http.PostAsync($"{_baseUrl}{path}", content);
+        });
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
@@ -337,7 +357,7 @@ public class AgentClient : IDisposable
         var path = $"{WebViewApi}/source";
         if (!string.IsNullOrEmpty(webviewId))
             path += $"?webview={Uri.EscapeDataString(webviewId)}";
-        return await _http.GetStringAsync($"{_baseUrl}{path}");
+        return await GetStringWithTransientRetriesAsync($"{_baseUrl}{path}");
     }
 
     public async Task<bool> NavigateWebViewAsync(string url, string? contextId = null)
@@ -398,7 +418,7 @@ public class AgentClient : IDisposable
         var path = $"{UiApi}/hit-test?x={x}&y={y}";
         if (window.HasValue)
             path += $"&window={window.Value}";
-        return await _http.GetStringAsync($"{_baseUrl}{path}");
+        return await GetStringWithTransientRetriesAsync($"{_baseUrl}{path}");
     }
 
     public async Task<ProfilerCapabilities?> GetProfilerCapabilitiesAsync()
@@ -472,53 +492,59 @@ public class AgentClient : IDisposable
     {
         try
         {
-            var response = await _http.GetStringAsync($"{_baseUrl}{path}");
+            var response = await GetStringWithTransientRetriesAsync($"{_baseUrl}{path}");
             return DriverJson.Deserialize<T>(response);
         }
-        catch { return null; }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return null; }
     }
 
     private async Task<JsonElement> GetJsonAsync(string path)
     {
         try
         {
-            using var response = await _http.GetAsync($"{_baseUrl}{path}");
+            using var response = await SendWithTransientRetriesAsync(() => _http.GetAsync($"{_baseUrl}{path}"));
             var body = await response.Content.ReadAsStringAsync();
             if (string.IsNullOrWhiteSpace(body))
                 return default;
 
             return DriverJson.ParseElement(body);
         }
-        catch { return default; }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return default; }
     }
 
     private async Task<bool> PostActionAsync(string path, JsonNode body)
     {
         try
         {
-            using var content = DriverJson.CreateJsonContent(body);
-            var response = await _http.PostAsync($"{_baseUrl}{path}", content);
+            using var response = await SendWithTransientRetriesAsync(async () =>
+            {
+                using var content = DriverJson.CreateJsonContent(body);
+                return await _http.PostAsync($"{_baseUrl}{path}", content);
+            });
             if (!response.IsSuccessStatusCode) return false;
 
             var responseBody = await response.Content.ReadAsStringAsync();
             var result = DriverJson.Deserialize<ActionResponse>(responseBody);
             return result?.Success == true;
         }
-        catch { return false; }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return false; }
     }
 
     private async Task<T?> PostJsonAsync<T>(string path, JsonNode body) where T : class
     {
         try
         {
-            using var content = DriverJson.CreateJsonContent(body);
-            var response = await _http.PostAsync($"{_baseUrl}{path}", content);
+            using var response = await SendWithTransientRetriesAsync(async () =>
+            {
+                using var content = DriverJson.CreateJsonContent(body);
+                return await _http.PostAsync($"{_baseUrl}{path}", content);
+            });
             var responseBody = await response.Content.ReadAsStringAsync();
             if (string.IsNullOrWhiteSpace(responseBody))
                 return null;
             return DriverJson.Deserialize<T>(responseBody);
         }
-        catch
+        catch (Exception ex) when (IsExpectedClientException(ex))
         {
             return null;
         }
@@ -528,13 +554,13 @@ public class AgentClient : IDisposable
     {
         try
         {
-            var response = await _http.DeleteAsync($"{_baseUrl}{path}");
+            using var response = await SendWithTransientRetriesAsync(() => _http.DeleteAsync($"{_baseUrl}{path}"));
             if (!response.IsSuccessStatusCode)
                 return null;
             var responseBody = await response.Content.ReadAsStringAsync();
             return DriverJson.Deserialize<T>(responseBody);
         }
-        catch
+        catch (Exception ex) when (IsExpectedClientException(ex))
         {
             return null;
         }
@@ -544,7 +570,7 @@ public class AgentClient : IDisposable
     {
         try
         {
-            var response = await _http.DeleteAsync($"{_baseUrl}{path}");
+            using var response = await SendWithTransientRetriesAsync(() => _http.DeleteAsync($"{_baseUrl}{path}"));
             if (!response.IsSuccessStatusCode)
                 return false;
 
@@ -552,11 +578,50 @@ public class AgentClient : IDisposable
             var result = DriverJson.Deserialize<ActionResponse>(responseBody);
             return result?.Success == true;
         }
-        catch
+        catch (Exception ex) when (IsExpectedClientException(ex))
         {
             return false;
         }
     }
+
+    private Task<string> GetStringWithTransientRetriesAsync(string url)
+        => SendWithTransientRetriesAsync(() => _http.GetStringAsync(url));
+
+    private async Task<T> SendWithTransientRetriesAsync<T>(Func<Task<T>> send)
+    {
+        var retryCount = Math.Max(0, TransientFailureRetryCount);
+
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                return await send();
+            }
+            catch (Exception ex) when (IsTransientTransportException(ex) && attempt < retryCount)
+            {
+                var delay = GetTransientFailureRetryDelay(attempt);
+                if (delay > TimeSpan.Zero)
+                    await Task.Delay(delay);
+            }
+        }
+    }
+
+    private TimeSpan GetTransientFailureRetryDelay(int attempt)
+    {
+        if (TransientFailureRetryDelay <= TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        var multiplier = Math.Min(attempt + 1, 5);
+        return TimeSpan.FromMilliseconds(TransientFailureRetryDelay.TotalMilliseconds * multiplier);
+    }
+
+    private static bool IsExpectedClientException(Exception ex)
+        => ex is HttpRequestException or TaskCanceledException or IOException or JsonException
+            || (ex.InnerException is not null && IsExpectedClientException(ex.InnerException));
+
+    private static bool IsTransientTransportException(Exception ex)
+        => ex is HttpRequestException or TaskCanceledException or IOException
+            || (ex.InnerException is not null && IsTransientTransportException(ex.InnerException));
 
     // ── DevFlow Actions ──
 
@@ -608,8 +673,11 @@ public class AgentClient : IDisposable
         if (!string.IsNullOrEmpty(type)) body["type"] = type;
         if (!string.IsNullOrEmpty(sharedName)) body["sharedName"] = sharedName;
 
-        using var content = DriverJson.CreateJsonContent(body);
-        var response = await _http.PutAsync($"{_baseUrl}{StorageApi}/preferences/{Uri.EscapeDataString(key)}", content);
+        using var response = await SendWithTransientRetriesAsync(async () =>
+        {
+            using var content = DriverJson.CreateJsonContent(body);
+            return await _http.PutAsync($"{_baseUrl}{StorageApi}/preferences/{Uri.EscapeDataString(key)}", content);
+        });
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
@@ -619,7 +687,7 @@ public class AgentClient : IDisposable
         var path = $"{StorageApi}/preferences/{Uri.EscapeDataString(key)}";
         if (!string.IsNullOrEmpty(sharedName))
             path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
-        var response = await _http.DeleteAsync($"{_baseUrl}{path}");
+        using var response = await SendWithTransientRetriesAsync(() => _http.DeleteAsync($"{_baseUrl}{path}"));
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
@@ -641,18 +709,21 @@ public class AgentClient : IDisposable
 
     public async Task<JsonElement> SetSecureStorageAsync(string key, string value)
     {
-        using var content = DriverJson.CreateJsonContent(new JsonObject
+        using var response = await SendWithTransientRetriesAsync(async () =>
         {
-            ["value"] = value
+            using var content = DriverJson.CreateJsonContent(new JsonObject
+            {
+                ["value"] = value
+            });
+            return await _http.PutAsync($"{_baseUrl}{StorageApi}/secure/{Uri.EscapeDataString(key)}", content);
         });
-        var response = await _http.PutAsync($"{_baseUrl}{StorageApi}/secure/{Uri.EscapeDataString(key)}", content);
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
 
     public async Task<JsonElement> DeleteSecureStorageAsync(string key)
     {
-        var response = await _http.DeleteAsync($"{_baseUrl}{StorageApi}/secure/{Uri.EscapeDataString(key)}");
+        using var response = await SendWithTransientRetriesAsync(() => _http.DeleteAsync($"{_baseUrl}{StorageApi}/secure/{Uri.EscapeDataString(key)}"));
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
@@ -721,14 +792,17 @@ public class AgentClient : IDisposable
             if (!string.IsNullOrWhiteSpace(type))
                 payload["type"] = type;
 
-            using var content = DriverJson.CreateJsonContent(payload);
-            using var response = await _http.PostAsync($"{_baseUrl}{DeviceApi}/jobs/{Uri.EscapeDataString(identifier)}/run", content);
+            using var response = await SendWithTransientRetriesAsync(async () =>
+            {
+                using var content = DriverJson.CreateJsonContent(payload);
+                return await _http.PostAsync($"{_baseUrl}{DeviceApi}/jobs/{Uri.EscapeDataString(identifier)}/run", content);
+            });
             var responseBody = await response.Content.ReadAsStringAsync();
             if (string.IsNullOrWhiteSpace(responseBody))
                 return default;
             return DriverJson.ParseElement(responseBody);
         }
-        catch { return default; }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return default; }
     }
 
     // ── Files ──
@@ -756,8 +830,11 @@ public class AgentClient : IDisposable
     public async Task<JsonElement> UploadFileAsync(string path, string contentBase64, string? root = null)
     {
         var body = new JsonObject { ["contentBase64"] = contentBase64 };
-        using var content = DriverJson.CreateJsonContent(body);
-        using var response = await _http.PutAsync($"{_baseUrl}{StorageApi}/files/{Uri.EscapeDataString(path)}{BuildRootQuery(root)}", content);
+        using var response = await SendWithTransientRetriesAsync(async () =>
+        {
+            using var content = DriverJson.CreateJsonContent(body);
+            return await _http.PutAsync($"{_baseUrl}{StorageApi}/files/{Uri.EscapeDataString(path)}{BuildRootQuery(root)}", content);
+        });
         var responseBody = await response.Content.ReadAsStringAsync();
         if (string.IsNullOrWhiteSpace(responseBody))
             return default;
@@ -802,20 +879,20 @@ public class AgentClient : IDisposable
             if (!string.IsNullOrEmpty(host)) url += $"&host={Uri.EscapeDataString(host)}";
             if (!string.IsNullOrEmpty(method)) url += $"&method={Uri.EscapeDataString(method)}";
 
-            var response = await _http.GetStringAsync(url);
+            var response = await GetStringWithTransientRetriesAsync(url);
             return DriverJson.Deserialize<List<NetworkRequest>>(response) ?? new();
         }
-        catch { return new(); }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return new(); }
     }
 
     public async Task<NetworkRequest?> GetNetworkRequestDetailAsync(string id)
     {
         try
         {
-            var response = await _http.GetStringAsync($"{_baseUrl}{NetworkApi}/requests/{Uri.EscapeDataString(id)}");
+            var response = await GetStringWithTransientRetriesAsync($"{_baseUrl}{NetworkApi}/requests/{Uri.EscapeDataString(id)}");
             return DriverJson.Deserialize<NetworkRequest>(response);
         }
-        catch { return null; }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return null; }
     }
 
     public async Task<bool> ClearNetworkRequestsAsync()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -28,7 +28,31 @@ public class AgentClient : IDisposable
     /// Additional attempts for transient transport failures such as a dropped ADB port
     /// forward. Defaults to 0 so normal client calls keep their current fail-fast behavior.
     /// </summary>
+    /// <remarks>
+    /// GET requests are idempotent and safe to retry. POST/PUT/DELETE requests, however,
+    /// can produce duplicate side effects on the agent (e.g. double-tap, double-navigate,
+    /// double-invoke of an action) if the transport drops after the agent has received the
+    /// request but before the response makes it back to the client. Retries for mutating
+    /// HTTP methods are gated by <see cref="RetryMutatingRequests"/>; production callers
+    /// that have not accepted that risk should leave <see cref="RetryMutatingRequests"/>
+    /// disabled even when this property is non-zero.
+    /// </remarks>
     public int TransientFailureRetryCount { get; set; }
+
+    /// <summary>
+    /// Whether transient-failure retries (controlled by <see cref="TransientFailureRetryCount"/>)
+    /// also apply to mutating HTTP methods (POST, PUT, DELETE). Defaults to <c>true</c> so
+    /// existing callers that have opted in to retries continue to retry every request type.
+    /// </summary>
+    /// <remarks>
+    /// Retrying mutating requests can duplicate side effects when a response is lost in flight
+    /// (for example, a tap may fire twice, or a Shell navigation may push the same route twice).
+    /// GET requests remain safe to retry because they are idempotent. Production agents that
+    /// have not explicitly accepted the duplicate-side-effect risk should set this to
+    /// <c>false</c>; integration tests that need to ride out an agent process restart can leave
+    /// it at the default.
+    /// </remarks>
+    public bool RetryMutatingRequests { get; set; } = true;
 
     /// <summary>
     /// Base delay between transient transport retries.
@@ -206,7 +230,7 @@ public class AgentClient : IDisposable
             ["actions"] = items
         };
 
-        using var response = await SendWithTransientRetriesAsync(async () =>
+        using var response = await SendWithTransientRetriesAsync(HttpMethod.Post, async () =>
         {
             using var content = DriverJson.CreateJsonContent(body);
             return await _http.PostAsync($"{_baseUrl}{UiApi}/actions/batch", content);
@@ -296,7 +320,7 @@ public class AgentClient : IDisposable
     {
         try
         {
-            using var response = await SendWithTransientRetriesAsync(async () =>
+            using var response = await SendWithTransientRetriesAsync(HttpMethod.Put, async () =>
             {
                 using var content = DriverJson.CreateJsonContent(new JsonObject
                 {
@@ -336,7 +360,7 @@ public class AgentClient : IDisposable
         if (@params != null)
             body["params"] = @params.DeepClone();
 
-        using var response = await SendWithTransientRetriesAsync(async () =>
+        using var response = await SendWithTransientRetriesAsync(HttpMethod.Post, async () =>
         {
             using var content = DriverJson.CreateJsonContent(body);
             return await _http.PostAsync($"{_baseUrl}{path}", content);
@@ -517,7 +541,7 @@ public class AgentClient : IDisposable
     {
         try
         {
-            using var response = await SendWithTransientRetriesAsync(async () =>
+            using var response = await SendWithTransientRetriesAsync(HttpMethod.Post, async () =>
             {
                 using var content = DriverJson.CreateJsonContent(body);
                 return await _http.PostAsync($"{_baseUrl}{path}", content);
@@ -535,7 +559,7 @@ public class AgentClient : IDisposable
     {
         try
         {
-            using var response = await SendWithTransientRetriesAsync(async () =>
+            using var response = await SendWithTransientRetriesAsync(HttpMethod.Post, async () =>
             {
                 using var content = DriverJson.CreateJsonContent(body);
                 return await _http.PostAsync($"{_baseUrl}{path}", content);
@@ -555,7 +579,7 @@ public class AgentClient : IDisposable
     {
         try
         {
-            using var response = await SendWithTransientRetriesAsync(() => _http.DeleteAsync($"{_baseUrl}{path}"));
+            using var response = await SendWithTransientRetriesAsync(HttpMethod.Delete, () => _http.DeleteAsync($"{_baseUrl}{path}"));
             if (!response.IsSuccessStatusCode)
                 return null;
             var responseBody = await response.Content.ReadAsStringAsync();
@@ -571,7 +595,7 @@ public class AgentClient : IDisposable
     {
         try
         {
-            using var response = await SendWithTransientRetriesAsync(() => _http.DeleteAsync($"{_baseUrl}{path}"));
+            using var response = await SendWithTransientRetriesAsync(HttpMethod.Delete, () => _http.DeleteAsync($"{_baseUrl}{path}"));
             if (!response.IsSuccessStatusCode)
                 return false;
 
@@ -588,9 +612,15 @@ public class AgentClient : IDisposable
     private Task<string> GetStringWithTransientRetriesAsync(string url)
         => SendWithTransientRetriesAsync(() => _http.GetStringAsync(url));
 
-    private async Task<T> SendWithTransientRetriesAsync<T>(Func<Task<T>> send)
+    private Task<T> SendWithTransientRetriesAsync<T>(Func<Task<T>> send)
+        => SendWithTransientRetriesAsync(HttpMethod.Get, send);
+
+    private async Task<T> SendWithTransientRetriesAsync<T>(HttpMethod method, Func<Task<T>> send)
     {
         var retryCount = Math.Max(0, TransientFailureRetryCount);
+        var isMutating = method != HttpMethod.Get;
+        if (isMutating && !RetryMutatingRequests)
+            retryCount = 0;
 
         for (var attempt = 0; ; attempt++)
         {
@@ -684,7 +714,7 @@ public class AgentClient : IDisposable
         if (!string.IsNullOrEmpty(type)) body["type"] = type;
         if (!string.IsNullOrEmpty(sharedName)) body["sharedName"] = sharedName;
 
-        using var response = await SendWithTransientRetriesAsync(async () =>
+        using var response = await SendWithTransientRetriesAsync(HttpMethod.Put, async () =>
         {
             using var content = DriverJson.CreateJsonContent(body);
             return await _http.PutAsync($"{_baseUrl}{StorageApi}/preferences/{Uri.EscapeDataString(key)}", content);
@@ -698,7 +728,7 @@ public class AgentClient : IDisposable
         var path = $"{StorageApi}/preferences/{Uri.EscapeDataString(key)}";
         if (!string.IsNullOrEmpty(sharedName))
             path += $"?sharedName={Uri.EscapeDataString(sharedName)}";
-        using var response = await SendWithTransientRetriesAsync(() => _http.DeleteAsync($"{_baseUrl}{path}"));
+        using var response = await SendWithTransientRetriesAsync(HttpMethod.Delete, () => _http.DeleteAsync($"{_baseUrl}{path}"));
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
@@ -720,7 +750,7 @@ public class AgentClient : IDisposable
 
     public async Task<JsonElement> SetSecureStorageAsync(string key, string value)
     {
-        using var response = await SendWithTransientRetriesAsync(async () =>
+        using var response = await SendWithTransientRetriesAsync(HttpMethod.Put, async () =>
         {
             using var content = DriverJson.CreateJsonContent(new JsonObject
             {
@@ -734,7 +764,7 @@ public class AgentClient : IDisposable
 
     public async Task<JsonElement> DeleteSecureStorageAsync(string key)
     {
-        using var response = await SendWithTransientRetriesAsync(() => _http.DeleteAsync($"{_baseUrl}{StorageApi}/secure/{Uri.EscapeDataString(key)}"));
+        using var response = await SendWithTransientRetriesAsync(HttpMethod.Delete, () => _http.DeleteAsync($"{_baseUrl}{StorageApi}/secure/{Uri.EscapeDataString(key)}"));
         var responseBody = await response.Content.ReadAsStringAsync();
         return DriverJson.ParseElement(responseBody);
     }
@@ -803,7 +833,7 @@ public class AgentClient : IDisposable
             if (!string.IsNullOrWhiteSpace(type))
                 payload["type"] = type;
 
-            using var response = await SendWithTransientRetriesAsync(async () =>
+            using var response = await SendWithTransientRetriesAsync(HttpMethod.Post, async () =>
             {
                 using var content = DriverJson.CreateJsonContent(payload);
                 return await _http.PostAsync($"{_baseUrl}{DeviceApi}/jobs/{Uri.EscapeDataString(identifier)}/run", content);
@@ -841,7 +871,7 @@ public class AgentClient : IDisposable
     public async Task<JsonElement> UploadFileAsync(string path, string contentBase64, string? root = null)
     {
         var body = new JsonObject { ["contentBase64"] = contentBase64 };
-        using var response = await SendWithTransientRetriesAsync(async () =>
+        using var response = await SendWithTransientRetriesAsync(HttpMethod.Put, async () =>
         {
             using var content = DriverJson.CreateJsonContent(body);
             return await _http.PutAsync($"{_baseUrl}{StorageApi}/files/{Uri.EscapeDataString(path)}{BuildRootQuery(root)}", content);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -658,7 +658,12 @@ public class AgentClient : IDisposable
                 return true;
             case IOException:
                 return true;
-            case TaskCanceledException tcEx when tcEx.InnerException is not TimeoutException:
+            // Only retry a TaskCanceledException when it represents a real
+            // transport failure (i.e. wraps another exception that is not the
+            // HttpClient timeout marker). A bare TCE with no inner is almost
+            // always a caller-initiated CancellationToken cancellation, which
+            // must not be retried.
+            case TaskCanceledException tcEx when tcEx.InnerException is not null and not TimeoutException:
                 return true;
         }
         return ex.InnerException is not null && IsTransientTransportException(ex.InnerException);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -620,8 +621,18 @@ public class AgentClient : IDisposable
             || (ex.InnerException is not null && IsExpectedClientException(ex.InnerException));
 
     private static bool IsTransientTransportException(Exception ex)
-        => ex is HttpRequestException or TaskCanceledException or IOException
-            || (ex.InnerException is not null && IsTransientTransportException(ex.InnerException));
+    {
+        switch (ex)
+        {
+            case HttpRequestException httpEx when httpEx.InnerException is SocketException:
+                return true;
+            case IOException:
+                return true;
+            case TaskCanceledException tcEx when tcEx.InnerException is not TimeoutException:
+                return true;
+        }
+        return ex.InnerException is not null && IsTransientTransportException(ex.InnerException);
+    }
 
     // ── DevFlow Actions ──
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
@@ -41,26 +41,30 @@ public class AgentClientTests
     public async Task GetStatus_WithTransientRetry_RetriesConnectionRefused()
     {
         using var reserved = new TcpListener(IPAddress.Loopback, 0);
+        reserved.ExclusiveAddressUse = false;
         reserved.Start();
         var port = ((IPEndPoint)reserved.LocalEndpoint).Port;
         reserved.Stop();
 
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
         var serverTask = Task.Run(async () =>
         {
-            await Task.Delay(150);
+            await Task.Delay(150, cts.Token);
 
             using var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.ExclusiveAddressUse = false;
             listener.Start();
 
-            using var tcpClient = await listener.AcceptTcpClientAsync();
+            using var tcpClient = await listener.AcceptTcpClientAsync(cts.Token);
             using var stream = tcpClient.GetStream();
             var buffer = new byte[4096];
-            var read = await stream.ReadAtLeastAsync(buffer, 1, throwOnEndOfStream: false);
+            var read = await stream.ReadAtLeastAsync(buffer, 1, throwOnEndOfStream: false, cancellationToken: cts.Token);
             Assert.True(read > 0);
 
             var body = """{"agent":{"name":"test","version":"1.0"},"device":{"platform":"Test"},"app":{"name":"Sample"},"running":true}""";
             var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
-            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response), cts.Token);
         });
 
         using var client = new AgentClient("localhost", port)
@@ -69,12 +73,26 @@ public class AgentClientTests
             TransientFailureRetryDelay = TimeSpan.FromMilliseconds(50),
         };
 
-        var status = await client.GetStatusAsync();
+        try
+        {
+            var status = await client.GetStatusAsync();
 
-        Assert.NotNull(status);
-        Assert.True(status!.Running);
-
-        await serverTask;
+            Assert.NotNull(status);
+            Assert.True(status!.Running);
+        }
+        finally
+        {
+            // Guard against a missed accept hanging the test indefinitely.
+            var completed = await Task.WhenAny(serverTask, Task.Delay(2000));
+            if (completed == serverTask)
+            {
+                await serverTask;
+            }
+            else
+            {
+                cts.Cancel();
+            }
+        }
     }
 
     [Fact]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
@@ -48,9 +48,15 @@ public class AgentClientTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
+        // Generous startup delay so the client is virtually guaranteed to make at
+        // least one connection attempt (which fails with ECONNREFUSED) before the
+        // listener is bound. We additionally assert elapsed wall time below to
+        // prove the retry path actually fired.
+        var startupDelay = TimeSpan.FromMilliseconds(500);
+
         var serverTask = Task.Run(async () =>
         {
-            await Task.Delay(150, cts.Token);
+            await Task.Delay(startupDelay, cts.Token);
 
             using var listener = new TcpListener(IPAddress.Loopback, port);
             listener.ExclusiveAddressUse = false;
@@ -67,18 +73,30 @@ public class AgentClientTests
             await stream.WriteAsync(Encoding.UTF8.GetBytes(response), cts.Token);
         });
 
+        var retryDelay = TimeSpan.FromMilliseconds(50);
         using var client = new AgentClient("localhost", port)
         {
-            TransientFailureRetryCount = 10,
-            TransientFailureRetryDelay = TimeSpan.FromMilliseconds(50),
+            TransientFailureRetryCount = 20,
+            TransientFailureRetryDelay = retryDelay,
         };
 
         try
         {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             var status = await client.GetStatusAsync();
+            sw.Stop();
 
             Assert.NotNull(status);
             Assert.True(status!.Running);
+
+            // If the retry path was not exercised, GetStatusAsync would have returned
+            // either ~immediately (failure) or only after the very first successful
+            // connect. Asserting elapsed >= one retry delay catches the regression
+            // where the test passes without ever hitting the retry loop.
+            Assert.True(
+                sw.Elapsed >= retryDelay,
+                $"Expected GetStatusAsync to take at least one retry delay ({retryDelay.TotalMilliseconds} ms) " +
+                $"due to connection-refused retries, but completed in {sw.Elapsed.TotalMilliseconds:F1} ms.");
         }
         finally
         {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
 using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.DevFlow.Tests;
@@ -32,6 +35,46 @@ public class AgentClientTests
         using var client = new AgentClient("localhost", 19999);
         var tree = await client.GetTreeAsync();
         Assert.Empty(tree);
+    }
+
+    [Fact]
+    public async Task GetStatus_WithTransientRetry_RetriesConnectionRefused()
+    {
+        using var reserved = new TcpListener(IPAddress.Loopback, 0);
+        reserved.Start();
+        var port = ((IPEndPoint)reserved.LocalEndpoint).Port;
+        reserved.Stop();
+
+        var serverTask = Task.Run(async () =>
+        {
+            await Task.Delay(150);
+
+            using var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+
+            using var tcpClient = await listener.AcceptTcpClientAsync();
+            using var stream = tcpClient.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAtLeastAsync(buffer, 1, throwOnEndOfStream: false);
+            Assert.True(read > 0);
+
+            var body = """{"agent":{"name":"test","version":"1.0"},"device":{"platform":"Test"},"app":{"name":"Sample"},"running":true}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        using var client = new AgentClient("localhost", port)
+        {
+            TransientFailureRetryCount = 10,
+            TransientFailureRetryDelay = TimeSpan.FromMilliseconds(50),
+        };
+
+        var status = await client.GetStatusAsync();
+
+        Assert.NotNull(status);
+        Assert.True(status!.Running);
+
+        await serverTask;
     }
 
     [Fact]


### PR DESCRIPTION
The Android integration CI failure showed the app process still resumed while localhost agent calls started returning connection refused, which points at transient ADB/forward instability rather than a deterministic app crash. This hardens the test transport so hosted-runner blips do not cascade into dozens of false failures.

## Changes
- Add opt-in transient transport retries to `AgentClient` and enable them only for Android integration fixture calls.
- Re-establish missing `adb forward` entries while Android tests are running.
- Debounce process-loss detection and fall back from `pidof` to `ps -A` before treating the app as gone.
- Capture forward-list and agent-status diagnostics when app-loss diagnostics are collected.
- Let `DEVFLOW_TEST_ANDROID_SERIAL` target connected physical devices for local debugging.

## Validation
- `dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/Microsoft.Maui.DevFlow.Tests.csproj -c Debug --logger "trx;LogFileName=devflow-unit-after-fix.trx"`
- `DEVFLOW_TEST_PLATFORM=android DEVFLOW_TEST_ANDROID_SERIAL=38020DLJG004ZG dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Microsoft.Maui.DevFlow.Agent.IntegrationTests.csproj -c Debug --logger "trx;LogFileName=android-full-after-fix.trx" --results-directory artifacts/TestResults/devflow-integration/android-full-after-fix`