### PR TITLE
Fix CI workload installation SDK

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -86,34 +86,25 @@ jobs:
         if: inputs.native-deps != ''
         run: ${{ inputs.native-deps }}
 
-      # cibuild bootstraps and uses the repo-local .dotnet SDK with multilevel lookup disabled.
-      # Install workloads and Android SDK dependencies into that SDK, not the runner/global dotnet.
-      - name: Bootstrap repo .NET SDK (Windows)
-        if: inputs.install-workloads && matrix.os == 'windows-latest'
-        run: eng\common\dotnet.cmd --info
-        shell: cmd
-
-      - name: Bootstrap repo .NET SDK (Unix)
-        if: inputs.install-workloads && matrix.os != 'windows-latest'
-        run: ./eng/common/dotnet.sh --info
-
+      # Use Arcade's dotnet wrapper for workload-related setup so SDK resolution
+      # matches the later cibuild invocation.
       - name: Install workloads (Windows)
         if: inputs.install-workloads && matrix.os == 'windows-latest'
-        run: .dotnet\dotnet workload install ${{ inputs.workloads }} --version 10.0.203
+        run: eng\common\dotnet.cmd workload install ${{ inputs.workloads }} --version 10.0.203
         shell: cmd
 
       - name: Install workloads (Unix)
         if: inputs.install-workloads && matrix.os != 'windows-latest'
-        run: ./.dotnet/dotnet workload install ${{ inputs.workloads }} --version 10.0.203
+        run: ./eng/common/dotnet.sh workload install ${{ inputs.workloads }} --version 10.0.203
 
       - name: Install Android SDK dependencies (Windows)
         if: inputs.install-workloads && matrix.os == 'windows-latest'
-        run: .dotnet\dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true ${{ inputs.android-project }}
+        run: eng\common\dotnet.cmd build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true ${{ inputs.android-project }}
         shell: cmd
 
       - name: Install Android SDK dependencies (macOS)
         if: inputs.install-workloads && matrix.os == 'macos-latest'
-        run: ./.dotnet/dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="$ANDROID_HOME" -p:AcceptAndroidSDKLicenses=true ${{ inputs.android-project }}
+        run: ./eng/common/dotnet.sh build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="$ANDROID_HOME" -p:AcceptAndroidSDKLicenses=true ${{ inputs.android-project }}
 
       - name: Build, Test and Pack (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -86,18 +86,34 @@ jobs:
         if: inputs.native-deps != ''
         run: ${{ inputs.native-deps }}
 
-      - name: Install workloads
-        if: inputs.install-workloads
-        run: dotnet workload install ${{ inputs.workloads }} --version 10.0.203
+      # cibuild bootstraps and uses the repo-local .dotnet SDK with multilevel lookup disabled.
+      # Install workloads and Android SDK dependencies into that SDK, not the runner/global dotnet.
+      - name: Bootstrap repo .NET SDK (Windows)
+        if: inputs.install-workloads && matrix.os == 'windows-latest'
+        run: eng\common\dotnet.cmd --info
+        shell: cmd
+
+      - name: Bootstrap repo .NET SDK (Unix)
+        if: inputs.install-workloads && matrix.os != 'windows-latest'
+        run: ./eng/common/dotnet.sh --info
+
+      - name: Install workloads (Windows)
+        if: inputs.install-workloads && matrix.os == 'windows-latest'
+        run: .dotnet\dotnet workload install ${{ inputs.workloads }} --version 10.0.203
+        shell: cmd
+
+      - name: Install workloads (Unix)
+        if: inputs.install-workloads && matrix.os != 'windows-latest'
+        run: ./.dotnet/dotnet workload install ${{ inputs.workloads }} --version 10.0.203
 
       - name: Install Android SDK dependencies (Windows)
         if: inputs.install-workloads && matrix.os == 'windows-latest'
-        run: dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true ${{ inputs.android-project }}
+        run: .dotnet\dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="%ANDROID_HOME%" -p:AcceptAndroidSDKLicenses=true ${{ inputs.android-project }}
         shell: cmd
 
       - name: Install Android SDK dependencies (macOS)
         if: inputs.install-workloads && matrix.os == 'macos-latest'
-        run: dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="$ANDROID_HOME" -p:AcceptAndroidSDKLicenses=true ${{ inputs.android-project }}
+        run: ./.dotnet/dotnet build -t:InstallAndroidDependencies -f net10.0-android -p:AndroidSdkDirectory="$ANDROID_HOME" -p:AcceptAndroidSDKLicenses=true ${{ inputs.android-project }}
 
       - name: Build, Test and Pack (Windows)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
## Summary
- Use Arcade's `eng/common/dotnet.{cmd,sh}` wrappers for MAUI workload installation in the shared GitHub Actions build workflow.
- Use the same wrappers for `InstallAndroidDependencies` setup.
- Document the invariant inline: workload-related setup should use the same SDK resolution path as `cibuild`.

## Why
`eng/common/cibuild` does not necessarily use the same `dotnet` selected by `actions/setup-dotnet`/the runner environment. Running workload setup through Arcade's dotnet wrapper avoids installing workloads into a different SDK location than the later build uses, which can surface as `NETSDK1147` missing workload failures.

## Prevention
The workflow now avoids both fragile extremes: it does not rely on the runner/global `dotnet`, and it does not assume a repo-local `.dotnet` folder exists. Instead, all pre-build workload commands go through the same Arcade SDK-selection wrapper used by the build infrastructure.