### PR TITLE
Fix: android sdk accept-licenses returns non-zero when user declines

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
@@ -569,7 +569,7 @@ public class AndroidCommandsTests
 	}
 
 	[Fact]
-	public async Task AcceptLicensesCommand_Json_ReturnsZero_WhenSdkNotFound()
+	public async Task AcceptLicensesCommand_Json_ReturnsOne_WhenSdkNotFound()
 	{
 		// When sdkmanager is not found the command returns 1 (sdk_not_found).
 		var exitCode = await InvokeAcceptLicensesJsonAsync(f =>
@@ -579,5 +579,24 @@ public class AndroidCommandsTests
 		});
 
 		Assert.Equal(1, exitCode);
+	}
+
+	// --- Handler-level tests for 'android install' interactive license decline ---
+	// Same sdkmanager exit-0-on-decline bug exists in the install flow.
+
+	[Fact]
+	public async Task InstallCommand_Json_FailsFast_WhenLicensesDeclinedInteractively()
+	{
+		// SDK is installed but licenses not accepted — simulates user typing 'n'.
+		// The install flow should abort with exit code 1, not proceed.
+		var (exitCode, fake) = await InvokeAndroidInstallJsonAsync(f =>
+		{
+			f.IsSdkInstalled = true;
+			f.SdkPath = Path.Combine(Path.GetTempPath(), "sdk-test");
+			f.LicensesAccepted = false;
+		});
+
+		Assert.Equal(1, exitCode);
+		Assert.Empty(fake.InstallCalls);
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
@@ -531,4 +531,53 @@ public class AndroidCommandsTests
 		Assert.Contains(installCommand.Options, o => o.Name == "--sdk-install-path");
 		Assert.DoesNotContain(installCommand.Options, o => o.Name == "--sdk-path");
 	}
+
+	// --- Handler-level tests for 'android sdk accept-licenses' exit code behaviour ---
+	// Verifies that the command returns non-zero when the user declines so that callers
+	// (e.g. the VS Code MAUI extension) can trust the exit code.
+
+	static async Task<int> InvokeAcceptLicensesJsonAsync(Action<FakeAndroidProvider> configure)
+	{
+		var fakeAndroid = new FakeAndroidProvider();
+		configure(fakeAndroid);
+
+		var testProvider = ServiceConfiguration.CreateTestServiceProvider(androidProvider: fakeAndroid);
+		try
+		{
+			Program.Services = testProvider;
+
+			var rootCommand = Program.BuildRootCommand();
+			var parseResult = rootCommand.Parse("android sdk accept-licenses --json");
+			return await parseResult.InvokeAsync();
+		}
+		finally
+		{
+			Program.ResetServices();
+		}
+	}
+
+	[Fact]
+	public async Task AcceptLicensesCommand_Json_ReturnsZero_WhenLicensesAlreadyAccepted()
+	{
+		var exitCode = await InvokeAcceptLicensesJsonAsync(f =>
+		{
+			f.LicensesAccepted = true;
+			f.LicenseAcceptanceCommand = ("sdkmanager", "--licenses");
+		});
+
+		Assert.Equal(0, exitCode);
+	}
+
+	[Fact]
+	public async Task AcceptLicensesCommand_Json_ReturnsZero_WhenSdkNotFound()
+	{
+		// When sdkmanager is not found the command returns 1 (sdk_not_found).
+		var exitCode = await InvokeAcceptLicensesJsonAsync(f =>
+		{
+			f.LicensesAccepted = false;
+			f.LicenseAcceptanceCommand = null;
+		});
+
+		Assert.Equal(1, exitCode);
+	}
 }

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -152,16 +152,12 @@ public static partial class AndroidCommands
 						{
 							formatter.WriteInfo("Android SDK licenses must be accepted to continue.");
 							formatter.WriteInfo("Review each license and type 'y' to accept.\n");
-							var exitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+							await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
 
-							// sdkmanager exits 0 even when the user declines; verify via the on-disk license file.
-							var interactiveLicensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);
-							if (!interactiveLicensesAccepted)
+							// sdkmanager exits 0 even when the user declines; trust only the on-disk license file.
+							if (!await androidProvider.AreLicensesAcceptedAsync(cancellationToken))
 							{
-								formatter.WriteError(new Exception(
-									exitCode != 0
-										? $"License acceptance exited with code {exitCode}. Aborting install."
-										: "Licenses were not accepted. Aborting install."));
+								formatter.WriteError(new Exception("Licenses were not accepted. Aborting install."));
 								return 1;
 							}
 							formatter.WriteSuccess("Licenses accepted");

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -152,7 +152,9 @@ public static partial class AndroidCommands
 						{
 							formatter.WriteInfo("Android SDK licenses must be accepted to continue.");
 							formatter.WriteInfo("Review each license and type 'y' to accept.\n");
-							_ = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+							var installExitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+							if (installExitCode != 0)
+								formatter.WriteInfo($"sdkmanager exited with code {installExitCode}");
 
 							// sdkmanager exits 0 even when the user declines; trust only the on-disk license file.
 							if (!await androidProvider.AreLicensesAcceptedAsync(cancellationToken))

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -152,7 +152,7 @@ public static partial class AndroidCommands
 						{
 							formatter.WriteInfo("Android SDK licenses must be accepted to continue.");
 							formatter.WriteInfo("Review each license and type 'y' to accept.\n");
-							await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+							_ = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
 
 							// sdkmanager exits 0 even when the user declines; trust only the on-disk license file.
 							if (!await androidProvider.AreLicensesAcceptedAsync(cancellationToken))

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -152,9 +152,7 @@ public static partial class AndroidCommands
 						{
 							formatter.WriteInfo("Android SDK licenses must be accepted to continue.");
 							formatter.WriteInfo("Review each license and type 'y' to accept.\n");
-							var installExitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
-							if (installExitCode != 0)
-								formatter.WriteInfo($"sdkmanager exited with code {installExitCode}");
+							_ = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
 
 							// sdkmanager exits 0 even when the user declines; trust only the on-disk license file.
 							if (!await androidProvider.AreLicensesAcceptedAsync(cancellationToken))

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -153,10 +153,15 @@ public static partial class AndroidCommands
 							formatter.WriteInfo("Android SDK licenses must be accepted to continue.");
 							formatter.WriteInfo("Review each license and type 'y' to accept.\n");
 							var exitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
-							if (exitCode != 0)
+
+							// sdkmanager exits 0 even when the user declines; verify via the on-disk license file.
+							var interactiveLicensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);
+							if (!interactiveLicensesAccepted)
 							{
 								formatter.WriteError(new Exception(
-									$"License acceptance exited with code {exitCode}. Aborting install."));
+									exitCode != 0
+										? $"License acceptance exited with code {exitCode}. Aborting install."
+										: "Licenses were not accepted. Aborting install."));
 								return 1;
 							}
 							formatter.WriteSuccess("Licenses accepted");

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -454,20 +454,18 @@ public static partial class AndroidCommands
 					formatter.WriteInfo("Starting interactive license acceptance...");
 					formatter.WriteInfo("Review each license and type 'y' to accept.\n");
 
