### PR TITLE
Update CI pool image to windows.vs2026.amd64

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -269,7 +269,7 @@ The official pipeline is **`eng/pipelines/devflow-official.yml`**. It handles Ar
             displayName: {Product} - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -319,7 +319,7 @@ This stage filters the product's `.nupkg` files from the shared `PackageArtifact
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -343,7 +343,7 @@ This stage filters the product's `.nupkg` files from the shared `PackageArtifact
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -269,7 +269,7 @@ The official pipeline is **`eng/pipelines/devflow-official.yml`**. It handles Ar
             displayName: {Product} - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -319,7 +319,7 @@ This stage filters the product's `.nupkg` files from the shared `PackageArtifact
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -343,7 +343,7 @@ This stage filters the product's `.nupkg` files from the shared `PackageArtifact
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob

--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -25,10 +25,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        image: windows.vs2026preview.scout.amd64.open
+        image: windows.amd64.vs2026.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: windows.vs2026preview.scout.amd64
+        image: windows.amd64.vs2026
 
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:

--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -25,10 +25,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        image: windows.amd64.vs2026.open
+        image: windows.vs2026.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: windows.amd64.vs2026
+        image: windows.vs2026.amd64
 
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -128,11 +128,11 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+            demands: ImageOverride -equals windows.amd64.vs2026
 
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
@@ -190,7 +190,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+            demands: ImageOverride -equals windows.amd64.vs2026
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:
@@ -265,7 +265,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+            demands: ImageOverride -equals windows.amd64.vs2026
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -128,11 +128,11 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.amd64.vs2026
+            demands: ImageOverride -equals windows.vs2026.amd64
 
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
@@ -190,7 +190,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.amd64.vs2026
+            demands: ImageOverride -equals windows.vs2026.amd64
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:
@@ -265,7 +265,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.amd64.vs2026
+            demands: ImageOverride -equals windows.vs2026.amd64
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -66,7 +66,7 @@ extends:
   parameters:
     pool:
       name: NetCore1ESPool-Internal
-      image: windows.amd64.vs2026
+      image: windows.vs2026.amd64
       os: windows
     # Required for publishing to external feeds like nuget.org
     settings:
@@ -97,7 +97,7 @@ extends:
             displayName: DevFlow - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -125,7 +125,7 @@ extends:
             displayName: Cli - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -149,7 +149,7 @@ extends:
             displayName: AI Extensions - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -173,7 +173,7 @@ extends:
             displayName: AppProjectReference - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -201,7 +201,7 @@ extends:
             displayName: Linux GTK4 - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -267,7 +267,7 @@ extends:
             dependsOn: EssentialsAI_macOS
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -341,7 +341,7 @@ extends:
             displayName: WPF - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -368,7 +368,7 @@ extends:
             displayName: macOS AppKit - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.amd64.vs2026
+              demands: ImageOverride -equals windows.vs2026.amd64
             strategy:
               matrix:
                 Release:
@@ -407,7 +407,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -430,7 +430,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob
@@ -462,7 +462,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -486,7 +486,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob
@@ -518,7 +518,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -541,7 +541,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob
@@ -573,7 +573,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -596,7 +596,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob
@@ -628,7 +628,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -651,7 +651,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob
@@ -683,7 +683,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -706,7 +706,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob
@@ -738,7 +738,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -761,7 +761,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob
@@ -793,7 +793,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             outputs:
@@ -816,7 +816,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.amd64.vs2026
+            image: windows.vs2026.amd64
             os: windows
           templateContext:
             type: releaseJob

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -66,7 +66,7 @@ extends:
   parameters:
     pool:
       name: NetCore1ESPool-Internal
-      image: windows.vs2026preview.scout.amd64
+      image: windows.amd64.vs2026
       os: windows
     # Required for publishing to external feeds like nuget.org
     settings:
@@ -97,7 +97,7 @@ extends:
             displayName: DevFlow - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -125,7 +125,7 @@ extends:
             displayName: Cli - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -149,7 +149,7 @@ extends:
             displayName: AI Extensions - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -173,7 +173,7 @@ extends:
             displayName: AppProjectReference - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -201,7 +201,7 @@ extends:
             displayName: Linux GTK4 - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -267,7 +267,7 @@ extends:
             dependsOn: EssentialsAI_macOS
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -341,7 +341,7 @@ extends:
             displayName: WPF - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -368,7 +368,7 @@ extends:
             displayName: macOS AppKit - Windows
             pool:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
+              demands: ImageOverride -equals windows.amd64.vs2026
             strategy:
               matrix:
                 Release:
@@ -407,7 +407,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -430,7 +430,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob
@@ -462,7 +462,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -486,7 +486,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob
@@ -518,7 +518,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -541,7 +541,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob
@@ -573,7 +573,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -596,7 +596,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob
@@ -628,7 +628,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -651,7 +651,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob
@@ -683,7 +683,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -706,7 +706,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob
@@ -738,7 +738,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -761,7 +761,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob
@@ -793,7 +793,7 @@ extends:
           timeoutInMinutes: 15
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             outputs:
@@ -816,7 +816,7 @@ extends:
           timeoutInMinutes: 30
           pool:
             name: NetCore1ESPool-Internal
-            image: windows.vs2026preview.scout.amd64
+            image: windows.amd64.vs2026
             os: windows
           templateContext:
             type: releaseJob


### PR DESCRIPTION
Replaces `windows.vs2026preview.scout.amd64` with `windows.vs2026.amd64` across the official pipeline, `eng/common` post-build/source-index templates, and the new-product CI templates in `.github/copilot-instructions.md`.

Note: `eng/common/` is normally regenerated by Arcade dependency flow; this is a temporary local override until Arcade flows the updated image.