### PR TITLE
Add DevFlow theme switching support

### DIFF
--- a/docs/DevFlow/spec/examples/capabilities-maui-response.json
+++ b/docs/DevFlow/spec/examples/capabilities-maui-response.json
@@ -1,65 +1,72 @@
 {
-  "agent": {
-    "name": "devflow-maui",
-    "version": "1.0.0",
-    "framework": "maui",
-    "frameworkVersion": "10.0"
+  "ui": {
+    "supported": true,
+    "features": [
+      "tree",
+      "query",
+      "hit-test",
+      "tap",
+      "fill",
+      "clear",
+      "focus",
+      "scroll",
+      "navigate",
+      "resize",
+      "back",
+      "key",
+      "gesture",
+      "batch",
+      "properties",
+      "screenshot"
+    ]
   },
-  "capabilities": {
-    "ui.tree": {
-      "version": 1,
-      "features": ["css-selectors", "hit-test", "native-layer", "render-layer"]
-    },
-    "ui.actions": {
-      "version": 1,
-      "features": [
-        "tap",
-        "fill",
-        "clear",
-        "scroll",
-        "focus",
-        "navigate",
-        "back",
-        "gesture",
-        "batch"
-      ]
-    },
-    "ui.screenshot": {
-      "version": 1,
-      "features": ["fullPage", "element"]
-    },
-    "profiler": {
-      "version": 1,
-      "features": ["samples", "spans", "markers", "hotspots"]
-    },
-    "logs": {
-      "version": 1,
-      "features": ["stream", "query"]
-    },
-    "device.info": {
-      "version": 1,
-      "features": ["display", "battery", "connectivity", "geolocation"]
-    },
-    "app.theme": {
-      "version": 1,
-      "features": ["get", "set"]
-    },
-    "device.sensors": {
-      "version": 1,
-      "features": ["accelerometer", "gyroscope", "magnetometer"]
-    },
-    "device.jobs": {
-      "version": 1,
-      "features": ["list", "run"],
-      "supported": true
-    },
-    "storage.preferences": {
-      "version": 1,
-      "features": ["get", "set", "delete", "clear"]
-    },
-    "storage.secure": {
-      "version": 1,
-      "features": ["get", "set", "delete", "clear"]
-    }
+  "webview": {
+    "supported": true,
+    "features": [
+      "evaluate",
+      "contexts",
+      "source",
+      "dom",
+      "dom-query",
+      "network",
+      "console",
+      "screenshot"
+    ]
+  },
+  "network": {
+    "supported": true,
+    "features": ["list", "detail", "clear", "stream"]
+  },
+  "logs": {
+    "supported": true,
+    "features": ["list", "stream"]
+  },
+  "sensors": {
+    "supported": true,
+    "features": ["list", "start", "stop", "stream"]
+  },
+  "storage": {
+    "supported": true,
+    "features": ["preferences", "secure-storage", "roots", "files"]
+  },
+  "profiler": {
+    "supported": true,
+    "features": ["capabilities", "sessions", "samples", "markers", "spans", "hotspots"]
+  },
+  "jobs": {
+    "supported": true,
+    "features": ["list", "run"]
+  },
+  "theme": {
+    "supported": true,
+    "features": ["get", "set"]
+  },
+  "app.theme": {
+    "supported": true,
+    "features": ["get", "set"]
+  },
+  "invoke": {
+    "supported": true,
+    "features": ["actions"]
   }
 }

--- a/docs/DevFlow/spec/examples/capabilities-maui-response.json
+++ b/docs/DevFlow/spec/examples/capabilities-maui-response.json
@@ -40,6 +40,10 @@
       "version": 1,
       "features": ["display", "battery", "connectivity", "geolocation"]
     },
+    "app.theme": {
+      "version": 1,
+      "features": ["get", "set"]
+    },
     "device.sensors": {
       "version": 1,
       "features": ["accelerometer", "gyroscope", "magnetometer"]

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -1313,6 +1313,51 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/v1/device/app/theme:
+    get:
+      operationId: getAppTheme
+      tags: [device]
+      summary: Get app theme
+      description: >
+        Returns the current in-app theme override and effective application
+        theme. This is app-scoped and does not change the host operating
+        system appearance.
+      responses:
+        "200":
+          description: Application theme information.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/ThemeInfo"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    put:
+      operationId: setAppTheme
+      tags: [device]
+      summary: Set app theme
+      description: >
+        Sets the in-app theme override. Use `light` or `dark` to force the
+        application theme, or `system` to clear the override and follow the
+        host/device setting.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./schemas/device.json#/$defs/ThemeSetRequest"
+      responses:
+        "200":
+          description: Updated application theme information.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/device.json#/$defs/ThemeInfo"
+        "400":
+          $ref: "#/components/responses/InvalidArgument"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /api/v1/device/sensors:
     get:
       operationId: listSensors
@@ -1987,6 +2032,18 @@ components:
             title: Invalid storage path
             status: 400
             errorCode: invalid-path
+
+    InvalidArgument:
+      description: Invalid request argument.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/common.json#/$defs/ProblemDetails"
+          example:
+            type: "urn:devflow:error:invalid-argument"
+            title: Invalid argument
+            status: 400
+            errorCode: invalid-argument
 
     Timeout:
       description: Operation timed out.

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -127,6 +127,13 @@
               "connectivity"
             ]
           },
+          "app.theme": {
+            "version": 1,
+            "features": [
+              "get",
+              "set"
+            ]
+          },
           "device.sensors": {
             "version": 1,
             "features": [

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -2,220 +2,84 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "agent-capabilities.json",
   "title": "AgentCapabilities",
-  "description": "Capability discovery response describing what the agent supports.",
+  "description": "Flat capability discovery response describing what the agent supports.",
   "type": "object",
-  "required": [
-    "agent",
-    "capabilities"
-  ],
+  "additionalProperties": {
+    "$ref": "#/$defs/Capability"
+  },
   "properties": {
-    "agent": {
+    "ui": {
+      "$ref": "#/$defs/Capability",
+      "description": "UI automation capabilities."
+    },
+    "webview": {
+      "$ref": "#/$defs/Capability",
+      "description": "Blazor WebView/CDP capabilities."
+    },
+    "network": {
+      "$ref": "#/$defs/Capability",
+      "description": "Network capture capabilities."
+    },
+    "logs": {
+      "$ref": "#/$defs/Capability",
+      "description": "Log retrieval capabilities."
+    },
+    "sensors": {
+      "$ref": "#/$defs/Capability",
+      "description": "Device sensor capabilities."
+    },
+    "storage": {
+      "$ref": "#/$defs/Capability",
+      "description": "Preferences, secure storage, and app file capabilities."
+    },
+    "profiler": {
+      "$ref": "#/$defs/Capability",
+      "description": "Profiling capabilities."
+    },
+    "jobs": {
+      "$ref": "#/$defs/Capability",
+      "description": "Background job capabilities."
+    },
+    "theme": {
+      "$ref": "#/$defs/Capability",
+      "description": "Application theme switching capabilities."
+    },
+    "app.theme": {
+      "$ref": "#/$defs/Capability",
+      "description": "Application theme switching capability namespace."
+    },
+    "invoke": {
+      "$ref": "#/$defs/Capability",
+      "description": "Registered action invocation capabilities."
+    }
+  },
+  "$defs": {
+    "Capability": {
       "type": "object",
-      "description": "Information about the DevFlow agent itself.",
+      "description": "Capability details.",
       "required": [
-        "name",
-        "version",
-        "framework",
-        "frameworkVersion"
+        "supported",
+        "features"
       ],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name of the DevFlow agent implementation."
+        "supported": {
+          "type": "boolean",
+          "description": "Whether this capability is available in the running app."
+        },
+        "features": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of supported features within this capability."
         },
         "version": {
-          "type": "string",
-          "description": "Semantic version of the agent."
-        },
-        "framework": {
-          "type": "string",
-          "description": "The UI framework the agent is instrumented for."
-        },
-        "frameworkVersion": {
-          "type": "string",
-          "description": "Version of the UI framework."
+          "type": "integer",
+          "description": "Optional capability version number.",
+          "minimum": 1
         }
-      }
-    },
-    "capabilities": {
-      "type": "object",
-      "description": "Map of capability namespaces to their details. Keys are dot-separated namespaces.",
-      "additionalProperties": {
-        "type": "object",
-        "required": [
-          "version",
-          "features"
-        ],
-        "properties": {
-          "version": {
-            "type": "integer",
-            "description": "Capability version number.",
-            "minimum": 1
-          },
-          "features": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of supported features within this capability namespace."
-          }
-        },
-        "additionalProperties": true,
-        "description": "Capability details including version, features, and optional extra fields."
       },
-      "examples": [
-        {
-          "ui.tree": {
-            "version": 1,
-            "features": [
-              "find",
-              "query",
-              "snapshot"
-            ]
-          },
-          "ui.actions": {
-            "version": 1,
-            "features": [
-              "tap",
-              "fill",
-              "scroll",
-              "gesture"
-            ]
-          },
-          "ui.screenshot": {
-            "version": 1,
-            "features": [
-              "fullPage",
-              "element"
-            ]
-          },
-          "webview": {
-            "version": 1,
-            "features": [
-              "evaluate",
-              "dom",
-              "navigate"
-            ]
-          },
-          "profiler": {
-            "version": 1,
-            "features": [
-              "samples",
-              "spans",
-              "markers"
-            ]
-          },
-          "network": {
-            "version": 1,
-            "features": [
-              "capture",
-              "detail"
-            ]
-          },
-          "logs": {
-            "version": 1,
-            "features": [
-              "stream",
-              "query"
-            ]
-          },
-          "device.info": {
-            "version": 1,
-            "features": [
-              "display",
-              "battery",
-              "connectivity"
-            ]
-          },
-          "app.theme": {
-            "version": 1,
-            "features": [
-              "get",
-              "set"
-            ]
-          },
-          "device.sensors": {
-            "version": 1,
-            "features": [
-              "accelerometer",
-              "gyroscope",
-              "compass"
-            ]
-          },
-          "device.jobs": {
-            "version": 1,
-            "features": [
-              "list",
-              "run"
-            ],
-            "supported": true
-          },
-          "storage.preferences": {
-            "version": 1,
-            "features": [
-              "get",
-              "set",
-              "delete"
-            ]
-          },
-          "storage.secure": {
-            "version": 1,
-            "features": [
-              "get",
-              "set",
-              "delete"
-            ]
-          },
-          "storage.files": {
-            "version": 1,
-            "features": [
-              "roots",
-              "list",
-              "download",
-              "upload",
-              "delete"
-            ]
-          }
-        }
-      ]
-    },
-    "extensions": {
-      "type": "object",
-      "description": "Map of extension namespaces (reverse-domain notation) to their route registrations.",
-      "additionalProperties": {
-        "type": "object",
-        "required": [
-          "routes"
-        ],
-        "properties": {
-          "routes": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "method",
-                "path"
-              ],
-              "properties": {
-                "method": {
-                  "type": "string",
-                  "description": "HTTP method for this route (e.g. 'GET', 'POST')."
-                },
-                "path": {
-                  "type": "string",
-                  "description": "URL path for this route."
-                }
-              }
-            },
-            "description": "Routes registered by this extension."
-          },
-          "description": {
-            "type": "string",
-            "description": "Human-readable description of this extension."
-          }
-        },
-        "description": "Extension details including registered routes."
-      }
+      "additionalProperties": true
     }
   }
 }

