### PR TITLE
Bump Xamarin.Apple.Tools.MaciOS to 1.0.0-preview.1.26301.3

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -33,9 +33,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>73b3b5ac0e4a5658c7a0555b67d91a22ad39de4b</Sha>
     </Dependency>
-    <Dependency Name="Xamarin.Apple.Tools.MaciOS" Version="1.0.0-preview.1.26255.1">
+    <Dependency Name="Xamarin.Apple.Tools.MaciOS" Version="1.0.0-preview.1.26301.3">
       <Uri>https://github.com/dotnet/macios-devtools</Uri>
-      <Sha>87eb6abbc8d317b0b4c530b084ee3794b7f04c95</Sha>
+      <Sha>a3ef042ae81f3e26d1b4fe2d2390c65427c26589</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -66,7 +66,7 @@
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">
-    <XamarinAppleToolsMaciOSVersion>1.0.0-preview.1.26255.1</XamarinAppleToolsMaciOSVersion>
+    <XamarinAppleToolsMaciOSVersion>1.0.0-preview.1.26301.3</XamarinAppleToolsMaciOSVersion>
   </PropertyGroup>
   <PropertyGroup Label="Platform Extensions">
     <PlatformMauiLinuxGtk4Version>0.6.0</PlatformMauiLinuxGtk4Version>


### PR DESCRIPTION
## Summary

Updates `Xamarin.Apple.Tools.MaciOS` from **`1.0.0-preview.1.26255.1`** → **`1.0.0-preview.1.26301.3`** via `darc update-dependencies --channel ".NET 10.0.1xx SDK"`.

Upstream SHA range: [`87eb6abb...a3ef042a`](https://github.com/dotnet/macios-devtools/compare/87eb6abbc8d317b0b4c530b084ee3794b7f04c95...a3ef042ae81f3e26d1b4fe2d2390c65427c26589) (`dotnet/macios-devtools`).

## Notable changes

| Commit | Description | Relevance |
| --- | --- | --- |
| [`ace633f`](https://github.com/dotnet/macios-devtools/commit/ace633f) | Add simulator extras: privacy, appearance, status_bar, openurl, push, location, addmedia, screen capture | **New APIs** — see CLI follow-up |
| [`95ec821`](https://github.com/dotnet/macios-devtools/commit/95ec821) | Fix `ArgumentNullException` in `AppleSdkSettings` when no settings file exists | Robustness — used indirectly by `EnvironmentChecker` |
| [`a3ef042`](https://github.com/dotnet/macios-devtools/commit/a3ef042) | Enable `GenerateDocumentationFile` so NuGet package ships XML IntelliSense docs | DX improvement |
| [`fa33bf8`](https://github.com/dotnet/macios-devtools/commit/fa33bf8), [`4bfa9e8`](https://github.com/dotnet/macios-devtools/commit/4bfa9e8) | Fix native memory/resource leaks in `Keychain` | Internal robustness |
| [`a200df6`](https://github.com/dotnet/macios-devtools/commit/a200df6) | Fix potential crash extracting path from URI with no segments | Internal robustness |
| [`3b81c64`](https://github.com/dotnet/macios-devtools/commit/3b81c64) | Include parameter name in `ArgumentNullException` for SDK version types | Better diagnostics |
| [`ac7f924`](https://github.com/dotnet/macios-devtools/commit/ac7f924) | Fix `NullReferenceException` and crash in `ManifestExtensions` | Internal robustness |
| [`00d5dfe`](https://github.com/dotnet/macios-devtools/commit/00d5dfe) | Fix `PathUtils.IsSymlink` throwing on common lstat failures | Internal robustness |
| [`30400f1`](https://github.com/dotnet/macios-devtools/commit/30400f1) | Update arcade sdk | Internal |

## CLI follow-up

**No CLI changes needed in this PR.** Rationale:

- The robustness fixes (`Keychain`, `AppleSdkSettings`, `PathUtils`, `ManifestExtensions`, URI parsing) are consumed transitively through `EnvironmentChecker`, `AppleInstaller`, `SimulatorService`, and `RuntimeService` — `src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs` benefits automatically. A grep for `workaround`, `HACK`, simctl-parsing or stdout-pollution comments turned up nothing tied to these areas.
- **Opportunity (not taken here):** `ace633f` adds a new `SimulatorServiceExtras` surface (privacy permissions, appearance, status bar, openurl, push, location, addmedia, screen capture). The CLI doesn't currently expose simulator-extra commands; adding them is feature work and should land in a dedicated PR.

## Validation

- ✅ `dotnet restore src/Cli/Cli.slnf`
- ✅ `dotnet build src/Cli/Cli.slnf -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/` — **548 / 548 passed**
- ⚠️ `./eng/smoke-tests/apple-cli-smoke-test.sh` (macOS) — **9 / 10 passed**
  - Tests 1–7, 9, 10 pass (Xcode list, runtime list, simulator list / start / stop, install dry-run all platforms, launch / get-app-container error handling).
  - Test 8 (`simulator install` invalid-UDID expecting `E2204`) returns `E1004` ("App bundle not found at '/tmp/Fake.app'") because the CLI validates the bundle path before the UDID. **Verified to also fail on the pre-bump commit** — pre-existing smoke-test bug, not a regression from this update. Worth a separate fix to either point Test 8 at a real bundle path or reorder the CLI's validation.

## Constraints respected

- Only files touched are the two darc-managed manifests (`eng/Version.Details.xml`, `eng/Versions.props`).
- `eng/common/` untouched.
- No drive-by refactors.

Please review — not merging.