### PR TITLE
Set Essentials AI package version override

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,9 +78,11 @@
     <PlatformMauiMacOSBlazorWebViewVersion>$(PlatformMauiMacOSVersion)</PlatformMauiMacOSBlazorWebViewVersion>
     <PlatformMauiMacOSEssentialsVersion>$(PlatformMauiMacOSVersion)</PlatformMauiMacOSEssentialsVersion>
   </PropertyGroup>
-  <!-- EssentialsAI preview iteration (bump for each new preview drop when DotNetFinalVersionKind=release) -->
+  <!-- EssentialsAI package version (continues the NuGet line that existed before moving into this repo). -->
   <PropertyGroup Label="EssentialsAI">
-    <EssentialsAIPreviewVersionIteration>1</EssentialsAIPreviewVersionIteration>
+    <EssentialsAIVersionPrefix>11.0.0</EssentialsAIVersionPrefix>
+    <EssentialsAIPreReleaseVersionLabel>preview</EssentialsAIPreReleaseVersionLabel>
+    <EssentialsAIPreviewVersionIteration>5</EssentialsAIPreviewVersionIteration>
     <!-- Microsoft Extensions AI -->
     <MicrosoftExtensionsAIAbstractionsVersion>10.4.1</MicrosoftExtensionsAIAbstractionsVersion>
     <!-- Microsoft Agents AI (sample only) -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -80,7 +80,9 @@
   </PropertyGroup>
   <!-- EssentialsAI package version (continues the NuGet line that existed before moving into this repo). -->
   <PropertyGroup Label="EssentialsAI">
-    <EssentialsAIVersionPrefix>11.0.0</EssentialsAIVersionPrefix>
+    <EssentialsAIMajorVersion>11</EssentialsAIMajorVersion>
+    <EssentialsAIMinorVersion>0</EssentialsAIMinorVersion>
+    <EssentialsAIPatchVersion>0</EssentialsAIPatchVersion>
     <EssentialsAIPreReleaseVersionLabel>preview</EssentialsAIPreReleaseVersionLabel>
     <EssentialsAIPreviewVersionIteration>5</EssentialsAIPreviewVersionIteration>
     <!-- Microsoft Extensions AI -->

--- a/src/AI/Microsoft.Maui.Essentials.AI/Microsoft.Maui.Essentials.AI.csproj
+++ b/src/AI/Microsoft.Maui.Essentials.AI/Microsoft.Maui.Essentials.AI.csproj
@@ -17,14 +17,14 @@
     <IsShipping>true</IsShipping>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.Maui.Essentials.AI</PackageId>
-    <!-- Keep this package always preview — it is experimental and should not ship stable
-         even when the rest of the repo stabilizes. Bump EssentialsAIPreviewVersionIteration
-         in eng/Versions.props for new previews.
-         The label/iteration only activate during stable builds (DotNetFinalVersionKind=release).
-         During preview builds, the AI package uses the same label as the rest of the repo. -->
+    <!-- Keep this package always preview on its independent NuGet version line.
+         Bump the EssentialsAI version properties in eng/Versions.props for new previews. -->
+    <MajorVersion>$(EssentialsAIVersionPrefix.Split('.')[0])</MajorVersion>
+    <MinorVersion>$(EssentialsAIVersionPrefix.Split('.')[1])</MinorVersion>
+    <PatchVersion>$(EssentialsAIVersionPrefix.Split('.')[2])</PatchVersion>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PreReleaseVersionLabel Condition="'$(DotNetFinalVersionKind)' == 'release'">preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration Condition="'$(DotNetFinalVersionKind)' == 'release'">$(EssentialsAIPreviewVersionIteration)</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>$(EssentialsAIPreReleaseVersionLabel)</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>$(EssentialsAIPreviewVersionIteration)</PreReleaseVersionIteration>
     <PackageTags>$(DefaultPackageTags);essentials;ai</PackageTags>
     <Description>.NET Multi-platform App UI (.NET MAUI) is a cross-platform framework for creating native mobile and desktop apps with C# and XAML. This package contains a collection of cross-platform APIs for working with device AI and local models.</Description>
     <PackRepoRootReadme>false</PackRepoRootReadme>

--- a/src/AI/Microsoft.Maui.Essentials.AI/Microsoft.Maui.Essentials.AI.csproj
+++ b/src/AI/Microsoft.Maui.Essentials.AI/Microsoft.Maui.Essentials.AI.csproj
@@ -17,11 +17,11 @@
     <IsShipping>true</IsShipping>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.Maui.Essentials.AI</PackageId>
-    <!-- Keep this package always preview on its independent NuGet version line.
+    <!-- Keep this package always preview on its independent NuGet version line for all package builds.
          Bump the EssentialsAI version properties in eng/Versions.props for new previews. -->
-    <MajorVersion>$(EssentialsAIVersionPrefix.Split('.')[0])</MajorVersion>
-    <MinorVersion>$(EssentialsAIVersionPrefix.Split('.')[1])</MinorVersion>
-    <PatchVersion>$(EssentialsAIVersionPrefix.Split('.')[2])</PatchVersion>
+    <MajorVersion>$(EssentialsAIMajorVersion)</MajorVersion>
+    <MinorVersion>$(EssentialsAIMinorVersion)</MinorVersion>
+    <PatchVersion>$(EssentialsAIPatchVersion)</PatchVersion>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PreReleaseVersionLabel>$(EssentialsAIPreReleaseVersionLabel)</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>$(EssentialsAIPreviewVersionIteration)</PreReleaseVersionIteration>


### PR DESCRIPTION
## Summary
- Centralize the Essentials AI package version override in `eng/Versions.props`
- Continue the existing NuGet package line as `11.0.0-preview.5.*`
- Keep the override scoped to `Microsoft.Maui.Essentials.AI` so other packages stay on the repo default version

## Versioning note
- The Essentials AI package intentionally uses its independent `11.0.0-preview.5.*` version line for all package builds, not only `DotNetFinalVersionKind=release` builds
- The version components are stored as scalar MSBuild properties to avoid parsing a dotted version string during project evaluation

## Validation
- Evaluated `Microsoft.Maui.Essentials.AI` package version locally with an example official build number: `11.0.0-preview.5.26270.1`
- Evaluated `Microsoft.Maui.Cli` package version locally with the same build number: `0.1.0-preview.10.26270.1`

@mattleibow can you review this versioning approach?