### PR TITLE
Add MAUI PR artifact hives

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -30,6 +30,10 @@ public class CommandConstructionTests
 		Assert.Contains(versionCommand.Subcommands, command => command.Name == "list");
 		Assert.Contains(versionCommand.Subcommands, command => command.Name == "set");
 		Assert.Contains(versionCommand.Subcommands, command => command.Name == "use-workload");
+		var setCommand = Assert.Single(versionCommand.Subcommands, command => command.Name == "set");
+		Assert.Contains(setCommand.Options, option => option.Name == "--pr");
+		var hivePathOption = Assert.Single(setCommand.Options, option => option.Name == "--hive-path");
+		Assert.Contains("--artifact-path", hivePathOption.Aliases);
 
 		var showCommand = Assert.Single(versionCommand.Subcommands, command => command.Name == "show");
 		Assert.Contains("check", showCommand.Aliases);

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/CommandConstructionTests.cs
@@ -34,6 +34,9 @@ public class CommandConstructionTests
 		Assert.Contains(setCommand.Options, option => option.Name == "--pr");
 		var hivePathOption = Assert.Single(setCommand.Options, option => option.Name == "--hive-path");
 		Assert.Contains("--artifact-path", hivePathOption.Aliases);
+		var frameworkOption = Assert.Single(setCommand.Options, option => option.Name == "--target-framework");
+		Assert.Contains("--framework", frameworkOption.Aliases);
+		Assert.Contains("-f", frameworkOption.Aliases);
 
 		var showCommand = Assert.Single(versionCommand.Subcommands, command => command.Name == "show");
 		Assert.Contains("check", showCommand.Aliases);

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiPrArtifactServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiPrArtifactServiceTests.cs
@@ -96,6 +96,42 @@ public class MauiPrArtifactServiceTests
 	}
 
 	[Fact]
+	public async Task FindInProgressBuildAsync_AzureDevOpsInProgressBuild_ReturnsBuildProgress()
+	{
+		var service = CreateService(request =>
+		{
+			var url = request.RequestUri!.ToString();
+			if (url.Contains("_apis/build/builds?api-version=7.1", StringComparison.Ordinal))
+			{
+				return JsonResponse("""
+					{
+					  "value": [
+					    {
+					      "id": 123457,
+					      "buildNumber": "20260608.2",
+					      "status": "inProgress",
+					      "sourceVersion": "def456",
+					      "definition": { "name": "maui-pr" }
+					    }
+					  ]
+					}
+					""");
+			}
+
+			return NotFound();
+		});
+
+		var progress = await service.FindInProgressBuildAsync(24888);
+
+		Assert.NotNull(progress);
+		Assert.Equal(24888, progress.PullRequest);
+		Assert.Equal(123457, progress.BuildId);
+		Assert.Equal("20260608.2", progress.BuildNumber);
+		Assert.Equal("inProgress", progress.Status);
+		Assert.Equal("https://dev.azure.com/dnceng-public/public/_build/results?buildId=123457", progress.BuildUrl);
+	}
+
+	[Fact]
 	public async Task DownloadPackageArtifactAsync_CopiesPackagesAndReadsControlsVersionFromNuspec()
 	{
 		using var directory = TemporaryDirectory.Create();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiPrArtifactServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiPrArtifactServiceTests.cs
@@ -1,0 +1,348 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.Net;
+using System.Text.Json;
+using Microsoft.Maui.Cli.Services;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class MauiPrArtifactServiceTests
+{
+	[Fact]
+	public async Task FindPackageArtifactAsync_AzureDevOpsBuildWithPackageArtifacts_ReturnsArtifact()
+	{
+		var service = CreateService(request =>
+		{
+			var url = request.RequestUri!.ToString();
+			if (url.Contains("_apis/build/builds?api-version=7.1", StringComparison.Ordinal))
+			{
+				return JsonResponse("""
+					{
+					  "value": [
+					    {
+					      "id": 123456,
+					      "buildNumber": "20260608.1",
+					      "status": "completed",
+					      "result": "succeeded",
+					      "sourceVersion": "abc123",
+					      "definition": { "name": "maui-pr" }
+					    }
+					  ]
+					}
+					""");
+			}
+
+			if (url.Contains("_apis/build/builds/123456/artifacts", StringComparison.Ordinal))
+			{
+				return JsonResponse("""
+					{
+					  "value": [
+					    {
+					      "name": "PackageArtifacts",
+					      "resource": { "downloadUrl": "https://example.test/artifacts.zip" }
+					    }
+					  ]
+					}
+					""");
+			}
+
+			return NotFound();
+		});
+
+		var artifact = await service.FindPackageArtifactAsync(24888);
+
+		Assert.Equal(24888, artifact.PullRequest);
+		Assert.Equal(123456, artifact.BuildId);
+		Assert.Equal("20260608.1", artifact.BuildNumber);
+		Assert.Equal("https://example.test/artifacts.zip", artifact.DownloadUrl);
+		Assert.Equal("https://dev.azure.com/dnceng-public/public/_build/results?buildId=123456", artifact.BuildUrl);
+	}
+
+	[Fact]
+	public async Task FindPackageArtifactAsync_FailedAzureDevOpsBuild_DoesNotReturnArtifact()
+	{
+		var service = CreateService(request =>
+		{
+			var url = request.RequestUri!.ToString();
+			if (url.Contains("_apis/build/builds?api-version=7.1", StringComparison.Ordinal))
+			{
+				return JsonResponse("""
+					{
+					  "value": [
+					    {
+					      "id": 123456,
+					      "buildNumber": "20260608.1",
+					      "status": "completed",
+					      "result": "failed",
+					      "sourceVersion": "abc123",
+					      "definition": { "name": "maui-pr" }
+					    }
+					  ]
+					}
+					""");
+			}
+
+			if (url.Contains("/pulls/24888/commits", StringComparison.Ordinal))
+				return JsonResponse("[]");
+
+			return NotFound();
+		});
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.FindPackageArtifactAsync(24888));
+		Assert.Contains("No completed dotnet/maui PR build", exception.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task DownloadPackageArtifactAsync_CopiesPackagesAndReadsControlsVersionFromNuspec()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var artifactZip = CreateArtifactZip(
+			("nested/Microsoft.Maui.Controls.Build.Tasks.1.0.0.nupkg", CreateNupkg("Microsoft.Maui.Controls.Build.Tasks", "1.0.0")),
+			("nested/Microsoft.Maui.Controls.10.0.999-ci.pr.1.nupkg", CreateNupkg("Microsoft.Maui.Controls", "10.0.999-ci.pr.1")));
+		var service = CreateService(request =>
+		{
+			if (request.RequestUri!.ToString() == "https://example.test/artifacts.zip")
+			{
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new ByteArrayContent(artifactZip),
+				};
+			}
+
+			return NotFound();
+		});
+		var artifact = new MauiPrBuildArtifact
+		{
+			PullRequest = 24888,
+			BuildId = 123456,
+			BuildNumber = "20260608.1",
+			Status = "completed",
+			Result = "succeeded",
+			SourceVersion = "abc123",
+			Organization = "dnceng-public",
+			Project = "public",
+			ArtifactName = "PackageArtifacts",
+			DownloadUrl = "https://example.test/artifacts.zip",
+			BuildUrl = "https://dev.azure.com/dnceng-public/public/_build/results?buildId=123456",
+		};
+
+		var result = await service.DownloadPackageArtifactAsync(artifact, directory.Path);
+
+		Assert.Equal("10.0.999-ci.pr.1", result.Version);
+		Assert.Equal(directory.Path, result.HiveRoot);
+		Assert.Equal(Path.Combine(directory.Path, "dotnet-maui", "pr-24888", "build-123456"), result.ArtifactPath);
+		Assert.Equal(Path.Combine(result.ArtifactPath, "packages"), result.PackageSourcePath);
+		Assert.Equal(Path.Combine(result.ArtifactPath, "metadata.json"), result.MetadataPath);
+		Assert.True(File.Exists(Path.Combine(result.PackageSourcePath, "Microsoft.Maui.Controls.10.0.999-ci.pr.1.nupkg")));
+		Assert.True(File.Exists(Path.Combine(result.PackageSourcePath, "Microsoft.Maui.Controls.Build.Tasks.1.0.0.nupkg")));
+		Assert.True(File.Exists(result.MetadataPath));
+
+		using var metadata = JsonDocument.Parse(File.ReadAllText(result.MetadataPath));
+		var root = metadata.RootElement;
+		Assert.Equal(1, root.GetProperty("schema_version").GetInt32());
+		Assert.Equal("dotnet/maui", root.GetProperty("repository").GetString());
+		Assert.Equal(24888, root.GetProperty("pull_request").GetInt32());
+		Assert.Equal(123456, root.GetProperty("build_id").GetInt32());
+		Assert.Equal("20260608.1", root.GetProperty("build_number").GetString());
+		Assert.Equal("abc123", root.GetProperty("source_version").GetString());
+		Assert.Equal("10.0.999-ci.pr.1", root.GetProperty("package_version").GetString());
+		Assert.Equal(result.PackageSourcePath, root.GetProperty("package_source_path").GetString());
+		Assert.Equal(result.ArtifactPath, root.GetProperty("hive_path").GetString());
+	}
+
+	[Fact]
+	public async Task DownloadPackageArtifactAsync_DownloadFailure_DoesNotReplaceExistingHive()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var service = CreateService(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+		var artifact = CreateArtifact();
+		var paths = service.GetHivePaths(artifact, directory.Path);
+		Directory.CreateDirectory(paths.HivePath);
+		var existingFile = Path.Combine(paths.HivePath, "existing.txt");
+		await File.WriteAllTextAsync(existingFile, "keep");
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.DownloadPackageArtifactAsync(artifact, directory.Path));
+
+		Assert.Contains("Failed to download", exception.Message, StringComparison.Ordinal);
+		Assert.True(File.Exists(existingFile));
+		Assert.Empty(Directory.EnumerateDirectories(Path.GetDirectoryName(paths.HivePath)!, $"{Path.GetFileName(paths.HivePath)}.tmp-*"));
+	}
+
+	[Fact]
+	public async Task DownloadPackageArtifactAsync_ZipSlipEntry_ThrowsAndDoesNotCreateHive()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var artifactZip = CreateArtifactZip(("../evil.txt", [1, 2, 3]));
+		var service = CreateDownloadService(artifactZip);
+		var artifact = CreateArtifact();
+		var paths = service.GetHivePaths(artifact, directory.Path);
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.DownloadPackageArtifactAsync(artifact, directory.Path));
+
+		Assert.Contains("outside the extraction directory", exception.Message, StringComparison.Ordinal);
+		Assert.False(File.Exists(Path.Combine(directory.Path, "dotnet-maui", "evil.txt")));
+		Assert.False(Directory.Exists(paths.HivePath));
+	}
+
+	[Fact]
+	public async Task DownloadPackageArtifactAsync_MissingControlsPackage_DoesNotReplaceExistingHive()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var artifactZip = CreateArtifactZip(("nested/Microsoft.Maui.Core.1.0.0.nupkg", CreateNupkg("Microsoft.Maui.Core", "1.0.0")));
+		var service = CreateDownloadService(artifactZip);
+		var artifact = CreateArtifact();
+		var paths = service.GetHivePaths(artifact, directory.Path);
+		Directory.CreateDirectory(paths.HivePath);
+		var existingFile = Path.Combine(paths.HivePath, "existing.txt");
+		await File.WriteAllTextAsync(existingFile, "keep");
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.DownloadPackageArtifactAsync(artifact, directory.Path));
+
+		Assert.Contains("did not contain a Microsoft.Maui.Controls package", exception.Message, StringComparison.Ordinal);
+		Assert.True(File.Exists(existingFile));
+		Assert.False(File.Exists(paths.MetadataPath));
+	}
+
+	[Fact]
+	public void GetHivePaths_CustomRoot_ReturnsRepositoryScopedBuildHive()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var service = CreateService(_ => NotFound());
+		var artifact = new MauiPrBuildArtifact
+		{
+			PullRequest = 24888,
+			BuildId = 123456,
+			BuildNumber = "20260608.1",
+			Status = "completed",
+			Result = "succeeded",
+			SourceVersion = "abc123",
+			Organization = "dnceng-public",
+			Project = "public",
+			ArtifactName = "PackageArtifacts",
+			DownloadUrl = "https://example.test/artifacts.zip",
+			BuildUrl = "https://dev.azure.com/dnceng-public/public/_build/results?buildId=123456",
+		};
+
+		var paths = service.GetHivePaths(artifact, directory.Path);
+
+		var expectedHivePath = Path.Combine(directory.Path, "dotnet-maui", "pr-24888", "build-123456");
+		Assert.Equal(directory.Path, paths.HiveRoot);
+		Assert.Equal(expectedHivePath, paths.HivePath);
+		Assert.Equal(Path.Combine(expectedHivePath, "extracted"), paths.ExtractPath);
+		Assert.Equal(Path.Combine(expectedHivePath, "packages"), paths.PackageSourcePath);
+		Assert.Equal(Path.Combine(expectedHivePath, "PackageArtifacts.zip"), paths.ZipPath);
+		Assert.Equal(Path.Combine(expectedHivePath, "metadata.json"), paths.MetadataPath);
+	}
+
+	static MauiPrArtifactService CreateService(Func<HttpRequestMessage, HttpResponseMessage> handler) =>
+		new(new HttpClient(new StubHandler(handler))
+		{
+			Timeout = Timeout.InfiniteTimeSpan,
+		});
+
+	static MauiPrArtifactService CreateDownloadService(byte[] artifactZip) =>
+		CreateService(request =>
+		{
+			if (request.RequestUri!.ToString() == "https://example.test/artifacts.zip")
+			{
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new ByteArrayContent(artifactZip),
+				};
+			}
+
+			return NotFound();
+		});
+
+	static MauiPrBuildArtifact CreateArtifact() =>
+		new()
+		{
+			PullRequest = 24888,
+			BuildId = 123456,
+			BuildNumber = "20260608.1",
+			Status = "completed",
+			Result = "succeeded",
+			SourceVersion = "abc123",
+			Organization = "dnceng-public",
+			Project = "public",
+			ArtifactName = "PackageArtifacts",
+			DownloadUrl = "https://example.test/artifacts.zip",
+			BuildUrl = "https://dev.azure.com/dnceng-public/public/_build/results?buildId=123456",
+		};
+
+	static HttpResponseMessage JsonResponse(string json) =>
+		new(HttpStatusCode.OK)
+		{
+			Content = new StringContent(json),
+		};
+
+	static HttpResponseMessage NotFound() =>
+		new(HttpStatusCode.NotFound)
+		{
+			Content = new StringContent("{}"),
+		};
+
+	static byte[] CreateArtifactZip(params (string Path, byte[] Content)[] entries)
+	{
+		using var stream = new MemoryStream();
+		using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+		{
+			foreach (var entry in entries)
+			{
+				var zipEntry = archive.CreateEntry(entry.Path);
+				using var entryStream = zipEntry.Open();
+				entryStream.Write(entry.Content);
+			}
+		}
+
+		return stream.ToArray();
+	}
+
+	static byte[] CreateNupkg(string id, string version)
+	{
+		using var stream = new MemoryStream();
+		using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+		{
+			var nuspec = archive.CreateEntry($"{id}.nuspec");
+			using var writer = new StreamWriter(nuspec.Open());
+			writer.Write($"""
+				<?xml version="1.0" encoding="utf-8"?>
+				<package>
+				  <metadata>
+				    <id>{id}</id>
+				    <version>{version}</version>
+				  </metadata>
+				</package>
+				""");
+		}
+
+		return stream.ToArray();
+	}
+
+	sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(handler(request));
+	}
+
+	sealed class TemporaryDirectory : IDisposable
+	{
+		public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "maui-cli-tests", Guid.NewGuid().ToString("N"));
+
+		TemporaryDirectory()
+		{
+			Directory.CreateDirectory(Path);
+		}
+
+		public static TemporaryDirectory Create() => new();
+
+		public void Dispose()
+		{
+			if (Directory.Exists(Path))
+				Directory.Delete(Path, recursive: true);
+		}
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiProjectVersionServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiProjectVersionServiceTests.cs
@@ -461,6 +461,31 @@ public class MauiProjectVersionServiceTests
 	}
 
 	[Fact]