--- a/docs/DevFlow/spec/schemas/device.json
+++ b/docs/DevFlow/spec/schemas/device.json
@@ -189,8 +189,12 @@
           "description": "Effective application theme after applying any in-app override."
         },
         "requestedTheme": {
+          "type": "string",
+          "description": "Legacy MAUI AppTheme name requested by the host/device setting (for example, 'Light', 'Dark', or 'Unspecified')."
+        },
+        "requestedThemeValue": {
           "$ref": "#/$defs/ThemeValue",
-          "description": "Theme requested by the host/device setting."
+          "description": "Protocol-normalized theme requested by the host/device setting."
         },
         "userAppTheme": {
           "$ref": "#/$defs/ThemeValue",

--- a/docs/DevFlow/spec/schemas/device.json
+++ b/docs/DevFlow/spec/schemas/device.json
@@ -151,6 +151,80 @@
         }
       }
     },
+    "ThemeValue": {
+      "type": "string",
+      "description": "Application theme value. `system` means no app override; follow the host/device theme.",
+      "enum": [
+        "light",
+        "dark",
+        "system"
+      ]
+    },
+    "ThemeSetRequest": {
+      "type": "object",
+      "description": "Request to set the in-app theme override.",
+      "required": [
+        "theme"
+      ],
+      "properties": {
+        "theme": {
+          "$ref": "#/$defs/ThemeValue"
+        }
+      }
+    },
+    "ThemeInfo": {
+      "type": "object",
+      "description": "Application theme state.",
+      "required": [
+        "theme",
+        "requestedTheme",
+        "userAppTheme",
+        "effectiveTheme",
+        "supportedThemes",
+        "source"
+      ],
+      "properties": {
+        "theme": {
+          "$ref": "#/$defs/ThemeValue",
+          "description": "Effective application theme after applying any in-app override."
+        },
+        "requestedTheme": {
+          "$ref": "#/$defs/ThemeValue",
+          "description": "Theme requested by the host/device setting."
+        },
+        "userAppTheme": {
+          "$ref": "#/$defs/ThemeValue",
+          "description": "Current in-app override; `system` means no override."
+        },
+        "effectiveTheme": {
+          "$ref": "#/$defs/ThemeValue",
+          "description": "Effective application theme after combining host/device and in-app override."
+        },
+        "supportedThemes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ThemeValue"
+          },
+          "description": "Theme values accepted by the in-app endpoint."
+        },
+        "source": {
+          "type": "string",
+          "description": "Where the theme value was applied or read from.",
+          "enum": [
+            "app",
+            "system",
+            "auto"
+          ]
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional human-readable status detail."
+        }
+      }
+    },
     "AppInfo": {
       "type": "object",
       "description": "Application metadata.",
@@ -178,11 +252,20 @@
           "description": "Application package identifier (e.g. 'com.example.myapp')."
         },
         "theme": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Current application theme (e.g. 'light', 'dark', 'system')."
+          "$ref": "#/$defs/ThemeValue",
+          "description": "Effective application theme."
+        },
+        "requestedTheme": {
+          "$ref": "#/$defs/ThemeValue",
+          "description": "Theme requested by the host/device setting."
+        },
+        "userAppTheme": {
+          "$ref": "#/$defs/ThemeValue",
+          "description": "Current in-app override; `system` means no override."
+        },
+        "effectiveTheme": {
+          "$ref": "#/$defs/ThemeValue",
+          "description": "Effective application theme after combining host/device and in-app override."
         }
       }
     },

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -58,6 +58,22 @@ public class CommandConstructionTests
 	}
 
 	[Fact]
+	public void DevFlowCommand_IncludesThemeCommands()
+	{
+		var jsonOption = new Option<bool>("--json");
+		var devflowCommand = DevFlowCommands.CreateDevFlowCommand(jsonOption);
+
+		var themeCommand = Assert.Single(devflowCommand.Subcommands, c => c.Name == "theme");
+		Assert.Contains(themeCommand.Subcommands, c => c.Name == "get");
+		var setCommand = Assert.Single(themeCommand.Subcommands, c => c.Name == "set");
+		var scopeOption = (Option<string>)Assert.Single(setCommand.Options, option => option.Name == "--scope");
+		var parseResult = themeCommand.Parse("set dark");
+
+		Assert.Empty(parseResult.Errors);
+		Assert.Equal("auto", parseResult.GetValue(scopeOption));
+	}
+
+	[Fact]
 	public void DevFlowCommand_UpdateSkillIsHiddenCompatibilityAliasForSkillsUpdate()
 	{
 		var jsonOption = new Option<bool>("--json");

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow;
 using Microsoft.Maui.Cli.UnitTests.Fixtures;
+using Microsoft.Maui.DevFlow.Driver;
 using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
@@ -407,6 +409,43 @@ public class DevFlowCliCommandTests
         Assert.Equal("app", json.GetProperty("source").GetString());
         var req = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/device/app/theme" && r.Method == "PUT");
         Assert.Contains("\"theme\":\"dark\"", req.Body);
+    }
+
+    [Theory]
+    [InlineData("ios", "Virtual", null, null, true)]
+    [InlineData("ios", "Physical", null, null, false)]
+    [InlineData("ios", null, null, "A-SIMULATOR-UDID", true)]
+    [InlineData("android", "Virtual", null, null, true)]
+    [InlineData("android", "Physical", null, null, false)]
+    [InlineData("android", null, "emulator-5554", null, true)]
+    public void ThemeHostSelector_Auto_UsesHostOnlyForDisposableVirtualTargets(
+        string platform,
+        string? deviceType,
+        string? androidDevice,
+        string? simulatorUdid,
+        bool expected)
+    {
+        var actual = ThemeHostSelector.ShouldUseHostThemeScopeAutomatically(
+            platform,
+            deviceType,
+            DevFlowTheme.Dark,
+            androidDevice,
+            simulatorUdid);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ThemeHostSelector_Auto_DoesNotUseHostForSystemTheme()
+    {
+        var actual = ThemeHostSelector.ShouldUseHostThemeScopeAutomatically(
+            "ios",
+            "Virtual",
+            DevFlowTheme.System,
+            androidDevice: null,
+            simulatorUdid: null);
+
+        Assert.False(actual);
     }
 
     // ========== device/platform info ==========

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
@@ -376,6 +376,39 @@ public class DevFlowCliCommandTests
         Assert.Equal("DELETE", req.Method);
     }
 