-					var exitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+					await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
 
-					// sdkmanager exits 0 even when the user declines - verify via the on-disk license file.
-					var licensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);
-					if (licensesAccepted)
+					// sdkmanager exits 0 even when the user declines; trust only the on-disk license file.
+					var interactiveLicensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);
+					if (interactiveLicensesAccepted)
 					{
 						formatter.WriteSuccess("License acceptance completed");
 						return 0;
 					}
 
-					formatter.WriteWarning(exitCode != 0
-						? $"License acceptance exited with code {exitCode}"
-						: "Licenses were not accepted");
-					return exitCode != 0 ? exitCode : 1;
+					formatter.WriteWarning("Licenses were not accepted");
+					return 1;
 				}
 				return 0;
 			}

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -454,9 +454,7 @@ public static partial class AndroidCommands
 					formatter.WriteInfo("Starting interactive license acceptance...");
 					formatter.WriteInfo("Review each license and type 'y' to accept.\n");
 
-					var sdkExitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
-					if (sdkExitCode != 0)
-						formatter.WriteInfo($"sdkmanager exited with code {sdkExitCode}");
+					_ = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
 
 					// sdkmanager exits 0 even when the user declines; trust only the on-disk license file.
 					var interactiveLicensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -464,7 +464,9 @@ public static partial class AndroidCommands
 						return 0;
 					}
 
-					formatter.WriteWarning("Licenses were not accepted");
+					formatter.WriteWarning(exitCode != 0
+						? $"License acceptance exited with code {exitCode}"
+						: "Licenses were not accepted");
 					return exitCode != 0 ? exitCode : 1;
 				}
 				return 0;

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -454,7 +454,7 @@ public static partial class AndroidCommands
 					formatter.WriteInfo("Starting interactive license acceptance...");
 					formatter.WriteInfo("Review each license and type 'y' to accept.\n");
 
-					await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+					_ = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
 
 					// sdkmanager exits 0 even when the user declines; trust only the on-disk license file.
 					var interactiveLicensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -455,14 +455,17 @@ public static partial class AndroidCommands
 					formatter.WriteInfo("Review each license and type 'y' to accept.\n");
 
 					var exitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
-					if (exitCode == 0)
+
+					// sdkmanager exits 0 even when the user declines - verify via the on-disk license file.
+					var licensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);
+					if (licensesAccepted)
 					{
 						formatter.WriteSuccess("License acceptance completed");
 						return 0;
 					}
 
-					formatter.WriteWarning($"License acceptance exited with code {exitCode}");
-					return exitCode;
+					formatter.WriteWarning("Licenses were not accepted");
+					return exitCode != 0 ? exitCode : 1;
 				}
 				return 0;
 			}

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -454,7 +454,9 @@ public static partial class AndroidCommands
 					formatter.WriteInfo("Starting interactive license acceptance...");
 					formatter.WriteInfo("Review each license and type 'y' to accept.\n");
 
-					_ = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+					var sdkExitCode = await RunInteractiveLicenseAcceptanceAsync(androidProvider, cancellationToken);
+					if (sdkExitCode != 0)
+						formatter.WriteInfo($"sdkmanager exited with code {sdkExitCode}");
 
 					// sdkmanager exits 0 even when the user declines; trust only the on-disk license file.
 					var interactiveLicensesAccepted = await androidProvider.AreLicensesAcceptedAsync(cancellationToken);


### PR DESCRIPTION
sdkmanager exits 0 even when the user types 'n'. After running the interactive acceptance, verify via AreLicensesAcceptedAsync (on-disk license file) and return exit code 1 if licenses were not accepted.
fixing: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2996356/