+	public async Task SetTargetFrameworkAsync_NonPropertyGroupTargetFrameworkElement_IgnoresElement()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			    <TargetFramework>net9.0</TargetFramework>
+			  </PropertyGroup>
+			  <ItemGroup>
+			    <TargetFrameworks>not-a-msbuild-property</TargetFrameworks>
+			  </ItemGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetTargetFrameworkAsync(projectPath, "net10.0", dryRun: false);
+		var content = File.ReadAllText(projectPath);
+
+		Assert.True(result.Changed);
+		Assert.Contains("<TargetFramework>net10.0</TargetFramework>", content);
+		Assert.Contains("<TargetFrameworks>not-a-msbuild-property</TargetFrameworks>", content);
+	}
+
+	[Fact]
 	public async Task SetTargetFrameworkAsync_PropertyComposedTargetFrameworks_ThrowsWithoutPartialUpdate()
 	{
 		using var directory = TemporaryDirectory.Create();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiProjectVersionServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiProjectVersionServiceTests.cs
@@ -395,6 +395,187 @@ public class MauiProjectVersionServiceTests
 	}
 
 	[Fact]
+	public async Task GetVersionInfoAsync_TargetFrameworks_ReturnsTargetFrameworkInfo()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-windows10.0.19041.0</TargetFrameworks>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var info = await service.GetVersionInfoAsync(projectPath);
+
+		Assert.Equal(["net9.0-android", "net9.0-ios", "net9.0-windows10.0.19041.0"], info.TargetFrameworks);
+		Assert.Equal("net9.0", info.TargetDotNetFramework);
+	}
+
+	[Fact]
+	public async Task SetTargetFrameworkAsync_TargetFrameworks_ReplacesOnlyDotNetPrefix()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-windows10.0.19041.0</TargetFrameworks>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetTargetFrameworkAsync(projectPath, "net10.0", dryRun: false);
+		var content = File.ReadAllText(projectPath);
+
+		Assert.True(result.Changed);
+		Assert.Contains("net10.0-android;net10.0-ios;net10.0-windows10.0.19041.0", content);
+	}
+
+	[Fact]
+	public async Task SetTargetFrameworkAsync_ConditionalTargetFrameworkAppend_UpdatesLiteralAppend()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			    <TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+			  </PropertyGroup>
+			  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
+			    <TargetFrameworks>$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetTargetFrameworkAsync(projectPath, "net10.0", dryRun: false);
+		var content = File.ReadAllText(projectPath);
+
+		Assert.True(result.Changed);
+		Assert.Contains("net10.0-android;net10.0-ios", content);
+		Assert.Contains("$(TargetFrameworks);net10.0-windows10.0.19041.0", content);
+	}
+
+	[Fact]
+	public async Task SetTargetFrameworkAsync_PropertyComposedTargetFrameworks_ThrowsWithoutPartialUpdate()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			    <ExtraTargetFrameworks>net9.0-ios</ExtraTargetFrameworks>
+			    <TargetFrameworks>net9.0-android;$(ExtraTargetFrameworks)</TargetFrameworks>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			service.SetTargetFrameworkAsync(projectPath, "net10.0", dryRun: false));
+
+		Assert.Contains("not a literal netX.Y target framework list", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("net9.0-android;$(ExtraTargetFrameworks)", File.ReadAllText(projectPath));
+	}
+
+	[Fact]
+	public async Task SetTargetFrameworkAsync_ConditionalAppendWithInheritedBase_ThrowsWithoutPartialUpdate()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("Directory.Build.props", """
+			<Project>
+			  <PropertyGroup>
+			    <TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
+			    <TargetFrameworks>$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			service.SetTargetFrameworkAsync(projectPath, "net10.0", dryRun: false));
+
+		Assert.Contains("not defined in the project file", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("$(TargetFrameworks);net9.0-windows10.0.19041.0", File.ReadAllText(projectPath));
+	}
+
+	[Fact]
+	public async Task SetTargetFrameworkAsync_DryRun_DoesNotUpdateProject()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			    <TargetFramework>net9.0</TargetFramework>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var result = await service.SetTargetFrameworkAsync(projectPath, "10.0", dryRun: true);
+
+		Assert.True(result.Changed);
+		Assert.Contains("<TargetFramework>net9.0</TargetFramework>", File.ReadAllText(projectPath));
+		Assert.Equal("net10.0", result.Changes.Single().NewValue);
+	}
+
+	[Fact]
+	public async Task SetTargetFrameworkAsync_InheritedTargetFramework_ThrowsInsteadOfAddingSingularFramework()
+	{
+		using var directory = TemporaryDirectory.Create();
+		directory.WriteFile("Directory.Build.props", """
+			<Project>
+			  <PropertyGroup>
+			    <TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var service = CreateService("10.0.41");
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			service.SetTargetFrameworkAsync(projectPath, "net10.0", dryRun: false));
+
+		Assert.Contains("inherited", exception.Message, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("<TargetFramework>", File.ReadAllText(projectPath));
+	}
+
+	[Fact]
+	public void NormalizeTargetFramework_InvalidPlatformQualifiedValue_Throws()
+	{
+		var exception = Assert.Throws<ArgumentException>(() =>
+			MauiProjectVersionService.NormalizeTargetFramework("net10.0-android"));
+
+		Assert.Contains("netX.Y", exception.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void TryGetRequiredTargetFramework_MauiVersion_ReturnsMajorTargetFramework()
+	{
+		Assert.Equal("net10.0", MauiProjectVersionService.TryGetRequiredTargetFramework("10.0.999-ci.pr.1"));
+	}
+
+	[Fact]
 	public async Task EnsureNuGetSourceAsync_AbsoluteLocalPath_AddsPackageSource()
 	{
 		using var directory = TemporaryDirectory.Create();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiProjectVersionServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiProjectVersionServiceTests.cs
@@ -395,6 +395,32 @@ public class MauiProjectVersionServiceTests
 	}
 
 	[Fact]
+	public async Task EnsureNuGetSourceAsync_AbsoluteLocalPath_AddsPackageSource()
+	{
+		using var directory = TemporaryDirectory.Create();
+		var projectPath = directory.WriteFile("App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <UseMaui>true</UseMaui>
+			  </PropertyGroup>
+			</Project>
+			""");
+		var packageSourcePath = Path.Combine(directory.Path, "hives", "dotnet-maui", "pr-1", "build-2", "packages");
+		Directory.CreateDirectory(packageSourcePath);
+		var service = CreateService("10.0.41");
+
+		var change = await service.EnsureNuGetSourceAsync(
+			projectPath,
+			".NET MAUI PR Build",
+			packageSourcePath,
+			dryRun: false);
+
+		Assert.NotNull(change);
+		Assert.Equal(packageSourcePath, change.NewValue);
+		Assert.Contains(packageSourcePath, File.ReadAllText(Path.Combine(directory.Path, "NuGet.config")));
+	}
+
+	[Fact]
 	public void DiscoverProjectFile_MultipleProjects_ReturnsNull()
 	{
 		using var directory = TemporaryDirectory.Create();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiVersionFeedServiceTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/MauiVersionFeedServiceTests.cs
@@ -34,6 +34,19 @@ public class MauiVersionFeedServiceTests
 		Assert.Equal("9.0.90-ci.main.25354.2", version.Version);
 	}
 
+	[Fact]
+	public async Task GetLatestVersionAsync_TargetFramework_ReturnsLatestCompatibleMajor()
+	{
+		var service = CreateService("""
+			{"versions":["9.0.90","10.0.1","9.0.100","10.0.2"]}
+			""");
+
+		var version = await service.GetLatestVersionAsync(MauiVersionChannel.Stable, includePrerelease: false, targetFramework: "net9.0");
+
+		Assert.NotNull(version);
+		Assert.Equal("9.0.100", version.Version);
+	}
+
 	static MauiVersionFeedService CreateService(string response) =>
 		new(new HttpClient(new StubHandler(response)));
 

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/ServiceConfigurationTests.cs
@@ -29,6 +29,7 @@ public class ServiceConfigurationTests
 		Assert.NotNull(provider.GetService<IDevFlowOutputWriter>());
 		Assert.NotNull(provider.GetService<IMauiVersionFeedService>());
 		Assert.NotNull(provider.GetService<IMauiProjectVersionService>());
+		Assert.NotNull(provider.GetService<IMauiPrArtifactService>());
 	}
 
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.Version.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.Version.cs
@@ -101,7 +101,7 @@ public static partial class ProjectCommands
 	{
 		var versionArgument = new Argument<string?>("version")
 		{
-			Description = "Specific .NET MAUI version to use. Omit when using --latest or --latest-nightly.",
+			Description = "Specific .NET MAUI version to use. Omit when using --latest, --latest-nightly, or --pr.",
 			Arity = ArgumentArity.ZeroOrOne,
 		};
 		var latestOption = new Option<bool>("--latest")
@@ -112,13 +112,17 @@ public static partial class ProjectCommands
 		{
 			Description = "Set the project to the latest version from the MAUI nightly feed.",
 		};
+		var prOption = new Option<int?>("--pr", "--pull-request")
+		{
+			Description = "Set the project to the package version produced by a dotnet/maui pull request build.",
+		};
 		var nugetConfigOption = new Option<bool>("--nuget-config")
 		{
 			Description = "Add or update a NuGet.config source for the selected feed.",
 		};
 		var sourceOption = new Option<string>("--source")
 		{
-			Description = "NuGet v3 source URL to add to NuGet.config, useful for PR or custom builds.",
+			Description = "NuGet v3 source URL to add to NuGet.config, useful for custom builds.",
 		};
 		var sourceNameOption = new Option<string>("--source-name")
 		{
@@ -129,21 +133,28 @@ public static partial class ProjectCommands
 		{
 			Description = "Do not run dotnet restore after updating files.",
 		};
+		var hivePathOption = new Option<string?>("--hive-path", "--artifact-path")
+		{
+			Description = "MAUI hives root used for downloaded PR build packages. Defaults to ~/.maui/hives. --artifact-path is also accepted as an alias and has the same hive-root behavior.",
+		};
 
 		var command = new Command("set", "Set the .NET MAUI version used by a project")
 		{
 			versionArgument,
 			latestOption,
 			latestNightlyOption,
+			prOption,
 			nugetConfigOption,
 			sourceOption,
 			sourceNameOption,
 			noRestoreOption,
+			hivePathOption,
 		};
 
 		SetHandledAction(command, async (parseResult, cancellationToken) =>
 		{
 			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
 			var dryRun = Program.IsDryRun(parseResult);
 			var projectService = Program.Services.GetRequiredService<IMauiProjectVersionService>();
 			var feedService = Program.Services.GetRequiredService<IMauiVersionFeedService>();
@@ -151,24 +162,38 @@ public static partial class ProjectCommands
 			var explicitVersion = parseResult.GetValue(versionArgument);
 			var latest = parseResult.GetValue(latestOption);
 			var latestNightly = parseResult.GetValue(latestNightlyOption);
+			var prNumber = parseResult.GetValue(prOption);
 			var noRestore = parseResult.GetValue(noRestoreOption);
 			var nugetConfig = parseResult.GetValue(nugetConfigOption);
 			var source = parseResult.GetValue(sourceOption);
 			var sourceName = parseResult.GetValue(sourceNameOption) ?? ".NET MAUI Packages";
+			var hivePath = parseResult.GetValue(hivePathOption);
 			var sourceSpecified = parseResult.GetResult(sourceOption)?.Tokens.Count > 0;
 			var sourceNameSpecified = parseResult.GetResult(sourceNameOption)?.Tokens.Count > 0;
 
-			var sourceCount = (string.IsNullOrWhiteSpace(explicitVersion) ? 0 : 1) + (latest ? 1 : 0) + (latestNightly ? 1 : 0);
+			var sourceCount =
+				(string.IsNullOrWhiteSpace(explicitVersion) ? 0 : 1) +
+				(latest ? 1 : 0) +
+				(latestNightly ? 1 : 0) +
+				(prNumber.HasValue ? 1 : 0);
 			if (sourceCount == 0)
-				throw new InvalidOperationException("Specify a version, --latest, or --latest-nightly.");
+				throw new InvalidOperationException("Specify a version, --latest, --latest-nightly, or --pr.");
 			if (sourceCount > 1)
-				throw new InvalidOperationException("Specify only one of version, --latest, or --latest-nightly.");
-			if (!nugetConfig && (sourceSpecified || sourceNameSpecified))
+				throw new InvalidOperationException("Specify only one of version, --latest, --latest-nightly, or --pr.");
+			if (prNumber.HasValue && prNumber.Value <= 0)
+				throw new InvalidOperationException("--pr must be a positive pull request number.");
+			if (prNumber.HasValue && sourceSpecified)
+				throw new InvalidOperationException("--pr downloads PackageArtifacts and cannot be combined with --source.");
+			if (!nugetConfig && !prNumber.HasValue && (sourceSpecified || sourceNameSpecified))
 				throw new InvalidOperationException("--source and --source-name require --nuget-config.");
+			if (!prNumber.HasValue && !string.IsNullOrWhiteSpace(hivePath))
+				throw new InvalidOperationException("--hive-path can only be used with --pr.");
 
 			string version;
 			string? sourceForConfig = source;
 			string sourceNameForConfig = sourceName;
+			MauiPrArtifactDownload? prDownload = null;
+			MauiPrBuildArtifact? prBuild = null;
 			if (latest)
 			{
 				var latestStable = await feedService.GetLatestVersionAsync(MauiVersionChannel.Stable, includePrerelease: false, cancellationToken);
@@ -181,6 +206,28 @@ public static partial class ProjectCommands
 				sourceForConfig ??= feedService.GetFeedUrl(MauiVersionChannel.Nightly);
 				sourceNameForConfig = sourceName == ".NET MAUI Packages" ? ".NET MAUI Nightly" : sourceName;
 			}
+			else if (prNumber.HasValue)
+			{
+				var prArtifactService = Program.Services.GetRequiredService<IMauiPrArtifactService>();
+				prBuild = await prArtifactService.FindPackageArtifactAsync(prNumber.Value, cancellationToken);
+				sourceNameForConfig = sourceNameSpecified ? sourceName : ".NET MAUI PR Build";
+
+				if (dryRun)
+				{
+					WritePrDryRunResult(formatter, parseResult, projectPath, prArtifactService, prBuild, hivePath, sourceNameForConfig);
+					return 0;
+				}
+
+				if (!useJson)
+					formatter.WriteInfo($"Found dotnet/maui PR #{prNumber.Value} build {prBuild.BuildId} ({prBuild.BuildNumber}).");
+
+				prDownload = await prArtifactService.DownloadPackageArtifactAsync(prBuild, hivePath, cancellationToken);
+				version = prDownload.Version;
+				sourceForConfig = prDownload.PackageSourcePath;
+
+				if (!useJson)
+					formatter.WriteInfo($"Downloaded PR packages to {prDownload.PackageSourcePath}.");
+			}
 			else
 			{
 				version = explicitVersion!;
@@ -188,7 +235,7 @@ public static partial class ProjectCommands
 
 			var versionResult = await projectService.SetVersionAsync(projectPath, version, dryRun: true, cancellationToken);
 			var changes = new List<MauiProjectVersionChange>();
-			if (nugetConfig)
+			if (nugetConfig || prDownload is not null)
 			{
 				if (string.IsNullOrWhiteSpace(sourceForConfig))
 					throw new InvalidOperationException("--nuget-config requires --source unless --latest-nightly is used.");
@@ -207,7 +254,7 @@ public static partial class ProjectCommands
 			if (!dryRun && !noRestore && changes.Count > 0)
 				restoreResult = await projectService.RestoreAsync(projectPath, cancellationToken);
 
-			WriteUpdateResult(formatter, parseResult, result with { Changes = changes }, restoreResult);
+			WriteUpdateResult(formatter, parseResult, result with { Changes = changes }, restoreResult, prDownload, prDownload is null ? null : sourceNameForConfig);
 			return 0;
 		});
 
@@ -358,7 +405,9 @@ public static partial class ProjectCommands
 		IOutputFormatter formatter,
 		ParseResult parseResult,
 		MauiProjectVersionUpdateResult result,
-		MauiProjectRestoreResult? restoreResult)
+		MauiProjectRestoreResult? restoreResult,
+		MauiPrArtifactDownload? prDownload = null,
+		string? prSourceName = null)
 	{
 		if (parseResult.GetValue(GlobalOptions.JsonOption))
 		{
@@ -370,6 +419,15 @@ public static partial class ProjectCommands
 				Changed = result.Changed,
 				Changes = result.Changes,
 				Restored = restoreResult?.Success,
+				PullRequest = prDownload?.Build.PullRequest,
+				BuildId = prDownload?.Build.BuildId,
+				BuildNumber = prDownload?.Build.BuildNumber,
+				BuildUrl = prDownload?.Build.BuildUrl,
+				HiveRoot = prDownload?.HiveRoot,
+				ArtifactPath = prDownload?.ArtifactPath,
+				PackageSourcePath = prDownload?.PackageSourcePath,
+				MetadataPath = prDownload?.MetadataPath,
+				SourceName = prSourceName,
 			});
 			return;
 		}
@@ -395,6 +453,42 @@ public static partial class ProjectCommands
 		else if (!result.DryRun)
 			formatter.WriteSuccess($"Updated MAUI version to {result.Version}.");
 	}
+
+	static void WritePrDryRunResult(
+		IOutputFormatter formatter,
+		ParseResult parseResult,
+		string projectPath,
+		IMauiPrArtifactService prArtifactService,
+		MauiPrBuildArtifact build,
+		string? hiveRoot,
+		string sourceName)
+	{
+		var paths = prArtifactService.GetHivePaths(build, hiveRoot);
+
+		if (parseResult.GetValue(GlobalOptions.JsonOption))
+		{
+			formatter.Write(new MauiProjectVersionCommandResult
+			{
+				ProjectPath = projectPath,
+				DryRun = true,
+				Changed = false,
+				PullRequest = build.PullRequest,
+				BuildId = build.BuildId,
+				BuildNumber = build.BuildNumber,
+				BuildUrl = build.BuildUrl,
+				HiveRoot = paths.HiveRoot,
+				ArtifactPath = paths.HivePath,
+				PackageSourcePath = paths.PackageSourcePath,
+				MetadataPath = paths.MetadataPath,
+				SourceName = sourceName,
+			});
+			return;
+		}
+
+		formatter.WriteInfo($"[dry-run] Found dotnet/maui PR #{build.PullRequest} build {build.BuildId} ({build.BuildNumber}).");
+		formatter.WriteInfo($"[dry-run] Would download {build.ArtifactName} into {paths.HivePath} and add NuGet source '{sourceName}'.");
+		formatter.WriteInfo("[dry-run] Would set MAUI version to the Microsoft.Maui.Controls version discovered in the downloaded artifact.");
+	}
 }
 
 public sealed record MauiVersionListResult
@@ -408,9 +502,18 @@ public sealed record MauiVersionListResult
 public sealed record MauiProjectVersionCommandResult
 {
 	public required string ProjectPath { get; init; }
-	public required string Version { get; init; }
+	public string? Version { get; init; }
 	public bool DryRun { get; init; }
 	public bool Changed { get; init; }
 	public bool? Restored { get; init; }
 	public List<MauiProjectVersionChange> Changes { get; init; } = [];
+	public int? PullRequest { get; init; }
+	public int? BuildId { get; init; }
+	public string? BuildNumber { get; init; }
+	public string? BuildUrl { get; init; }
+	public string? HiveRoot { get; init; }
+	public string? ArtifactPath { get; init; }
+	public string? PackageSourcePath { get; init; }
+	public string? MetadataPath { get; init; }
+	public string? SourceName { get; init; }
 }

--- a/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.Version.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.Version.cs
@@ -291,21 +291,6 @@ public static partial class ProjectCommands
 						projectPath, sourceNameForConfig, sourceForConfig, dryRun: true, cancellationToken);
 				}
 
-				if (prDownload?.IsStaged == true && prArtifactService is not null)
-				{
-					if (dryRun)
-					{
-						prArtifactService.DiscardStagedPackageArtifact(prDownload);
-					}
-					else
-					{
-						await prArtifactService.PromoteStagedPackageArtifactAsync(prDownload, cancellationToken);
-						prDownload = prDownload with { IsStaged = false, StagingArtifactPath = null };
-						if (!useJson)
-							formatter.WriteInfo($"Downloaded PR packages to {prDownload.PackageSourcePath}.");
-					}
-				}
-
 				var changes = new List<MauiProjectVersionChange>();
 				if (targetFrameworkResult is not null)
 				{
@@ -327,6 +312,21 @@ public static partial class ProjectCommands
 					? versionResult
 					: await projectService.SetVersionAsync(projectPath, version, dryRun: false, cancellationToken);
 				changes.AddRange(result.Changes);
+
+				if (prDownload?.IsStaged == true && prArtifactService is not null)
+				{
+					if (dryRun)
+					{
+						prArtifactService.DiscardStagedPackageArtifact(prDownload);
+					}
+					else
+					{
+						await prArtifactService.PromoteStagedPackageArtifactAsync(prDownload, cancellationToken);
+						prDownload = prDownload with { IsStaged = false, StagingArtifactPath = null };
+						if (!useJson)
+							formatter.WriteInfo($"Downloaded PR packages to {prDownload.PackageSourcePath}.");
+					}
+				}
 
 				MauiProjectRestoreResult? restoreResult = null;
 				if (!dryRun && !noRestore && changes.Count > 0)

--- a/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.Version.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/ProjectCommands.Version.cs
@@ -137,6 +137,10 @@ public static partial class ProjectCommands
 		{
 			Description = "MAUI hives root used for downloaded PR build packages. Defaults to ~/.maui/hives. --artifact-path is also accepted as an alias and has the same hive-root behavior.",
 		};
+		var targetFrameworkOption = new Option<string?>("--target-framework", "--framework", "-f")
+		{
+			Description = "Update project target frameworks to the specified netX.Y value, for example net10.0. Values like 10.0 are normalized to net10.0.",
+		};
 
 		var command = new Command("set", "Set the .NET MAUI version used by a project")
 		{
@@ -149,6 +153,7 @@ public static partial class ProjectCommands
 			sourceNameOption,
 			noRestoreOption,
 			hivePathOption,
+			targetFrameworkOption,
 		};
 
 		SetHandledAction(command, async (parseResult, cancellationToken) =>
@@ -168,6 +173,10 @@ public static partial class ProjectCommands
 			var source = parseResult.GetValue(sourceOption);
 			var sourceName = parseResult.GetValue(sourceNameOption) ?? ".NET MAUI Packages";
 			var hivePath = parseResult.GetValue(hivePathOption);
+			var targetFrameworkInput = parseResult.GetValue(targetFrameworkOption);
+			var targetFramework = string.IsNullOrWhiteSpace(targetFrameworkInput)
+				? null
+				: MauiProjectVersionService.NormalizeTargetFramework(targetFrameworkInput);
 			var sourceSpecified = parseResult.GetResult(sourceOption)?.Tokens.Count > 0;
 			var sourceNameSpecified = parseResult.GetResult(sourceNameOption)?.Tokens.Count > 0;
 
@@ -189,73 +198,149 @@ public static partial class ProjectCommands
 			if (!prNumber.HasValue && !string.IsNullOrWhiteSpace(hivePath))
 				throw new InvalidOperationException("--hive-path can only be used with --pr.");
 
+			var projectInfo = await projectService.GetVersionInfoAsync(projectPath, cancellationToken);
+			var selectionTargetFramework = targetFramework ?? projectInfo.TargetDotNetFramework;
+
 			string version;
 			string? sourceForConfig = source;
 			string sourceNameForConfig = sourceName;
 			MauiPrArtifactDownload? prDownload = null;
 			MauiPrBuildArtifact? prBuild = null;
+			MauiPrBuildProgress? inProgressBuild = null;
+			IMauiPrArtifactService? prArtifactService = null;
+			string? selectionMessage = null;
 			if (latest)
 			{
-				var latestStable = await feedService.GetLatestVersionAsync(MauiVersionChannel.Stable, includePrerelease: false, cancellationToken);
-				version = latestStable?.Version ?? throw new InvalidOperationException("Could not determine the latest stable MAUI version.");
+				var latestStable = await feedService.GetLatestVersionAsync(MauiVersionChannel.Stable, includePrerelease: false, selectionTargetFramework, cancellationToken);
+				version = latestStable?.Version ?? throw new InvalidOperationException(
+					selectionTargetFramework is null
+						? "Could not determine the latest stable MAUI version."
+						: $"Could not determine a stable MAUI version compatible with {selectionTargetFramework}.");
+				if (selectionTargetFramework is not null)
+					selectionMessage = $"Selected MAUI version {version} compatible with {selectionTargetFramework}.";
 			}
 			else if (latestNightly)
 			{
-				var latestNightlyVersion = await feedService.GetLatestVersionAsync(MauiVersionChannel.Nightly, includePrerelease: true, cancellationToken);
-				version = latestNightlyVersion?.Version ?? throw new InvalidOperationException("Could not determine the latest nightly MAUI version.");
+				var latestNightlyVersion = await feedService.GetLatestVersionAsync(MauiVersionChannel.Nightly, includePrerelease: true, selectionTargetFramework, cancellationToken);
+				version = latestNightlyVersion?.Version ?? throw new InvalidOperationException(
+					selectionTargetFramework is null
+						? "Could not determine the latest nightly MAUI version."
+						: $"Could not determine a nightly MAUI version compatible with {selectionTargetFramework}.");
 				sourceForConfig ??= feedService.GetFeedUrl(MauiVersionChannel.Nightly);
 				sourceNameForConfig = sourceName == ".NET MAUI Packages" ? ".NET MAUI Nightly" : sourceName;
+				if (selectionTargetFramework is not null)
+					selectionMessage = $"Selected MAUI version {version} compatible with {selectionTargetFramework}.";
 			}
 			else if (prNumber.HasValue)
 			{
-				var prArtifactService = Program.Services.GetRequiredService<IMauiPrArtifactService>();
-				prBuild = await prArtifactService.FindPackageArtifactAsync(prNumber.Value, cancellationToken);
+				prArtifactService = Program.Services.GetRequiredService<IMauiPrArtifactService>();
+				inProgressBuild = await prArtifactService.FindInProgressBuildAsync(prNumber.Value, cancellationToken);
+				try
+				{
+					prBuild = await prArtifactService.FindPackageArtifactAsync(prNumber.Value, cancellationToken);
+				}
+				catch (InvalidOperationException exception) when (inProgressBuild is not null)
+				{
+					throw new InvalidOperationException(
+						$"dotnet/maui PR #{prNumber.Value} has a build in progress ({inProgressBuild.Status}, build {inProgressBuild.BuildId}). " +
+						"Try again after it completes; no completed PackageArtifacts build is available yet.",
+						exception);
+				}
 				sourceNameForConfig = sourceNameSpecified ? sourceName : ".NET MAUI PR Build";
 
 				if (dryRun)
 				{
-					WritePrDryRunResult(formatter, parseResult, projectPath, prArtifactService, prBuild, hivePath, sourceNameForConfig);
+					WritePrDryRunResult(formatter, parseResult, projectPath, prArtifactService, prBuild, hivePath, sourceNameForConfig, inProgressBuild);
 					return 0;
 				}
 
 				if (!useJson)
+				{
+					if (inProgressBuild is not null)
+						formatter.WriteWarning($"dotnet/maui PR #{prNumber.Value} also has an in-progress build {inProgressBuild.BuildId} ({inProgressBuild.Status}); using the latest completed PackageArtifacts build.");
 					formatter.WriteInfo($"Found dotnet/maui PR #{prNumber.Value} build {prBuild.BuildId} ({prBuild.BuildNumber}).");
+				}
 
-				prDownload = await prArtifactService.DownloadPackageArtifactAsync(prBuild, hivePath, cancellationToken);
+				prDownload = await prArtifactService.StagePackageArtifactAsync(prBuild, hivePath, cancellationToken);
 				version = prDownload.Version;
 				sourceForConfig = prDownload.PackageSourcePath;
-
-				if (!useJson)
-					formatter.WriteInfo($"Downloaded PR packages to {prDownload.PackageSourcePath}.");
 			}
 			else
 			{
 				version = explicitVersion!;
 			}
 
-			var versionResult = await projectService.SetVersionAsync(projectPath, version, dryRun: true, cancellationToken);
-			var changes = new List<MauiProjectVersionChange>();
-			if (nugetConfig || prDownload is not null)
+			try
 			{
-				if (string.IsNullOrWhiteSpace(sourceForConfig))
-					throw new InvalidOperationException("--nuget-config requires --source unless --latest-nightly is used.");
-				var nugetConfigChange = await projectService.EnsureNuGetSourceAsync(
-					projectPath, sourceNameForConfig, sourceForConfig, dryRun, cancellationToken);
-				if (nugetConfigChange is not null)
-					changes.Add(nugetConfigChange);
+				EnsureTargetFrameworkCompatibility(version, projectInfo, targetFramework);
+				MauiProjectVersionUpdateResult? targetFrameworkResult = null;
+				if (targetFramework is not null)
+					targetFrameworkResult = await projectService.SetTargetFrameworkAsync(projectPath, targetFramework, dryRun: true, cancellationToken);
+
+				if (!useJson && selectionMessage is not null)
+					formatter.WriteInfo(selectionMessage);
+
+				var versionResult = await projectService.SetVersionAsync(projectPath, version, dryRun: true, cancellationToken);
+				MauiProjectVersionChange? nugetConfigChange = null;
+				var shouldUpdateNuGetConfig = nugetConfig || prDownload is not null;
+				if (shouldUpdateNuGetConfig)
+				{
+					if (string.IsNullOrWhiteSpace(sourceForConfig))
+						throw new InvalidOperationException("--nuget-config requires --source unless --latest-nightly is used.");
+					nugetConfigChange = await projectService.EnsureNuGetSourceAsync(
+						projectPath, sourceNameForConfig, sourceForConfig, dryRun: true, cancellationToken);
+				}
+
+				if (prDownload?.IsStaged == true && prArtifactService is not null)
+				{
+					if (dryRun)
+					{
+						prArtifactService.DiscardStagedPackageArtifact(prDownload);
+					}
+					else
+					{
+						await prArtifactService.PromoteStagedPackageArtifactAsync(prDownload, cancellationToken);
+						prDownload = prDownload with { IsStaged = false, StagingArtifactPath = null };
+						if (!useJson)
+							formatter.WriteInfo($"Downloaded PR packages to {prDownload.PackageSourcePath}.");
+					}
+				}
+
+				var changes = new List<MauiProjectVersionChange>();
+				if (targetFrameworkResult is not null)
+				{
+					var appliedTargetFrameworkResult = dryRun
+						? targetFrameworkResult
+						: await projectService.SetTargetFrameworkAsync(projectPath, targetFramework!, dryRun: false, cancellationToken);
+					changes.AddRange(appliedTargetFrameworkResult.Changes);
+				}
+				if (shouldUpdateNuGetConfig)
+				{
+					var appliedNuGetConfigChange = dryRun
+						? nugetConfigChange
+						: await projectService.EnsureNuGetSourceAsync(projectPath, sourceNameForConfig, sourceForConfig!, dryRun: false, cancellationToken);
+					if (appliedNuGetConfigChange is not null)
+						changes.Add(appliedNuGetConfigChange);
+				}
+
+				var result = dryRun
+					? versionResult
+					: await projectService.SetVersionAsync(projectPath, version, dryRun: false, cancellationToken);
+				changes.AddRange(result.Changes);
+
+				MauiProjectRestoreResult? restoreResult = null;
+				if (!dryRun && !noRestore && changes.Count > 0)
+					restoreResult = await projectService.RestoreAsync(projectPath, cancellationToken);
+
+				WriteUpdateResult(formatter, parseResult, result with { Changes = changes }, restoreResult, prDownload, prDownload is null ? null : sourceNameForConfig, targetFramework, inProgressBuild);
+				return 0;
 			}
-
-			var result = dryRun
-				? versionResult
-				: await projectService.SetVersionAsync(projectPath, version, dryRun: false, cancellationToken);
-			changes.AddRange(result.Changes);
-
-			MauiProjectRestoreResult? restoreResult = null;
-			if (!dryRun && !noRestore && changes.Count > 0)
-				restoreResult = await projectService.RestoreAsync(projectPath, cancellationToken);
-
-			WriteUpdateResult(formatter, parseResult, result with { Changes = changes }, restoreResult, prDownload, prDownload is null ? null : sourceNameForConfig);
-			return 0;
+			catch
+			{
+				if (prDownload?.IsStaged == true && prArtifactService is not null)
+					prArtifactService.DiscardStagedPackageArtifact(prDownload);
+				throw;
+			}
 		});
 
 		return command;
@@ -361,6 +446,46 @@ public static partial class ProjectCommands
 			_ => throw new InvalidOperationException($"Invalid channel '{channel}'. Valid values: stable, nightly."),
 		};
 
+	static void EnsureTargetFrameworkCompatibility(
+		string version,
+		MauiProjectVersionInfo projectInfo,
+		string? requestedTargetFramework)
+	{
+		var requiredTargetFramework = MauiProjectVersionService.TryGetRequiredTargetFramework(version);
+		if (requiredTargetFramework is null)
+			return;
+
+		if (requestedTargetFramework is not null)
+		{
+			if (!string.Equals(requestedTargetFramework, requiredTargetFramework, StringComparison.OrdinalIgnoreCase))
+			{
+				throw new InvalidOperationException(
+					$"MAUI version {version} requires {requiredTargetFramework}, but --framework was {requestedTargetFramework}.");
+			}
+
+			return;
+		}
+
+		if (projectInfo.TargetDotNetFramework is null)
+		{
+			if (projectInfo.TargetFrameworks.Count > 0)
+			{
+				throw new InvalidOperationException(
+					$"MAUI version {version} requires {requiredTargetFramework}, but {Path.GetFileName(projectInfo.ProjectPath)} targets multiple or non-literal frameworks. " +
+					$"Rerun with --framework {requiredTargetFramework} to update project target frameworks.");
+			}
+
+			return;
+		}
+
+		if (!string.Equals(projectInfo.TargetDotNetFramework, requiredTargetFramework, StringComparison.OrdinalIgnoreCase))
+		{
+			throw new InvalidOperationException(
+				$"MAUI version {version} requires {requiredTargetFramework}, but {Path.GetFileName(projectInfo.ProjectPath)} targets {projectInfo.TargetDotNetFramework}. " +
+				$"Rerun with --framework {requiredTargetFramework} to update project target frameworks.");
+		}
+	}
+
 	static void WriteProjectVersionInfo(IOutputFormatter formatter, MauiProjectVersionInfo info)
 	{
 		formatter.WriteInfo($"Project: {Path.GetFileName(info.ProjectPath)}");
@@ -370,6 +495,8 @@ public static partial class ProjectCommands
 			formatter.WriteInfo($"MauiVersion property: {info.MauiVersion}");
 		if (info.WorkloadVersion is not null)
 			formatter.WriteInfo($"Installed workload version: {info.WorkloadVersion}");
+		if (info.TargetFrameworks.Count > 0)
+			formatter.WriteInfo($"Target frameworks: {string.Join("; ", info.TargetFrameworks)}");
 		if (info.EffectiveVersion is not null)
 			formatter.WriteSuccess($"Effective MAUI version: {info.EffectiveVersion}");
 		else
@@ -407,7 +534,9 @@ public static partial class ProjectCommands
 		MauiProjectVersionUpdateResult result,
 		MauiProjectRestoreResult? restoreResult,
 		MauiPrArtifactDownload? prDownload = null,
-		string? prSourceName = null)
+		string? prSourceName = null,
+		string? targetFramework = null,
+		MauiPrBuildProgress? inProgressBuild = null)
 	{
 		if (parseResult.GetValue(GlobalOptions.JsonOption))
 		{
@@ -428,6 +557,11 @@ public static partial class ProjectCommands
 				PackageSourcePath = prDownload?.PackageSourcePath,
 				MetadataPath = prDownload?.MetadataPath,
 				SourceName = prSourceName,
+				TargetFramework = targetFramework,
+				BuildInProgress = inProgressBuild is not null,
+				InProgressBuildId = inProgressBuild?.BuildId,
+				InProgressBuildNumber = inProgressBuild?.BuildNumber,
+				InProgressBuildUrl = inProgressBuild?.BuildUrl,
 			});
 			return;
 		}
@@ -461,7 +595,8 @@ public static partial class ProjectCommands
 		IMauiPrArtifactService prArtifactService,
 		MauiPrBuildArtifact build,
 		string? hiveRoot,
-		string sourceName)
+		string sourceName,
+		MauiPrBuildProgress? inProgressBuild)
 	{
 		var paths = prArtifactService.GetHivePaths(build, hiveRoot);
 
@@ -481,13 +616,20 @@ public static partial class ProjectCommands
 				PackageSourcePath = paths.PackageSourcePath,
 				MetadataPath = paths.MetadataPath,
 				SourceName = sourceName,
+				BuildInProgress = inProgressBuild is not null,
+				InProgressBuildId = inProgressBuild?.BuildId,
+				InProgressBuildNumber = inProgressBuild?.BuildNumber,
+				InProgressBuildUrl = inProgressBuild?.BuildUrl,
 			});
 			return;
 		}
 
+		if (inProgressBuild is not null)
+			formatter.WriteWarning($"dotnet/maui PR #{build.PullRequest} also has an in-progress build {inProgressBuild.BuildId} ({inProgressBuild.Status}); this dry run uses the latest completed PackageArtifacts build.");
 		formatter.WriteInfo($"[dry-run] Found dotnet/maui PR #{build.PullRequest} build {build.BuildId} ({build.BuildNumber}).");
 		formatter.WriteInfo($"[dry-run] Would download {build.ArtifactName} into {paths.HivePath} and add NuGet source '{sourceName}'.");
 		formatter.WriteInfo("[dry-run] Would set MAUI version to the Microsoft.Maui.Controls version discovered in the downloaded artifact.");
+		formatter.WriteInfo("[dry-run] PR artifact target framework compatibility is validated after downloading the package version during a real run.");
 	}
 }
 
@@ -516,4 +658,9 @@ public sealed record MauiProjectVersionCommandResult
 	public string? PackageSourcePath { get; init; }
 	public string? MetadataPath { get; init; }
 	public string? SourceName { get; init; }
+	public string? TargetFramework { get; init; }
+	public bool BuildInProgress { get; init; }
+	public int? InProgressBuildId { get; init; }
+	public string? InProgressBuildNumber { get; init; }
+	public string? InProgressBuildUrl { get; init; }
 }

--- a/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Cli.Output;
 [JsonSerializable(typeof(MauiProjectVersionInfo))]
 [JsonSerializable(typeof(MauiVersionListResult))]
 [JsonSerializable(typeof(MauiPrBuildArtifact))]
+[JsonSerializable(typeof(MauiPrBuildProgress))]
 [JsonSerializable(typeof(MauiPrArtifactDownload))]
 [JsonSerializable(typeof(SimulatorCreateResult))]
 [JsonSerializable(typeof(SimulatorEraseResult))]

--- a/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Maui.Cli.Output;
 [JsonSerializable(typeof(MauiProjectVersionCommandResult))]
 [JsonSerializable(typeof(MauiProjectVersionInfo))]
 [JsonSerializable(typeof(MauiVersionListResult))]
+[JsonSerializable(typeof(MauiPrBuildArtifact))]
+[JsonSerializable(typeof(MauiPrArtifactDownload))]
 [JsonSerializable(typeof(SimulatorCreateResult))]
 [JsonSerializable(typeof(SimulatorEraseResult))]
 [JsonSerializable(typeof(SimulatorAppResult))]

--- a/src/Cli/Microsoft.Maui.Cli/ServiceConfiguration.cs
+++ b/src/Cli/Microsoft.Maui.Cli/ServiceConfiguration.cs
@@ -44,6 +44,10 @@ public static class ServiceConfiguration
 		services.AddSingleton<HttpClient>();
 		services.AddSingleton<IMauiVersionFeedService, MauiVersionFeedService>();
 		services.AddSingleton<IMauiProjectVersionService, MauiProjectVersionService>();
+		services.AddSingleton<IMauiPrArtifactService>(_ => new MauiPrArtifactService(new HttpClient
+		{
+			Timeout = Timeout.InfiniteTimeSpan,
+		}));
 
 		// DevFlow output
 		services.AddSingleton<IDevFlowOutputWriter, DevFlowOutputWriter>();
@@ -64,7 +68,8 @@ public static class ServiceConfiguration
 		IDeviceManager? deviceManager = null,
 		IDevFlowOutputWriter? devFlowOutputWriter = null,
 		IMauiVersionFeedService? mauiVersionFeedService = null,
-		IMauiProjectVersionService? mauiProjectVersionService = null)
+		IMauiProjectVersionService? mauiProjectVersionService = null,
+		IMauiPrArtifactService? mauiPrArtifactService = null)
 	{
 		var services = new ServiceCollection();
 
@@ -110,6 +115,14 @@ public static class ServiceConfiguration
 			services.AddSingleton(mauiProjectVersionService);
 		else
 			services.AddSingleton<IMauiProjectVersionService, MauiProjectVersionService>();
+
+		if (mauiPrArtifactService != null)
+			services.AddSingleton(mauiPrArtifactService);
+		else
+			services.AddSingleton<IMauiPrArtifactService>(_ => new MauiPrArtifactService(new HttpClient
+			{
+				Timeout = Timeout.InfiniteTimeSpan,
+			}));
 
 		return services.BuildServiceProvider();
 	}

--- a/src/Cli/Microsoft.Maui.Cli/Services/MauiPrArtifactService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/MauiPrArtifactService.cs
@@ -1,0 +1,695 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Microsoft.Maui.Cli.Services;
+
+public sealed record MauiPrBuildArtifact
+{
+	public int PullRequest { get; init; }
+	public int BuildId { get; init; }
+	public required string BuildNumber { get; init; }
+	public required string Status { get; init; }
+	public string? Result { get; init; }
+	public required string SourceVersion { get; init; }
+	public required string Organization { get; init; }
+	public required string Project { get; init; }
+	public required string ArtifactName { get; init; }
+	public required string DownloadUrl { get; init; }
+	public required string BuildUrl { get; init; }
+}
+
+public sealed record MauiPrArtifactDownload
+{
+	public required MauiPrBuildArtifact Build { get; init; }
+	public required string HiveRoot { get; init; }
+	public required string ArtifactPath { get; init; }
+	public required string PackageSourcePath { get; init; }
+	public required string MetadataPath { get; init; }
+	public required string Version { get; init; }
+}
+
+public sealed record MauiPrArtifactHivePaths
+{
+	public required string HiveRoot { get; init; }
+	public required string HivePath { get; init; }
+	public required string ExtractPath { get; init; }
+	public required string PackageSourcePath { get; init; }
+	public required string ZipPath { get; init; }
+	public required string MetadataPath { get; init; }
+}
+
+public sealed record MauiPrArtifactMetadata
+{
+	public int SchemaVersion { get; init; } = 1;
+	public DateTimeOffset CreatedAtUtc { get; init; }
+	public required string Repository { get; init; }
+	public int PullRequest { get; init; }
+	public int BuildId { get; init; }
+	public required string BuildNumber { get; init; }
+	public required string BuildUrl { get; init; }
+	public required string Status { get; init; }
+	public string? Result { get; init; }
+	public required string SourceVersion { get; init; }
+	public required string Organization { get; init; }
+	public required string Project { get; init; }
+	public required string ArtifactName { get; init; }
+	public required string PackageVersion { get; init; }
+	public required string HiveRoot { get; init; }
+	public required string HivePath { get; init; }
+	public required string PackageSourcePath { get; init; }
+	public required string ZipPath { get; init; }
+}
+
+public interface IMauiPrArtifactService
+{
+	Task<MauiPrBuildArtifact> FindPackageArtifactAsync(int prNumber, CancellationToken cancellationToken = default);
+	MauiPrArtifactHivePaths GetHivePaths(MauiPrBuildArtifact artifact, string? hiveRoot = null);
+	Task<MauiPrArtifactDownload> DownloadPackageArtifactAsync(
+		MauiPrBuildArtifact artifact,
+		string? hiveRoot = null,
+		CancellationToken cancellationToken = default);
+}
+
+public sealed class MauiPrArtifactService : IMauiPrArtifactService
+{
+	internal const string DotNetMauiOwner = "dotnet";
+	internal const string DotNetMauiRepo = "maui";
+	internal const string DefaultAzureDevOpsOrganization = "dnceng-public";
+	internal const string DefaultAzureDevOpsProject = "public";
+	internal const string MauiPrDefinitionName = "maui-pr";
+	internal const string PackageArtifactName = "PackageArtifacts";
+	internal const string VersionPackageId = "Microsoft.Maui.Controls";
+	internal const long MaxArtifactZipBytes = 2_500_000_000;
+	internal const long MaxExtractedArtifactBytes = 10_000_000_000;
+	internal const long MaxPackageBytes = 1_500_000_000;
+	internal const int MaxExtractedArtifactEntries = 100_000;
+
+	static readonly Regex s_buildUrlRegex = new(
+		@"dev\.azure\.com/([^/]+)/([^/]+)/_build/results\?buildId=(\d+)",
+		RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+	readonly HttpClient _httpClient;
+
+	public MauiPrArtifactService(HttpClient httpClient)
+	{
+		_httpClient = httpClient;
+	}
+
+	public async Task<MauiPrBuildArtifact> FindPackageArtifactAsync(int prNumber, CancellationToken cancellationToken = default)
+	{
+		if (prNumber <= 0)
+			throw new ArgumentOutOfRangeException(nameof(prNumber), "PR number must be positive.");
+
+		var directBuild = await FindBuildFromAzureDevOpsAsync(prNumber, cancellationToken);
+		if (directBuild is not null)
+			return directBuild;
+
+		var checkBuild = await FindBuildFromGitHubChecksAsync(prNumber, cancellationToken);
+		if (checkBuild is not null)
+			return checkBuild;
+
+		throw new InvalidOperationException(
+			$"No completed dotnet/maui PR build with {PackageArtifactName} was found for PR #{prNumber}. " +
+			$"Check https://github.com/dotnet/maui/pull/{prNumber} to confirm the PR build has completed.");
+	}
+
+	public async Task<MauiPrArtifactDownload> DownloadPackageArtifactAsync(
+		MauiPrBuildArtifact artifact,
+		string? hiveRoot = null,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(artifact);
+
+		var finalPaths = GetHivePaths(artifact, hiveRoot);
+		var stagingPaths = CreateStagingPaths(finalPaths);
+		await using var hiveLock = await AcquireHiveLockAsync(finalPaths.HivePath, cancellationToken);
+
+		if (Directory.Exists(stagingPaths.HivePath))
+			Directory.Delete(stagingPaths.HivePath, recursive: true);
+		Directory.CreateDirectory(stagingPaths.HivePath);
+
+		try
+		{
+			using (var response = await SendAsync(artifact.DownloadUrl, cancellationToken, HttpCompletionOption.ResponseHeadersRead))
+			{
+				if (!response.IsSuccessStatusCode)
+					throw new InvalidOperationException($"Failed to download {artifact.ArtifactName} from build {artifact.BuildId}: {response.StatusCode}");
+
+				await DownloadContentAsync(response, stagingPaths.ZipPath, cancellationToken);
+			}
+
+			ExtractArtifact(stagingPaths.ZipPath, stagingPaths.ExtractPath);
+			Directory.CreateDirectory(stagingPaths.PackageSourcePath);
+
+			var version = CopyPackagesAndFindVersion(stagingPaths.ExtractPath, stagingPaths.PackageSourcePath);
+			WriteMetadata(artifact, finalPaths, stagingPaths.MetadataPath, version);
+			ReplaceHive(stagingPaths.HivePath, finalPaths.HivePath);
+
+			return new MauiPrArtifactDownload
+			{
+				Build = artifact,
+				HiveRoot = finalPaths.HiveRoot,
+				ArtifactPath = finalPaths.HivePath,
+				PackageSourcePath = finalPaths.PackageSourcePath,
+				MetadataPath = finalPaths.MetadataPath,
+				Version = version,
+			};
+		}
+
+		catch
+		{
+			if (Directory.Exists(stagingPaths.HivePath))
+				Directory.Delete(stagingPaths.HivePath, recursive: true);
+
+			throw;
+		}
+	}
+
+	static async Task<FileStream> AcquireHiveLockAsync(string hivePath, CancellationToken cancellationToken)
+	{
+		var lockDirectory = Path.GetDirectoryName(hivePath);
+		if (!string.IsNullOrWhiteSpace(lockDirectory))
+			Directory.CreateDirectory(lockDirectory);
+
+		var lockPath = hivePath + ".lock";
+		while (true)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			try
+			{
+				return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+			}
+			catch (IOException)
+			{
+				await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+			}
+		}
+	}
+
+	public MauiPrArtifactHivePaths GetHivePaths(MauiPrBuildArtifact artifact, string? hiveRoot = null)
+	{
+		ArgumentNullException.ThrowIfNull(artifact);
+
+		var root = ResolveHiveRoot(hiveRoot);
+		var hivePath = Path.Combine(
+			root,
+			GetRepositoryHiveName(),
+			$"pr-{artifact.PullRequest}",
+			$"build-{artifact.BuildId}");
+
+		return new MauiPrArtifactHivePaths
+		{
+			HiveRoot = root,
+			HivePath = hivePath,
+			ExtractPath = Path.Combine(hivePath, "extracted"),
+			PackageSourcePath = Path.Combine(hivePath, "packages"),
+			ZipPath = Path.Combine(hivePath, "PackageArtifacts.zip"),
+			MetadataPath = Path.Combine(hivePath, "metadata.json"),
+		};
+	}
+
+	static MauiPrArtifactHivePaths CreateStagingPaths(MauiPrArtifactHivePaths finalPaths)
+	{
+		var stagingHivePath = finalPaths.HivePath + $".tmp-{Guid.NewGuid():N}";
+		return new MauiPrArtifactHivePaths
+		{
+			HiveRoot = finalPaths.HiveRoot,
+			HivePath = stagingHivePath,
+			ExtractPath = Path.Combine(stagingHivePath, "extracted"),
+			PackageSourcePath = Path.Combine(stagingHivePath, "packages"),
+			ZipPath = Path.Combine(stagingHivePath, "PackageArtifacts.zip"),
+			MetadataPath = Path.Combine(stagingHivePath, "metadata.json"),
+		};
+	}
+
+	static void ReplaceHive(string stagingHivePath, string finalHivePath)
+	{
+		var parentDirectory = Path.GetDirectoryName(finalHivePath);
+		if (!string.IsNullOrWhiteSpace(parentDirectory))
+			Directory.CreateDirectory(parentDirectory);
+
+		if (Directory.Exists(finalHivePath))
+			Directory.Delete(finalHivePath, recursive: true);
+
+		Directory.Move(stagingHivePath, finalHivePath);
+	}
+
+	async Task<MauiPrBuildArtifact?> FindBuildFromAzureDevOpsAsync(int prNumber, CancellationToken cancellationToken)
+	{
+		var buildsUrl =
+			$"https://dev.azure.com/{DefaultAzureDevOpsOrganization}/{DefaultAzureDevOpsProject}/_apis/build/builds" +
+			$"?api-version=7.1&branchName=refs/pull/{prNumber}/merge&$top=25";
+
+		using var response = await SendAsync(buildsUrl, cancellationToken);
+		if (!response.IsSuccessStatusCode)
+			throw new InvalidOperationException($"Failed to query Azure DevOps builds for PR #{prNumber}: {response.StatusCode}");
+
+		using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+		if (!document.RootElement.TryGetProperty("value", out var builds) || builds.ValueKind != JsonValueKind.Array)
+			throw new InvalidOperationException("Azure DevOps builds response did not contain a value array.");
+
+		foreach (var build in builds.EnumerateArray())
+		{
+			if (!IsCompletedMauiPrBuild(build))
+				continue;
+
+			var buildId = build.GetProperty("id").GetInt32();
+			var artifact = await TryGetPackageArtifactAsync(
+				prNumber,
+				buildId,
+				DefaultAzureDevOpsOrganization,
+				DefaultAzureDevOpsProject,
+				build,
+				cancellationToken);
+			if (artifact is not null)
+				return artifact;
+		}
+
+		return null;
+	}
+
+	async Task<MauiPrBuildArtifact?> FindBuildFromGitHubChecksAsync(int prNumber, CancellationToken cancellationToken)
+	{
+		foreach (var commitSha in await GetPullRequestCommitsAsync(prNumber, cancellationToken))
+		{
+			var page = 1;
+			while (true)
+			{
+				var url = $"https://api.github.com/repos/{DotNetMauiOwner}/{DotNetMauiRepo}/commits/{commitSha}/check-runs?per_page=100&page={page}";
+				using var response = await SendAsync(url, cancellationToken);
+				if (!response.IsSuccessStatusCode)
+					throw new InvalidOperationException($"Failed to query GitHub check runs for PR #{prNumber}: {response.StatusCode}");
+
+				using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+				using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+				var root = document.RootElement;
+				if (!root.TryGetProperty("check_runs", out var checkRuns) || checkRuns.ValueKind != JsonValueKind.Array)
+					throw new InvalidOperationException("GitHub check-runs response did not contain a check_runs array.");
+
+				foreach (var checkRun in checkRuns.EnumerateArray())
+				{
+					var artifact = await TryGetBuildFromCheckRunAsync(prNumber, commitSha, checkRun, cancellationToken);
+					if (artifact is not null)
+						return artifact;
+				}
+
+				var totalCount = root.TryGetProperty("total_count", out var totalCountProperty)
+					? totalCountProperty.GetInt32()
+					: checkRuns.GetArrayLength();
+				if (page * 100 >= totalCount)
+					break;
+
+				page++;
+			}
+		}
+
+		return null;
+	}
+
+	async Task<List<string>> GetPullRequestCommitsAsync(int prNumber, CancellationToken cancellationToken)
+	{
+		var url = $"https://api.github.com/repos/{DotNetMauiOwner}/{DotNetMauiRepo}/pulls/{prNumber}/commits?per_page=100";
+		using var response = await SendAsync(url, cancellationToken);
+		if (!response.IsSuccessStatusCode)
+		{
+			if (response.StatusCode == HttpStatusCode.NotFound)
+				throw new InvalidOperationException($"dotnet/maui PR #{prNumber} was not found.");
+			if (response.StatusCode == HttpStatusCode.Forbidden)
+				throw new InvalidOperationException(
+					$"GitHub denied the PR lookup for dotnet/maui PR #{prNumber}. " +
+					"Set GITHUB_TOKEN or GH_TOKEN if you are rate limited.");
+
+			throw new InvalidOperationException($"Failed to query GitHub commits for PR #{prNumber}: {response.StatusCode}");
+		}
+
+		using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+		if (document.RootElement.ValueKind != JsonValueKind.Array)
+			throw new InvalidOperationException("GitHub commits response was not an array.");
+
+		var commits = document.RootElement.EnumerateArray()
+			.Select(commit => commit.GetProperty("sha").GetString())
+			.Where(sha => !string.IsNullOrWhiteSpace(sha))
+			.Select(sha => sha!)
+			.Reverse()
+			.ToList();
+
+		return commits;
+	}
+
+	async Task<MauiPrBuildArtifact?> TryGetBuildFromCheckRunAsync(
+		int prNumber,
+		string commitSha,
+		JsonElement checkRun,
+		CancellationToken cancellationToken)
+	{
+		var name = checkRun.GetProperty("name").GetString();
+		if (!IsRelevantMauiCheckName(name))
+			return null;
+
+		var status = checkRun.GetProperty("status").GetString();
+		if (!string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase))
+			return null;
+
+		var conclusion = checkRun.TryGetProperty("conclusion", out var conclusionProperty) && conclusionProperty.ValueKind != JsonValueKind.Null
+			? conclusionProperty.GetString()
+			: null;
+		if (!IsSuccessfulBuildResult(conclusion))
+			return null;
+
+		if (!checkRun.TryGetProperty("details_url", out var detailsUrlProperty))
+			return null;
+
+		var detailsUrl = detailsUrlProperty.GetString();
+		if (string.IsNullOrWhiteSpace(detailsUrl))
+			return null;
+
+		var match = s_buildUrlRegex.Match(detailsUrl);
+		if (!match.Success || !int.TryParse(match.Groups[3].Value, out var buildId))
+			return null;
+
+		var organization = match.Groups[1].Value;
+		var project = match.Groups[2].Value;
+		if (!string.Equals(organization, DefaultAzureDevOpsOrganization, StringComparison.OrdinalIgnoreCase) ||
+			!string.Equals(project, DefaultAzureDevOpsProject, StringComparison.OrdinalIgnoreCase))
+		{
+			return null;
+		}
+
+		return await TryGetPackageArtifactAsync(
+			prNumber,
+			buildId,
+			organization,
+			project,
+			buildNumber: $"PR-{prNumber}",
+			status: status ?? "completed",
+			result: conclusion,
+			sourceVersion: commitSha,
+			cancellationToken);
+	}
+
+	async Task<MauiPrBuildArtifact?> TryGetPackageArtifactAsync(
+		int prNumber,
+		int buildId,
+		string organization,
+		string project,
+		JsonElement build,
+		CancellationToken cancellationToken)
+	{
+		return await TryGetPackageArtifactAsync(
+			prNumber,
+			buildId,
+			organization,
+			project,
+			buildNumber: build.GetProperty("buildNumber").GetString() ?? buildId.ToString(),
+			status: build.GetProperty("status").GetString() ?? "completed",
+			result: build.TryGetProperty("result", out var resultProperty) ? resultProperty.GetString() : null,
+			sourceVersion: build.TryGetProperty("sourceVersion", out var sourceVersionProperty) ? sourceVersionProperty.GetString() ?? string.Empty : string.Empty,
+			cancellationToken);
+	}
+
+	async Task<MauiPrBuildArtifact?> TryGetPackageArtifactAsync(
+		int prNumber,
+		int buildId,
+		string organization,
+		string project,
+		string buildNumber,
+		string status,
+		string? result,
+		string sourceVersion,
+		CancellationToken cancellationToken)
+	{
+		if (!IsSuccessfulBuildResult(result))
+			return null;
+
+		var artifactsUrl = $"https://dev.azure.com/{organization}/{project}/_apis/build/builds/{buildId}/artifacts?api-version=7.1";
+		using var response = await SendAsync(artifactsUrl, cancellationToken);
+		if (!response.IsSuccessStatusCode)
+			throw new InvalidOperationException($"Failed to query artifacts for Azure DevOps build {buildId}: {response.StatusCode}");
+
+		using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+		if (!document.RootElement.TryGetProperty("value", out var artifacts) || artifacts.ValueKind != JsonValueKind.Array)
+			throw new InvalidOperationException("Azure DevOps artifacts response did not contain a value array.");
+
+		foreach (var artifact in artifacts.EnumerateArray())
+		{
+			var name = artifact.GetProperty("name").GetString();
+			if (!string.Equals(name, PackageArtifactName, StringComparison.OrdinalIgnoreCase))
+				continue;
+
+			var downloadUrl = artifact.GetProperty("resource").GetProperty("downloadUrl").GetString();
+			if (string.IsNullOrWhiteSpace(downloadUrl))
+				throw new InvalidOperationException($"{PackageArtifactName} for build {buildId} did not include a download URL.");
+
+			return new MauiPrBuildArtifact
+			{
+				PullRequest = prNumber,
+				BuildId = buildId,
+				BuildNumber = buildNumber,
+				Status = status,
+				Result = result,
+				SourceVersion = sourceVersion,
+				Organization = organization,
+				Project = project,
+				ArtifactName = name ?? PackageArtifactName,
+				DownloadUrl = downloadUrl,
+				BuildUrl = $"https://dev.azure.com/{organization}/{project}/_build/results?buildId={buildId}",
+			};
+		}
+
+		return null;
+	}
+
+	async Task<HttpResponseMessage> SendAsync(
+		string url,
+		CancellationToken cancellationToken,
+		HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, url);
+		request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Microsoft.Maui.Cli", "1.0"));
+		request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+		var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? Environment.GetEnvironmentVariable("GH_TOKEN");
+		if (!string.IsNullOrWhiteSpace(token) && url.Contains("api.github.com", StringComparison.OrdinalIgnoreCase))
+			request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+		return await _httpClient.SendAsync(request, completionOption, cancellationToken);
+	}
+
+	static async Task DownloadContentAsync(HttpResponseMessage response, string destinationPath, CancellationToken cancellationToken)
+	{
+		var contentLength = response.Content.Headers.ContentLength;
+		if (contentLength > MaxArtifactZipBytes)
+			throw new InvalidOperationException($"{PackageArtifactName} is too large to download ({contentLength} bytes).");
+
+		await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		await using var fileStream = File.Create(destinationPath);
+
+		var buffer = new byte[128 * 1024];
+		long totalBytes = 0;
+		while (true)
+		{
+			var bytesRead = await contentStream.ReadAsync(buffer, cancellationToken);
+			if (bytesRead == 0)
+				break;
+
+			totalBytes += bytesRead;
+			if (totalBytes > MaxArtifactZipBytes)
+				throw new InvalidOperationException($"{PackageArtifactName} exceeded the maximum download size of {MaxArtifactZipBytes} bytes.");
+
+			await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+		}
+	}
+
+	static void ExtractArtifact(string zipPath, string extractPath)
+	{
+		var extractRoot = Path.GetFullPath(extractPath);
+		Directory.CreateDirectory(extractRoot);
+
+		using var archive = ZipFile.OpenRead(zipPath);
+		long extractedBytes = 0;
+		var entryCount = 0;
+		foreach (var entry in archive.Entries)
+		{
+			entryCount++;
+			if (entryCount > MaxExtractedArtifactEntries)
+				throw new InvalidOperationException($"{PackageArtifactName} contains too many files to extract.");
+
+			var destinationPath = Path.GetFullPath(Path.Combine(extractRoot, entry.FullName));
+			if (!IsPathWithinDirectory(destinationPath, extractRoot))
+				throw new InvalidOperationException($"{PackageArtifactName} contains an entry outside the extraction directory: {entry.FullName}");
+
+			if (string.IsNullOrEmpty(entry.Name))
+			{
+				Directory.CreateDirectory(destinationPath);
+				continue;
+			}
+
+			extractedBytes += entry.Length;
+			if (extractedBytes > MaxExtractedArtifactBytes)
+				throw new InvalidOperationException($"{PackageArtifactName} exceeds the maximum extracted size of {MaxExtractedArtifactBytes} bytes.");
+
+			var destinationDirectory = Path.GetDirectoryName(destinationPath);
+			if (!string.IsNullOrWhiteSpace(destinationDirectory))
+				Directory.CreateDirectory(destinationDirectory);
+
+			entry.ExtractToFile(destinationPath, overwrite: true);
+		}
+	}
+
+	static bool IsCompletedMauiPrBuild(JsonElement build)
+	{
+		var status = build.GetProperty("status").GetString();
+		if (!string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase))
+			return false;
+
+		var result = build.TryGetProperty("result", out var resultProperty) ? resultProperty.GetString() : null;
+		if (!IsSuccessfulBuildResult(result))
+			return false;
+
+		if (!build.TryGetProperty("definition", out var definition))
+			return false;
+
+		var definitionName = definition.GetProperty("name").GetString();
+		return string.Equals(definitionName, MauiPrDefinitionName, StringComparison.OrdinalIgnoreCase);
+	}
+
+	static bool IsRelevantMauiCheckName(string? name)
+	{
+		if (string.IsNullOrWhiteSpace(name))
+			return false;
+
+		if (string.Equals(name, MauiPrDefinitionName, StringComparison.OrdinalIgnoreCase))
+			return true;
+
+		if (name.StartsWith("maui-pr (", StringComparison.OrdinalIgnoreCase) ||
+			name.StartsWith("maui-pr-", StringComparison.OrdinalIgnoreCase))
+		{
+			return !name.Contains("uitests", StringComparison.OrdinalIgnoreCase);
+		}
+
+		return false;
+	}
+
+	static bool IsSuccessfulBuildResult(string? result)
+	{
+		return string.Equals(result, "succeeded", StringComparison.OrdinalIgnoreCase) ||
+			string.Equals(result, "success", StringComparison.OrdinalIgnoreCase);
+	}
+
+	static bool IsPathWithinDirectory(string path, string directory)
+	{
+		var normalizedDirectory = directory.EndsWith(Path.DirectorySeparatorChar)
+			? directory
+			: directory + Path.DirectorySeparatorChar;
+
+		return path.StartsWith(normalizedDirectory, StringComparison.Ordinal) ||
+			string.Equals(path, directory, StringComparison.Ordinal);
+	}
+
+	static string CopyPackagesAndFindVersion(string extractPath, string packageSourcePath)
+	{
+		string? version = null;
+		foreach (var packagePath in Directory.EnumerateFiles(extractPath, "*.nupkg", SearchOption.AllDirectories))
+		{
+			var packageLength = new FileInfo(packagePath).Length;
+			if (packageLength > MaxPackageBytes)
+				throw new InvalidOperationException($"{packagePath} exceeds the maximum package size of {MaxPackageBytes} bytes.");
+
+			var destination = Path.Combine(packageSourcePath, Path.GetFileName(packagePath));
+			File.Copy(packagePath, destination, overwrite: true);
+
+			version ??= TryGetPackageVersion(destination, VersionPackageId);
+		}
+
+		return version ?? throw new InvalidOperationException(
+			$"{PackageArtifactName} did not contain a {VersionPackageId} package.");
+	}
+
+	static string? TryGetPackageVersion(string packagePath, string packageId)
+	{
+		using var archive = ZipFile.OpenRead(packagePath);
+		foreach (var entry in archive.Entries.Where(entry => entry.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)))
+		{
+			using var stream = entry.Open();
+			var document = XDocument.Load(stream);
+			var id = document.Descendants().FirstOrDefault(element => element.Name.LocalName == "id")?.Value.Trim();
+			if (!string.Equals(id, packageId, StringComparison.OrdinalIgnoreCase))
+				continue;
+
+			var version = document.Descendants().FirstOrDefault(element => element.Name.LocalName == "version")?.Value.Trim();
+			if (string.IsNullOrWhiteSpace(version))
+				throw new InvalidOperationException($"{packagePath} contains {packageId} but no package version.");
+
+			return version;
+		}
+
+		return null;
+	}
+
+	static void WriteMetadata(MauiPrBuildArtifact artifact, MauiPrArtifactHivePaths paths, string metadataPath, string version)
+	{
+		var metadata = new MauiPrArtifactMetadata
+		{
+			CreatedAtUtc = DateTimeOffset.UtcNow,
+			Repository = $"{DotNetMauiOwner}/{DotNetMauiRepo}",
+			PullRequest = artifact.PullRequest,
+			BuildId = artifact.BuildId,
+			BuildNumber = artifact.BuildNumber,
+			BuildUrl = artifact.BuildUrl,
+			Status = artifact.Status,
+			Result = artifact.Result,
+			SourceVersion = artifact.SourceVersion,
+			Organization = artifact.Organization,
+			Project = artifact.Project,
+			ArtifactName = artifact.ArtifactName,
+			PackageVersion = version,
+			HiveRoot = paths.HiveRoot,
+			HivePath = paths.HivePath,
+			PackageSourcePath = paths.PackageSourcePath,
+			ZipPath = paths.ZipPath,
+		};
+
+		var tempPath = metadataPath + ".tmp";
+		using (var stream = File.Create(tempPath))
+		{
+			JsonSerializer.Serialize(stream, metadata, MauiPrArtifactJsonContext.Default.MauiPrArtifactMetadata);
+		}
+
+		File.Move(tempPath, metadataPath, overwrite: true);
+	}
+
+	static string ResolveHiveRoot(string? hiveRoot)
+	{
+		if (!string.IsNullOrWhiteSpace(hiveRoot))
+			return Path.GetFullPath(hiveRoot);
+
+		var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+		if (string.IsNullOrWhiteSpace(userProfile))
+			throw new InvalidOperationException("Could not determine the user profile directory for the MAUI hives cache.");
+
+		return Path.Combine(userProfile, ".maui", "hives");
+	}
+
+	static string GetRepositoryHiveName()
+	{
+		return $"{DotNetMauiOwner}-{DotNetMauiRepo}";
+	}
+}
+
+[JsonSourceGenerationOptions(
+	DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+	PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+	WriteIndented = true)]
+[JsonSerializable(typeof(MauiPrArtifactMetadata))]
+internal sealed partial class MauiPrArtifactJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/Services/MauiPrArtifactService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/MauiPrArtifactService.cs
@@ -26,6 +26,15 @@ public sealed record MauiPrBuildArtifact
 	public required string BuildUrl { get; init; }
 }
 
+public sealed record MauiPrBuildProgress
+{
+	public int PullRequest { get; init; }
+	public int BuildId { get; init; }
+	public required string BuildNumber { get; init; }
+	public required string Status { get; init; }
+	public required string BuildUrl { get; init; }
+}
+
 public sealed record MauiPrArtifactDownload
 {
 	public required MauiPrBuildArtifact Build { get; init; }
@@ -34,6 +43,8 @@ public sealed record MauiPrArtifactDownload
 	public required string PackageSourcePath { get; init; }
 	public required string MetadataPath { get; init; }
 	public required string Version { get; init; }
+	public bool IsStaged { get; init; }
+	public string? StagingArtifactPath { get; init; }
 }
 
 public sealed record MauiPrArtifactHivePaths
@@ -71,11 +82,18 @@ public sealed record MauiPrArtifactMetadata
 public interface IMauiPrArtifactService
 {
 	Task<MauiPrBuildArtifact> FindPackageArtifactAsync(int prNumber, CancellationToken cancellationToken = default);
+	Task<MauiPrBuildProgress?> FindInProgressBuildAsync(int prNumber, CancellationToken cancellationToken = default);
 	MauiPrArtifactHivePaths GetHivePaths(MauiPrBuildArtifact artifact, string? hiveRoot = null);
 	Task<MauiPrArtifactDownload> DownloadPackageArtifactAsync(
 		MauiPrBuildArtifact artifact,
 		string? hiveRoot = null,
 		CancellationToken cancellationToken = default);
+	Task<MauiPrArtifactDownload> StagePackageArtifactAsync(
+		MauiPrBuildArtifact artifact,
+		string? hiveRoot = null,
+		CancellationToken cancellationToken = default);
+	Task PromoteStagedPackageArtifactAsync(MauiPrArtifactDownload download, CancellationToken cancellationToken = default);
+	void DiscardStagedPackageArtifact(MauiPrArtifactDownload download);
 }
 
 public sealed class MauiPrArtifactService : IMauiPrArtifactService
@@ -121,7 +139,62 @@ public sealed class MauiPrArtifactService : IMauiPrArtifactService
 			$"Check https://github.com/dotnet/maui/pull/{prNumber} to confirm the PR build has completed.");
 	}
 
+	public async Task<MauiPrBuildProgress?> FindInProgressBuildAsync(int prNumber, CancellationToken cancellationToken = default)
+	{
+		if (prNumber <= 0)
+			throw new ArgumentOutOfRangeException(nameof(prNumber), "PR number must be positive.");
+
+		var buildsUrl =
+			$"https://dev.azure.com/{DefaultAzureDevOpsOrganization}/{DefaultAzureDevOpsProject}/_apis/build/builds" +
+			$"?api-version=7.1&branchName=refs/pull/{prNumber}/merge&$top=25";
+
+		using var response = await SendAsync(buildsUrl, cancellationToken);
+		if (!response.IsSuccessStatusCode)
+			throw new InvalidOperationException($"Failed to query Azure DevOps builds for PR #{prNumber}: {response.StatusCode}");
+
+		using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+		if (!document.RootElement.TryGetProperty("value", out var builds) || builds.ValueKind != JsonValueKind.Array)
+			throw new InvalidOperationException("Azure DevOps builds response did not contain a value array.");
+
+		foreach (var build in builds.EnumerateArray())
+		{
+			if (!IsInProgressMauiPrBuild(build))
+				continue;
+
+			var buildId = build.GetProperty("id").GetInt32();
+			return new MauiPrBuildProgress
+			{
+				PullRequest = prNumber,
+				BuildId = buildId,
+				BuildNumber = build.GetProperty("buildNumber").GetString() ?? buildId.ToString(),
+				Status = build.GetProperty("status").GetString() ?? "inProgress",
+				BuildUrl = $"https://dev.azure.com/{DefaultAzureDevOpsOrganization}/{DefaultAzureDevOpsProject}/_build/results?buildId={buildId}",
+			};
+		}
+
+		return null;
+	}
+
 	public async Task<MauiPrArtifactDownload> DownloadPackageArtifactAsync(
+		MauiPrBuildArtifact artifact,
+		string? hiveRoot = null,
+		CancellationToken cancellationToken = default)
+	{
+		var download = await StagePackageArtifactAsync(artifact, hiveRoot, cancellationToken);
+		try
+		{
+			await PromoteStagedPackageArtifactAsync(download, cancellationToken);
+			return download with { IsStaged = false, StagingArtifactPath = null };
+		}
+		catch
+		{
+			DiscardStagedPackageArtifact(download);
+			throw;
+		}
+	}
+
+	public async Task<MauiPrArtifactDownload> StagePackageArtifactAsync(
 		MauiPrBuildArtifact artifact,
 		string? hiveRoot = null,
 		CancellationToken cancellationToken = default)
@@ -130,7 +203,6 @@ public sealed class MauiPrArtifactService : IMauiPrArtifactService
 
 		var finalPaths = GetHivePaths(artifact, hiveRoot);
 		var stagingPaths = CreateStagingPaths(finalPaths);
-		await using var hiveLock = await AcquireHiveLockAsync(finalPaths.HivePath, cancellationToken);
 
 		if (Directory.Exists(stagingPaths.HivePath))
 			Directory.Delete(stagingPaths.HivePath, recursive: true);
@@ -151,7 +223,6 @@ public sealed class MauiPrArtifactService : IMauiPrArtifactService
 
 			var version = CopyPackagesAndFindVersion(stagingPaths.ExtractPath, stagingPaths.PackageSourcePath);
 			WriteMetadata(artifact, finalPaths, stagingPaths.MetadataPath, version);
-			ReplaceHive(stagingPaths.HivePath, finalPaths.HivePath);
 
 			return new MauiPrArtifactDownload
 			{
@@ -161,6 +232,8 @@ public sealed class MauiPrArtifactService : IMauiPrArtifactService
 				PackageSourcePath = finalPaths.PackageSourcePath,
 				MetadataPath = finalPaths.MetadataPath,
 				Version = version,
+				IsStaged = true,
+				StagingArtifactPath = stagingPaths.HivePath,
 			};
 		}
 
@@ -170,6 +243,29 @@ public sealed class MauiPrArtifactService : IMauiPrArtifactService
 				Directory.Delete(stagingPaths.HivePath, recursive: true);
 
 			throw;
+		}
+	}
+
+	public async Task PromoteStagedPackageArtifactAsync(MauiPrArtifactDownload download, CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(download);
+		if (!download.IsStaged || string.IsNullOrWhiteSpace(download.StagingArtifactPath))
+			return;
+		if (!Directory.Exists(download.StagingArtifactPath))
+			throw new InvalidOperationException($"Staged PR artifact hive no longer exists: {download.StagingArtifactPath}");
+
+		await using var hiveLock = await AcquireHiveLockAsync(download.ArtifactPath, cancellationToken);
+		ReplaceHive(download.StagingArtifactPath, download.ArtifactPath);
+	}
+
+	public void DiscardStagedPackageArtifact(MauiPrArtifactDownload download)
+	{
+		ArgumentNullException.ThrowIfNull(download);
+		if (download.IsStaged &&
+			!string.IsNullOrWhiteSpace(download.StagingArtifactPath) &&
+			Directory.Exists(download.StagingArtifactPath))
+		{
+			Directory.Delete(download.StagingArtifactPath, recursive: true);
 		}
 	}
 
@@ -564,6 +660,24 @@ public sealed class MauiPrArtifactService : IMauiPrArtifactService
 		return string.Equals(definitionName, MauiPrDefinitionName, StringComparison.OrdinalIgnoreCase);
 	}
 
+	static bool IsInProgressMauiPrBuild(JsonElement build)
+	{
+		var status = build.GetProperty("status").GetString();
+		if (!IsInProgressBuildStatus(status))
+			return false;
+
+		if (!build.TryGetProperty("definition", out var definition))
+			return false;
+
+		var definitionName = definition.GetProperty("name").GetString();
+		return string.Equals(definitionName, MauiPrDefinitionName, StringComparison.OrdinalIgnoreCase);
+	}
+
+	static bool IsInProgressBuildStatus(string? status) =>
+		string.Equals(status, "inProgress", StringComparison.OrdinalIgnoreCase) ||
+		string.Equals(status, "notStarted", StringComparison.OrdinalIgnoreCase) ||
+		string.Equals(status, "postponed", StringComparison.OrdinalIgnoreCase);
+
 	static bool IsRelevantMauiCheckName(string? name)
 	{
 		if (string.IsNullOrWhiteSpace(name))
@@ -589,12 +703,15 @@ public sealed class MauiPrArtifactService : IMauiPrArtifactService
 
 	static bool IsPathWithinDirectory(string path, string directory)
 	{
+		var comparison = OperatingSystem.IsWindows()
+			? StringComparison.OrdinalIgnoreCase
+			: StringComparison.Ordinal;
 		var normalizedDirectory = directory.EndsWith(Path.DirectorySeparatorChar)
 			? directory
 			: directory + Path.DirectorySeparatorChar;
 
-		return path.StartsWith(normalizedDirectory, StringComparison.Ordinal) ||
-			string.Equals(path, directory, StringComparison.Ordinal);
+		return path.StartsWith(normalizedDirectory, comparison) ||
+			string.Equals(path, directory, comparison);
 	}
 
 	static string CopyPackagesAndFindVersion(string extractPath, string packageSourcePath)
@@ -692,4 +809,5 @@ public sealed class MauiPrArtifactService : IMauiPrArtifactService
 	PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
 	WriteIndented = true)]
 [JsonSerializable(typeof(MauiPrArtifactMetadata))]
+[JsonSerializable(typeof(MauiPrBuildProgress))]
 internal sealed partial class MauiPrArtifactJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/Services/MauiProjectVersionService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/MauiProjectVersionService.cs
@@ -445,8 +445,9 @@ public sealed class MauiProjectVersionService : IMauiProjectVersionService
 		var document = LoadXml(projectPath);
 		var targetElements = document.Descendants()
 			.Where(element =>
-				element.Name.LocalName == TargetFrameworkProperty ||
-				element.Name.LocalName == TargetFrameworksProperty)
+				(element.Name.LocalName == TargetFrameworkProperty ||
+				element.Name.LocalName == TargetFrameworksProperty) &&
+				element.Parent?.Name.LocalName == "PropertyGroup")
 			.ToList();
 		var localBaseTargetProperties = targetElements
 			.Where(IsUnconditionalProperty)

--- a/src/Cli/Microsoft.Maui.Cli/Services/MauiProjectVersionService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/MauiProjectVersionService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Xml.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Maui.Cli.Utils;
 
 namespace Microsoft.Maui.Cli.Services;
@@ -25,6 +26,8 @@ public sealed record MauiProjectVersionInfo
 	public string? EffectiveVersion { get; init; }
 	public bool HasMixedPackageVersions { get; init; }
 	public string? CentralPackageFilePath { get; init; }
+	public List<string> TargetFrameworks { get; init; } = [];
+	public string? TargetDotNetFramework { get; init; }
 	public List<MauiProjectPackageVersion> Packages { get; init; } = [];
 }
 
@@ -57,6 +60,7 @@ public interface IMauiProjectVersionService
 	string? DiscoverProjectFile(string? path = null);
 	Task<MauiProjectVersionInfo> GetVersionInfoAsync(string projectPath, CancellationToken cancellationToken = default);
 	Task<MauiProjectVersionUpdateResult> SetVersionAsync(string projectPath, string version, bool dryRun, CancellationToken cancellationToken = default);
+	Task<MauiProjectVersionUpdateResult> SetTargetFrameworkAsync(string projectPath, string targetFramework, bool dryRun, CancellationToken cancellationToken = default);
 	Task<MauiProjectVersionUpdateResult> UseWorkloadVersionAsync(string projectPath, bool dryRun, CancellationToken cancellationToken = default);
 	Task<MauiProjectVersionChange?> EnsureNuGetSourceAsync(string projectPath, string sourceName, string sourceUrl, bool dryRun, CancellationToken cancellationToken = default);
 	Task<MauiProjectRestoreResult> RestoreAsync(string projectPath, CancellationToken cancellationToken = default);
@@ -66,6 +70,11 @@ public sealed class MauiProjectVersionService : IMauiProjectVersionService
 {
 	internal const string MauiVersionProperty = "MauiVersion";
 	internal const string WorkloadVersionExpression = "$(MauiVersion)";
+	internal const string TargetFrameworkProperty = "TargetFramework";
+	internal const string TargetFrameworksProperty = "TargetFrameworks";
+
+	static readonly Regex s_targetFrameworkRegex = new(@"(?<![A-Za-z0-9.])net\d+\.\d+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+	static readonly Regex s_targetFrameworkValueRegex = new(@"^net\d+\.\d+$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 	static readonly HashSet<string> s_mauiPackageIds = new(StringComparer.OrdinalIgnoreCase)
 	{
@@ -111,6 +120,8 @@ public sealed class MauiProjectVersionService : IMauiProjectVersionService
 		var centralPackageFile = FindCentralPackageFile(Path.GetDirectoryName(projectPath) ?? Environment.CurrentDirectory);
 		var properties = LoadKnownProperties(projectPath, centralPackageFile);
 		var mauiVersion = ResolvePropertyExpression(GetPropertyValue(document, MauiVersionProperty), properties);
+		var targetFrameworks = GetTargetFrameworks(document, properties);
+		var targetDotNetFramework = GetCommonDotNetTargetFramework(targetFrameworks);
 
 		var packages = new List<MauiProjectPackageVersion>();
 		var projectPackages = GetProjectPackageVersions(document, projectPath, properties).ToList();
@@ -149,6 +160,8 @@ public sealed class MauiProjectVersionService : IMauiProjectVersionService
 			EffectiveVersion = effectiveVersion,
 			HasMixedPackageVersions = rawVersions.Count > 1,
 			CentralPackageFilePath = centralPackageFile,
+			TargetFrameworks = targetFrameworks,
+			TargetDotNetFramework = targetDotNetFramework,
 			Packages = packages,
 		};
 	}
@@ -161,6 +174,16 @@ public sealed class MauiProjectVersionService : IMauiProjectVersionService
 	{
 		ValidateVersionValue(version, allowWorkloadExpression: false);
 		return UpdateVersionAsync(projectPath, version, removeMauiVersionProperty: false, dryRun, cancellationToken);
+	}
+
+	public Task<MauiProjectVersionUpdateResult> SetTargetFrameworkAsync(
+		string projectPath,
+		string targetFramework,
+		bool dryRun,
+		CancellationToken cancellationToken = default)
+	{
+		targetFramework = NormalizeTargetFramework(targetFramework);
+		return UpdateTargetFrameworkAsync(projectPath, targetFramework, dryRun, cancellationToken);
 	}
 
 	public Task<MauiProjectVersionUpdateResult> UseWorkloadVersionAsync(
@@ -328,6 +351,7 @@ public sealed class MauiProjectVersionService : IMauiProjectVersionService
 			{
 				projectChanged = true;
 			}
+
 			else if (packageVersion is null)
 			{
 				projectPackageReferencesWithoutVersion.Add(packageId);
@@ -404,6 +428,110 @@ public sealed class MauiProjectVersionService : IMauiProjectVersionService
 		};
 	}
 
+	async Task<MauiProjectVersionUpdateResult> UpdateTargetFrameworkAsync(
+		string projectPath,
+		string targetFramework,
+		bool dryRun,
+		CancellationToken cancellationToken)
+	{
+		projectPath = Path.GetFullPath(projectPath);
+		if (!File.Exists(projectPath))
+			throw new FileNotFoundException($"Project file not found: {projectPath}", projectPath);
+
+		var info = await GetVersionInfoAsync(projectPath, cancellationToken);
+		if (!info.IsMauiProject)
+			throw new InvalidOperationException($"No .NET MAUI project markers found in {Path.GetFileName(projectPath)}.");
+
+		var document = LoadXml(projectPath);
+		var targetElements = document.Descendants()
+			.Where(element =>
+				element.Name.LocalName == TargetFrameworkProperty ||
+				element.Name.LocalName == TargetFrameworksProperty)
+			.ToList();
+		var localBaseTargetProperties = targetElements
+			.Where(IsUnconditionalProperty)
+			.Select(element => element.Name.LocalName)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+		var changes = new List<MauiProjectVersionChange>();
+		var changed = false;
+
+		if (targetElements.Count == 0)
+		{
+			if (info.TargetFrameworks.Count > 0)
+			{
+				throw new InvalidOperationException(
+					$"Target frameworks for {Path.GetFileName(projectPath)} are inherited or use MSBuild properties. " +
+					$"Update the file that defines them to {targetFramework}, then rerun this command.");
+			}
+
+			changes.Add(new MauiProjectVersionChange
+			{
+				FilePath = projectPath,
+				Description = "Set TargetFramework property",
+				NewValue = targetFramework,
+			});
+
+			var root = document.Root ?? throw new InvalidOperationException("Project file does not have a root element.");
+			var ns = root.Name.Namespace;
+			var propertyGroup = root.Elements().FirstOrDefault(element =>
+				element.Name.LocalName == "PropertyGroup" &&
+				element.Attribute("Condition") is null);
+			if (propertyGroup is null)
+			{
+				propertyGroup = new XElement(ns + "PropertyGroup");
+				root.AddFirst(propertyGroup);
+			}
+
+			propertyGroup.Add(new XElement(ns + TargetFrameworkProperty, targetFramework));
+			changed = true;
+		}
+		else
+		{
+			var updates = new List<(XElement Element, string OldValue, string NewValue)>();
+			foreach (var targetElement in targetElements)
+			{
+				var oldValue = targetElement.Value.Trim();
+				var newValue = ReplaceDotNetTargetFramework(targetElement, oldValue, targetFramework, localBaseTargetProperties);
+				if (string.Equals(oldValue, newValue, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				updates.Add((targetElement, oldValue, newValue));
+			}
+
+			foreach (var (targetElement, oldValue, newValue) in updates)
+			{
+				changes.Add(new MauiProjectVersionChange
+				{
+					FilePath = projectPath,
+					Description = $"Update {targetElement.Name.LocalName} property",
+					OldValue = oldValue,
+					NewValue = newValue,
+				});
+				targetElement.Value = newValue;
+				changed = true;
+			}
+
+			if (!changed && info.TargetDotNetFramework is null && info.TargetFrameworks.Count > 0)
+			{
+				throw new InvalidOperationException(
+					$"Could not update target frameworks in {Path.GetFileName(projectPath)} because they are not literal netX.Y values. " +
+					$"Update them to {targetFramework} manually, then rerun this command.");
+			}
+		}
+
+		if (!dryRun && changed)
+			await SaveXmlAsync(document, projectPath, cancellationToken);
+
+		return new MauiProjectVersionUpdateResult
+		{
+			ProjectPath = projectPath,
+			Version = targetFramework,
+			DryRun = dryRun,
+			Changes = changes,
+		};
+	}
+
 	static IEnumerable<string> EnumerateProjectFiles(string directory)
 	{
 		var pending = new Queue<string>();
@@ -440,6 +568,139 @@ public sealed class MauiProjectVersionService : IMauiProjectVersionService
 		if (mauiVersion is not null)
 			return mauiVersion;
 		return workloadVersion;
+	}
+
+	static List<string> GetTargetFrameworks(XDocument document, IReadOnlyDictionary<string, string> properties)
+	{
+		var values = new List<string>();
+		AddTargetFrameworkValues(GetPropertyValue(document, TargetFrameworkProperty), properties, values);
+		AddTargetFrameworkValues(GetPropertyValue(document, TargetFrameworksProperty), properties, values);
+
+		if (values.Count == 0)
+		{
+			properties.TryGetValue(TargetFrameworkProperty, out var inheritedTargetFramework);
+			properties.TryGetValue(TargetFrameworksProperty, out var inheritedTargetFrameworks);
+			AddTargetFrameworkValues(inheritedTargetFramework, properties, values);
+			AddTargetFrameworkValues(inheritedTargetFrameworks, properties, values);
+		}
+
+		return values
+			.Where(value => !string.IsNullOrWhiteSpace(value))
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToList();
+	}
+
+	static void AddTargetFrameworkValues(string? value, IReadOnlyDictionary<string, string> properties, List<string> values)
+	{
+		var resolvedValue = ResolvePropertyExpression(value, properties);
+		if (string.IsNullOrWhiteSpace(resolvedValue))
+			return;
+
+		values.AddRange(resolvedValue
+			.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+	}
+
+	static string? GetCommonDotNetTargetFramework(IReadOnlyList<string> targetFrameworks)
+	{
+		var dotNetTargets = targetFrameworks
+			.Select(GetDotNetTargetFramework)
+			.Where(target => target is not null)
+			.Select(target => target!)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToList();
+
+		return dotNetTargets.Count == 1 ? dotNetTargets[0] : null;
+	}
+
+	static string? GetDotNetTargetFramework(string targetFramework)
+	{
+		var match = s_targetFrameworkRegex.Match(targetFramework);
+		return match.Success ? match.Value.ToLowerInvariant() : null;
+	}
+
+	static string ReplaceDotNetTargetFramework(
+		XElement targetElement,
+		string targetFrameworkValue,
+		string targetFramework,
+		IReadOnlySet<string> localBaseTargetProperties)
+	{
+		var segments = targetFrameworkValue
+			.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+			.ToList();
+		if (segments.Count == 0)
+			return targetFrameworkValue;
+
+		foreach (var segment in segments)
+		{
+			if (TryGetAllowedTargetFrameworkExpression(segment, out var referencedProperty))
+			{
+				if (referencedProperty is not null && localBaseTargetProperties.Contains(referencedProperty))
+					continue;
+
+				throw new InvalidOperationException(
+					$"Could not update {targetElement.Name.LocalName} value '{targetFrameworkValue}' because {segment} is not defined in the project file. " +
+					$"Update the file that defines it to {targetFramework}, then rerun this command.");
+			}
+
+			if (segment.Contains("$(", StringComparison.Ordinal) ||
+				GetDotNetTargetFramework(segment) is null)
+			{
+				throw new InvalidOperationException(
+					$"Could not update {targetElement.Name.LocalName} value '{targetFrameworkValue}' because it is not a literal netX.Y target framework list. " +
+					$"Update it to {targetFramework} manually, then rerun this command.");
+			}
+		}
+
+		if (!s_targetFrameworkRegex.IsMatch(targetFrameworkValue))
+			return targetFrameworkValue;
+
+		return s_targetFrameworkRegex.Replace(targetFrameworkValue, targetFramework);
+	}
+
+	static bool TryGetAllowedTargetFrameworkExpression(string segment, out string? referencedProperty)
+	{
+		referencedProperty = null;
+		if (string.Equals(segment, $"$({TargetFrameworkProperty})", StringComparison.OrdinalIgnoreCase))
+		{
+			referencedProperty = TargetFrameworkProperty;
+			return true;
+		}
+
+		if (string.Equals(segment, $"$({TargetFrameworksProperty})", StringComparison.OrdinalIgnoreCase))
+		{
+			referencedProperty = TargetFrameworksProperty;
+			return true;
+		}
+
+		return false;
+	}
+
+	public static string NormalizeTargetFramework(string targetFramework)
+	{
+		if (string.IsNullOrWhiteSpace(targetFramework))
+			throw new ArgumentException("Target framework cannot be empty.", nameof(targetFramework));
+
+		targetFramework = targetFramework.Trim();
+		if (char.IsDigit(targetFramework[0]))
+			targetFramework = $"net{targetFramework}";
+		targetFramework = targetFramework.ToLowerInvariant();
+
+		if (!s_targetFrameworkValueRegex.IsMatch(targetFramework))
+			throw new ArgumentException($"Target framework must be a netX.Y value such as net10.0: {targetFramework}", nameof(targetFramework));
+
+		return targetFramework;
+	}
+
+	public static string? TryGetRequiredTargetFramework(string version)
+	{
+		if (string.IsNullOrWhiteSpace(version))
+			return null;
+
+		var versionStart = version.Split('-', 2)[0].Split('+', 2)[0];
+		var majorText = versionStart.Split('.', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+		return int.TryParse(majorText, out var major) && major > 0
+			? $"net{major}.0"
+			: null;
 	}
 
 	static bool HasTrueProperty(XDocument document, string propertyName) =>

--- a/src/Cli/Microsoft.Maui.Cli/Services/MauiVersionFeedService.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/MauiVersionFeedService.cs
@@ -27,6 +27,7 @@ public interface IMauiVersionFeedService
 	Task<MauiPackageFeedVersion?> GetLatestVersionAsync(
 		MauiVersionChannel channel,
 		bool includePrerelease,
+		string? targetFramework = null,
 		CancellationToken cancellationToken = default);
 
 	string GetFeedUrl(MauiVersionChannel channel);
@@ -56,10 +57,18 @@ public sealed class MauiVersionFeedService : IMauiVersionFeedService
 	public async Task<MauiPackageFeedVersion?> GetLatestVersionAsync(
 		MauiVersionChannel channel,
 		bool includePrerelease,
+		string? targetFramework = null,
 		CancellationToken cancellationToken = default)
 	{
 		var versions = await GetVersionsAsync(channel, includePrerelease, cancellationToken);
-		return versions.LastOrDefault();
+		if (string.IsNullOrWhiteSpace(targetFramework))
+			return versions.LastOrDefault();
+
+		return versions.LastOrDefault(version =>
+			string.Equals(
+				MauiProjectVersionService.TryGetRequiredTargetFramework(version.Version),
+				targetFramework,
+				StringComparison.OrdinalIgnoreCase));
 	}
 
 	public async Task<IReadOnlyList<MauiPackageFeedVersion>> GetVersionsAsync(

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -44,11 +44,12 @@ maui project version set 10.0.60
 
 # Try packages from a dotnet/maui pull request build
 maui project version set --pr 24888
+maui project version set --pr 24888 --framework net10.0
 maui project version set --pr 24888 --hive-path ~/.maui/hives
 
 # Use the latest stable or nightly package version
 maui project version set --latest
-maui project version set --latest-nightly --nuget-config
+maui project version set --latest-nightly --nuget-config --framework net10.0
 
 # Switch back to the installed workload version
 maui project version use-workload
@@ -152,6 +153,15 @@ PR build packages are downloaded into a managed MAUI hive under
 project `NuGet.config` is pointed at that hive's `packages/` folder. Use
 `--hive-path` to choose a different hives root; `--artifact-path` is also
 accepted as an alias with the same hive-root behavior.
+
+`maui project version set` keeps MAUI package versions aligned with the
+project's target framework when it can infer one. Use
+`--framework`/`--target-framework`/`-f` with a `netX.Y` value to update
+`<TargetFramework>` or `<TargetFrameworks>` in the project file, for example
+when a PR or nightly package is built for a newer .NET version. If a PR also
+has a newer build still running, the command warns that it is using the latest
+completed PackageArtifacts build; `--json` reports the in-progress build
+metadata for automation.
 
 DevFlow file commands can use local files directly:
 

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -42,6 +42,10 @@ maui project version list --channel nightly --take 20
 # Pin a specific version and restore
 maui project version set 10.0.60
 
+# Try packages from a dotnet/maui pull request build
+maui project version set --pr 24888
+maui project version set --pr 24888 --hive-path ~/.maui/hives
+
 # Use the latest stable or nightly package version
 maui project version set --latest
 maui project version set --latest-nightly --nuget-config
@@ -93,7 +97,7 @@ maui apple simulator delete "iPhone 16 Pro"
 | `maui device list` | List connected devices and emulators |
 | `maui project version` | Show the effective .NET MAUI version for a project |
 | `maui project version list` | List available .NET MAUI package versions |
-| `maui project version set` | Pin a project to a specific, latest stable, nightly, or custom-source MAUI version |
+| `maui project version set` | Pin a project to a specific, latest stable, nightly, dotnet/maui PR build, or custom-source MAUI version |
 | `maui project version use-workload` | Use the installed MAUI workload version instead of a pinned project version |
 | `maui version` | Display version information |
 | **Android** | |
@@ -142,6 +146,12 @@ maui apple simulator delete "iPhone 16 Pro"
 | `maui go upgrade` | Graduate a Go project to a full MAUI project |
 
 Run `maui <command> --help` for detailed options on any command.
+
+PR build packages are downloaded into a managed MAUI hive under
+`~/.maui/hives/dotnet-maui/pr-<number>/build-<build-id>/` by default. The
+project `NuGet.config` is pointed at that hive's `packages/` folder. Use
+`--hive-path` to choose a different hives root; `--artifact-path` is also
+accepted as an alias with the same hive-root behavior.
 
 DevFlow file commands can use local files directly:
 


### PR DESCRIPTION
## Summary
- add `maui project version set --pr/--pull-request` to discover and apply dotnet/maui PR PackageArtifacts
- store downloaded artifacts in managed MAUI hives under `~/.maui/hives/dotnet-maui/pr-<number>/build-<id>/`
- write hive metadata, stage replacements safely, lock per hive, guard zip extraction, and update project NuGet.config/package versions
- add `--hive-path` with `--artifact-path` as a hive-root alias
- add `--target-framework` / `--framework` / `-f` so PR/nightly/stable version changes can update project TFMs safely
- select latest stable/nightly versions compatible with the project/requested target framework when possible
- surface in-progress dotnet/maui PR builds so users know the latest completed artifacts may be stale

## Validation
- `./eng/common/dotnet.sh test src/Cli/Microsoft.Maui.Cli.UnitTests/Microsoft.Maui.Cli.UnitTests.csproj --configuration Debug --no-restore` (`578 passed`)
- packed and installed local `Microsoft.Maui.Cli 0.1.0-dev`
- smoke-tested help/options, explicit `--framework` updates, conditional TFM appends, invalid framework/source failures, inherited/property-composed TFM failures, latest stable compatibility selection, PR dry-runs for `35783`/`35786`, and real PR apply for `35783`
- verified failed PR preflight and failed project-file writes discard staged hives without promoting final artifacts, while successful PR apply promotes the hive and writes metadata