+    // ========== theme ==========
+
+    [Fact]
+    public async Task ThemeGet_HitsThemeRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "theme", "get", "--json");
+
+        Assert.True(result.ExitCode == 0, $"stdout: {result.StdOut}\nstderr: {result.StdErr}");
+        var json = result.ParseJsonOutput();
+        Assert.Equal("dark", json.GetProperty("theme").GetString());
+        var req = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/device/app/theme");
+        Assert.Equal("GET", req.Method);
+    }
+
+    [Fact]
+    public async Task ThemeSet_DefaultAutoOnDesktop_UsesAppThemeRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "theme", "set", "dark", "--json");
+
+        Assert.True(result.ExitCode == 0, $"stdout: {result.StdOut}\nstderr: {result.StdErr}");
+        var json = result.ParseJsonOutput();
+        Assert.Equal("dark", json.GetProperty("theme").GetString());
+        Assert.Equal("app", json.GetProperty("source").GetString());
+        var req = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/device/app/theme" && r.Method == "PUT");
+        Assert.Contains("\"theme\":\"dark\"", req.Body);
+    }
+
     // ========== device/platform info ==========
 
     [Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
@@ -122,6 +122,17 @@ internal static class MockAgentResponses
         }
         """;
 
+    public const string ThemeInfo = """
+        {
+          "theme": "dark",
+          "requestedTheme": "dark",
+          "userAppTheme": "dark",
+          "effectiveTheme": "dark",
+          "supportedThemes": ["light", "dark", "system"],
+          "source": "app"
+        }
+        """;
+
     public const string PreferencesList = """
         ["theme", "launchCount"]
         """;

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
@@ -110,6 +110,22 @@ public sealed class MockAgentServer : IAsyncDisposable
     {
         app.MapGet("/api/v1/device/info", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
         app.MapGet("/api/v1/device/app", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
+        app.MapGet("/api/v1/device/app/theme", () => Results.Content(MockAgentResponses.ThemeInfo, "application/json"));
+        app.MapPut("/api/v1/device/app/theme", async (HttpContext context) =>
+        {
+            using var document = await JsonDocument.ParseAsync(context.Request.Body);
+            var theme = document.RootElement.GetProperty("theme").GetString() ?? "system";
+            return Results.Content($$"""
+                {
+                  "theme": "{{theme}}",
+                  "requestedTheme": "{{theme}}",
+                  "userAppTheme": "{{theme}}",
+                  "effectiveTheme": "{{theme}}",
+                  "supportedThemes": ["light", "dark", "system"],
+                  "source": "app"
+                }
+                """, "application/json");
+        });
         app.MapGet("/api/v1/device/display", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
         app.MapGet("/api/v1/device/battery", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));
         app.MapGet("/api/v1/device/connectivity", () => Results.Content(MockAgentResponses.DeviceInfo, "application/json"));

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Maui.Cli.DevFlow;
 [JsonSerializable(typeof(List<ElementInfo>))]
 [JsonSerializable(typeof(NetworkRequest))]
 [JsonSerializable(typeof(List<NetworkRequest>))]
+[JsonSerializable(typeof(ThemeResult))]
+[JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(AgentRegistration))]
 [JsonSerializable(typeof(List<AgentRegistration>))]
 [JsonSerializable(typeof(AgentRegistration[]))]

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Cli.DevFlow.Skills;
 using Microsoft.Maui.Cli.Utils;
+using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.Cli.DevFlow;
 
@@ -274,6 +275,40 @@ public class DevFlowCommands
         cdpCommand.Add(sourceCmd);
         
         devflowCommand.Add(cdpCommand);
+
+        // ===== Theme commands =====
+        var themeCommand = new Command("theme", "Get or set the app/system light-dark theme");
+
+        var themeGetCmd = new Command("get", "Get the app-scoped theme reported by the agent");
+        themeGetCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            await ThemeGetAsync(host, port, isJson);
+        });
+        themeCommand.Add(themeGetCmd);
+
+        var themeArg = new Argument<string>("theme") { Description = "Theme to apply: light, dark, or system" };
+        var themeScopeOption = new Option<string>("--scope") { Description = "Where to apply the theme: auto, app, or system", DefaultValueFactory = _ => "auto" };
+        var themeDeviceOption = new Option<string?>("--device", "-d") { Description = "Android adb device/emulator serial for system-scope changes" };
+        var themeUdidOption = new Option<string?>("--udid") { Description = "iOS Simulator UDID for system-scope changes (auto-detects booted simulator if omitted for simulator targets)" };
+        var themeSetCmd = new Command("set", "Set the app or system light-dark theme") { themeArg, themeScopeOption, themeDeviceOption, themeUdidOption };
+        themeSetCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var platform = ctx.GetValue(platformOption)!;
+            var theme = ctx.GetValue(themeArg)!;
+            var scope = ctx.GetValue(themeScopeOption)!;
+            var device = ctx.GetValue(themeDeviceOption);
+            var udid = ctx.GetValue(themeUdidOption);
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            await ThemeSetAsync(host, port, platform, theme, scope, device, udid, isJson);
+        });
+        themeCommand.Add(themeSetCmd);
+
+        devflowCommand.Add(themeCommand);
         
         // ===== UI commands =====
 
@@ -2343,6 +2378,8 @@ public class DevFlowCommands
         new("webview Page captureScreenshot", "Take WebView screenshot", false),
         new("webview snapshot", "Get simplified DOM snapshot", false),
         new("webview source", "Get page HTML source", false),
+        new("theme get", "Get the current app theme", false),
+        new("theme set", "Set the app or system light-dark theme", true),
         new("agent list", "List all connected agents", false),
         new("agent wait", "Wait for an agent to connect", false),
         new("batch", "Execute commands from stdin", true),
@@ -2368,7 +2405,7 @@ public class DevFlowCommands
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = new AgentClient(host, port);
             var status = await client.GetStatusAsync(window);
             if (status == null)
             {
@@ -2387,11 +2424,182 @@ public class DevFlowCommands
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
+    private static async Task ThemeGetAsync(string host, int port, bool json)
+    {
+        try
+        {
+            using var client = new AgentClient(host, port);
+            var result = await client.GetThemeAsync();
+            if (result == null)
+            {
+                Output.WriteError($"Cannot get theme from agent at {host}:{port}", json);
+                _errorOccurred = true;
+                return;
+            }
+
+            WriteThemeResult(result, json);
+        }
+        catch (Exception ex)
+        {
+            Output.WriteError(ex.Message, json);
+            _errorOccurred = true;
+        }
+    }
+
+    private static async Task ThemeSetAsync(
+        string host,
+        int port,
+        string platform,
+        string themeValue,
+        string scopeValue,
+        string? androidDevice,
+        string? simulatorUdid,
+        bool json)
+    {
+        if (!ThemeExtensions.TryParseTheme(themeValue, out var theme))
+        {
+            Output.WriteError($"Invalid theme '{themeValue}'. Use light, dark, or system.", json, "InvalidArgument");
+            _errorOccurred = true;
+            return;
+        }
+
+        if (!ThemeExtensions.TryParseScope(scopeValue, out var scope))
+        {
+            Output.WriteError($"Invalid scope '{scopeValue}'. Use auto, app, or system.", json, "InvalidArgument");
+            _errorOccurred = true;
+            return;
+        }
+
+        try
+        {
+            using var client = new AgentClient(host, port);
+            AgentStatus? status = null;
+
+            if (scope != ThemeSetScope.System)
+                status = await client.GetStatusAsync();
+
+            var platformName = status?.Platform ?? platform;
+            var deviceType = status?.DeviceType;
+            var useHost = scope == ThemeSetScope.System
+                || ShouldUseHostThemeScopeAutomatically(platformName, deviceType, theme, androidDevice, simulatorUdid);
+
+            ThemeResult result;
+            if (useHost)
+            {
+                result = await SetHostThemeAsync(platformName, deviceType, theme, androidDevice, simulatorUdid);
+            }
+            else
+            {
+                result = await client.SetThemeAsync(theme);
+            }
+
+            WriteThemeResult(result, json);
+        }
+        catch (Exception ex)
+        {
+            Output.WriteError(ex.Message, json);
+            _errorOccurred = true;
+        }
+    }
+
+    private static bool ShouldUseHostThemeScopeAutomatically(
+        string? platform,
+        string? deviceType,
+        DevFlowTheme theme,
+        string? androidDevice,
+        string? simulatorUdid)
+    {
+        if (IsAndroidTarget(platform, androidDevice))
+            return IsVirtualDevice(deviceType) || IsAndroidEmulatorSerial(androidDevice);
+
+        if (theme == DevFlowTheme.System)
+            return false;
+
+        return IsIosSimulatorTarget(platform, deviceType, simulatorUdid);
+    }
+
+    private static async Task<ThemeResult> SetHostThemeAsync(
+        string? platform,
+        string? deviceType,
+        DevFlowTheme theme,
+        string? androidDevice,
+        string? simulatorUdid)
+    {
+        if (IsAndroidTarget(platform, androidDevice))
+        {
+            var driver = new AndroidAppDriver { Serial = androidDevice };
+            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
+        }
+
+        if (IsIosSimulatorTarget(platform, deviceType, simulatorUdid) || IsIosPlatform(platform))
+        {
+            var resolvedUdid = await ResolveUdidAsync(simulatorUdid);
+            var driver = new iOSSimulatorAppDriver { DeviceUdid = resolvedUdid };
+            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
+        }
+
+        return new ThemeResult
+        {
+            Theme = theme,
+            RequestedTheme = theme,
+            Source = "system",
+            Success = false,
+            Message = $"System theme switching is not supported for platform '{platform ?? "unknown"}'. Use --scope app.",
+        };
+    }
+
+    private static bool IsAndroidTarget(string? platform, string? androidDevice)
+        => !string.IsNullOrWhiteSpace(androidDevice)
+            || (platform?.Contains("android", StringComparison.OrdinalIgnoreCase) == true);
+
+    private static bool IsIosSimulatorTarget(string? platform, string? deviceType, string? simulatorUdid)
+    {
+        if (!string.IsNullOrWhiteSpace(simulatorUdid))
+            return true;
+
+        if (!IsVirtualDevice(deviceType))
+            return false;
+
+        return IsIosPlatform(platform);
+    }
+
+    private static bool IsIosPlatform(string? platform)
+        => platform?.Equals("ios", StringComparison.OrdinalIgnoreCase) == true
+            || platform?.Contains("iossimulator", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static bool IsVirtualDevice(string? deviceType)
+        => deviceType?.Equals("Virtual", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static bool IsAndroidEmulatorSerial(string? androidDevice)
+        => androidDevice?.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static void WriteThemeResult(ThemeResult result, bool json)
+    {
+        if (!result.Success)
+        {
+            Output.WriteError(result.Message ?? "Failed to set theme.", json, "NotSupported");
+            _errorOccurred = true;
+            return;
+        }
+
+        Output.WriteResult(result, json, static r =>
+        {
+            Console.WriteLine($"Theme: {r.Theme.ToProtocolString()}");
+            if (r.UserAppTheme is { } userTheme)
+                Console.WriteLine($"App override: {userTheme.ToProtocolString()}");
+            if (r.EffectiveTheme is { } effectiveTheme)
+                Console.WriteLine($"Effective: {effectiveTheme.ToProtocolString()}");
+            Console.WriteLine($"Source: {r.Source}");
+            if (!string.IsNullOrWhiteSpace(r.Message))
+                Console.WriteLine(r.Message);
+        });
+    }
+
     private static async Task MauiTreeAsync(string host, int port, bool json, int depth, int? window, string? fields, string? format)
     {
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = new AgentClient(host, port);
             var tree = await client.GetTreeAsync(depth, window);
             if (json)
             {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -2473,20 +2473,17 @@ public class DevFlowCommands
         try
         {
             using var client = new AgentClient(host, port);
-            AgentStatus? status = null;
-
-            if (scope != ThemeSetScope.System)
-                status = await client.GetStatusAsync();
+            var status = await client.GetStatusAsync();
 
             var platformName = status?.Platform ?? platform;
             var deviceType = status?.DeviceType;
             var useHost = scope == ThemeSetScope.System
-                || ShouldUseHostThemeScopeAutomatically(platformName, deviceType, theme, androidDevice, simulatorUdid);
+                || ThemeHostSelector.ShouldUseHostThemeScopeAutomatically(platformName, deviceType, theme, androidDevice, simulatorUdid);
 
             ThemeResult result;
             if (useHost)
             {
-                result = await SetHostThemeAsync(platformName, deviceType, theme, androidDevice, simulatorUdid);
+                result = await ThemeHostSelector.SetHostThemeAsync(platformName, deviceType, theme, androidDevice, simulatorUdid, "--scope app");
             }
             else
             {
@@ -2501,77 +2498,6 @@ public class DevFlowCommands
             _errorOccurred = true;
         }
     }
-
-    private static bool ShouldUseHostThemeScopeAutomatically(
-        string? platform,
-        string? deviceType,
-        DevFlowTheme theme,
-        string? androidDevice,
-        string? simulatorUdid)
-    {
-        if (IsAndroidTarget(platform, androidDevice))
-            return IsVirtualDevice(deviceType) || IsAndroidEmulatorSerial(androidDevice);
-
-        if (theme == DevFlowTheme.System)
-            return false;
-
-        return IsIosSimulatorTarget(platform, deviceType, simulatorUdid);
-    }
-
-    private static async Task<ThemeResult> SetHostThemeAsync(
-        string? platform,
-        string? deviceType,
-        DevFlowTheme theme,
-        string? androidDevice,
-        string? simulatorUdid)
-    {
-        if (IsAndroidTarget(platform, androidDevice))
-        {
-            var driver = new AndroidAppDriver { Serial = androidDevice };
-            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
-        }
-
-        if (IsIosSimulatorTarget(platform, deviceType, simulatorUdid) || IsIosPlatform(platform))
-        {
-            var resolvedUdid = await ResolveUdidAsync(simulatorUdid);
-            var driver = new iOSSimulatorAppDriver { DeviceUdid = resolvedUdid };
-            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
-        }
-
-        return new ThemeResult
-        {
-            Theme = theme,
-            RequestedTheme = theme,
-            Source = "system",
-            Success = false,
-            Message = $"System theme switching is not supported for platform '{platform ?? "unknown"}'. Use --scope app.",
-        };
-    }
-
-    private static bool IsAndroidTarget(string? platform, string? androidDevice)
-        => !string.IsNullOrWhiteSpace(androidDevice)
-            || (platform?.Contains("android", StringComparison.OrdinalIgnoreCase) == true);
-
-    private static bool IsIosSimulatorTarget(string? platform, string? deviceType, string? simulatorUdid)
-    {
-        if (!string.IsNullOrWhiteSpace(simulatorUdid))
-            return true;
-
-        if (!IsVirtualDevice(deviceType))
-            return false;
-
-        return IsIosPlatform(platform);
-    }
-
-    private static bool IsIosPlatform(string? platform)
-        => platform?.Equals("ios", StringComparison.OrdinalIgnoreCase) == true
-            || platform?.Contains("iossimulator", StringComparison.OrdinalIgnoreCase) == true;
-
-    private static bool IsVirtualDevice(string? deviceType)
-        => deviceType?.Equals("Virtual", StringComparison.OrdinalIgnoreCase) == true;
-
-    private static bool IsAndroidEmulatorSerial(string? androidDevice)
-        => androidDevice?.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase) == true;
 
     private static void WriteThemeResult(ThemeResult result, bool json)
     {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -43,6 +43,7 @@ public static class McpServerHost
 			.WithTools<RecordingTools>()
 			.WithTools<PreferencesTools>()
 			.WithTools<PlatformTools>()
+			.WithTools<ThemeTools>()
 			.WithTools<SensorTools>()
 			.WithTools<JobTools>()
 			.WithTools<FileTools>()

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ThemeTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ThemeTools.cs
@@ -1,9 +1,7 @@
 using System.ComponentModel;
-using System.Text.Json;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
-using Microsoft.Maui.Cli.Utils;
 using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
@@ -42,17 +40,15 @@ public sealed class ThemeTools
             throw new McpException($"Invalid scope '{scope}'. Use auto, app, or system.");
 
         using var agent = await session.GetAgentClientAsync(agentPort);
-        AgentStatus? status = null;
-        if (parsedScope != ThemeSetScope.System)
-            status = await agent.GetStatusAsync();
+        var status = await agent.GetStatusAsync();
 
         var platform = status?.Platform;
         var deviceType = status?.DeviceType;
         var useHost = parsedScope == ThemeSetScope.System
-            || ShouldUseHostThemeScopeAutomatically(platform, deviceType, parsedTheme, androidDevice, simulatorUdid);
+            || ThemeHostSelector.ShouldUseHostThemeScopeAutomatically(platform, deviceType, parsedTheme, androidDevice, simulatorUdid);
 
         ThemeResult result = useHost
-            ? await SetHostThemeAsync(platform, deviceType, parsedTheme, androidDevice, simulatorUdid)
+            ? await ThemeHostSelector.SetHostThemeAsync(platform, deviceType, parsedTheme, androidDevice, simulatorUdid, "app scope")
             : await agent.SetThemeAsync(parsedTheme);
 
         if (!result.Success)
@@ -60,98 +56,4 @@ public sealed class ThemeTools
 
         return CliJson.SerializeUntyped(result, indented: false);
     }
-
-    private static bool ShouldUseHostThemeScopeAutomatically(
-        string? platform,
-        string? deviceType,
-        DevFlowTheme theme,
-        string? androidDevice,
-        string? simulatorUdid)
-    {
-        if (IsAndroidTarget(platform, androidDevice))
-            return IsVirtualDevice(deviceType) || IsAndroidEmulatorSerial(androidDevice);
-
-        if (theme == DevFlowTheme.System)
-            return false;
-
-        return IsIosSimulatorTarget(platform, deviceType, simulatorUdid);
-    }
-
-    private static async Task<ThemeResult> SetHostThemeAsync(
-        string? platform,
-        string? deviceType,
-        DevFlowTheme theme,
-        string? androidDevice,
-        string? simulatorUdid)
-    {
-        if (IsAndroidTarget(platform, androidDevice))
-        {
-            var driver = new AndroidAppDriver { Serial = androidDevice };
-            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
-        }
-
-        if (IsIosSimulatorTarget(platform, deviceType, simulatorUdid))
-        {
-            var resolvedUdid = await ResolveUdidAsync(simulatorUdid);
-            var driver = new iOSSimulatorAppDriver { DeviceUdid = resolvedUdid };
-            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
-        }
-
-        return new ThemeResult
-        {
-            Theme = theme,
-            RequestedTheme = theme,
-            Source = "system",
-            Success = false,
-            Message = $"System theme switching is not supported for platform '{platform ?? "unknown"}'. Use app scope.",
-        };
-    }
-
-    private static async Task<string> ResolveUdidAsync(string? udid)
-    {
-        if (!string.IsNullOrWhiteSpace(udid))
-            return udid;
-
-        var result = await ProcessRunner.RunAsync("xcrun", ["simctl", "list", "devices", "booted", "-j"]);
-        if (!result.Success)
-            throw new McpException($"Failed to resolve simulator UDID: {result.StandardError.Trim()}");
-
-        using var document = JsonDocument.Parse(result.StandardOutput);
-        if (document.RootElement.TryGetProperty("devices", out var devices))
-        {
-            foreach (var runtime in devices.EnumerateObject())
-            {
-                foreach (var device in runtime.Value.EnumerateArray())
-                {
-                    var state = device.TryGetProperty("state", out var stateElement) ? stateElement.GetString() : null;
-                    if (state == "Booted")
-                        return device.GetProperty("udid").GetString()!;
-                }
-            }
-        }
-
-        throw new McpException("No booted simulator found. Pass simulatorUdid or boot a simulator.");
-    }
-
-    private static bool IsAndroidTarget(string? platform, string? androidDevice)
-        => !string.IsNullOrWhiteSpace(androidDevice)
-            || (platform?.Contains("android", StringComparison.OrdinalIgnoreCase) == true);
-
-    private static bool IsIosSimulatorTarget(string? platform, string? deviceType, string? simulatorUdid)
-    {
-        if (!string.IsNullOrWhiteSpace(simulatorUdid))
-            return true;
-
-        if (!IsVirtualDevice(deviceType))
-            return false;
-
-        return platform?.Equals("ios", StringComparison.OrdinalIgnoreCase) == true
-            || platform?.Contains("iossimulator", StringComparison.OrdinalIgnoreCase) == true;
-    }
-
-    private static bool IsVirtualDevice(string? deviceType)
-        => deviceType?.Equals("Virtual", StringComparison.OrdinalIgnoreCase) == true;
-
-    private static bool IsAndroidEmulatorSerial(string? androidDevice)
-        => androidDevice?.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ThemeTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ThemeTools.cs
@@ -1,0 +1,157 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using Microsoft.Maui.Cli.DevFlow.Mcp;
+using Microsoft.Maui.Cli.Utils;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class ThemeTools
+{
+    [McpServerTool(Name = "maui_get_theme"),
+     Description("Get the current app-scoped light/dark theme reported by the connected MAUI DevFlow agent.")]
+    public static async Task<string> GetTheme(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+    {
+        using var agent = await session.GetAgentClientAsync(agentPort);
+        var result = await agent.GetThemeAsync();
+        if (result == null)
+            throw new McpException("Unable to retrieve theme. The agent may not be running or may not support theme switching.");
+
+        return CliJson.SerializeUntyped(result, indented: false);
+    }
+
+    [McpServerTool(Name = "maui_set_theme"),
+     Description("Set the running app or disposable emulator/simulator to light, dark, or system theme. Scope defaults to auto: uses system scope only for Android emulators and iOS simulators, and app scope for desktops or physical devices.")]
+    public static async Task<string> SetTheme(
+        McpAgentSession session,
+        [Description("Theme to apply: light, dark, or system. System means follow the OS in app scope; iOS Simulator host scope supports only light and dark.")] string theme,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+        [Description("Where to apply the theme: auto, app, or system. Auto uses host-side switching only for Android emulators and iOS simulators.")] string scope = "auto",
+        [Description("Android adb device/emulator serial for system-scope changes. Optional when adb has exactly one target.")] string? androidDevice = null,
+        [Description("iOS Simulator UDID for system-scope changes. If omitted for simulator targets, the booted simulator is auto-detected.")] string? simulatorUdid = null)
+    {
+        if (!ThemeExtensions.TryParseTheme(theme, out var parsedTheme))
+            throw new McpException($"Invalid theme '{theme}'. Use light, dark, or system.");
+
+        if (!ThemeExtensions.TryParseScope(scope, out var parsedScope))
+            throw new McpException($"Invalid scope '{scope}'. Use auto, app, or system.");
+
+        using var agent = await session.GetAgentClientAsync(agentPort);
+        AgentStatus? status = null;
+        if (parsedScope != ThemeSetScope.System)
+            status = await agent.GetStatusAsync();
+
+        var platform = status?.Platform;
+        var deviceType = status?.DeviceType;
+        var useHost = parsedScope == ThemeSetScope.System
+            || ShouldUseHostThemeScopeAutomatically(platform, deviceType, parsedTheme, androidDevice, simulatorUdid);
+
+        ThemeResult result = useHost
+            ? await SetHostThemeAsync(platform, deviceType, parsedTheme, androidDevice, simulatorUdid)
+            : await agent.SetThemeAsync(parsedTheme);
+
+        if (!result.Success)
+            throw new McpException(result.Message ?? "Failed to set theme.");
+
+        return CliJson.SerializeUntyped(result, indented: false);
+    }
+
+    private static bool ShouldUseHostThemeScopeAutomatically(
+        string? platform,
+        string? deviceType,
+        DevFlowTheme theme,
+        string? androidDevice,
+        string? simulatorUdid)
+    {
+        if (IsAndroidTarget(platform, androidDevice))
+            return IsVirtualDevice(deviceType) || IsAndroidEmulatorSerial(androidDevice);
+
+        if (theme == DevFlowTheme.System)
+            return false;
+
+        return IsIosSimulatorTarget(platform, deviceType, simulatorUdid);
+    }
+
+    private static async Task<ThemeResult> SetHostThemeAsync(
+        string? platform,
+        string? deviceType,
+        DevFlowTheme theme,
+        string? androidDevice,
+        string? simulatorUdid)
+    {
+        if (IsAndroidTarget(platform, androidDevice))
+        {
+            var driver = new AndroidAppDriver { Serial = androidDevice };
+            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
+        }
+
+        if (IsIosSimulatorTarget(platform, deviceType, simulatorUdid))
+        {
+            var resolvedUdid = await ResolveUdidAsync(simulatorUdid);
+            var driver = new iOSSimulatorAppDriver { DeviceUdid = resolvedUdid };
+            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
+        }
+
+        return new ThemeResult
+        {
+            Theme = theme,
+            RequestedTheme = theme,
+            Source = "system",
+            Success = false,
+            Message = $"System theme switching is not supported for platform '{platform ?? "unknown"}'. Use app scope.",
+        };
+    }
+
+    private static async Task<string> ResolveUdidAsync(string? udid)
+    {
+        if (!string.IsNullOrWhiteSpace(udid))
+            return udid;
+
+        var result = await ProcessRunner.RunAsync("xcrun", ["simctl", "list", "devices", "booted", "-j"]);
+        if (!result.Success)
+            throw new McpException($"Failed to resolve simulator UDID: {result.StandardError.Trim()}");
+
+        using var document = JsonDocument.Parse(result.StandardOutput);
+        if (document.RootElement.TryGetProperty("devices", out var devices))
+        {
+            foreach (var runtime in devices.EnumerateObject())
+            {
+                foreach (var device in runtime.Value.EnumerateArray())
+                {
+                    var state = device.TryGetProperty("state", out var stateElement) ? stateElement.GetString() : null;
+                    if (state == "Booted")
+                        return device.GetProperty("udid").GetString()!;
+                }
+            }
+        }
+
+        throw new McpException("No booted simulator found. Pass simulatorUdid or boot a simulator.");
+    }
+
+    private static bool IsAndroidTarget(string? platform, string? androidDevice)
+        => !string.IsNullOrWhiteSpace(androidDevice)
+            || (platform?.Contains("android", StringComparison.OrdinalIgnoreCase) == true);
+
+    private static bool IsIosSimulatorTarget(string? platform, string? deviceType, string? simulatorUdid)
+    {
+        if (!string.IsNullOrWhiteSpace(simulatorUdid))
+            return true;
+
+        if (!IsVirtualDevice(deviceType))
+            return false;
+
+        return platform?.Equals("ios", StringComparison.OrdinalIgnoreCase) == true
+            || platform?.Contains("iossimulator", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    private static bool IsVirtualDevice(string? deviceType)
+        => deviceType?.Equals("Virtual", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static bool IsAndroidEmulatorSerial(string? androidDevice)
+        => androidDevice?.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/ThemeHostSelector.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/ThemeHostSelector.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using Microsoft.Maui.Cli.Utils;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.Cli.DevFlow;
+
+internal static class ThemeHostSelector
+{
+    public static bool ShouldUseHostThemeScopeAutomatically(
+        string? platform,
+        string? deviceType,
+        DevFlowTheme theme,
+        string? androidDevice,
+        string? simulatorUdid)
+    {
+        if (IsAndroidTarget(platform, androidDevice))
+            return IsVirtualDevice(deviceType) || IsAndroidEmulatorSerial(androidDevice);
+
+        if (theme == DevFlowTheme.System)
+            return false;
+
+        return IsIosSimulatorTarget(platform, deviceType, simulatorUdid);
+    }
+
+    public static async Task<ThemeResult> SetHostThemeAsync(
+        string? platform,
+        string? deviceType,
+        DevFlowTheme theme,
+        string? androidDevice,
+        string? simulatorUdid,
+        string appScopeSuggestion)
+    {
+        if (IsAndroidTarget(platform, androidDevice))
+        {
+            var driver = new AndroidAppDriver { Serial = androidDevice };
+            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
+        }
+
+        if (IsIosSimulatorTarget(platform, deviceType, simulatorUdid))
+        {
+            var resolvedUdid = await ResolveUdidAsync(simulatorUdid);
+            var driver = new iOSSimulatorAppDriver { DeviceUdid = resolvedUdid };
+            return await driver.SetThemeAsync(theme, ThemeSetScope.System);
+        }
+
+        return new ThemeResult
+        {
+            Theme = theme,
+            RequestedTheme = theme,
+            Source = "system",
+            Success = false,
+            Message = $"System theme switching is not supported for platform '{platform ?? "unknown"}'. Use {appScopeSuggestion}.",
+        };
+    }
+
+    private static async Task<string> ResolveUdidAsync(string? udid)
+    {
+        if (!string.IsNullOrWhiteSpace(udid))
+            return udid;
+
+        var result = await ProcessRunner.RunAsync("xcrun", ["simctl", "list", "devices", "booted", "-j"]);
+        if (!result.Success || string.IsNullOrWhiteSpace(result.StandardOutput))
+        {
+            var detail = string.IsNullOrWhiteSpace(result.StandardError)
+                ? $"xcrun simctl list devices booted -j exited with code {result.ExitCode}."
+                : result.StandardError.Trim();
+            throw new InvalidOperationException($"Failed to resolve simulator UDID: {detail}");
+        }
+
+        using var document = JsonDocument.Parse(result.StandardOutput);
+        if (document.RootElement.TryGetProperty("devices", out var devices))
+        {
+            foreach (var runtime in devices.EnumerateObject())
+            {
+                foreach (var device in runtime.Value.EnumerateArray())
+                {
+                    var state = device.TryGetProperty("state", out var stateElement) ? stateElement.GetString() : null;
+                    if (state == "Booted")
+                        return device.GetProperty("udid").GetString()!;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("No booted simulator found. Pass --udid or boot a simulator.");
+    }
+
+    private static bool IsAndroidTarget(string? platform, string? androidDevice)
+        => !string.IsNullOrWhiteSpace(androidDevice)
+            || (platform?.Contains("android", StringComparison.OrdinalIgnoreCase) == true);
+
+    private static bool IsIosSimulatorTarget(string? platform, string? deviceType, string? simulatorUdid)
+    {
+        if (!string.IsNullOrWhiteSpace(simulatorUdid))
+            return true;
+
+        if (!IsVirtualDevice(deviceType))
+            return false;
+
+        return platform?.Equals("ios", StringComparison.OrdinalIgnoreCase) == true
+            || platform?.Contains("iossimulator", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    private static bool IsVirtualDevice(string? deviceType)
+        => deviceType?.Equals("Virtual", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static bool IsAndroidEmulatorSerial(string? androidDevice)
+        => androidDevice?.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -519,6 +520,8 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         _server.MapGet("/api/v1/device/jobs", HandleJobsList);
         _server.MapPost("/api/v1/device/jobs/{identifier}/run", HandleJobRun);
 
+        _server.MapGet("/api/v1/device/app/theme", HandleThemeGet);
+        _server.MapPut("/api/v1/device/app/theme", HandleThemeSet);
         _server.MapGet("/api/v1/storage/preferences", HandlePreferencesList);
         _server.MapGet("/api/v1/storage/preferences/{key}", HandlePreferencesGet);
         _server.MapPut("/api/v1/storage/preferences/{key}", HandlePreferencesSet);
@@ -680,6 +683,11 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                 features = IsJobsSupported
                     ? IsJobRunSupported ? new[] { "list", "run" } : new[] { "list" }
                     : Array.Empty<string>()
+            },
+            theme = new
+            {
+                supported = true,
+                features = new[] { "get", "set" }
             },
             invoke = new
             {
@@ -5772,6 +5780,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     private const string PlatformErrorReasonUnknown = "unknown";
     private const string PlatformErrorReasonInvalidRequest = "invalid_request";
     private static readonly Regex AndroidPermissionRegex = new(@"android\.permission\.[A-Z0-9_\.]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly string[] SupportedThemeNames = ["light", "dark", "system"];
 
     private static HttpResponse CreatePlatformError(string message, Exception ex, int statusCode = 400, Dictionary<string, object?>? details = null)
     {
@@ -5875,13 +5884,17 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             return await MainThread.InvokeOnMainThreadAsync(() =>
             {
                 var info = AppInfo.Current;
+                var theme = BuildThemeInfoPayload(Application.Current ?? _app);
                 return HttpResponse.Json(new
                 {
                     name = info.Name,
                     packageName = info.PackageName,
                     version = info.VersionString,
                     buildNumber = info.BuildString,
-                    requestedTheme = info.RequestedTheme.ToString(),
+                    theme = theme.Theme,
+                    requestedTheme = theme.RequestedTheme,
+                    userAppTheme = theme.UserAppTheme,
+                    effectiveTheme = theme.EffectiveTheme,
                     requestedLayoutDirection = info.RequestedLayoutDirection.ToString(),
                 });
             });
@@ -5891,6 +5904,151 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             return CreatePlatformError($"Failed to get app info: {ex.Message}", ex);
         }
     }
+
+    private async Task<HttpResponse> HandleThemeGet(HttpRequest request)
+    {
+        try
+        {
+            var app = Application.Current ?? _app;
+            if (app == null)
+                return HttpResponse.Error("Agent not bound to app", reason: "agent-not-bound");
+
+            var theme = await DispatchAsync(() => BuildThemeInfoPayload(app));
+            return HttpResponse.Json(theme);
+        }
+        catch (Exception ex)
+        {
+            return CreatePlatformError($"Failed to get app theme: {ex.Message}", ex);
+        }
+    }
+
+    private async Task<HttpResponse> HandleThemeSet(HttpRequest request)
+    {
+        var body = request.BodyAs<ThemeSetRequest>();
+        if (string.IsNullOrWhiteSpace(body?.Theme))
+            return HttpResponse.Error("theme is required", reason: "invalid-argument");
+
+        if (!TryParseTheme(body.Theme, out var appTheme))
+        {
+            return HttpResponse.Error(
+                $"Theme '{body.Theme}' is not supported. Use light, dark, or system.",
+                reason: "invalid-argument",
+                details: new { supportedThemes = SupportedThemeNames });
+        }
+
+        try
+        {
+            var app = Application.Current ?? _app;
+            if (app == null)
+                return HttpResponse.Error("Agent not bound to app", reason: "agent-not-bound");
+
+            var theme = await DispatchAsync(() =>
+            {
+                app.UserAppTheme = appTheme;
+                return BuildThemeInfoPayload(app);
+            });
+
+            PublishUiEvent("themeChange", new
+            {
+                theme = theme.Theme,
+                requestedTheme = theme.RequestedTheme,
+                userAppTheme = theme.UserAppTheme,
+                effectiveTheme = theme.EffectiveTheme,
+                source = theme.Source,
+                timestamp = DateTimeOffset.UtcNow.ToString("O")
+            });
+
+            return HttpResponse.Json(theme);
+        }
+        catch (Exception ex)
+        {
+            return CreatePlatformError($"Failed to set app theme: {ex.Message}", ex);
+        }
+    }
+
+    private static ThemeInfoPayload BuildThemeInfoPayload(Application? app, string source = "app", string? message = null)
+    {
+        var requestedTheme = SafeGetRequestedTheme(app);
+        var userAppTheme = SafeGetUserAppTheme(app);
+        var effectiveTheme = userAppTheme == AppTheme.Unspecified ? requestedTheme : userAppTheme;
+
+        return new ThemeInfoPayload(
+            ThemeToProtocolString(effectiveTheme),
+            ThemeToProtocolString(requestedTheme),
+            ThemeToProtocolString(userAppTheme),
+            ThemeToProtocolString(effectiveTheme),
+            SupportedThemeNames,
+            source,
+            message);
+    }
+
+    private static AppTheme SafeGetRequestedTheme(Application? app)
+    {
+        if (app == null)
+            return AppTheme.Unspecified;
+
+        try
+        {
+            return app.RequestedTheme;
+        }
+        catch
+        {
+            return AppTheme.Unspecified;
+        }
+    }
+
+    private static AppTheme SafeGetUserAppTheme(Application? app)
+    {
+        if (app == null)
+            return AppTheme.Unspecified;
+
+        try
+        {
+            return app.UserAppTheme;
+        }
+        catch
+        {
+            return AppTheme.Unspecified;
+        }
+    }
+
+    private static bool TryParseTheme(string value, out AppTheme theme)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "light":
+                theme = AppTheme.Light;
+                return true;
+            case "dark":
+                theme = AppTheme.Dark;
+                return true;
+            case "system":
+            case "default":
+            case "unspecified":
+            case "unset":
+                theme = AppTheme.Unspecified;
+                return true;
+            default:
+                theme = AppTheme.Unspecified;
+                return false;
+        }
+    }
+
+    private static string ThemeToProtocolString(AppTheme theme) => theme switch
+    {
+        AppTheme.Light => "light",
+        AppTheme.Dark => "dark",
+        _ => "system"
+    };
+
+    private sealed record ThemeInfoPayload(
+        [property: JsonPropertyName("theme")] string Theme,
+        [property: JsonPropertyName("requestedTheme")] string RequestedTheme,
+        [property: JsonPropertyName("userAppTheme")] string UserAppTheme,
+        [property: JsonPropertyName("effectiveTheme")] string EffectiveTheme,
+        [property: JsonPropertyName("supportedThemes")] IReadOnlyList<string> SupportedThemes,
+        [property: JsonPropertyName("source")] string Source,
+        [property: JsonPropertyName("message")] string? Message);
 
     private Task<HttpResponse> HandlePlatformDeviceInfo(HttpRequest request)
     {
@@ -6374,6 +6532,11 @@ public class PreferenceSetRequest
     public object? Value { get; set; }
     public string? Type { get; set; }
     public string? SharedName { get; set; }
+}
+
+public class ThemeSetRequest
+{
+    public string? Theme { get; set; }
 }
 
 public class SecureStorageSetRequest

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -636,60 +636,62 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
     private Task<HttpResponse> HandleCapabilities(HttpRequest request)
     {
-        var result = new
+        var themeCapability = new
         {
-            ui = new
+            supported = true,
+            features = new[] { "get", "set" }
+        };
+        var result = new Dictionary<string, object>
+        {
+            ["ui"] = new
             {
                 supported = true,
                 features = new[] { "tree", "query", "hit-test", "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "properties", "screenshot" }
             },
-            webview = new
+            ["webview"] = new
             {
                 supported = _cdpWebViews.Any(v => v.IsReady),
                 features = _cdpWebViews.Any(v => v.IsReady)
                     ? new[] { "evaluate", "contexts", "source", "dom", "dom-query", "network", "console", "screenshot" }
                     : Array.Empty<string>()
             },
-            network = new
+            ["network"] = new
             {
                 supported = true,
                 features = new[] { "list", "detail", "clear", "stream" }
             },
-            logs = new
+            ["logs"] = new
             {
                 supported = true,
                 features = new[] { "list", "stream" }
             },
-            sensors = new
+            ["sensors"] = new
             {
                 supported = true,
                 features = new[] { "list", "start", "stop", "stream" }
             },
-            storage = new
+            ["storage"] = new
             {
                 supported = true,
                 features = new[] { "preferences", "secure-storage", "roots", "files" }
             },
-            profiler = new
+            ["profiler"] = new
             {
                 supported = IsProfilerFeatureAvailable,
                 features = IsProfilerFeatureAvailable
                     ? new[] { "capabilities", "sessions", "samples", "markers", "spans", "hotspots" }
                     : Array.Empty<string>()
             },
-            jobs = new
+            ["jobs"] = new
             {
                 supported = IsJobsSupported,
                 features = IsJobsSupported
                     ? IsJobRunSupported ? new[] { "list", "run" } : new[] { "list" }
                     : Array.Empty<string>()
             },
-            theme = new
-            {
-                supported = true,
-                features = new[] { "get", "set" }
-            },
-            invoke = new
+            ["theme"] = themeCapability,
+            ["app.theme"] = themeCapability,
+            ["invoke"] = new
             {
                 supported = true,
                 features = new[] { "actions" }
@@ -5892,7 +5894,8 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     version = info.VersionString,
                     buildNumber = info.BuildString,
                     theme = theme.Theme,
-                    requestedTheme = theme.RequestedTheme,
+                    requestedTheme = info.RequestedTheme.ToString(),
+                    requestedThemeValue = theme.RequestedTheme,
                     userAppTheme = theme.UserAppTheme,
                     effectiveTheme = theme.EffectiveTheme,
                     requestedLayoutDirection = info.RequestedLayoutDirection.ToString(),

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -292,6 +292,50 @@ public class AgentClient : IDisposable
     }
 
     /// <summary>
+    /// Get the app-scoped theme currently reported by the agent.
+    /// </summary>
+    public async Task<ThemeResult?> GetThemeAsync()
+    {
+        var result = await GetAsync<ThemeResult>($"{DeviceApi}/app/theme");
+        return result == null ? null : WithSuccessfulThemeResult(result);
+    }
+
+    /// <summary>
+    /// Set the app-scoped theme inside the running MAUI app.
+    /// </summary>
+    public async Task<ThemeResult> SetThemeAsync(DevFlowTheme theme)
+    {
+        var body = new JsonObject
+        {
+            ["theme"] = theme.ToProtocolString(),
+        };
+
+        var result = await PutJsonAsync<ThemeResult>($"{DeviceApi}/app/theme", body);
+        return result != null ? WithSuccessfulThemeResult(result) : new ThemeResult
+        {
+            Theme = theme,
+            RequestedTheme = theme,
+            UserAppTheme = theme,
+            Source = "app",
+            Success = false,
+            Message = "Failed to set app theme.",
+        };
+    }
+
+    private static ThemeResult WithSuccessfulThemeResult(ThemeResult result)
+        => new()
+        {
+            Theme = result.Theme,
+            RequestedTheme = result.RequestedTheme,
+            UserAppTheme = result.UserAppTheme,
+            EffectiveTheme = result.EffectiveTheme,
+            SupportedThemes = result.SupportedThemes,
+            Source = result.Source,
+            Success = true,
+            Message = result.Message,
+        };
+
+    /// <summary>
     /// Retrieve application logs from the agent.
     /// </summary>
     public async Task<string> GetLogsAsync(int limit = 100, int skip = 0, string? source = null)
@@ -513,6 +557,26 @@ public class AgentClient : IDisposable
         {
             using var content = DriverJson.CreateJsonContent(body);
             var response = await _http.PostAsync($"{_baseUrl}{path}", content);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(responseBody))
+                return null;
+            return DriverJson.Deserialize<T>(responseBody);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task<T?> PutJsonAsync<T>(string path, JsonNode body) where T : class
+    {
+        try
+        {
+            using var content = DriverJson.CreateJsonContent(body);
+            var response = await _http.PutAsync($"{_baseUrl}{path}", content);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
             var responseBody = await response.Content.ReadAsStringAsync();
             if (string.IsNullOrWhiteSpace(responseBody))
                 return null;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
@@ -43,6 +43,67 @@ public class AndroidAppDriver : AppDriverBase
         await RunAdbAsync($"shell input keyevent {keycode}");
     }
 
+    public override async Task<ThemeResult> SetThemeAsync(DevFlowTheme theme, ThemeSetScope scope = ThemeSetScope.Auto)
+    {
+        if (scope == ThemeSetScope.App)
+            return await base.SetThemeAsync(theme, scope).ConfigureAwait(false);
+
+        if (scope == ThemeSetScope.System || await ShouldUseHostThemeAsync().ConfigureAwait(false))
+            return await SetHostThemeAsync(theme).ConfigureAwait(false);
+
+        return await base.SetThemeAsync(theme, ThemeSetScope.App).ConfigureAwait(false);
+    }
+
+    private async Task<bool> ShouldUseHostThemeAsync()
+    {
+        try
+        {
+            var status = await GetStatusAsync().ConfigureAwait(false);
+            if (status?.DeviceType?.Equals("Virtual", StringComparison.OrdinalIgnoreCase) == true)
+                return true;
+            if (status?.DeviceType?.Equals("Physical", StringComparison.OrdinalIgnoreCase) == true)
+                return false;
+        }
+        catch
+        {
+        }
+
+        if (Serial?.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase) == true)
+            return true;
+
+        try
+        {
+            var qemu = await RunAdbWithOutputAsync("shell getprop ro.kernel.qemu").ConfigureAwait(false);
+            return qemu.Trim().Equals("1", StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task<ThemeResult> SetHostThemeAsync(DevFlowTheme theme)
+    {
+        var mode = theme switch
+        {
+            DevFlowTheme.Light => "no",
+            DevFlowTheme.Dark => "yes",
+            _ => "auto",
+        };
+
+        await RunAdbAsync($"shell cmd uimode night {mode}").ConfigureAwait(false);
+
+        return new ThemeResult
+        {
+            Theme = theme,
+            RequestedTheme = theme,
+            EffectiveTheme = theme,
+            Source = "system",
+            Success = true,
+            Message = $"Android system theme set to {theme.ToProtocolString()}.",
+        };
+    }
+
     // ──────────────────────────────────────────────
     // Dialog Detection & Dismissal via UIAutomator
     // ──────────────────────────────────────────────

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AppDriverBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AppDriverBase.cs
@@ -28,6 +28,26 @@ public abstract class AppDriverBase : IAppDriver
     public Task<AgentStatus?> GetStatusAsync()
         => EnsureClient().GetStatusAsync();
 
+    public Task<ThemeResult?> GetThemeAsync()
+        => EnsureClient().GetThemeAsync();
+
+    public virtual Task<ThemeResult> SetThemeAsync(DevFlowTheme theme, ThemeSetScope scope = ThemeSetScope.Auto)
+    {
+        if (scope == ThemeSetScope.System)
+        {
+            return Task.FromResult(new ThemeResult
+            {
+                Theme = theme,
+                RequestedTheme = theme,
+                Source = "system",
+                Success = false,
+                Message = $"System theme switching is not supported on {Platform}. Use app scope instead.",
+            });
+        }
+
+        return EnsureClient().SetThemeAsync(theme);
+    }
+
     public Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0)
         => EnsureClient().GetTreeAsync(maxDepth);
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/DevFlowDriverJson.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/DevFlowDriverJson.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui.DevFlow.Driver;
 [JsonSerializable(typeof(ProfilerBatch))]
 [JsonSerializable(typeof(List<ProfilerHotspot>))]
 [JsonSerializable(typeof(RecordingState))]
+[JsonSerializable(typeof(ThemeResult))]
+[JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(AgentClient.ProfilerSessionEnvelope))]
 [JsonSerializable(typeof(AgentClient.ActionResponse))]
 [JsonSerializable(typeof(InvokeResult))]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/IAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/IAppDriver.cs
@@ -22,6 +22,16 @@ public interface IAppDriver : IDisposable
     Task<AgentStatus?> GetStatusAsync();
 
     /// <summary>
+    /// Get the current app theme.
+    /// </summary>
+    Task<ThemeResult?> GetThemeAsync();
+
+    /// <summary>
+    /// Set the current app or system theme.
+    /// </summary>
+    Task<ThemeResult> SetThemeAsync(DevFlowTheme theme, ThemeSetScope scope = ThemeSetScope.Auto);
+
+    /// <summary>
     /// Get the visual tree.
     /// </summary>
     Task<List<ElementInfo>> GetTreeAsync(int maxDepth = 0);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ThemeModels.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ThemeModels.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.DevFlow.Driver;
+
+[JsonConverter(typeof(DevFlowThemeJsonConverter))]
+public enum DevFlowTheme
+{
+    System,
+    Light,
+    Dark,
+}
+
+[JsonConverter(typeof(ThemeSetScopeJsonConverter))]
+public enum ThemeSetScope
+{
+    Auto,
+    App,
+    System,
+}
+
+public sealed class ThemeResult
+{
+    private bool? _success;
+
+    [JsonPropertyName("theme")]
+    public DevFlowTheme Theme { get; init; }
+
+    [JsonPropertyName("requestedTheme")]
+    public DevFlowTheme? RequestedTheme { get; init; }
+
+    [JsonPropertyName("userAppTheme")]
+    public DevFlowTheme? UserAppTheme { get; init; }
+
+    [JsonPropertyName("effectiveTheme")]
+    public DevFlowTheme? EffectiveTheme { get; init; }
+
+    [JsonPropertyName("supportedThemes")]
+    public string[]? SupportedThemes { get; init; }
+
+    [JsonPropertyName("source")]
+    public string Source { get; init; } = "app";
+
+    [JsonPropertyName("success")]
+    public bool Success
+    {
+        get => _success ?? true;
+        init => _success = value;
+    }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+}
+
+public sealed class DevFlowThemeJsonConverter : JsonConverter<DevFlowTheme>
+{
+    public override DevFlowTheme Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String &&
+            ThemeExtensions.TryParseTheme(reader.GetString(), out var theme))
+            return theme;
+
+        throw new JsonException("Expected theme value light, dark, or system.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, DevFlowTheme value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.ToProtocolString());
+}
+
+public sealed class ThemeSetScopeJsonConverter : JsonConverter<ThemeSetScope>
+{
+    public override ThemeSetScope Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String &&
+            ThemeExtensions.TryParseScope(reader.GetString(), out var scope))
+            return scope;
+
+        throw new JsonException("Expected theme scope value auto, app, or system.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, ThemeSetScope value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.ToProtocolString());
+}
+
+public static class ThemeExtensions
+{
+    public static string ToProtocolString(this DevFlowTheme theme) => theme switch
+    {
+        DevFlowTheme.Light => "light",
+        DevFlowTheme.Dark => "dark",
+        _ => "system",
+    };
+
+    public static string ToProtocolString(this ThemeSetScope scope) => scope switch
+    {
+        ThemeSetScope.App => "app",
+        ThemeSetScope.System => "system",
+        _ => "auto",
+    };
+
+    public static bool TryParseTheme(string? value, out DevFlowTheme theme)
+    {
+        switch (value?.Trim().ToLowerInvariant())
+        {
+            case "light":
+                theme = DevFlowTheme.Light;
+                return true;
+            case "dark":
+                theme = DevFlowTheme.Dark;
+                return true;
+            case "system":
+            case "default":
+            case "unspecified":
+            case "unset":
+                theme = DevFlowTheme.System;
+                return true;
+            default:
+                theme = DevFlowTheme.System;
+                return false;
+        }
+    }
+
+    public static bool TryParseScope(string? value, out ThemeSetScope scope)
+    {
+        switch (value?.Trim().ToLowerInvariant())
+        {
+            case null:
+            case "":
+            case "auto":
+                scope = ThemeSetScope.Auto;
+                return true;
+            case "app":
+            case "application":
+                scope = ThemeSetScope.App;
+                return true;
+            case "system":
+            case "host":
+            case "device":
+                scope = ThemeSetScope.System;
+                return true;
+            default:
+                scope = ThemeSetScope.Auto;
+                return false;
+        }
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/iOSSimulatorAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/iOSSimulatorAppDriver.cs
@@ -35,6 +35,38 @@ public class iOSSimulatorAppDriver : AppDriverBase
     /// </summary>
     public string? BundleId { get; set; }
 
+    public override async Task<ThemeResult> SetThemeAsync(DevFlowTheme theme, ThemeSetScope scope = ThemeSetScope.Auto)
+    {
+        if (scope == ThemeSetScope.App || (scope == ThemeSetScope.Auto && theme == DevFlowTheme.System))
+            return await base.SetThemeAsync(theme, ThemeSetScope.App).ConfigureAwait(false);
+
+        if (theme == DevFlowTheme.System)
+        {
+            return new ThemeResult
+            {
+                Theme = theme,
+                RequestedTheme = theme,
+                Source = "system",
+                Success = false,
+                Message = "iOS Simulator host appearance supports light and dark only. Use app scope for system theme.",
+            };
+        }
+
+        EnsureDeviceUdid();
+        var appearance = theme == DevFlowTheme.Dark ? "dark" : "light";
+        await RunProcessAsync("xcrun", $"simctl ui {DeviceUdid} appearance {appearance}").ConfigureAwait(false);
+
+        return new ThemeResult
+        {
+            Theme = theme,
+            RequestedTheme = theme,
+            EffectiveTheme = theme,
+            Source = "system",
+            Success = true,
+            Message = $"iOS Simulator appearance set to {appearance}.",
+        };
+    }
+
     // --- Permission management via xcrun simctl privacy ---
 
     /// <summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ThemeAgentClientTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ThemeAgentClientTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class ThemeAgentClientTests
+{
+    [Fact]
+    public async Task Theme_GetSetFlow_WorksThroughAgentClient()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var serverTask = Task.Run(async () =>
+        {
+            for (var i = 0; i < 2; i++)
+            {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                var request = await ReadRequestAsync(stream);
+
+                if (request.Contains("GET /api/v1/device/app/theme", StringComparison.Ordinal))
+                {
+                    await WriteJsonResponseAsync(stream, """
+                    {
+                      "theme": "dark",
+                      "requestedTheme": "dark",
+                      "userAppTheme": "dark",
+                      "effectiveTheme": "dark",
+                      "supportedThemes": ["light", "dark", "system"],
+                      "source": "app"
+                    }
+                    """);
+                    continue;
+                }
+
+                if (request.Contains("PUT /api/v1/device/app/theme", StringComparison.Ordinal))
+                {
+                    Assert.Contains("\"theme\":\"light\"", request);
+                    await WriteJsonResponseAsync(stream, """
+                    {
+                      "theme": "light",
+                      "requestedTheme": "light",
+                      "userAppTheme": "light",
+                      "effectiveTheme": "light",
+                      "supportedThemes": ["light", "dark", "system"],
+                      "source": "app"
+                    }
+                    """);
+                    continue;
+                }
+
+                throw new InvalidOperationException($"Unexpected request: {request}");
+            }
+        });
+
+        using var agent = new AgentClient("localhost", port);
+
+        var current = await agent.GetThemeAsync();
+        Assert.NotNull(current);
+        Assert.Equal(DevFlowTheme.Dark, current.Theme);
+        Assert.Equal(DevFlowTheme.Dark, current.EffectiveTheme);
+        Assert.True(current.Success);
+
+        var updated = await agent.SetThemeAsync(DevFlowTheme.Light);
+        Assert.Equal(DevFlowTheme.Light, updated.Theme);
+        Assert.Equal(DevFlowTheme.Light, updated.UserAppTheme);
+        Assert.Equal("app", updated.Source);
+        Assert.True(updated.Success);
+
+        await serverTask;
+    }
+
+    private static async Task<string> ReadRequestAsync(NetworkStream stream)
+    {
+        var buffer = new byte[8192];
+        var builder = new StringBuilder();
+        int read;
+        do
+        {
+            read = await stream.ReadAsync(buffer);
+            builder.Append(Encoding.UTF8.GetString(buffer, 0, read));
+        }
+        while (stream.DataAvailable);
+
+        return builder.ToString();
+    }
+
+    private static async Task WriteJsonResponseAsync(NetworkStream stream, string body)
+    {
+        var bytes = Encoding.UTF8.GetBytes(body);
+        var header = Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {bytes.Length}\r\nConnection: close\r\n\r\n");
+        await stream.WriteAsync(header);
+        await stream.WriteAsync(bytes);
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ThemeAgentClientTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ThemeAgentClientTests.cs
@@ -76,17 +76,68 @@ public class ThemeAgentClientTests
 
     private static async Task<string> ReadRequestAsync(NetworkStream stream)
     {
-        var buffer = new byte[8192];
-        var builder = new StringBuilder();
-        int read;
-        do
-        {
-            read = await stream.ReadAsync(buffer);
-            builder.Append(Encoding.UTF8.GetString(buffer, 0, read));
-        }
-        while (stream.DataAvailable);
+        var buffer = new byte[1024];
+        using var request = new MemoryStream();
+        var headerEnd = -1;
+        var contentLength = 0;
 
-        return builder.ToString();
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer);
+            if (read == 0)
+                break;
+
+            request.Write(buffer, 0, read);
+            var bytes = request.ToArray();
+
+            if (headerEnd < 0)
+            {
+                headerEnd = IndexOf(bytes, HeaderTerminator);
+                if (headerEnd >= 0)
+                    contentLength = ParseContentLength(bytes.AsSpan(0, headerEnd));
+            }
+
+            if (headerEnd >= 0 && bytes.Length >= headerEnd + HeaderTerminator.Length + contentLength)
+                break;
+        }
+
+        return Encoding.UTF8.GetString(request.ToArray());
+    }
+
+    private static readonly byte[] HeaderTerminator = Encoding.ASCII.GetBytes("\r\n\r\n");
+
+    private static int ParseContentLength(ReadOnlySpan<byte> headerBytes)
+    {
+        var headers = Encoding.ASCII.GetString(headerBytes);
+        foreach (var line in headers.Split("\r\n"))
+        {
+            if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase)
+                && int.TryParse(line["Content-Length:".Length..].Trim(), out var length))
+                return length;
+        }
+
+        return 0;
+    }
+
+    private static int IndexOf(byte[] source, byte[] pattern)
+    {
+        for (var i = 0; i <= source.Length - pattern.Length; i++)
+        {
+            var found = true;
+            for (var j = 0; j < pattern.Length; j++)
+            {
+                if (source[i + j] != pattern[j])
+                {
+                    found = false;
+                    break;
+                }
+            }
+
+            if (found)
+                return i;
+        }
+
+        return -1;
     }
 
     private static async Task WriteJsonResponseAsync(NetworkStream stream, string body)


### PR DESCRIPTION
DevFlow needs a way for automation agents to switch light/dark mode without forcing every target through host-level system settings. This adds an app-scoped agent protocol plus a scope-aware host policy so disposable emulators and simulators can use OS toggles while desktops and physical devices stay app-local.

## Summary

- Adds `GET`/`PUT /api/v1/device/app/theme` to the agent protocol, docs, capabilities, and app info payloads.
- Adds Driver theme models and `AgentClient`/`IAppDriver` APIs for app-scoped and system-scoped theme switching.
- Implements host-side switching for Android via `adb shell cmd uimode night ...` and iOS Simulator via `xcrun simctl ui ... appearance ...`.
- Adds `maui devflow theme get/set` and MCP tools `maui_get_theme` / `maui_set_theme`.
- Adds focused CLI and AgentClient tests for command shape, routing, and theme serialization.

## Notes

`--scope auto` is the default. It uses host-side switching for Android emulators and iOS simulators, and otherwise defers to the app-scoped agent endpoint to avoid changing a developer's desktop or a physical device system theme. iOS Simulator host scope supports only light and dark; use app scope for `system`.

## Validation

- `dotnet build src/DevFlow/DevFlow.slnf --no-restore --verbosity minimal`
- `dotnet build src/Cli/Cli.slnf --no-restore --verbosity minimal`
- `dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/ --filter "FullyQualifiedName~DevFlowCliCommandTests|FullyQualifiedName~CommandConstructionTests" --verbosity minimal`
- `dotnet test src/DevFlow/Microsoft.Maui.DevFlow.Tests/ --filter "FullyQualifiedName~ThemeAgentClientTests|FullyQualifiedName~ProtocolSpecTests" --verbosity minimal`

Fixes: #264