### PR TITLE
Bump Xamarin.Android.Tools.AndroidSdk to 1.0.189-preview.58

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,8 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <!-- NU1507: official builds inject internal feeds via SetupNugetSources that aren't in packageSourceMapping -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
+    <!-- NU3027: Xamarin.Android.Tools.AndroidSdk on dotnet11-transport is signed but not long-term timestamped -->
+    <NoWarn>$(NoWarn);NU3027</NoWarn>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <!-- Default to non-shipping; shipping projects override per-csproj -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,8 +15,6 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <!-- NU1507: official builds inject internal feeds via SetupNugetSources that aren't in packageSourceMapping -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
-    <!-- NU3027: Xamarin.Android.Tools.AndroidSdk on dotnet11-transport is signed but not long-term timestamped -->
-    <NoWarn>$(NoWarn);NU3027</NoWarn>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <!-- Default to non-shipping; shipping projects override per-csproj -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" protocolVersion="3" />
+    <add key="dotnet11-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,7 +14,6 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" protocolVersion="3" />
-
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
     <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.)
          The package is built by dotnet/android which includes android-tools as a submodule. -->
-    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.155-preview.137">
+    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.179-ci.main.323">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>e8fb4bc8f779fd0d27c5c0ed04637a5dd25c083b</Sha>
+      <Sha>9e7ba6ea897d5dbffcf4e1e6c675fc08c2f1b2e6</Sha>
     </Dependency>
     <!-- dotnet/maui -->
     <Dependency Name="Microsoft.Maui.Controls" Version="10.0.41">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
     <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.)
          The package is built by dotnet/android which includes android-tools as a submodule. -->
-    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.179-ci.main.323">
+    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.189-preview.58">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>9e7ba6ea897d5dbffcf4e1e6c675fc08c2f1b2e6</Sha>
+      <Sha>2114bc81fed892c4d166aeff637ca2387b0fcd8a</Sha>
     </Dependency>
     <!-- dotnet/maui -->
     <Dependency Name="Microsoft.Maui.Controls" Version="10.0.41">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   </PropertyGroup>
   <!-- Android platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Android Tools">
-    <XamarinAndroidToolsAndroidSdkVersion>1.0.155-preview.137</XamarinAndroidToolsAndroidSdkVersion>
+    <XamarinAndroidToolsAndroidSdkVersion>1.0.179-ci.main.323</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   </PropertyGroup>
   <!-- Android platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Android Tools">
-    <XamarinAndroidToolsAndroidSdkVersion>1.0.179-ci.main.323</XamarinAndroidToolsAndroidSdkVersion>
+    <XamarinAndroidToolsAndroidSdkVersion>1.0.189-preview.58</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">


### PR DESCRIPTION
## Summary

Bump `Xamarin.Android.Tools.AndroidSdk` from **`1.0.155-preview.137`** to **`1.0.189-preview.58`**.

Source: `dotnet/android` `release/11.0.1xx-preview6` @ [`2114bc81`](https://github.com/dotnet/android/commit/2114bc81fed892c4d166aeff637ca2387b0fcd8a).
Channel: `.NET 11.0.1xx SDK Preview 6`.
Compare with previous pin: https://github.com/dotnet/android/compare/e8fb4bc8f779fd0d27c5c0ed04637a5dd25c083b...2114bc81fed892c4d166aeff637ca2387b0fcd8a

## Notable upstream changes

Actionable diff lives in the `external/xamarin-android-tools` submodule. Highlights:

- New `AvdManagerRunner.ListDeviceProfilesAsync()` API ([dotnet/android-tools#325](https://github.com/dotnet/android-tools/pull/325)) — returns all AVD device profiles from `avdmanager list device`.
- Android API 37 (CinnamonBun) support.
- Emulator process robustness fixes ([#359](https://github.com/dotnet/android-tools/pull/359), [#361](https://github.com/dotnet/android-tools/pull/361), [#362](https://github.com/dotnet/android-tools/pull/362)) around `HasExited` / `ExitCode` on the launcher fork pattern.

## CLI follow-up

**No CLI code changes in this PR.**

- Source-compat verified: all types the CLI uses (`AdbRunner`, `AvdManagerRunner`, `EmulatorRunner`, `SdkManager`, `SdkPackage`, `AvdInfo`, `JdkInfo`, `SdkBootstrap*`) still present with the same public surface. Confirmed via `PublicAPI.{Shipped,Unshipped}.txt` at the new SHA and a clean local Release build.
- The upstream emulator fixes wrap `EmulatorRunner`'s process handling; our own `AvdManager.cs` (L275-318) wraps *our own* `Process.Start`, so those fixes don't simplify our code.
- The new `ListDeviceProfilesAsync()` looks tempting for the emulator device picker, but its output (`record AvdDeviceProfile(string Id)` with no friendly name) would regress the current curated 7-profile UX. Filed as #306 for follow-up (hybrid picker with an "All device profiles…" opt-in).

## Feed / signing notes

The package is classified **non-shipping** by `dotnet/android` (fixed in [dotnet/android#11281](https://github.com/dotnet/android/pull/11281), May 2026), so it now publishes to `dotnet11-transport` rather than `dotnet11`. This PR adds `dotnet11-transport` to `NuGet.config` so public restore can resolve the pin.

Earlier iterations of the branch (see commit history) pinned to `1.0.179-ci.main.323`, a CI build that is signed only with the `Microsoft Testing Root CA 2010` test cert and lacks an RFC 3161 timestamp countersignature. That triggered `NU3027` on Windows CI. Moving to `1.0.189-preview.58` — which is production-signed by `CN=Microsoft Corporation` via DigiCert with a timestamp — removes the need for that workaround and restores strict signature validation.

## Validation

- `dotnet restore src/Cli/Cli.slnf` — ✅ resolves `1.0.189-preview.58` from `dotnet11-transport`
- `dotnet build src/Cli/Cli.slnf -c Release` — ✅ 0 warnings, 0 errors
- `dotnet nuget verify` on the package — ✅ passes with no `NU3027`