### PR TITLE
Add phase 3 MAUI app skills

### DIFF
--- a/plugins/dotnet-maui/plugin.json
+++ b/plugins/dotnet-maui/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-maui",
-  "version": "0.4.0",
-  "description": "Skills for .NET MAUI development: current API guidance, app architecture, project structure, app display/build versioning, UI patterns, common app features, accessibility, performance, testing, DevFlow automation, session review, platform bindings, and workload diagnostics. App version properties use ApplicationDisplayVersion/ApplicationVersion; do not use maui project version for app display/build versions. Some skills require the maui CLI tool.",
+  "version": "0.5.0",
+  "description": "Skills for .NET MAUI development: current API guidance, app architecture, project structure, app display/build versioning, UI patterns, common app features, Xamarin.Forms migration, handlers, platform invoke, advanced controls, MAUI Labs platforms, on-device AI, AI tool bindings, release notes, accessibility, performance, testing, DevFlow automation, session review, platform bindings, and workload diagnostics. App version properties use ApplicationDisplayVersion/ApplicationVersion; do not use maui project version for app display/build versions. Some skills require the maui CLI tool.",
   "skills": ["./skills/"]
 }

--- a/plugins/dotnet-maui/plugin.json
+++ b/plugins/dotnet-maui/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-maui",
   "version": "0.5.0",
-  "description": "Skills for .NET MAUI development: current API guidance, app architecture, project structure, app display/build versioning, UI patterns, common app features, Xamarin.Forms migration, handlers, platform invoke, advanced controls, MAUI Labs platforms, on-device AI, AI tool bindings, release notes, accessibility, performance, testing, DevFlow automation, session review, platform bindings, and workload diagnostics. App version properties use ApplicationDisplayVersion/ApplicationVersion; do not use maui project version for app display/build versions. Some skills require the maui CLI tool.",
+  "description": "Skills for .NET MAUI app development, migration, UI, platform APIs, MAUI Labs platforms, AI, testing, performance, accessibility, DevFlow automation, bindings, workload diagnostics, and app version guidance (ApplicationDisplayVersion/ApplicationVersion; not maui project version). Some skills require the maui CLI tool.",
   "skills": ["./skills/"]
 }

--- a/plugins/dotnet-maui/skills/ios-slim-bindings/SKILL.md
+++ b/plugins/dotnet-maui/skills/ios-slim-bindings/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: ios-slim-bindings
 description: >-
-  Create and update slim/native platform interop bindings for iOS in .NET MAUI and .NET for iOS projects.
-  Guides through creating Swift/Objective-C wrappers, configuring Xcode projects, generating C# API definitions,
-  and integrating native iOS libraries using the Native Library Interop (NLI) approach.
-  USE FOR: iOS bindings, xcframework integration, Swift interop, Objective
-  Sharpie, bridging native iOS SDKs to .NET, and diagnosing iOS binding runtime
-  crashes including NSInvalidArgumentException, unrecognized selector sent to
-  instance, and ObjC/Swift selector mismatch errors.
-  DO NOT USE FOR: Android bindings (use android-slim-bindings), general MAUI app development, NuGet package issues.
+  Create and debug iOS slim bindings for .NET MAUI using Swift/Objective-C
+  wrappers, XcodeGen project generation, CocoaPods static linking, Objective
+  Sharpie, C# binding definitions, and fixing runtime selector mismatches
+  (@objc(selector:) vs [Export]). USE FOR: Creating slim iOS bindings with
+  XcodeGen and Podfile, configuring static CocoaPods linking, Swift wrapper
+  class design with @objc annotations, Objective-C selector matching between
+  @objc and [Export], fixing "unrecognized selector" runtime crashes, wrapping
+  async Swift APIs with completion handlers, and integrating iOS native SDKs
+  into MAUI. DO NOT USE FOR: Android bindings (use android-slim-bindings),
+  general MAUI app development, or NuGet packaging issues.
 ---
 
 # When to use this skill

--- a/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
@@ -105,6 +105,9 @@ instead of returning fake success.
 The library does not create DI scopes. Keep the scope alive for as long as the
 chat session can invoke tools, then dispose it when the session ends:
 
+`AdditionalTools` on the invocation middleware injects tools into every request
+automatically, which is idiomatic for a session-scoped tool set.
+
 ```csharp
 private IServiceScope? _sessionScope;
 private IChatClient? _sessionClient;

--- a/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
@@ -102,16 +102,22 @@ instead of returning fake success.
 
 ## Scope and Lifetime
 
-The library does not create DI scopes. Build the chat client with the provider
-whose lifetime should back tool calls:
+The library does not create DI scopes. Keep the scope alive for as long as the
+chat session can invoke tools, then dispose it when the session ends:
 
 ```csharp
-using var scope = serviceScopeFactory.CreateScope(); // Inject IServiceScopeFactory.
+private IServiceScope? _sessionScope;
+private IChatClient? _sessionClient;
 
-var sessionClient = innerClient.AsBuilder()
+_sessionScope?.Dispose();
+_sessionScope = serviceScopeFactory.CreateScope(); // Inject IServiceScopeFactory.
+
+_sessionClient = innerClient.AsBuilder()
     .UseFunctionInvocation(configure: invocation =>
         invocation.AdditionalTools = [.. GardenTools.Default.Tools])
-    .Build(scope.ServiceProvider);
+    .Build(_sessionScope.ServiceProvider);
+
+// Dispose _sessionScope when the chat session or view model ends.
 ```
 
 Use a per-chat-session scope when tools hold conversational state.

--- a/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
@@ -112,6 +112,11 @@ automatically, which is idiomatic for a session-scoped tool set.
 private IServiceScope? _sessionScope;
 private IChatClient? _sessionClient;
 
+if (_sessionClient is IAsyncDisposable asyncDisposable)
+    await asyncDisposable.DisposeAsync();
+else
+    _sessionClient?.Dispose();
+
 _sessionScope?.Dispose();
 _sessionScope = serviceScopeFactory.CreateScope(); // Inject IServiceScopeFactory.
 
@@ -120,7 +125,7 @@ _sessionClient = innerClient.AsBuilder()
         invocation.AdditionalTools = [.. GardenTools.Default.Tools])
     .Build(_sessionScope.ServiceProvider);
 
-// Dispose _sessionScope when the chat session or view model ends.
+// Also dispose _sessionClient and _sessionScope when the chat session or view model ends.
 ```
 
 Use a per-chat-session scope when tools hold conversational state.

--- a/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: maui-ai-tool-bindings
+description: >-
+  Use Microsoft.Maui.AI.Attributes / AIExtensions to source-generate
+  Microsoft.Extensions.AI tools for MAUI apps. USE FOR: [ExportAIFunction],
+  [AIToolSource], AIToolContext, generated Default.Tools, DI parameter binding,
+  [FromServices], [FromKeyedServices], ApprovalRequired, AOT-friendly tool
+  definitions, and wiring tools into IChatClient. DO NOT USE FOR:
+  Microsoft.Maui.Essentials.AI chat or embedding setup itself (use
+  maui-essentials-ai), hand-written native platform bindings, or general
+  non-MAUI tool-calling theory.
+---
+
+# MAUI AI Tool Bindings
+
+Use this skill when a MAUI app needs AI-callable tools backed by app services,
+view models, or static utility methods. `Microsoft.Maui.AI.Attributes` generates
+`Microsoft.Extensions.AI` tools at compile time to avoid reflection-heavy
+invocation paths.
+
+## Basic Workflow
+
+1. Install the package:
+
+   ```bash
+   dotnet add package Microsoft.Maui.AI.Attributes --prerelease
+   ```
+
+2. Annotate methods or property accessors:
+
+   ```csharp
+   using System.ComponentModel;
+   using Microsoft.Maui.AI.Attributes;
+
+   public sealed class PlantCatalogService
+   {
+       [Description("Searches the plant catalog by name or category.")]
+       [ExportAIFunction("search_plants")]
+       public IReadOnlyList<PlantInfo> SearchPlants(
+           [Description("Optional filter text")] string? query = null)
+       {
+           return [];
+       }
+   }
+   ```
+
+3. Create a curated tool context:
+
+   ```csharp
+   [AIToolSource(typeof(PlantCatalogService))]
+   public partial class GardenTools : AIToolContext
+   {
+   }
+   ```
+
+4. Register services normally in `MauiProgram.cs`:
+
+   ```csharp
+   builder.Services.AddSingleton<PlantCatalogService>();
+   ```
+
+5. Pass generated tools into an `IChatClient`:
+
+   ```csharp
+   var client = innerClient.AsBuilder()
+       .UseFunctionInvocation()
+       .ConfigureOptions(options =>
+       {
+           options.Tools ??= [];
+           foreach (var tool in GardenTools.Default.Tools)
+               options.Tools.Add(tool);
+       })
+       .Build(serviceProvider);
+   ```
+
+## Tool Context Choices
+
+| Need | Pattern |
+| --- | --- |
+| Curated feature-specific tools | Explicit partial `AIToolContext` with `[AIToolSource]` |
+| Small prototype exposing all exported tools | Assembly-wide `<AssemblyName>ToolContext.Default.Tools` |
+| Sensitive mutation | `[ExportAIFunction(ApprovalRequired = true)]` |
+| Static utility tool | Static `[ExportAIFunction]` method |
+| Service-backed tool | Instance method on a DI-registered service |
+
+Prefer explicit contexts for production features so tool names and scope stay
+stable.
+
+## DI Parameter Binding
+
+The generator classifies parameters at compile time:
+
+| Parameter | Binding |
+| --- | --- |
+| Plain `string`, `int`, records, enums | JSON argument in the tool schema |
+| `CancellationToken` | Function invocation cancellation token |
+| `IServiceProvider` | `AIFunctionArguments.Services` |
+| `[FromServices] IMyService service` | Resolved from the provider, excluded from schema |
+| `[FromKeyedServices("key")] IMyService service` | Resolved from keyed DI, excluded from schema |
+
+For instance methods, the host service itself is resolved from the provider. If
+the provider is missing, generated tools throw a clear `InvalidOperationException`
+instead of returning fake success.
+
+## Scope and Lifetime
+
+The library does not create DI scopes. Build the chat client with the provider
+whose lifetime should back tool calls:
+
+```csharp
+using var scope = app.Services.CreateScope();
+
+var sessionClient = innerClient.AsBuilder()
+    .UseFunctionInvocation(configure: invocation =>
+        invocation.AdditionalTools = [.. GardenTools.Default.Tools])
+    .Build(scope.ServiceProvider);
+```
+
+Use a per-chat-session scope when tools hold conversational state.
+
+## AOT and Analyzer Guardrails
+
+- Use declared methods on declared types. Lambdas, local functions, and dynamic
+  methods are not source-generated tools.
+- Add `[Description]` to tools and user-visible parameters.
+- Avoid generic methods, `ref`/`out`/`in` parameters, delegates, pointers, and
+  shapes that cannot round-trip through JSON.
+- Materialize `IAsyncEnumerable<T>` results to arrays/lists if the consumer
+  expects JSON array output.
+- Watch diagnostics such as `MAUIAI002`, `MAUIAI003`, and `MAUIAI004`.
+
+## Validation Checklist
+
+- Tool names are stable and safe for the assistant to call.
+- Sensitive tools require approval.
+- DI services used by tools are registered with the intended lifetime.
+- `UseFunctionInvocation().Build(serviceProvider)` flows a provider to tool
+  invocations.
+- The app builds so the generator emits the context and diagnostics.
+- Tool output is deterministic enough for the app's AI UX.

--- a/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
@@ -106,7 +106,7 @@ The library does not create DI scopes. Build the chat client with the provider
 whose lifetime should back tool calls:
 
 ```csharp
-using var scope = app.Services.CreateScope();
+using var scope = serviceScopeFactory.CreateScope(); // Inject IServiceScopeFactory.
 
 var sessionClient = innerClient.AsBuilder()
     .UseFunctionInvocation(configure: invocation =>

--- a/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
@@ -3,10 +3,11 @@ name: maui-ai-tool-bindings
 description: >-
   Use Microsoft.Maui.AI.Attributes / AIExtensions to source-generate
   Microsoft.Extensions.AI tools for MAUI apps. USE FOR: [ExportAIFunction],
-  [AIToolSource], AIToolContext, Default.Tools, DI parameter binding,
-  [FromServices], [FromKeyedServices], ApprovalRequired, AOT-friendly tools, and
-  IChatClient wiring. DO NOT USE FOR: Essentials.AI chat/embedding setup,
-  native platform bindings, or non-MAUI tool-calling theory.
+  [AIToolSource], AIToolContext, Default.Tools, [FromServices],
+  [FromKeyedServices], ApprovalRequired, per-chat-session scopes, AOT-friendly
+  tools, and IChatClient.UseFunctionInvocation wiring. DO NOT USE FOR:
+  Essentials.AI chat/embedding setup, native platform bindings, or non-MAUI
+  tool-calling theory.
 ---
 
 # MAUI AI Tool Bindings

--- a/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ai-tool-bindings/SKILL.md
@@ -3,12 +3,10 @@ name: maui-ai-tool-bindings
 description: >-
   Use Microsoft.Maui.AI.Attributes / AIExtensions to source-generate
   Microsoft.Extensions.AI tools for MAUI apps. USE FOR: [ExportAIFunction],
-  [AIToolSource], AIToolContext, generated Default.Tools, DI parameter binding,
-  [FromServices], [FromKeyedServices], ApprovalRequired, AOT-friendly tool
-  definitions, and wiring tools into IChatClient. DO NOT USE FOR:
-  Microsoft.Maui.Essentials.AI chat or embedding setup itself (use
-  maui-essentials-ai), hand-written native platform bindings, or general
-  non-MAUI tool-calling theory.
+  [AIToolSource], AIToolContext, Default.Tools, DI parameter binding,
+  [FromServices], [FromKeyedServices], ApprovalRequired, AOT-friendly tools, and
+  IChatClient wiring. DO NOT USE FOR: Essentials.AI chat/embedding setup,
+  native platform bindings, or non-MAUI tool-calling theory.
 ---
 
 # MAUI AI Tool Bindings

--- a/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
@@ -15,6 +15,14 @@ Use this skill when the user is already working with MAUI controls and needs
 details beyond basic layout guidance. Keep control choices aligned with current
 MAUI APIs.
 
+## Response Checklist
+
+- For list scenarios, prefer `CollectionView` with `EmptyView`,
+  `RemainingItemsThreshold`, and stable `AutomationId` hooks.
+- For edge-to-edge scenarios, call out `.NET 10` `SafeAreaEdges` values.
+- For `GraphicsView`, keep `IDrawable.Draw` hot-path guidance and add semantic
+  alternatives (`SemanticProperties` / accessible companion UI).
+
 ## Workflow
 
 1. Inspect the target framework and whether the UI is XAML, C# Markup, or another

--- a/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
@@ -20,8 +20,9 @@ MAUI APIs.
    MAUI UI style.
 2. Identify the control area: `CollectionView`, safe area, gestures, animations,
    or `GraphicsView`.
-3. Apply the focused guidance below and route broader architecture, accessibility,
-   or profiling work to the relevant skill.
+3. Apply the focused guidance below and route broader architecture, accessibility
+   (`maui-accessibility`), or profiling (`maui-performance`) work to the relevant
+   skill.
 4. Validate the control on the intended device sizes/platforms, including
    automation hooks and accessibility alternatives for critical actions.
 

--- a/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
@@ -20,11 +20,11 @@ MAUI APIs.
    MAUI UI style.
 2. Identify the control area: `CollectionView`, safe area, gestures, animations,
    or `GraphicsView`.
-3. Apply the focused guidance below and route broader architecture, accessibility
-   (`maui-accessibility`), or profiling (`maui-performance`) work to the relevant
-   skill.
-4. Validate the control on the intended device sizes/platforms, including
-   automation hooks and accessibility alternatives for critical actions.
+3. Apply the focused guidance below. Route broad accessibility audits to
+   `maui-accessibility`; for GraphicsView-specific semantics, apply
+   `SemanticProperties` and `AutomationId` directly (see GraphicsView section).
+   Route performance profiling to `maui-performance`.
+4. Validate the control on the intended device sizes and platforms.
 
 ## CollectionView
 
@@ -68,21 +68,30 @@ Example state shell:
 
 ## Safe Areas
 
-- Inspect the MAUI target version first; use `maui-current-apis` when uncertain.
-- For .NET 10+ safe-area work, prefer `SafeAreaEdges` over manual iOS-only
-  padding.
-- Keep safe-area behavior declarative in XAML or shared UI when possible.
-- Test with notches, rounded corners, desktop title bars, and soft keyboard
-  scenarios when the page uses edge-to-edge layout.
+For .NET 10+ safe-area work, use `SafeAreaEdges` on the root container instead
+of hard-coded iOS-only padding:
+
+| Value | Effect |
+|---|---|
+| `SafeAreaEdges.Container` | Insets only the device bezel/notch boundary |
+| `SafeAreaEdges.SoftInput` | Also avoids the on-screen keyboard |
+| `SafeAreaEdges.All` | All edges including status bar and navigation areas |
 
 ```xml
+<!-- XAML: apply on the outermost layout that should respect device edges -->
 <Grid SafeAreaEdges="Container">
     ...
 </Grid>
 ```
 
-Avoid hard-coded top padding unless it is tied to a measured design requirement
-and guarded by platform/version checks.
+```csharp
+// C# Markup
+new Grid { SafeAreaEdges = SafeAreaEdges.Container }
+```
+
+Keep safe-area behavior declarative. Test with notches, rounded corners, desktop
+title bars, and soft keyboard scenarios when the page uses edge-to-edge layout.
+If the MAUI version is unknown, use `maui-current-apis` before changing APIs.
 
 ## Gestures
 
@@ -118,10 +127,12 @@ visualizations:
 - Store state outside the drawable and call `Invalidate()` when state changes.
 - Handle pointer/touch input at the view or page layer and translate it to
   drawing state.
-- Add accessible surrounding UI for important information drawn on the canvas.
-  Screen readers cannot infer arbitrary canvas content.
-- Use `maui-performance` if drawing stutters, allocates heavily, or invalidates
-  too often.
+- For important information in the drawing, provide accessible alternatives
+  outside the canvas: wrap the `GraphicsView` alongside a `Label` or use
+  `SemanticProperties.Description` on the view so screen readers announce it.
+  `AutomationId` on the `GraphicsView` enables UI-test targeting.
+- Use `SemanticScreenReader.Announce` for dynamic changes that must be audible.
+- If drawing stutters or allocates heavily, consult `maui-performance`.
 
 ## Validation Checklist
 

--- a/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maui-controls-deep-dive
 description: >-
-  Apply advanced .NET MAUI control guidance for CollectionView, safe areas,
-  gestures, animations, and GraphicsView. USE FOR: virtualization, item sizing,
-  empty/loading states, SafeAreaEdges, gestures, animation lifecycle, drawing,
-  and performance/accessibility guardrails. DO NOT USE FOR: general page layout,
-  full accessibility audits, broad profiling, or native handler implementation.
+  Apply advanced .NET MAUI control guidance. USE FOR: CollectionView incremental
+  loading, EmptyView and AutomationId patterns, SafeAreaEdges on .NET 10,
+  GraphicsView/IDrawable/Invalidate accessibility guidance, gestures, and
+  animation lifecycle/performance tradeoffs. DO NOT USE FOR: general page
+  layout, full accessibility audits, broad profiling, or native handler
+  implementation.
 ---
 
 # MAUI Controls Deep Dive

--- a/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
@@ -2,13 +2,10 @@
 name: maui-controls-deep-dive
 description: >-
   Apply advanced .NET MAUI control guidance for CollectionView, safe areas,
-  gestures, animations, and GraphicsView. USE FOR: deep control behavior,
-  virtualization, item sizing, empty/loading states, safe area handling,
-  Tap/Pointer/Pan/Swipe/Pinch gestures, animation lifecycle, custom drawing, and
-  performance/accessibility guardrails. DO NOT USE FOR: general page layout
-  (use maui-ui-patterns), full accessibility audits (use maui-accessibility),
-  broad performance profiling (use maui-performance), or native handler
-  implementation (use maui-custom-handlers).
+  gestures, animations, and GraphicsView. USE FOR: virtualization, item sizing,
+  empty/loading states, SafeAreaEdges, gestures, animation lifecycle, drawing,
+  and performance/accessibility guardrails. DO NOT USE FOR: general page layout,
+  full accessibility audits, broad profiling, or native handler implementation.
 ---
 
 # MAUI Controls Deep Dive

--- a/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-controls-deep-dive/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: maui-controls-deep-dive
+description: >-
+  Apply advanced .NET MAUI control guidance for CollectionView, safe areas,
+  gestures, animations, and GraphicsView. USE FOR: deep control behavior,
+  virtualization, item sizing, empty/loading states, safe area handling,
+  Tap/Pointer/Pan/Swipe/Pinch gestures, animation lifecycle, custom drawing, and
+  performance/accessibility guardrails. DO NOT USE FOR: general page layout
+  (use maui-ui-patterns), full accessibility audits (use maui-accessibility),
+  broad performance profiling (use maui-performance), or native handler
+  implementation (use maui-custom-handlers).
+---
+
+# MAUI Controls Deep Dive
+
+Use this skill when the user is already working with MAUI controls and needs
+details beyond basic layout guidance. Keep control choices aligned with current
+MAUI APIs.
+
+## Workflow
+
+1. Inspect the target framework and whether the UI is XAML, C# Markup, or another
+   MAUI UI style.
+2. Identify the control area: `CollectionView`, safe area, gestures, animations,
+   or `GraphicsView`.
+3. Apply the focused guidance below and route broader architecture, accessibility,
+   or profiling work to the relevant skill.
+4. Validate the control on the intended device sizes/platforms, including
+   automation hooks and accessibility alternatives for critical actions.
+
+## CollectionView
+
+Use `CollectionView` for repeated data and let it own scrolling:
+
+- Do not wrap it in `ScrollView`.
+- Use `EmptyView`, header/footer, and surrounding `Grid` rows for non-item UI.
+- Use `RemainingItemsThreshold` / `RemainingItemsThresholdReachedCommand` for
+  incremental loading.
+- Use `SelectionMode`, `SelectedItem`, and `SelectionChangedCommand` instead of
+  tap gestures on item roots when selection is the intent.
+- Keep item templates lightweight. Avoid nested layouts and expensive converters
+  in large lists.
+- Prefer stable `AutomationId` values on the list and critical item controls.
+- For .NET 10 iOS/Mac Catalyst behavior, check current handler guidance before
+  opting into or reverting CollectionView handlers.
+
+Example state shell:
+
+```xml
+<Grid RowDefinitions="Auto,*">
+    <ActivityIndicator
+        AutomationId="orders-loading"
+        IsRunning="{Binding IsBusy}"
+        IsVisible="{Binding IsBusy}" />
+
+    <CollectionView
+        Grid.Row="1"
+        AutomationId="orders-list"
+        ItemsSource="{Binding Orders}"
+        RemainingItemsThreshold="5"
+        RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}">
+        <CollectionView.EmptyView>
+            <Label
+                AutomationId="orders-empty"
+                Text="No orders found." />
+        </CollectionView.EmptyView>
+    </CollectionView>
+</Grid>
+```
+
+## Safe Areas
+
+- Inspect the MAUI target version first; use `maui-current-apis` when uncertain.
+- For .NET 10+ safe-area work, prefer `SafeAreaEdges` over manual iOS-only
+  padding.
+- Keep safe-area behavior declarative in XAML or shared UI when possible.
+- Test with notches, rounded corners, desktop title bars, and soft keyboard
+  scenarios when the page uses edge-to-edge layout.
+
+```xml
+<Grid SafeAreaEdges="Container">
+    ...
+</Grid>
+```
+
+Avoid hard-coded top padding unless it is tied to a measured design requirement
+and guarded by platform/version checks.
+
+## Gestures
+
+- Use `TapGestureRecognizer` for click/tap. Do not use removed or obsolete
+  click gesture APIs.
+- Use `PointerGestureRecognizer` for hover/desktop pointer affordances.
+- Use `PanGestureRecognizer`, `SwipeGestureRecognizer`, and
+  `PinchGestureRecognizer` only where the gesture maps to an obvious UI action.
+- Do not attach competing gestures to deeply nested controls without testing
+  hit-testing and scrolling interactions.
+- Preserve accessibility alternatives: commands, buttons, menu items, keyboard
+  accelerators, or semantic descriptions as appropriate.
+
+## Animations
+
+- Prefer built-in async animation helpers such as `FadeTo`, `ScaleTo`,
+  `TranslateTo`, and `RotateTo` for view animations.
+- Await or coordinate animations so state changes do not race.
+- Cancel or ignore stale animations when view models unload or commands rerun.
+- Avoid animation-only feedback for important state; expose semantic state and
+  visual states too.
+- Keep list item animations modest; animating many recycled cells can hurt
+  scrolling performance.
+
+## GraphicsView
+
+Use `GraphicsView` for custom drawing, charts, signatures, or lightweight
+visualizations:
+
+- Put drawing code in an `IDrawable`.
+- Treat `Draw(ICanvas canvas, RectF dirtyRect)` as a hot path: avoid allocations,
+  blocking I/O, async calls, and service lookups.
+- Store state outside the drawable and call `Invalidate()` when state changes.
+- Handle pointer/touch input at the view or page layer and translate it to
+  drawing state.
+- Add accessible surrounding UI for important information drawn on the canvas.
+  Screen readers cannot infer arbitrary canvas content.
+- Use `maui-performance` if drawing stutters, allocates heavily, or invalidates
+  too often.
+
+## Validation Checklist
+
+- `CollectionView` owns its scrolling and has empty/loading behavior where data
+  can be absent.
+- Safe-area code matches the detected MAUI version and target platforms.
+- Gestures have accessible alternatives for critical actions.
+- Animations cannot leave the UI in stale state after cancellation or navigation.
+- `GraphicsView` drawing is allocation-conscious and exposes important content
+  outside the canvas.

--- a/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
@@ -16,6 +16,14 @@ Use this skill when a MAUI visual element needs native platform behavior. Keep
 handlers focused on views. Route non-visual APIs to platform services and route
 large native SDK surfaces to slim bindings.
 
+## Response Checklist
+
+- Use handler language explicitly: `AppendToMapping`, `PropertyMapper`,
+  `CommandMapper`, and `ViewHandler`.
+- For renderer migration, map subscription/setup to `ConnectHandler` and cleanup
+  to `DisconnectHandler`.
+- Keep mapper changes scoped to the intended control type, not all controls.
+
 ## Decision Tree
 
 | Need | Prefer |

--- a/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
@@ -4,10 +4,12 @@ description: >-
   Implement and migrate .NET MAUI handler customizations using mapper APIs.
   USE FOR: AppendToMapping, PropertyMapper, CommandMapper, handler lifecycle
   (ConnectHandler/DisconnectHandler), platform-specific native view changes,
-  scoped mapper customization, renderer-to-handler migration, and deciding when
-  to use handlers versus platform services or slim bindings. DO NOT USE FOR:
-  non-visual platform APIs, full Xamarin migration, native SDK bindings, or MAUI
-  platform backend implementation.
+  scoped mapper customization, renderer-to-handler migration, Xamarin renderer
+  lifecycle (OnElementChanged/Dispose) conversion to ConnectHandler/
+  DisconnectHandler, and deciding when to use handlers versus platform services
+  or slim bindings. DO NOT USE FOR: non-visual platform APIs, full Xamarin
+  migration, native SDK bindings, or MAUI platform backend implementation.
+---
 ---
 
 # MAUI Custom Handlers

--- a/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: maui-custom-handlers
 description: >-
-  Implement and migrate .NET MAUI handler customizations. USE FOR: handler
-  mappers, property/command mappers, native view tweaks, handler lifecycle
-  cleanup, renderer replacement, and choosing handlers versus platform services
-  or bindings. DO NOT USE FOR: non-visual platform APIs, full Xamarin migration,
-  native SDK bindings, or MAUI platform backend implementation.
+  Implement and migrate .NET MAUI handler customizations using mapper APIs.
+  USE FOR: AppendToMapping, PropertyMapper, CommandMapper, handler lifecycle
+  (ConnectHandler/DisconnectHandler), platform-specific native view changes,
+  scoped mapper customization, renderer-to-handler migration, and deciding when
+  to use handlers versus platform services or slim bindings. DO NOT USE FOR:
+  non-visual platform APIs, full Xamarin migration, native SDK bindings, or MAUI
+  platform backend implementation.
 ---
 
 # MAUI Custom Handlers

--- a/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: maui-custom-handlers
+description: >-
+  Implement and migrate .NET MAUI handler customizations. USE FOR: handler
+  mapper customization, property and command mappers, platform-specific native
+  view changes, ConnectHandler/DisconnectHandler lifecycle cleanup, replacing
+  Xamarin.Forms custom renderers, and choosing handlers versus platform services
+  or slim bindings. DO NOT USE FOR: non-visual platform APIs (use
+  maui-platform-invoke), full Xamarin.Forms migration planning (use
+  xamarin-forms-migration), native SDK bindings (use android-slim-bindings or
+  ios-slim-bindings), or implementing a new MAUI platform backend (use
+  maui-platform-backend).
+---
+
+# MAUI Custom Handlers
+
+Use this skill when a MAUI visual element needs native platform behavior. Keep
+handlers focused on views. Route non-visual APIs to platform services and route
+large native SDK surfaces to slim bindings.
+
+## Decision Tree
+
+| Need | Prefer |
+| --- | --- |
+| Tweak an existing control for the whole app | `Handler.Mapper.AppendToMapping` in `MauiProgram.cs` |
+| Tweak only specific control instances | Subclass the control and guard mapper logic with `if (view is MyControl)` |
+| Add a reusable cross-platform control | Custom `ViewHandler<TVirtualView,TPlatformView>` |
+| Map bindable properties to native properties | `PropertyMapper` entries |
+| Invoke actions such as play/pause/scroll | `CommandMapper` entries |
+| Use camera, sensors, payment, health, or background APIs | Platform service through DI |
+| Wrap a third-party Android/iOS/macOS SDK | Slim binding plus a platform service facade |
+
+## Workflow
+
+1. Inspect the target frameworks and existing UI architecture.
+2. Define the cross-platform view API first: bindable properties, commands, and
+   events that make sense to app code.
+3. Choose global mapper customization, subclass-scoped mapper customization, or a
+   full custom handler.
+4. Put native implementation in partial handler files or `#if` guarded blocks for
+   the exact platforms supported by the project.
+5. Register handlers in `MauiProgram.cs`:
+
+   ```csharp
+   builder.ConfigureMauiHandlers(handlers =>
+   {
+       handlers.AddHandler<CameraPreview, CameraPreviewHandler>();
+   });
+   ```
+
+6. Use `ConnectHandler` to subscribe native events and allocate native resources.
+7. Use `DisconnectHandler` to unsubscribe, stop timers, clear delegates, and
+   dispose only native objects owned by the handler. Call
+   `base.DisconnectHandler(platformView)` as the final statement so the base
+   handler clears its own state.
+8. Build each targeted platform and verify the behavior with UI automation or
+   DevFlow when available.
+
+## Scoped Mapper Customization
+
+For an existing MAUI control, avoid an unscoped global mapper when only one
+control instance should change:
+
+```csharp
+public class BorderlessEntry : Entry
+{
+}
+
+EntryHandler.Mapper.AppendToMapping("Borderless", (handler, view) =>
+{
+    if (view is not BorderlessEntry)
+        return;
+
+#if ANDROID
+    handler.PlatformView.Background = null;
+#elif IOS || MACCATALYST
+    handler.PlatformView.BorderStyle = UIKit.UITextBorderStyle.None;
+#elif WINDOWS
+    handler.PlatformView.BorderThickness = new Microsoft.UI.Xaml.Thickness(0);
+#endif
+});
+```
+
+Use a unique mapping key. Do not repeatedly append the same mapping from page
+constructors; register once during app startup or from a guarded initialization
+path.
+
+## Custom Handler Shape
+
+```csharp
+public class MeterView : View
+{
+    public static readonly BindableProperty ValueProperty =
+        BindableProperty.Create(nameof(Value), typeof(double), typeof(MeterView), 0d);
+
+    public double Value
+    {
+        get => (double)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+}
+
+public partial class MeterViewHandler
+{
+    public static readonly IPropertyMapper<MeterView, MeterViewHandler> Mapper =
+        new PropertyMapper<MeterView, MeterViewHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(MeterView.Value)] = MapValue
+        };
+
+    public MeterViewHandler() : base(Mapper)
+    {
+    }
+
+    public static partial void MapValue(MeterViewHandler handler, MeterView view);
+}
+```
+
+Implement `CreatePlatformView`, `ConnectHandler`, `DisconnectHandler`, and
+mapping partials per platform. Keep platform namespaces out of shared files.
+
+## Property and Command Mappers
+
+- Use `PropertyMapper` for state that should update when a bindable property
+  changes.
+- Use `CommandMapper` for imperative requests such as `Play`, `Pause`,
+  `ScrollTo`, or `Reload`.
+- Mapper methods should be idempotent. They may be called more than once.
+- Validate `handler.PlatformView` and `handler.VirtualView` assumptions through
+  types, not broad try/catch blocks.
+
+## Renderer Migration Notes
+
+When replacing Xamarin.Forms renderers:
+
+1. Move renderer logic that creates native controls into `CreatePlatformView`.
+2. Move `OnElementChanged` subscriptions into `ConnectHandler`.
+3. Move renderer cleanup into `DisconnectHandler`, and end with
+   `base.DisconnectHandler(platformView)`.
+4. Replace `OnElementPropertyChanged` switch statements with `PropertyMapper`
+   entries.
+5. Replace renderer actions with `CommandMapper` entries or view methods that
+   call `Handler?.Invoke`.
+
+## Validation Checklist
+
+- The handler is registered in one startup location.
+- Mapper keys are unique and scoped when customization should not be global.
+- Native event subscriptions are unsubscribed in `DisconnectHandler`.
+- No platform namespace leaks into shared code unintentionally.
+- The implementation builds for every target framework it is included in.
+- Non-visual SDK work is not hidden in a handler.

--- a/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: maui-custom-handlers
 description: >-
-  Implement and migrate .NET MAUI handler customizations using mapper APIs.
-  USE FOR: AppendToMapping, PropertyMapper, CommandMapper, handler lifecycle
-  (ConnectHandler/DisconnectHandler), platform-specific native view changes,
-  scoped mapper customization, renderer-to-handler migration, Xamarin renderer
-  lifecycle (OnElementChanged/Dispose) conversion to ConnectHandler/
-  DisconnectHandler, and deciding when to use handlers versus platform services
-  or slim bindings. DO NOT USE FOR: non-visual platform APIs, full Xamarin
-  migration, native SDK bindings, or MAUI platform backend implementation.
+  Implement and migrate .NET MAUI visual handlers using mapper APIs. USE FOR:
+  EntryHandler.Mapper.AppendToMapping, scoped BorderlessEntry customizations,
+  PropertyMapper, CommandMapper, ConnectHandler/DisconnectHandler event cleanup,
+  custom ViewHandler structures, and converting Xamarin.Forms renderers to
+  handlers. DO NOT USE FOR: non-visual platform APIs, full Xamarin migration,
+  native SDK bindings, or MAUI platform backend implementation.
 ---
 ---
 

--- a/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
@@ -113,7 +113,21 @@ public partial class MeterViewHandler
 ```
 
 Implement `CreatePlatformView`, `ConnectHandler`, `DisconnectHandler`, and
-mapping partials per platform. Keep platform namespaces out of shared files.
+mapping partials per platform. Put the `ViewHandler<TVirtualView, TPlatformView>`
+base class on the platform partial so native types stay out of shared files:
+
+```csharp
+// Platforms/Android/MeterViewHandler.android.cs
+public partial class MeterViewHandler : ViewHandler<MeterView, Android.Widget.FrameLayout>
+{
+    protected override Android.Widget.FrameLayout CreatePlatformView() => new(Context);
+
+    public static partial void MapValue(MeterViewHandler handler, MeterView view)
+    {
+        // Update handler.PlatformView from view.Value.
+    }
+}
+```
 
 ## Property and Command Mappers
 

--- a/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-custom-handlers/SKILL.md
@@ -2,14 +2,10 @@
 name: maui-custom-handlers
 description: >-
   Implement and migrate .NET MAUI handler customizations. USE FOR: handler
-  mapper customization, property and command mappers, platform-specific native
-  view changes, ConnectHandler/DisconnectHandler lifecycle cleanup, replacing
-  Xamarin.Forms custom renderers, and choosing handlers versus platform services
-  or slim bindings. DO NOT USE FOR: non-visual platform APIs (use
-  maui-platform-invoke), full Xamarin.Forms migration planning (use
-  xamarin-forms-migration), native SDK bindings (use android-slim-bindings or
-  ios-slim-bindings), or implementing a new MAUI platform backend (use
-  maui-platform-backend).
+  mappers, property/command mappers, native view tweaks, handler lifecycle
+  cleanup, renderer replacement, and choosing handlers versus platform services
+  or bindings. DO NOT USE FOR: non-visual platform APIs, full Xamarin migration,
+  native SDK bindings, or MAUI platform backend implementation.
 ---
 
 # MAUI Custom Handlers

--- a/plugins/dotnet-maui/skills/maui-device-capabilities/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-device-capabilities/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: maui-device-capabilities
 description: >-
-  Implement .NET MAUI device capability features with permissions, FilePicker,
-  MediaPicker, Geolocation, Maps, manifest/plist declarations, cancellation, and
-  permission UX. USE FOR: camera/photos/files/location/maps features, runtime
-  permission requests, Android manifest entries, iOS/Mac Catalyst Info.plist
-  usage descriptions, Android 13 READ_MEDIA_IMAGES/Photo Picker migration, and
-  graceful denied/cancelled flows. DO NOT USE FOR: notifications or deep links
-  (use maui-notifications-deep-links), secure auth flows (use
-  maui-auth-secure-storage), or visual layout patterns (use maui-ui-patterns).
+  Implement .NET MAUI device capabilities with platform permissions: camera and
+  MediaPicker (IsCaptureSupported, permission checks), FilePicker with durable
+  storage (copy to AppDataDirectory), Geolocation (GeolocationRequest,
+  LocationWhenInUse), and Maps setup. Add Android manifest entries
+  (android.permission.CAMERA, READ_MEDIA_IMAGES for Android 13+) and iOS/Mac
+  Catalyst plist entries (NSCameraUsageDescription, NSLocationWhenInUseUsageDescription).
+  USE FOR: Camera/photo/file/location/map features with permissions, platform
+  manifest/plist declarations, handling denied/cancelled flows, Android 13+
+  Photo Picker migration, runtime permission requests, and durable file access.
+  DO NOT USE FOR: Notifications/deep links (maui-notifications-deep-links), auth
+  (maui-auth-secure-storage), or UI layout (maui-ui-patterns).
 ---
 
 # MAUI Device Capabilities

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -49,7 +49,8 @@ builder.Services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp 
 ```
 
 Register platform-specific implementations conditionally if the app targets
-unsupported platforms too.
+unsupported platforms too. For MAUI Labs AppKit (`MACOS`), verify the
+Essentials.AI integration against the target package before shipping.
 
 ## Chat Workflow
 
@@ -104,7 +105,7 @@ patterns apply:
 
 ```csharp
 var innerClient = serviceProvider.GetRequiredService<IChatClient>();
-var appTools = AppTools.Default.Tools; // Generated context; see maui-ai-tool-bindings.
+var appTools = YourAppTools.Default.Tools; // Define with [AIToolSource]; see maui-ai-tool-bindings.
 
 var client = innerClient.AsBuilder()
     .UseFunctionInvocation()

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -35,11 +35,13 @@ dotnet add package Microsoft.Maui.Essentials.AI --prerelease
 
 ```csharp
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Essentials.AI;
 
 builder.Services.AddSingleton<IChatClient>(new AppleIntelligenceChatClient());
-builder.Services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(
-    _ => new NLEmbeddingGenerator(NLEmbeddingType.Sentence));
+builder.Services.AddSingleton<NLEmbeddingGenerator>();
+builder.Services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+    sp.GetRequiredService<NLEmbeddingGenerator>());
 ```
 
 Register platform-specific implementations conditionally if the app targets
@@ -67,10 +69,13 @@ use that convention. Otherwise, dispatch UI-bound property updates explicitly.
 
 ## Embeddings and Semantic Search
 
-Use `NLEmbeddingGenerator` for local semantic search over app-owned content:
+Use `NLEmbeddingGenerator` for local semantic search over app-owned content. The
+default constructor uses Apple's English sentence embedding; pass a
+`NaturalLanguage.NLLanguage` or an existing `NaturalLanguage.NLEmbedding` when
+the app needs a different supported language or embedding:
 
 ```csharp
-var generator = new NLEmbeddingGenerator(NLEmbeddingType.Sentence);
+var generator = new NLEmbeddingGenerator();
 var embeddings = await generator.GenerateAsync(
     ["sunset beach", "mountain hiking"],
     cancellationToken);

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -2,11 +2,10 @@
 name: maui-essentials-ai
 description: >-
   Adopt Microsoft.Maui.Essentials.AI in MAUI apps. USE FOR: local/on-device
-  chat, Apple Intelligence-backed IChatClient, NL embeddings, semantic search,
-  tool use with Microsoft.Extensions.AI, privacy/offline AI architecture, and
-  platform availability planning. DO NOT USE FOR: source-generating AI tool
-  bindings (use maui-ai-tool-bindings), cloud-only AI service setup, general AI
-  debugging (use maui-ai-debugging), or non-MAUI Microsoft.Extensions.AI apps.
+  chat, Apple Intelligence IChatClient, NL embeddings, semantic search, tool
+  use, privacy/offline architecture, and platform planning. DO NOT USE FOR:
+  source-generating AI tool bindings, cloud-only AI setup, AI debugging, or
+  non-MAUI Microsoft.Extensions.AI apps.
 ---
 
 # MAUI Essentials AI
@@ -38,10 +37,15 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Essentials.AI;
 
+#if IOS || MACCATALYST || MACOS
 builder.Services.AddSingleton<IChatClient>(new AppleIntelligenceChatClient());
 builder.Services.AddSingleton<NLEmbeddingGenerator>();
 builder.Services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
     sp.GetRequiredService<NLEmbeddingGenerator>());
+#else
+// On-device AI is not available on this platform yet.
+// Register an app-specific unavailable/null implementation or hide AI features.
+#endif
 ```
 
 Register platform-specific implementations conditionally if the app targets
@@ -75,10 +79,12 @@ default constructor uses Apple's English sentence embedding; pass a
 the app needs a different supported language or embedding:
 
 ```csharp
+#if IOS || MACCATALYST || MACOS
 var generator = new NLEmbeddingGenerator();
 var embeddings = await generator.GenerateAsync(
     ["sunset beach", "mountain hiking"],
     cancellationToken);
+#endif
 ```
 
 Recommended shape:

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maui-essentials-ai
 description: >-
-  Adopt Microsoft.Maui.Essentials.AI in MAUI apps. USE FOR: local/on-device
-  chat, Apple Intelligence IChatClient, NL embeddings, semantic search, tool
-  use, privacy/offline architecture, and platform planning. DO NOT USE FOR:
-  source-generating AI tool bindings, cloud-only AI setup, AI debugging, or
-  non-MAUI Microsoft.Extensions.AI apps.
+  Adopt Microsoft.Maui.Essentials.AI in MAUI apps. USE FOR: Apple Intelligence
+  IChatClient registration, NLEmbeddingGenerator semantic search, local/on-device
+  chat, wiring app tools into local chat via UseFunctionInvocation, privacy/offline
+  UX, and platform fallback planning. DO NOT USE FOR: source-generating AI tool
+  bindings, cloud-only AI setup, AI debugging, or non-MAUI
+  Microsoft.Extensions.AI apps.
 ---
 
 # MAUI Essentials AI

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -60,6 +60,11 @@ if (OperatingSystem.IsIOSVersionAtLeast(26) ||
 {
     builder.Services.AddSingleton<IChatClient>(new AppleIntelligenceChatClient());
 }
+else
+{
+    // Leave IChatClient unregistered and check availability before use,
+    // or register an app-specific unavailable implementation.
+}
 #endif
 ```
 

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -103,12 +103,15 @@ Essentials AI returns `Microsoft.Extensions.AI` clients, so normal tool calling
 patterns apply:
 
 ```csharp
+var innerClient = serviceProvider.GetRequiredService<IChatClient>();
+var appTools = AppTools.Default.Tools; // Generated context; see maui-ai-tool-bindings.
+
 var client = innerClient.AsBuilder()
     .UseFunctionInvocation()
     .ConfigureOptions(options =>
     {
         options.Tools ??= [];
-        foreach (var tool in GardenTools.Default.Tools)
+        foreach (var tool in appTools)
             options.Tools.Add(tool);
     })
     .Build(serviceProvider);

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -14,6 +14,16 @@ description: >-
 Use this skill when a MAUI app should use on-device AI through
 `Microsoft.Maui.Essentials.AI` and `Microsoft.Extensions.AI` abstractions.
 
+## Response Checklist
+
+- Mention the package and primary types explicitly:
+  `Microsoft.Maui.Essentials.AI`, `AppleIntelligenceChatClient`,
+  `NLEmbeddingGenerator`.
+- Keep platform support explicit (Apple chat support is iOS/macOS/Mac Catalyst
+  26+; embeddings have broader Apple OS coverage).
+- For app tools, show `UseFunctionInvocation` and route source-generated tool
+  definitions to `maui-ai-tool-bindings` when appropriate.
+
 ## Platform Support
 
 Chat support:

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: maui-essentials-ai
+description: >-
+  Adopt Microsoft.Maui.Essentials.AI in MAUI apps. USE FOR: local/on-device
+  chat, Apple Intelligence-backed IChatClient, NL embeddings, semantic search,
+  tool use with Microsoft.Extensions.AI, privacy/offline AI architecture, and
+  platform availability planning. DO NOT USE FOR: source-generating AI tool
+  bindings (use maui-ai-tool-bindings), cloud-only AI service setup, general AI
+  debugging (use maui-ai-debugging), or non-MAUI Microsoft.Extensions.AI apps.
+---
+
+# MAUI Essentials AI
+
+Use this skill when a MAUI app should use on-device AI through
+`Microsoft.Maui.Essentials.AI` and `Microsoft.Extensions.AI` abstractions.
+
+## Platform Support
+
+| Platform | Chat | Embeddings |
+| --- | --- | --- |
+| iOS 26+ | Apple Intelligence / Foundation Models | NaturalLanguage embeddings |
+| Mac Catalyst 26+ | Apple Intelligence | NaturalLanguage embeddings |
+| macOS 26+ | Apple Intelligence | NaturalLanguage embeddings |
+| Android | Coming soon | Coming soon |
+| Windows | Coming soon | Coming soon |
+
+Design fallback behavior for unsupported platforms. Do not silently route private
+data to a cloud model unless the user explicitly wants a cloud fallback.
+
+## Install and Register
+
+```bash
+dotnet add package Microsoft.Maui.Essentials.AI --prerelease
+```
+
+```csharp
+using Microsoft.Extensions.AI;
+using Microsoft.Maui.Essentials.AI;
+
+builder.Services.AddSingleton<IChatClient>(new AppleIntelligenceChatClient());
+builder.Services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(
+    _ => new NLEmbeddingGenerator(NLEmbeddingType.Sentence));
+```
+
+Register platform-specific implementations conditionally if the app targets
+unsupported platforms too.
+
+## Chat Workflow
+
+1. Inject `IChatClient` into a view model or service, not directly into a page
+   unless the app architecture already does that.
+2. Pass cancellation tokens from commands and lifecycle boundaries.
+3. Use streaming responses for interactive UI:
+
+   ```csharp
+   await foreach (var update in _chat.GetStreamingResponseAsync(messages, cancellationToken))
+   {
+       MainThread.BeginInvokeOnMainThread(() => ResponseText += update.Text);
+   }
+   ```
+
+4. Keep conversation state in an app service so it survives page recreation.
+5. Surface model availability and failure states in the UI.
+
+If your view model framework already marshals property changes to the UI thread,
+use that convention. Otherwise, dispatch UI-bound property updates explicitly.
+
+## Embeddings and Semantic Search
+
+Use `NLEmbeddingGenerator` for local semantic search over app-owned content:
+
+```csharp
+var generator = new NLEmbeddingGenerator(NLEmbeddingType.Sentence);
+var embeddings = await generator.GenerateAsync(
+    ["sunset beach", "mountain hiking"],
+    cancellationToken);
+```
+
+Recommended shape:
+
+- chunk app content into small searchable records;
+- generate embeddings at ingest/update time;
+- store vector plus metadata locally;
+- compare query embeddings with cosine similarity;
+- return source snippets and IDs so the UI can show grounded results.
+
+Avoid regenerating embeddings for the full corpus on every search.
+
+## Tool Use
+
+Essentials AI returns `Microsoft.Extensions.AI` clients, so normal tool calling
+patterns apply:
+
+```csharp
+var client = innerClient.AsBuilder()
+    .UseFunctionInvocation()
+    .ConfigureOptions(options =>
+    {
+        options.Tools ??= [];
+        foreach (var tool in GardenTools.Default.Tools)
+            options.Tools.Add(tool);
+    })
+    .Build(serviceProvider);
+```
+
+Use `maui-ai-tool-bindings` when tools should be generated from app methods with
+`[ExportAIFunction]`, DI parameter binding, or AOT-friendly definitions.
+
+## Privacy and UX Guardrails
+
+- Explain that AI runs on device for supported Apple platforms.
+- Ask before adding a cloud fallback.
+- Keep prompts, embeddings, and tool outputs within the app's data handling
+  policy.
+- Show unsupported-device and model-unavailable states.
+- Do not block the UI thread while generating responses or embeddings.
+- Use approval-required tools for actions that mutate data, send messages,
+  purchase, delete, or navigate unexpectedly.
+
+## Validation Checklist
+
+- The app target platform supports the requested AI capability or has an
+  explicit fallback.
+- AI clients are registered in DI and consumed from services/view models.
+- Streaming, cancellation, and error states are handled.
+- Semantic search stores metadata with embeddings and avoids full re-ingest per
+  query.
+- Tool use is scoped and user-approved for sensitive actions.

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -127,7 +127,13 @@ Essentials AI returns `Microsoft.Extensions.AI` clients, so normal tool calling
 patterns apply:
 
 ```csharp
-var innerClient = serviceProvider.GetRequiredService<IChatClient>();
+var innerClient = serviceProvider.GetService<IChatClient>();
+if (innerClient is null)
+{
+    // Chat is unavailable on this platform/OS version; hide or disable the feature.
+    return;
+}
+
 var appTools = YourAppTools.Default.Tools; // Define with [AIToolSource]; see maui-ai-tool-bindings.
 
 var client = innerClient.AsBuilder()

--- a/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-essentials-ai/SKILL.md
@@ -15,13 +15,25 @@ Use this skill when a MAUI app should use on-device AI through
 
 ## Platform Support
 
-| Platform | Chat | Embeddings |
-| --- | --- | --- |
-| iOS 26+ | Apple Intelligence / Foundation Models | NaturalLanguage embeddings |
-| Mac Catalyst 26+ | Apple Intelligence | NaturalLanguage embeddings |
-| macOS 26+ | Apple Intelligence | NaturalLanguage embeddings |
-| Android | Coming soon | Coming soon |
-| Windows | Coming soon | Coming soon |
+Chat support:
+
+| Platform | Status |
+| --- | --- |
+| iOS 26+ | Apple Intelligence / Foundation Models |
+| Mac Catalyst 26+ | Apple Intelligence |
+| macOS 26+ | Apple Intelligence |
+| Android | Coming soon |
+| Windows | Coming soon |
+
+Embedding support:
+
+| Platform | Status |
+| --- | --- |
+| iOS 13+ | NaturalLanguage embeddings |
+| Mac Catalyst 13.1+ | NaturalLanguage embeddings |
+| macOS 10.15+ | NaturalLanguage embeddings |
+| Android | Not supported |
+| Windows | Not supported |
 
 Design fallback behavior for unsupported platforms. Do not silently route private
 data to a cloud model unless the user explicitly wants a cloud fallback.
@@ -38,19 +50,25 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Essentials.AI;
 
 #if IOS || MACCATALYST || MACOS
-builder.Services.AddSingleton<IChatClient>(new AppleIntelligenceChatClient());
 builder.Services.AddSingleton<NLEmbeddingGenerator>();
 builder.Services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
     sp.GetRequiredService<NLEmbeddingGenerator>());
-#else
-// On-device AI is not available on this platform yet.
-// Register an app-specific unavailable/null implementation or hide AI features.
+
+if (OperatingSystem.IsIOSVersionAtLeast(26) ||
+    OperatingSystem.IsMacCatalystVersionAtLeast(26) ||
+    OperatingSystem.IsMacOSVersionAtLeast(26))
+{
+    builder.Services.AddSingleton<IChatClient>(new AppleIntelligenceChatClient());
+}
 #endif
 ```
 
 Register platform-specific implementations conditionally if the app targets
-unsupported platforms too. For MAUI Labs AppKit (`MACOS`), verify the
-Essentials.AI integration against the target package before shipping.
+unsupported platforms too. If the app's minimum Apple OS target is below 26,
+guard chat registration with runtime OS checks or register an app-specific
+unavailable implementation for older OS versions. For MAUI Labs AppKit
+(`MACOS`), verify the Essentials.AI integration against the target package
+before shipping.
 
 ## Chat Workflow
 

--- a/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
@@ -2,12 +2,10 @@
 name: maui-labs-platform-targeting
 description: >-
   Build MAUI apps for experimental MAUI Labs platform backends. USE FOR:
-  targeting Linux GTK4, macOS AppKit, WPF, using their templates/packages,
-  creating head projects, wiring hosting methods, understanding platform parity,
-  and validating apps on experimental backends. DO NOT USE FOR: implementing or
-  modifying a MAUI platform backend, control handler, or Essentials service (use
-  maui-platform-backend), official Android/iOS/Windows/Mac Catalyst targeting,
-  or general app architecture unrelated to MAUI Labs platforms.
+  targeting Linux GTK4, macOS AppKit, or WPF, using templates/packages, creating
+  head projects, wiring hosting, checking parity, and validating apps. DO NOT
+  USE FOR: implementing MAUI backends/handlers/Essentials services, official
+  platform targeting, or unrelated app architecture.
 ---
 
 # MAUI Labs Platform Targeting
@@ -70,8 +68,13 @@ reference the shared app/project:
 ```
 
 ```csharp
-builder.UseMauiAppLinuxGtk4<App>();
+builder
+    .UseMauiAppLinuxGtk4<App>()
+    .AddLinuxGtk4Essentials();
 ```
+
+If the app does not need Linux Essentials services, omit the Essentials package
+and `AddLinuxGtk4Essentials()` call.
 
 ## macOS AppKit
 

--- a/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
@@ -58,13 +58,13 @@ dotnet run --project MyApp.Linux
 ```
 
 For an existing app, create `MyApp.Linux` next to the shared MAUI project and
-reference the shared app/project:
+reference the shared app/project. Pin concrete package versions for production;
+the version below is a placeholder to replace with the selected prerelease:
 
 ```xml
 <ProjectReference Include="../MyApp/MyApp.csproj" />
-<!-- Pin a specific prerelease for production; *-* floats to latest prerelease. -->
-<PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4" Version="*-*" />
-<PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.Essentials" Version="*-*" />
+<PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4" Version="0.6.0-preview.1" />
+<PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.Essentials" Version="0.6.0-preview.1" />
 ```
 
 ```csharp
@@ -134,9 +134,9 @@ builder
 ## Do Not Confuse With Backend Implementation
 
 If the task is to add a handler, implement an Essentials API, scaffold backend
-source, or debug renderer internals in `platforms/*`, use the
-`maui-platform-backend` skill instead. This skill is only for app developers who
-consume the experimental platform packages.
+source, or debug renderer internals in `platforms/*`, use a platform-backend
+implementation skill if one is available in your environment. This skill is only
+for app developers who consume the experimental platform packages.
 
 ## Validation Checklist
 

--- a/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: maui-labs-platform-targeting
 description: >-
-  Build MAUI apps for experimental MAUI Labs platform backends. USE FOR:
-  targeting Linux GTK4, macOS AppKit, or WPF, using templates/packages, creating
-  head projects, wiring hosting, checking parity, and validating apps. DO NOT
-  USE FOR: implementing MAUI backends/handlers/Essentials services, official
-  platform targeting, or unrelated app architecture.
+  Build MAUI apps targeting the MAUI Labs experimental Linux GTK4, macOS
+  AppKit, and WPF platform backends. USE FOR: creating head projects,
+  configuring net10.0-linux/macos/windows targets, UseMauiAppLinuxGtk4 /
+  UseMauiAppMacOS / UseMauiAppWPF hosting calls, maui-linux-gtk4 / maui-macos /
+  maui-wpf templates and packages, parity checking, and validating apps on each
+  backend. DO NOT USE FOR: implementing MAUI backends, handlers, or Essentials
+  services — use a platform-backend implementation skill for that.
 ---
 
 # MAUI Labs Platform Targeting

--- a/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: maui-labs-platform-targeting
+description: >-
+  Build MAUI apps for experimental MAUI Labs platform backends. USE FOR:
+  targeting Linux GTK4, macOS AppKit, WPF, using their templates/packages,
+  creating head projects, wiring hosting methods, understanding platform parity,
+  and validating apps on experimental backends. DO NOT USE FOR: implementing or
+  modifying a MAUI platform backend, control handler, or Essentials service (use
+  maui-platform-backend), official Android/iOS/Windows/Mac Catalyst targeting,
+  or general app architecture unrelated to MAUI Labs platforms.
+---
+
+# MAUI Labs Platform Targeting
+
+Use this skill when an app developer wants to run a MAUI app on experimental
+MAUI Labs backends such as Linux GTK4, native macOS AppKit, or WPF. This is for
+consuming backends, not implementing them.
+
+## Workflow
+
+1. Confirm the app target: Linux GTK4, macOS AppKit, WPF, or a comparison between
+   those experimental backends.
+2. Choose the template/head-project pattern for that backend before editing app
+   code.
+3. Wire the backend-specific hosting call and optional Essentials package.
+4. Audit shared code for platform conditionals and unsupported Essentials APIs.
+5. Build and launch the selected backend, then record experimental parity gaps.
+
+## Platform Choices
+
+| Target | When to choose it | Key package/template |
+| --- | --- | --- |
+| Linux GTK4 | Native Linux desktop app using GTK4 widgets | `Microsoft.Maui.Platforms.Linux.Gtk4` / `maui-linux-gtk4` |
+| macOS AppKit | Native AppKit app instead of Mac Catalyst | `Microsoft.Maui.Platforms.MacOS` / `maui-macos` |
+| WPF | Windows desktop app using WPF instead of WinUI | `Microsoft.Maui.Platforms.Windows.WPF` / `maui-wpf` |
+
+These backends are experimental. Ask the user which controls, Essentials APIs,
+and desktop integrations are required before promising parity.
+
+## Linux GTK4
+
+Linux uses a separate head project because there is no official `net10.0-linux`
+MAUI TFM.
+
+Ubuntu/Debian:
+
+```bash
+sudo apt install libgtk-4-dev libwebkitgtk-6.0-dev \
+  gobject-introspection libgirepository1.0-dev \
+  gir1.2-gtk-4.0 gir1.2-webkit-6.0 pkg-config
+```
+
+Adjust package names for other distributions, for example Fedora/RHEL commonly
+use `gtk4-devel` and `webkitgtk6.0-devel`.
+
+```bash
+dotnet new install Microsoft.Maui.Platforms.Linux.Gtk4.Templates --prerelease
+dotnet new maui-linux-gtk4 -n MyApp.Linux
+dotnet run --project MyApp.Linux
+```
+
+For an existing app, create `MyApp.Linux` next to the shared MAUI project and
+reference the shared app/project:
+
+```xml
+<ProjectReference Include="../MyApp/MyApp.csproj" />
+<!-- Pin a specific prerelease for production; *-* floats to latest prerelease. -->
+<PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4" Version="*-*" />
+<PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.Essentials" Version="*-*" />
+```
+
+```csharp
+builder.UseMauiAppLinuxGtk4<App>();
+```
+
+## macOS AppKit
+
+Use this when the app should be a native AppKit app, not Mac Catalyst.
+
+```bash
+dotnet new install Microsoft.Maui.Platforms.MacOS.Templates --prerelease
+dotnet new maui-macos -n MyApp.MacOS
+dotnet run --project MyApp.MacOS
+```
+
+Manual projects target `net10.0-macos`, reference the AppKit backend packages,
+and call:
+
+```csharp
+builder
+    .UseMauiAppMacOS<App>()
+    .AddMacOSEssentials();
+```
+
+AppKit has different UI conventions and APIs than Mac Catalyst. Do not reuse
+UIKit-specific `IOS || MACCATALYST` code for AppKit without a separate `MACOS`
+path.
+
+## WPF
+
+Use WPF when the app needs WPF hosting or desktop integration instead of WinUI:
+
+```bash
+dotnet new install Microsoft.Maui.Platforms.Windows.WPF.Templates --prerelease
+dotnet new maui-wpf -n MyApp.WPF
+dotnet run --project MyApp.WPF
+```
+
+Manual projects target `net10.0-windows`, set `UseWPF`, reference the WPF
+backend packages, and call:
+
+```csharp
+builder
+    .UseMauiAppWPF<App>()
+    .UseWPFEssentials();
+```
+
+## App Adaptation Checklist
+
+- Factor shared UI, view models, services, and resources so experimental head
+  projects can reuse them.
+- Audit platform-specific code for `ANDROID`, `IOS`, `MACCATALYST`, `WINDOWS`,
+  and `MACOS` assumptions. Add separate paths for AppKit, WPF, or GTK where
+  behavior differs.
+- Check Essentials coverage for the target backend. Some desktop APIs are
+  partial or intentionally stubbed.
+- Test pointer, keyboard, window sizing, menu, file picker, secure storage,
+  clipboard, and WebView/Blazor Hybrid behavior if the app depends on them.
+- Use DevFlow where available to inspect visual tree, screenshots, and controls.
+
+## Do Not Confuse With Backend Implementation
+
+If the task is to add a handler, implement an Essentials API, scaffold backend
+source, or debug renderer internals in `platforms/*`, use the
+`maui-platform-backend` skill instead. This skill is only for app developers who
+consume the experimental platform packages.
+
+## Validation Checklist
+
+- The selected backend matches the app's desktop target and UI requirements.
+- Required native dependencies/templates/packages are installed.
+- Hosting calls match the backend: `UseMauiAppLinuxGtk4`, `UseMauiAppMacOS`, or
+  `UseMauiAppWPF`.
+- Experimental parity gaps are listed before shipping commitments.
+- The app builds and launches on the selected platform.

--- a/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   and net10.0-windows setup, UseMauiAppLinuxGtk4 / UseMauiAppMacOS /
   UseMauiAppWPF, AppKit instead of Mac Catalyst, and WPF/GTK/AppKit parity
   planning. DO NOT USE FOR: implementing MAUI backends, handlers, or Essentials
-  services — use a platform-backend implementation skill for that.
+  services.
 ---
 
 # MAUI Labs Platform Targeting

--- a/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
@@ -15,6 +15,14 @@ Use this skill when an app developer wants to run a MAUI app on experimental
 MAUI Labs backends such as Linux GTK4, native macOS AppKit, or WPF. This is for
 consuming backends, not implementing them.
 
+## Response Checklist
+
+- Keep backend terms explicit: `maui-linux-gtk4`, `maui-macos`, `maui-wpf`.
+- Show the hosting call for the selected backend (`UseMauiAppLinuxGtk4`,
+  `UseMauiAppMacOS`, or `UseMauiAppWPF`).
+- Distinguish AppKit (`MACOS`) from Mac Catalyst and call out experimental parity
+  validation.
+
 ## Workflow
 
 1. Confirm the app target: Linux GTK4, macOS AppKit, WPF, or a comparison between

--- a/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
@@ -109,8 +109,8 @@ dotnet new maui-wpf -n MyApp.WPF
 dotnet run --project MyApp.WPF
 ```
 
-Manual projects target `net10.0-windows`, set `UseWPF`, reference the WPF
-backend packages, and call:
+Manual projects target `net10.0-windows`, set both `UseWPF` and `UseMaui`,
+reference the WPF backend packages, and call:
 
 ```csharp
 builder

--- a/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-labs-platform-targeting/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: maui-labs-platform-targeting
 description: >-
-  Build MAUI apps targeting the MAUI Labs experimental Linux GTK4, macOS
-  AppKit, and WPF platform backends. USE FOR: creating head projects,
-  configuring net10.0-linux/macos/windows targets, UseMauiAppLinuxGtk4 /
-  UseMauiAppMacOS / UseMauiAppWPF hosting calls, maui-linux-gtk4 / maui-macos /
-  maui-wpf templates and packages, parity checking, and validating apps on each
-  backend. DO NOT USE FOR: implementing MAUI backends, handlers, or Essentials
+  Target MAUI Labs desktop backends from MAUI apps. USE FOR: separate Linux GTK4
+  head projects, maui-linux-gtk4 / maui-macos / maui-wpf templates, net10.0-macos
+  and net10.0-windows setup, UseMauiAppLinuxGtk4 / UseMauiAppMacOS /
+  UseMauiAppWPF, AppKit instead of Mac Catalyst, and WPF/GTK/AppKit parity
+  planning. DO NOT USE FOR: implementing MAUI backends, handlers, or Essentials
   services — use a platform-backend implementation skill for that.
 ---
 

--- a/plugins/dotnet-maui/skills/maui-performance/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-performance/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: maui-performance
 description: >-
-  Diagnose and improve .NET MAUI app performance with measurement-first startup
-  profiling, layout efficiency, compiled bindings, CollectionView tuning, image
-  resource optimization, trimming/NativeAOT considerations, and platform-aware
-  validation.   USE FOR: slow startup, janky scrolling, high memory use, slow page loading,
-  inefficient XAML/layouts, oversized image resources causing memory spikes,
-  and running the maui profile startup CLI command to measure MAUI app startup
-  time before optimizing. DO NOT USE FOR: DevFlow UI interaction bugs (use
-  maui-devflow-debug), SDK version lookup (use dotnet-workload-info), or generic
-  app architecture without a performance symptom.
+  Fix .NET MAUI performance issues: accurate startup profiling with `maui profile
+  startup` using Release builds and physical devices (not Debug/emulator),
+  eliminating janky CollectionView scrolling by removing nested ScrollView,
+  using x:DataType compiled bindings, simplifying templates, and optimizing
+  oversized image resources. USE FOR: Diagnosing slow startup with Release build
+  profiling, fixing CollectionView scrolling by removing ScrollView wrapper,
+  adding x:DataType compiled bindings, image memory optimization, layout nesting,
+  and validating performance claims with measurements. DO NOT USE FOR: UI
+  interaction bugs (maui-devflow-debug), SDK/CLI discovery (dotnet-workload-info),
+  or generic app architecture without specific performance symptoms.
 ---
 
 # MAUI Performance

--- a/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
@@ -15,6 +15,15 @@ Use this skill when a MAUI app needs platform APIs that are not already exposed
 by a cross-platform MAUI API. Prefer small, testable abstractions over scattered
 `#if` blocks.
 
+## Response Checklist
+
+- Define a DI abstraction first (for example `IAppReviewService`) and inject it
+  into app services or view models.
+- Mention required permission flow and platform metadata files
+  (`AndroidManifest.xml`, `Info.plist`, capabilities/entitlements).
+- Put lifecycle guidance in `ConfigureLifecycleEvents` (`AddAndroid`, `AddiOS`,
+  `AddWindows`) instead of page constructors.
+
 ## Choose the Right Extension Point
 
 | Need | Prefer |

--- a/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
@@ -53,13 +53,17 @@ by a cross-platform MAUI API. Prefer small, testable abstractions over scattered
    }
    ```
 
-3. Register it in `MauiProgram.cs`:
+3. Register only the platforms that have implementations in `MauiProgram.cs`:
 
    ```csharp
-   #if ANDROID || IOS || MACCATALYST || WINDOWS || MACOS
+   #if ANDROID
    builder.Services.AddSingleton<IAppReviewService, AppReviewService>();
    #endif
    ```
+
+   When adding iOS, Mac Catalyst, Windows, or MAUI Labs AppKit support, add the
+   matching platform implementation file first and then extend the guard, for
+   example `#if IOS || MACCATALYST` or `#if MACOS`.
 
 4. Inject `IAppReviewService` into view models or application services. Keep page
    constructors simple.

--- a/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: maui-platform-invoke
+description: >-
+  Add platform-specific API calls to .NET MAUI apps safely. USE FOR: partial
+  classes, conditional compilation, DI abstractions for native platform APIs,
+  permissions, manifests/Info.plist/capabilities, lifecycle hooks, and deciding
+  between platform services, handlers, Essentials APIs, and slim bindings.
+  DO NOT USE FOR: visual native view customization (use maui-custom-handlers),
+  full native SDK binding projects (use android-slim-bindings or
+  ios-slim-bindings), or implementing MAUI platform backends (use
+  maui-platform-backend).
+---
+
+# MAUI Platform Invoke
+
+Use this skill when a MAUI app needs platform APIs that are not already exposed
+by a cross-platform MAUI API. Prefer small, testable abstractions over scattered
+`#if` blocks.
+
+## Choose the Right Extension Point
+
+| Need | Prefer |
+| --- | --- |
+| Existing cross-platform Essentials API covers it | `Microsoft.Maui.ApplicationModel`, `Devices`, `Storage`, etc. |
+| Non-visual platform API or OS service | DI interface with per-platform implementation |
+| Native view/control behavior | Handler mapper or custom handler |
+| Platform lifecycle callback | `ConfigureLifecycleEvents` |
+| Third-party SDK with many native types | Slim binding plus a narrow app service |
+| One small compile-time constant | `#if` or `OnPlatform` |
+
+## Platform Service Pattern
+
+1. Define an interface in shared code:
+
+   ```csharp
+   public interface IAppReviewService
+   {
+       Task RequestReviewAsync(CancellationToken cancellationToken = default);
+   }
+   ```
+
+2. Implement it per platform using target-specific files:
+
+   ```csharp
+   // Platforms/Android/AppReviewService.android.cs
+   public sealed class AppReviewService : IAppReviewService
+   {
+       public Task RequestReviewAsync(CancellationToken cancellationToken = default)
+       {
+           // Call Android APIs or a bound SDK here.
+           return Task.CompletedTask;
+       }
+   }
+   ```
+
+3. Register it in `MauiProgram.cs`:
+
+   ```csharp
+   #if ANDROID || IOS || MACCATALYST || WINDOWS || MACOS
+   builder.Services.AddSingleton<IAppReviewService, AppReviewService>();
+   #endif
+   ```
+
+4. Inject `IAppReviewService` into view models or application services. Keep page
+   constructors simple.
+
+## Partial Classes and Conditional Compilation
+
+- Prefer platform-specific files under `Platforms/<Platform>/` for code that
+  imports native namespaces.
+- Use `partial` classes when one cross-platform type needs per-platform method
+  bodies.
+- Use `#if ANDROID`, `#if IOS`, `#if MACCATALYST`, `#if IOS || MACCATALYST`,
+  `#if MACOS`, and `#if WINDOWS` intentionally. iOS and Mac Catalyst often share
+  UIKit APIs, but AppKit macOS does not.
+- Avoid `Device.RuntimePlatform` for behavior that can be decided at compile
+  time.
+
+## Permissions and Capabilities
+
+Before calling a platform API:
+
+1. Check whether MAUI has a `Permissions.*` helper for the capability.
+2. Add required manifest, Info.plist, entitlements, or package declarations.
+3. Request permission from UI-safe code before invoking the service.
+4. Handle denied/restricted states explicitly and surface user-actionable
+   recovery instructions.
+
+```csharp
+var status = await Permissions.CheckStatusAsync<Permissions.Camera>();
+if (status != PermissionStatus.Granted)
+    status = await Permissions.RequestAsync<Permissions.Camera>();
+
+if (status != PermissionStatus.Granted)
+{
+    await Shell.Current.DisplayAlert(
+        "Camera permission required",
+        "Enable camera access in Settings to use this feature.",
+        "OK");
+    return;
+}
+```
+
+Do not swallow permission failures or return fake success. In a service layer,
+return a result such as `PermissionStatus` or `bool` and let the caller surface
+the denial in UI.
+
+## Lifecycle Hooks
+
+Use lifecycle hooks when the native API depends on app/window lifecycle:
+
+```csharp
+builder.ConfigureLifecycleEvents(events =>
+{
+#if ANDROID
+    events.AddAndroid(android => android
+        .OnResume(activity => { /* refresh platform state */ }));
+#elif IOS || MACCATALYST
+    events.AddiOS(ios => ios
+        .OnActivated(application => { /* refresh platform state */ }));
+#elif WINDOWS
+    events.AddWindows(windows => windows
+        .OnWindowCreated(window => { /* configure native window */ }));
+#endif
+});
+```
+
+Keep lifecycle code small. Forward work into registered services when state must
+be shared with view models.
+
+## Validation Checklist
+
+- A cross-platform interface isolates native API calls.
+- Platform implementation files compile only for their intended target.
+- Required permissions, manifests, plist entries, entitlements, or capabilities
+  are documented and added.
+- Denied permissions are handled explicitly.
+- Native lifecycle subscriptions are paired with cleanup where applicable.
+- Visual customization is not implemented as a generic platform service.

--- a/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maui-platform-invoke
 description: >-
-  Add platform-specific API calls to .NET MAUI apps safely. USE FOR: partial
-  classes, conditional compilation, DI platform services, permissions,
-  manifests/Info.plist/capabilities, lifecycle hooks, and choosing services vs
-  handlers vs bindings. DO NOT USE FOR: visual native view customization, native
-  SDK binding projects, or MAUI platform backend implementation.
+  Add native platform APIs to .NET MAUI apps safely. USE FOR: IAppReviewService-style
+  DI wrappers, camera/permission flows, ConfigureLifecycleEvents with AddAndroid /
+  AddiOS / AddWindows, partial classes, manifests/Info.plist/capabilities, and
+  choosing platform services vs handlers vs slim bindings. DO NOT USE FOR: visual
+  native view customization, native SDK binding projects, or MAUI platform backend
+  implementation.
 ---
 
 # MAUI Platform Invoke

--- a/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-platform-invoke/SKILL.md
@@ -2,13 +2,10 @@
 name: maui-platform-invoke
 description: >-
   Add platform-specific API calls to .NET MAUI apps safely. USE FOR: partial
-  classes, conditional compilation, DI abstractions for native platform APIs,
-  permissions, manifests/Info.plist/capabilities, lifecycle hooks, and deciding
-  between platform services, handlers, Essentials APIs, and slim bindings.
-  DO NOT USE FOR: visual native view customization (use maui-custom-handlers),
-  full native SDK binding projects (use android-slim-bindings or
-  ios-slim-bindings), or implementing MAUI platform backends (use
-  maui-platform-backend).
+  classes, conditional compilation, DI platform services, permissions,
+  manifests/Info.plist/capabilities, lifecycle hooks, and choosing services vs
+  handlers vs bindings. DO NOT USE FOR: visual native view customization, native
+  SDK binding projects, or MAUI platform backend implementation.
 ---
 
 # MAUI Platform Invoke

--- a/plugins/dotnet-maui/skills/maui-project-structure/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-project-structure/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: maui-project-structure
 description: >-
-  Inspect and update .NET MAUI app project structure and app display/build
-  versioning. USE FOR: single-project layout; Resources/Images/Fonts/Raw;
-  MauiImage/MauiFont/MauiAsset/MauiIcon/MauiSplashScreen item types;
-  Android/iOS/Windows platform configuration; Central Package Management
-  (Directory.Packages.props with versionless PackageReference); target
-  frameworks; ApplicationDisplayVersion/ApplicationVersion; and explaining that
-  `maui project version set` manages MAUI package/workload versioning, not app
-  store display/build versions. Also use when shared assets were placed under
-  Platforms/* and should be moved to Resources/Images with MauiImage for
-  cross-platform output. DO NOT USE FOR: runtime UI debugging
-  (maui-devflow-debug), SDK/workload discovery (dotnet-workload-info), or
-  general MVVM/Shell design (maui-app-architecture).
+  Configure .NET MAUI single-project structure: app icons and splash screens
+  with MauiIcon/MauiSplashScreen item types, resource folder organization
+  (Resources/Images/Fonts/Raw), moving platform-specific images to cross-platform
+  Resources, app versioning with ApplicationDisplayVersion/ApplicationVersion,
+  Central Package Management setup, and avoiding misuse of `maui project version`
+  for app store versions. USE FOR: Setting app icons/splash with MSBuild item
+  types, organizing assets, fixing misplaced platform-specific images, app
+  display/build versioning, Central Package Management in Directory.Packages.props,
+  and clarifying maui project version CLI purpose. DO NOT USE FOR: UI debugging
+  (maui-devflow-debug), SDK/workload discovery (dotnet-workload-info), or MVVM/Shell
+  architecture (maui-app-architecture).
 ---
 
 # MAUI Project Structure

--- a/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
@@ -2,11 +2,10 @@
 name: maui-release-notes
 description: >-
   Generate or update maintainer-oriented MAUI workload release notes. USE FOR:
-  .NET MAUI workload release notes, SDK/workload set summaries, manifest and
-  dependency version tables, Xcode/JDK/Android SDK requirement updates, and
-  coordinating with dotnet-workload-info for live workload data. DO NOT USE FOR:
-  app store release notes, marketing copy for user apps, general MAUI app
-  debugging, or workload installation troubleshooting.
+  MAUI workload notes, SDK/workload set summaries, manifest/dependency tables,
+  Xcode/JDK/Android SDK requirements, and dotnet-workload-info data. DO NOT USE
+  FOR: app store notes, app marketing copy, general MAUI debugging, or workload
+  installation troubleshooting.
 ---
 
 # MAUI Release Notes

--- a/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maui-release-notes
 description: >-
-  Generate or update maintainer-oriented MAUI workload release notes. USE FOR:
-  MAUI workload notes, SDK/workload set summaries, manifest/dependency tables,
-  Xcode/JDK/Android SDK requirements, and dotnet-workload-info data. DO NOT USE
-  FOR: app store notes, app marketing copy, general MAUI debugging, or workload
-  installation troubleshooting.
+  Write maintainer-facing .NET MAUI workload release notes. USE FOR: workload set
+  CLI to NuGet version conversion, Microsoft.NET.Workloads.* package IDs,
+  manifest/version tables, WorkloadDependencies.json requirements, install/update
+  commands, validation steps, and keeping SDK/workload notes separate from App
+  Store changelogs. DO NOT USE FOR: app release notes, app marketing copy,
+  general MAUI debugging, or workload installation troubleshooting.
 ---
 
 # MAUI Release Notes

--- a/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
@@ -6,9 +6,8 @@ description: >-
   move to a new .NET/MAUI release, summarizing breaking changes, Xcode/JDK/Android
   SDK requirements that affect app builds, package/workload update steps,
   migration checklists, CI updates, and app-team validation plans. DO NOT USE
-  FOR: authoring workload or manifest release notes for MAUI maintainers,
-  publishing SDK/package tables for the MAUI repo, app-store marketing copy,
-  or general debugging.
+  FOR: authoring MAUI workload release notes, SDK/package table publishing,
+  or app-store marketing copy.
 ---
 
 # MAUI Release Notes

--- a/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
@@ -16,6 +16,14 @@ Use this skill when an app team needs to answer: "What does this .NET or MAUI
 release mean for our app?" Focus on adoption guidance for app developers, QA,
 and CI owners rather than on shipping the MAUI SDK itself.
 
+## Response Checklist
+
+- Keep the audience app-focused: repo owners, app developers, QA, and CI owners.
+- Convert release notes into concrete app actions (SDK/workload/tooling updates,
+  risks, and validation plan), not maintainer publishing tasks.
+- Use `dotnet-workload-info` when exact workload or environment dependency data
+  is needed.
+
 ## Typical Inputs
 
 - The app's current .NET version, workload set, and MAUI package baseline.

--- a/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
@@ -1,112 +1,108 @@
 ---
 name: maui-release-notes
 description: >-
-  Write maintainer-facing .NET MAUI workload release notes. USE FOR: workload set
-  CLI to NuGet version conversion, Microsoft.NET.Workloads.* package IDs,
-  manifest/version tables, WorkloadDependencies.json requirements, install/update
-  commands, validation steps, and keeping SDK/workload notes separate from App
-  Store changelogs. DO NOT USE FOR: app release notes, app marketing copy,
-  general MAUI debugging, or workload installation troubleshooting.
+  Help .NET MAUI app teams read official .NET/MAUI release notes and turn them
+  into an upgrade plan for their app. USE FOR: deciding whether an app should
+  move to a new .NET/MAUI release, summarizing breaking changes, Xcode/JDK/Android
+  SDK requirements that affect app builds, package/workload update steps,
+  migration checklists, CI updates, and app-team validation plans. DO NOT USE
+  FOR: authoring workload or manifest release notes for MAUI maintainers,
+  publishing SDK/package tables for the MAUI repo, app-store marketing copy,
+  or general debugging.
 ---
 
 # MAUI Release Notes
 
-Use this skill narrowly for maintainers writing .NET MAUI workload or package
-release notes. The notes must be grounded in live workload/package data, not
-hardcoded guesses.
+Use this skill when an app team needs to answer: "What does this .NET or MAUI
+release mean for our app?" Focus on adoption guidance for app developers, QA,
+and CI owners rather than on shipping the MAUI SDK itself.
 
-## Required Inputs
+## Typical Inputs
 
-- Target .NET channel and SDK band, such as `10.0` / `10.0.100`.
-- Current release SDK or workload set version.
-- Previous release version for comparison when producing deltas.
-- Release scope: workload manifests, MAUI NuGet packages, platform dependency
-  requirements, known issues, or all of these.
+- The app's current .NET version, workload set, and MAUI package baseline.
+- The target release the team is considering.
+- Platforms in scope: Android, iOS, Mac Catalyst, macOS, Windows.
+- Whether the output should be a short summary, an upgrade checklist, or rollout
+  guidance.
 
-If version data is missing, use `dotnet-workload-info` before drafting.
+If exact workload, package, Xcode, JDK, or Android SDK version data is missing,
+use `dotnet-workload-info` to confirm it. Use live version discovery to support
+app upgrade planning, not to dump maintainer-only manifest data unless the user
+explicitly asks for it.
 
-## Data Collection Workflow
+## What to Extract from Release Notes
 
-1. Query live workload data with `dotnet-workload-info`:
-   - latest SDK;
-   - workload set CLI version;
-   - workload set NuGet package/version;
-   - MAUI, iOS, Android, Mac Catalyst, macOS, and other relevant manifest
-     versions;
-   - `WorkloadDependencies.json` contents for Xcode, JDK, Android SDK packages,
-     and related requirements.
-2. Query latest MAUI package versions when the notes mention out-of-band packages:
-   `Microsoft.Maui.Controls`, `Microsoft.Maui.Essentials`,
-   `Microsoft.Maui.Graphics`, and product-specific packages.
-3. Compare previous and current versions. Separate:
-   - requirement changes;
-   - package/manifest version changes;
-   - behavior changes;
-   - known issues and mitigations;
-   - validation steps.
-4. Pull change summaries from authoritative repo release notes, merged PRs, or
-   curated maintainer notes when available. Do not invent feature descriptions
-   from version numbers alone.
-5. Draft concise notes with commands and exact version tables.
+1. Breaking changes or deprecations that affect app code, project files, or
+   deployment.
+2. Required environment updates such as Xcode, JDK, Android SDK, Visual Studio,
+   or workload-set changes that affect building or shipping the app.
+3. MAUI package, workload, or CI updates the app repo needs.
+4. Known issues, regressions, or unsupported combinations that could block the
+   upgrade.
+5. Validation work the app team should plan after the upgrade.
+6. Rollback considerations if the new release introduces app-specific risk.
 
-## Suggested Release Note Shape
+## Recommended Workflow
+
+1. Establish the app's current baseline: target framework, workloads, packages,
+   CI image/tooling, and supported platforms.
+2. Read the official .NET and MAUI release notes for the target release.
+3. Pull only the changes that are relevant to app builders: environment
+   requirements, app-facing breaking changes, tooling shifts, and known issues.
+4. Use `dotnet-workload-info` when the team needs exact upgrade commands or
+   authoritative workload dependency requirements.
+5. Translate the release into app-specific actions, risks, and tests instead of
+   repeating framework internals.
+
+## Suggested Output Shape
 
 ````markdown
-# .NET MAUI workload release notes for <version>
+# Upgrade notes for <app/team> adopting .NET MAUI <version>
 
-## Highlights
+## Should we upgrade now?
+- Recommendation
+- Main benefits
+- Main risks or blockers
 
-## Install or update
+## What changes for our app?
+- Breaking or behavior changes that touch app code, project files, CI, or dependencies
 
-```bash
-dotnet workload install maui --version <workload-set-version>
-dotnet workload update --version <workload-set-version>
-```
+## Required environment updates
+- Xcode / JDK / Android SDK / workloads / IDE requirements
 
-## Workload and manifest versions
+## Repo and CI changes
+- global.json, workload install/update, package pinning, CI image/tooling updates
 
-| Workload | Manifest version | SDK band |
-| --- | --- | --- |
+## Validation checklist
+- Clean restore/build
+- Device or simulator smoke tests
+- Critical app flows such as auth, notifications, payments, deep links, or media
+- Archive, signing, and store submission checks if relevant
 
-## Platform requirements
+## Known issues and mitigations
 
-| Platform | Requirement | Version/range |
-| --- | --- | --- |
-
-## MAUI packages
-
-| Package | Version |
-| --- | --- |
-
-## Breaking changes and known issues
-
-## Validation
+## Rollback plan
 ````
 
-Adjust headings to the repository's existing release-note template if one exists.
-
-## Version Rules
-
-- Convert workload set CLI versions to NuGet package versions using the
-  `dotnet-workload-info` skill's conversion rules.
-- Include SDK band with manifest versions.
-- Include exact NuGet or blob URLs only when useful for reproducibility.
-- Prefer version ranges from `WorkloadDependencies.json` over prose guesses.
-- State "not found" or "not changed" when the data source confirms it.
+Only include manifest or package-version tables when the user explicitly asks
+for that level of detail.
 
 ## Guardrails
 
-- Do not hardcode current Xcode/JDK/Android SDK requirements from memory.
-- Do not claim workload install commands were tested unless they were.
-- Do not mix app release notes with workload/platform release notes.
-- Do not summarize all MAUI changes as "performance improvements" without
-  source-backed details.
-- Keep maintainer notes actionable for SDK, CI, and workload consumers.
+- Do not write from the perspective of MAUI workload maintainers.
+- Do not default to manifest tables, package internals, or repo publishing notes
+  unless the user asks for them.
+- Keep App Store or Play Store marketing notes separate from framework upgrade
+  notes.
+- Do not recommend an upgrade until platform and tooling prerequisites are
+  confirmed.
+- Prefer official release notes and linked issues over memory or guesses.
 
 ## Validation Checklist
 
-- Live workload/package data was queried or provided by the user.
-- Current and previous versions are clearly identified.
-- Dependency requirements come from workload manifests.
-- Install/update commands use the correct workload set version.
-- Known issues and breaking changes are sourced or explicitly marked unknown.
+- The output is framed for app builders, QA, and CI owners.
+- App-facing changes are called out separately from framework internals.
+- Environment prerequisites match the platforms the app ships.
+- Upgrade commands and CI guidance align with the target release.
+- Known issues, mitigations, and validation steps are concrete enough for a real
+  app rollout.

--- a/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-release-notes/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: maui-release-notes
+description: >-
+  Generate or update maintainer-oriented MAUI workload release notes. USE FOR:
+  .NET MAUI workload release notes, SDK/workload set summaries, manifest and
+  dependency version tables, Xcode/JDK/Android SDK requirement updates, and
+  coordinating with dotnet-workload-info for live workload data. DO NOT USE FOR:
+  app store release notes, marketing copy for user apps, general MAUI app
+  debugging, or workload installation troubleshooting.
+---
+
+# MAUI Release Notes
+
+Use this skill narrowly for maintainers writing .NET MAUI workload or package
+release notes. The notes must be grounded in live workload/package data, not
+hardcoded guesses.
+
+## Required Inputs
+
+- Target .NET channel and SDK band, such as `10.0` / `10.0.100`.
+- Current release SDK or workload set version.
+- Previous release version for comparison when producing deltas.
+- Release scope: workload manifests, MAUI NuGet packages, platform dependency
+  requirements, known issues, or all of these.
+
+If version data is missing, use `dotnet-workload-info` before drafting.
+
+## Data Collection Workflow
+
+1. Query live workload data with `dotnet-workload-info`:
+   - latest SDK;
+   - workload set CLI version;
+   - workload set NuGet package/version;
+   - MAUI, iOS, Android, Mac Catalyst, macOS, and other relevant manifest
+     versions;
+   - `WorkloadDependencies.json` contents for Xcode, JDK, Android SDK packages,
+     and related requirements.
+2. Query latest MAUI package versions when the notes mention out-of-band packages:
+   `Microsoft.Maui.Controls`, `Microsoft.Maui.Essentials`,
+   `Microsoft.Maui.Graphics`, and product-specific packages.
+3. Compare previous and current versions. Separate:
+   - requirement changes;
+   - package/manifest version changes;
+   - behavior changes;
+   - known issues and mitigations;
+   - validation steps.
+4. Pull change summaries from authoritative repo release notes, merged PRs, or
+   curated maintainer notes when available. Do not invent feature descriptions
+   from version numbers alone.
+5. Draft concise notes with commands and exact version tables.
+
+## Suggested Release Note Shape
+
+````markdown
+# .NET MAUI workload release notes for <version>
+
+## Highlights
+
+## Install or update
+
+```bash
+dotnet workload install maui --version <workload-set-version>
+dotnet workload update --version <workload-set-version>
+```
+
+## Workload and manifest versions
+
+| Workload | Manifest version | SDK band |
+| --- | --- | --- |
+
+## Platform requirements
+
+| Platform | Requirement | Version/range |
+| --- | --- | --- |
+
+## MAUI packages
+
+| Package | Version |
+| --- | --- |
+
+## Breaking changes and known issues
+
+## Validation
+````
+
+Adjust headings to the repository's existing release-note template if one exists.
+
+## Version Rules
+
+- Convert workload set CLI versions to NuGet package versions using the
+  `dotnet-workload-info` skill's conversion rules.
+- Include SDK band with manifest versions.
+- Include exact NuGet or blob URLs only when useful for reproducibility.
+- Prefer version ranges from `WorkloadDependencies.json` over prose guesses.
+- State "not found" or "not changed" when the data source confirms it.
+
+## Guardrails
+
+- Do not hardcode current Xcode/JDK/Android SDK requirements from memory.
+- Do not claim workload install commands were tested unless they were.
+- Do not mix app release notes with workload/platform release notes.
+- Do not summarize all MAUI changes as "performance improvements" without
+  source-backed details.
+- Keep maintainer notes actionable for SDK, CI, and workload consumers.
+
+## Validation Checklist
+
+- Live workload/package data was queried or provided by the user.
+- Current and previous versions are clearly identified.
+- Dependency requirements come from workload manifests.
+- Install/update commands use the correct workload set version.
+- Known issues and breaking changes are sourced or explicitly marked unknown.

--- a/plugins/dotnet-maui/skills/maui-ui-patterns/SKILL.md
+++ b/plugins/dotnet-maui/skills/maui-ui-patterns/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: maui-ui-patterns
 description: >-
-  Build or update vendor-neutral .NET MAUI UI pages and components with
-  responsive layouts, resources, visual states, AutomationIds, accessibility
-  hooks, and loading/empty/error states.   USE FOR: XAML or C# UI layout, Grid/FlexLayout choices, ResourceDictionary
-  styles, design tokens, CollectionView empty/loading states, responsive
-  phone/tablet/desktop UI, adding stable AutomationIds, and avoiding MAUI UI
-  anti-patterns such as wrapping a CollectionView inside a ScrollView. DO NOT USE FOR: Shell/DI/ViewModel architecture
-  (use maui-app-architecture), accessibility audits (use maui-accessibility), or
-  Syncfusion/vendor-specific control generation.
+  Fix MAUI UI layout and automation issues: CollectionView not scrolling,
+  missing AutomationId bindings in DataTemplate items, UI element property
+  bindings, Grid/FlexLayout responsive choices, loading/empty/error states,
+  and testable login/form UI patterns. USE FOR: Debugging CollectionView scrolling,
+  adding stable AutomationIds to views for UI automation, fixing Grid row/column
+  sizing (Auto vs Star), empty/loading states in data-driven screens, responsive
+  layout choices, and binding patterns in DataTemplates. DO NOT USE FOR: Shell
+  routes (use maui-app-architecture), comprehensive accessibility audits (use
+  maui-accessibility), or vendor-specific control generation (Syncfusion, etc).
 ---
 
 # MAUI UI Patterns

--- a/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
+++ b/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: xamarin-forms-migration
+description: >-
+  Plan and execute Xamarin.Forms to .NET MAUI app migrations. USE FOR:
+  migration audits, new-project migration workflows, namespace/API changes,
+  custom renderer to handler planning, DependencyService to DI, MessagingCenter
+  replacement, platform capability parity, and deciding when to route to
+  maui-current-apis, maui-custom-handlers, maui-platform-invoke, or slim
+  bindings. DO NOT USE FOR: brand-new MAUI apps with no Xamarin.Forms code
+  (use maui-app-architecture and maui-current-apis), implementing native
+  library bindings directly (use android-slim-bindings or ios-slim-bindings),
+  or backend/platform implementation work (use maui-platform-backend).
+---
+
+# Xamarin.Forms Migration
+
+Use this skill to move a Xamarin.Forms app to .NET MAUI without blindly copying
+obsolete patterns. Treat migration as an audit and phased rebuild on a fresh
+MAUI project unless the user explicitly needs a small tactical port.
+
+## Migration Tooling
+
+Before migrating manually, check whether the .NET Upgrade Assistant can cover
+the mechanical parts of the app:
+
+```bash
+dotnet tool install -g upgrade-assistant
+upgrade-assistant upgrade <your-solution>.sln
+```
+
+Upgrade Assistant can help with project conversion and namespace/API rewrites.
+Use this skill for decisions tooling cannot safely automate: renderer
+classification, `DependencyService` lifetimes, `MessagingCenter` replacement,
+platform capability parity, and validation planning.
+
+## Migration Workflow
+
+1. Inventory the current app:
+   - Xamarin.Forms version, target platforms, platform projects, NuGet packages,
+     renderers, effects, `DependencyService`, `MessagingCenter`, and native SDKs.
+   - App startup, navigation, resource dictionaries, images/fonts, and platform
+     entitlements/permissions.
+2. Create a new .NET MAUI project or solution structure that matches the target
+   app shape. Prefer this over editing the Xamarin.Forms project in place.
+3. Move shared code first: models, services, view models, converters, resources,
+   and XAML. Keep platform code out until shared code builds.
+4. Update namespaces and APIs using `maui-current-apis`; do not introduce new
+   `Xamarin.Forms` or `Xamarin.Essentials` references.
+5. Migrate app startup to `MauiProgram.cs`, `CreateMauiApp`, DI registration,
+   fonts, handlers, lifecycle events, and platform services.
+6. Migrate UI and navigation incrementally. Keep Shell route names, modal flows,
+   and deep-link behavior explicit.
+7. Plan custom renderer/effect replacements:
+   - simple native property tweak -> handler mapper customization;
+   - reusable custom control -> custom handler;
+   - non-visual platform API -> platform service via DI;
+   - third-party native SDK surface -> slim binding.
+8. Validate each migrated slice with build, platform launch, and accessibility or
+   performance checks for changed UI.
+
+## Common API Replacements
+
+| Xamarin.Forms-era pattern | MAUI direction |
+| --- | --- |
+| `using Xamarin.Forms` | `using Microsoft.Maui.Controls` |
+| `using Xamarin.Essentials` | `Microsoft.Maui.ApplicationModel`, `Microsoft.Maui.Devices`, `Microsoft.Maui.Storage`, or the specific MAUI namespace |
+| `Device.BeginInvokeOnMainThread` | `MainThread.BeginInvokeOnMainThread` or `Dispatcher.Dispatch` |
+| `Device.StartTimer` | `Dispatcher.StartTimer` or `IDispatcherTimer` |
+| `Device.RuntimePlatform` | `DeviceInfo.Platform`, `OnPlatform`, partial classes, or DI services |
+| `Color.Red`, `Color.FromHex` | `Colors.Red`, `Color.FromArgb`, or resource colors |
+| `Application.Current.MainPage = ...` | `Window.Page` for intentional resets, or Shell/navigation abstractions for routine navigation |
+| `DependencyService.Get<T>()` | Constructor-injected services registered in `MauiProgram.cs` |
+| `MessagingCenter` | `WeakReferenceMessenger`, events, observable state, or explicit domain services |
+| `ExportRenderer` / `CustomRenderer` | Handler mapper customization or `ViewHandler<TVirtualView,TPlatformView>` |
+
+## DependencyService to DI
+
+1. Move the cross-platform contract to shared code:
+
+   ```csharp
+   public interface IClipboardAuditService
+   {
+       Task TrackCopyAsync(string source, CancellationToken cancellationToken = default);
+   }
+   ```
+
+2. Implement each platform in `Platforms/<Platform>/` or target-specific files.
+3. Register the implementation in `MauiProgram.cs` with `AddSingleton`,
+   `AddScoped`, or `AddTransient` based on lifetime needs.
+4. Inject the service into view models or services. Avoid service locator calls
+   from pages unless the app already uses that pattern and you are containing
+   migration risk.
+
+## MessagingCenter Replacement
+
+Choose the smallest explicit communication pattern:
+
+| Existing use | Replacement |
+| --- | --- |
+| View model updates a bound page | Observable properties and binding |
+| Domain event across features | `WeakReferenceMessenger` or an app event aggregator |
+| One service asks another to work | Inject the target service and call a method |
+| Navigation trigger | Navigation service or Shell route call |
+| Platform callback | Platform service event or `IObservable<T>` exposed through DI |
+
+Do not migrate `MessagingCenter` by adding global static events everywhere.
+Document message names, payload types, sender/receiver lifetimes, and threading
+before replacing them.
+
+## Renderer to Handler Planning
+
+Audit each renderer and classify it before writing code:
+
+| Renderer shape | MAUI migration |
+| --- | --- |
+| Changes one native property on an existing MAUI control | `Handler.Mapper.AppendToMapping` scoped to a subclass or named mapping |
+| Needs a cross-platform custom control with bindable properties | Custom handler with `PropertyMapper` and optional `CommandMapper` |
+| Subscribes to native events | Handler `ConnectHandler`/`DisconnectHandler` with explicit unsubscribe cleanup |
+| Calls camera, health, maps, payment, or other SDK APIs | Platform service or slim binding; do not hide SDK workflow in a visual handler |
+| Uses Xamarin.Forms effects only for styling | Prefer styles, visual states, or a handler mapper |
+
+## Platform Capability Parity
+
+For each target platform, record:
+
+- required permissions, entitlements, manifests, Info.plist keys, and app
+  capabilities;
+- Essentials API coverage and behavioral differences;
+- native SDK availability and version requirements;
+- background tasks, push/deep link, secure storage, file picker, and biometric
+  differences;
+- UI parity risks such as safe areas, keyboard/soft input, gestures, and desktop
+  pointer behavior.
+
+## Cross-Skill Routing
+
+- Use `maui-current-apis` for version-specific MAUI API replacements.
+- Use `maui-custom-handlers` for handler mapper/custom handler implementation.
+- Use `maui-platform-invoke` for non-visual platform services, partial classes,
+  permissions, and lifecycle hooks.
+- Use `android-slim-bindings` or `ios-slim-bindings` when a native SDK needs a
+  maintainable binding surface.
+- Use `maui-accessibility` and `maui-performance` for migrated UI risk areas.
+
+## Validation Checklist
+
+- The migration plan starts from an audited Xamarin.Forms solution, not guesses.
+- New code targets MAUI namespaces and current APIs.
+- Platform capabilities and permissions are mapped for every retained platform.
+- Renderers/effects are classified before migration.
+- `DependencyService` and `MessagingCenter` replacements have explicit lifetimes.
+- Each migrated slice builds and runs on at least one intended platform.

--- a/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
+++ b/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
@@ -6,8 +6,7 @@ description: >-
   DependencyService to DI, MessagingCenter replacement, renderer triage into
   mapper customizations/custom handlers/platform services/slim bindings, and
   platform parity planning. DO NOT USE FOR: brand-new MAUI apps, native SDK
-  bindings (use slim bindings), or platform backend implementation (use an
-  available platform-backend implementation skill).
+  bindings, or platform backend implementation.
 ---
 
 # Xamarin.Forms Migration

--- a/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
+++ b/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   migration audits, new-project workflows, namespace/API changes, renderer to
   handler planning, DependencyService to DI, MessagingCenter replacement, and
   platform parity. DO NOT USE FOR: brand-new MAUI apps, native SDK bindings
-  (use slim bindings), or platform backend implementation (use
-  maui-platform-backend).
+  (use slim bindings), or platform backend implementation (use an available
+  platform-backend implementation skill).
 ---
 
 # Xamarin.Forms Migration

--- a/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
+++ b/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: xamarin-forms-migration
 description: >-
-  Plan and execute Xamarin.Forms to .NET MAUI app migrations. USE FOR:
-  migration audits, new-project workflows, namespace/API changes, renderer to
-  handler planning, DependencyService to DI, MessagingCenter replacement, and
-  platform parity. DO NOT USE FOR: brand-new MAUI apps, native SDK bindings
-  (use slim bindings), or platform backend implementation (use an available
-  platform-backend implementation skill).
+  Plan Xamarin.Forms to .NET MAUI migrations. USE FOR: migration audits,
+  fresh-project workflows, Xamarin.Forms/Xamarin.Essentials namespace replacement,
+  DependencyService to DI, MessagingCenter replacement, renderer triage into
+  mapper customizations/custom handlers/platform services/slim bindings, and
+  platform parity planning. DO NOT USE FOR: brand-new MAUI apps, native SDK
+  bindings (use slim bindings), or platform backend implementation (use an
+  available platform-backend implementation skill).
 ---
 
 # Xamarin.Forms Migration

--- a/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
+++ b/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
@@ -2,14 +2,11 @@
 name: xamarin-forms-migration
 description: >-
   Plan and execute Xamarin.Forms to .NET MAUI app migrations. USE FOR:
-  migration audits, new-project migration workflows, namespace/API changes,
-  custom renderer to handler planning, DependencyService to DI, MessagingCenter
-  replacement, platform capability parity, and deciding when to route to
-  maui-current-apis, maui-custom-handlers, maui-platform-invoke, or slim
-  bindings. DO NOT USE FOR: brand-new MAUI apps with no Xamarin.Forms code
-  (use maui-app-architecture and maui-current-apis), implementing native
-  library bindings directly (use android-slim-bindings or ios-slim-bindings),
-  or backend/platform implementation work (use maui-platform-backend).
+  migration audits, new-project workflows, namespace/API changes, renderer to
+  handler planning, DependencyService to DI, MessagingCenter replacement, and
+  platform parity. DO NOT USE FOR: brand-new MAUI apps, native SDK bindings
+  (use slim bindings), or platform backend implementation (use
+  maui-platform-backend).
 ---
 
 # Xamarin.Forms Migration

--- a/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
+++ b/plugins/dotnet-maui/skills/xamarin-forms-migration/SKILL.md
@@ -15,6 +15,14 @@ Use this skill to move a Xamarin.Forms app to .NET MAUI without blindly copying
 obsolete patterns. Treat migration as an audit and phased rebuild on a fresh
 MAUI project unless the user explicitly needs a small tactical port.
 
+## Response Checklist
+
+- Call out the migration audit first (`DependencyService`, `MessagingCenter`,
+  custom renderers/effects, permissions, and platform capabilities).
+- Prefer a fresh MAUI project workflow and `MauiProgram.cs` DI setup.
+- Explicitly classify renderer replacements into mapper customization, custom
+  handler, platform service, or slim binding.
+
 ## Migration Tooling
 
 Before migrating manually, check whether the .NET Upgrade Assistant can cover

--- a/tests/dotnet-maui/maui-ai-tool-bindings/eval.yaml
+++ b/tests/dotnet-maui/maui-ai-tool-bindings/eval.yaml
@@ -1,0 +1,63 @@
+scenarios:
+  - name: "Create source-generated app tools"
+    prompt: |
+      In my MAUI app I have a PlantCatalogService.SearchPlants method that I want
+      an AI assistant to call. Show the Microsoft.Maui.AI.Attributes pattern for
+      source-generated tools.
+    assertions:
+      - type: "output_contains"
+        value: "[ExportAIFunction"
+      - type: "output_contains"
+        value: "[AIToolSource"
+      - type: "output_contains"
+        value: "AIToolContext"
+      - type: "output_contains"
+        value: "Default.Tools"
+    rubric:
+      - "Annotates the service method with ExportAIFunction and Description"
+      - "Creates a partial AIToolContext with AIToolSource"
+      - "Uses the generated Default.Tools collection"
+      - "Explains that the generator emits tools at compile time for AOT-friendly invocation"
+    timeout: 240
+
+  - name: "Bind DI parameters and flow service provider"
+    prompt: |
+      My AI tool method needs a repository from DI but I do not want that
+      repository to appear as a JSON argument. How should I annotate the method
+      and build the chat client?
+    assertions:
+      - type: "output_contains"
+        value: "[FromServices]"
+      - type: "output_matches"
+        pattern: "Build\\(serviceProvider\\)|Build\\(.*ServiceProvider"
+      - type: "output_contains"
+        value: "UseFunctionInvocation"
+      - type: "output_matches"
+        pattern: "excluded from.*schema|not.*schema|ignored|invisible to AI"
+    rubric:
+      - "Uses FromServices or FromKeyedServices for DI-only parameters"
+      - "Explains that DI parameters are excluded from the JSON schema"
+      - "Builds the function-invoking chat client with a service provider"
+      - "Mentions that missing provider/service produces an explicit error rather than fake success"
+    timeout: 240
+
+  - name: "Use approval and per-session scope"
+    prompt: |
+      I have AI tools that can add items to a cart and update user preferences.
+      I also need scoped services to reset for each chat session. What AI
+      Attributes pattern should I use?
+    assertions:
+      - type: "output_contains"
+        value: "ApprovalRequired"
+      - type: "output_matches"
+        pattern: "CreateScope|IServiceScope|AsyncServiceScope"
+      - type: "output_contains"
+        value: "UseFunctionInvocation"
+      - type: "output_matches"
+        pattern: "Default\\.Tools|AIToolContext"
+    rubric:
+      - "Marks sensitive/mutating tools with ApprovalRequired"
+      - "Creates or uses a per-chat-session DI scope"
+      - "Builds the chat client with the scoped service provider"
+      - "Keeps tool scope curated through an explicit AIToolContext"
+    timeout: 240

--- a/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
+++ b/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
@@ -1,0 +1,61 @@
+scenarios:
+  - name: "Build performant incremental CollectionView"
+    prompt: |
+      My MAUI orders screen has thousands of records. I need a CollectionView
+      pattern with loading, empty state, incremental loading, and UI automation
+      hooks.
+    assertions:
+      - type: "output_contains"
+        value: "CollectionView"
+      - type: "output_contains"
+        value: "RemainingItemsThreshold"
+      - type: "output_contains"
+        value: "EmptyView"
+      - type: "output_contains"
+        value: "AutomationId"
+    rubric:
+      - "Lets CollectionView own scrolling and avoids wrapping it in ScrollView"
+      - "Uses EmptyView and a visible loading state"
+      - "Uses RemainingItemsThreshold or equivalent incremental load trigger"
+      - "Adds stable AutomationIds for the list and key states"
+    timeout: 240
+
+  - name: "Handle safe area with current API"
+    prompt: |
+      I am updating an edge-to-edge MAUI page for .NET 10 and want to stop using
+      hard-coded iOS top padding. What safe area pattern should I use?
+    assertions:
+      - type: "output_contains"
+        value: "SafeAreaEdges"
+      - type: "output_matches"
+        pattern: "Container|SoftInput|All"
+      - type: "output_matches"
+        pattern: "target framework|TFM|maui-current-apis|#if"
+      - type: "output_matches"
+        pattern: "notch|keyboard|rounded"
+    rubric:
+      - "Recommends SafeAreaEdges for .NET 10+ instead of hard-coded padding"
+      - "Says to verify the target MAUI version before changing APIs"
+      - "Mentions testing notches, rounded corners, desktop chrome, or soft keyboard scenarios"
+      - "Keeps safe area behavior declarative where possible"
+    timeout: 240
+
+  - name: "Design accessible GraphicsView drawing"
+    prompt: |
+      I need a MAUI GraphicsView chart that updates as sensor values arrive.
+      What drawing and accessibility guardrails should I follow?
+    assertions:
+      - type: "output_contains"
+        value: "IDrawable"
+      - type: "output_contains"
+        value: "Draw"
+      - type: "output_contains"
+        value: "Invalidate"
+      - type: "output_matches"
+        pattern: "SemanticProperties|SemanticScreenReader|screen reader|AutomationId"
+    rubric:
+      - "Places drawing code in IDrawable and treats Draw as a hot path"
+      - "Invalidates only when state changes and avoids allocations/blocking work in Draw"
+      - "Keeps input handling/state outside the drawable as appropriate"
+      - "Provides accessible surrounding UI or semantic alternatives for chart content"
+    timeout: 240

--- a/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
+++ b/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
@@ -5,8 +5,8 @@ scenarios:
       pattern with loading, empty state, incremental loading, and UI automation
       hooks.
     assertions:
-      - type: "output_contains"
-        value: "CollectionView"
+      - type: "output_matches"
+        pattern: "ItemsSource|ItemTemplate|SelectionMode|EmptyView"
       - type: "output_contains"
         value: "RemainingItemsThreshold"
       - type: "output_contains"

--- a/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
+++ b/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
@@ -24,7 +24,9 @@ scenarios:
   - name: "Handle safe area with current API"
     prompt: |
       I am updating an edge-to-edge MAUI page for .NET 10 and want to stop using
-      hard-coded iOS top padding. What SafeAreaEdges pattern should I use?
+      hard-coded iOS top padding. What SafeAreaEdges pattern should I use
+      (Container, SoftInput, or All), and how should I validate notch/keyboard
+      cases?
     assertions:
       - type: "output_contains"
         value: "SafeAreaEdges"

--- a/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
+++ b/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
@@ -28,7 +28,7 @@ scenarios:
       - type: "output_contains"
         value: "SafeAreaEdges"
       - type: "output_matches"
-        pattern: "Container|SoftInput|All"
+        pattern: "SafeAreaEdges\\s*=\\s*\"(Container|SoftInput|All)\"|SafeAreaEdges\\.(Container|SoftInput|All)"
       - type: "output_matches"
         pattern: "target framework|TFM|maui-current-apis|#if"
       - type: "output_matches"

--- a/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
+++ b/tests/dotnet-maui/maui-controls-deep-dive/eval.yaml
@@ -1,7 +1,8 @@
 scenarios:
   - name: "Build performant incremental CollectionView"
     prompt: |
-      My MAUI orders screen has thousands of records. I need a CollectionView
+      I need MAUI controls deep-dive guidance for an orders screen with thousands
+      of records. I need a CollectionView
       pattern with loading, empty state, incremental loading, and UI automation
       hooks.
     assertions:
@@ -23,7 +24,7 @@ scenarios:
   - name: "Handle safe area with current API"
     prompt: |
       I am updating an edge-to-edge MAUI page for .NET 10 and want to stop using
-      hard-coded iOS top padding. What safe area pattern should I use?
+      hard-coded iOS top padding. What SafeAreaEdges pattern should I use?
     assertions:
       - type: "output_contains"
         value: "SafeAreaEdges"
@@ -42,7 +43,8 @@ scenarios:
 
   - name: "Design accessible GraphicsView drawing"
     prompt: |
-      I need a MAUI GraphicsView chart that updates as sensor values arrive.
+      I need MAUI controls deep-dive guidance for a GraphicsView chart that
+      updates as sensor values arrive.
       What drawing and accessibility guardrails should I follow?
     assertions:
       - type: "output_contains"

--- a/tests/dotnet-maui/maui-custom-handlers/eval.yaml
+++ b/tests/dotnet-maui/maui-custom-handlers/eval.yaml
@@ -7,10 +7,8 @@ scenarios:
     assertions:
       - type: "output_matches"
         pattern: "EntryHandler\\.Mapper\\.AppendToMapping|AppendToMapping"
-      - type: "output_contains"
-        value: "BorderlessEntry"
       - type: "output_matches"
-        pattern: "view is BorderlessEntry|is not BorderlessEntry"
+        pattern: "is BorderlessEntry|as BorderlessEntry|== typeof\\(BorderlessEntry\\)"
       - type: "output_matches"
         pattern: "#if ANDROID|#elif IOS|#elif WINDOWS"
     rubric:

--- a/tests/dotnet-maui/maui-custom-handlers/eval.yaml
+++ b/tests/dotnet-maui/maui-custom-handlers/eval.yaml
@@ -25,7 +25,7 @@ scenarios:
       native text-changed and
       focus events in OnElementChanged and removes them in Dispose. Convert the
       lifecycle idea to a MAUI custom handler with ConnectHandler and
-      DisconnectHandler.
+      DisconnectHandler, and show where PropertyMapper fits.
     assertions:
       - type: "output_contains"
         value: "ConnectHandler"

--- a/tests/dotnet-maui/maui-custom-handlers/eval.yaml
+++ b/tests/dotnet-maui/maui-custom-handlers/eval.yaml
@@ -1,9 +1,10 @@
 scenarios:
   - name: "Scope an Entry mapper customization"
     prompt: |
-      In a MAUI app I only want BorderlessEntry controls to remove the native
+      In a MAUI custom handlers scenario, I only want BorderlessEntry controls to
+      remove the native
       border/underline. Show how to implement this as a handler mapper without
-      changing every Entry in the app.
+      changing every Entry in the app using EntryHandler.Mapper.AppendToMapping.
     assertions:
       - type: "output_matches"
         pattern: "EntryHandler\\.Mapper\\.AppendToMapping|AppendToMapping"
@@ -20,9 +21,11 @@ scenarios:
 
   - name: "Migrate renderer event cleanup"
     prompt: |
-      I have a Xamarin.Forms renderer that subscribes to native text-changed and
+      I have a Xamarin.Forms renderer-to-handler migration that subscribes to
+      native text-changed and
       focus events in OnElementChanged and removes them in Dispose. Convert the
-      lifecycle idea to a MAUI custom handler.
+      lifecycle idea to a MAUI custom handler with ConnectHandler and
+      DisconnectHandler.
     assertions:
       - type: "output_contains"
         value: "ConnectHandler"
@@ -41,7 +44,8 @@ scenarios:
 
   - name: "Create handler with property and command mappers"
     prompt: |
-      I am building a custom VideoPlayer MAUI control with Source, IsLooping,
+      I am building a custom VideoPlayer MAUI control using a custom ViewHandler
+      with Source, IsLooping,
       and Play/Pause/Stop commands. What should the handler structure look like?
     assertions:
       - type: "output_contains"

--- a/tests/dotnet-maui/maui-custom-handlers/eval.yaml
+++ b/tests/dotnet-maui/maui-custom-handlers/eval.yaml
@@ -1,0 +1,62 @@
+scenarios:
+  - name: "Scope an Entry mapper customization"
+    prompt: |
+      In a MAUI app I only want BorderlessEntry controls to remove the native
+      border/underline. Show how to implement this as a handler mapper without
+      changing every Entry in the app.
+    assertions:
+      - type: "output_matches"
+        pattern: "EntryHandler\\.Mapper\\.AppendToMapping|AppendToMapping"
+      - type: "output_contains"
+        value: "BorderlessEntry"
+      - type: "output_matches"
+        pattern: "view is BorderlessEntry|is not BorderlessEntry"
+      - type: "output_matches"
+        pattern: "#if ANDROID|#elif IOS|#elif WINDOWS"
+    rubric:
+      - "Uses EntryHandler.Mapper.AppendToMapping or equivalent mapper customization"
+      - "Scopes the customization to BorderlessEntry rather than all Entry controls"
+      - "Includes platform-specific native view code behind compile-time guards"
+      - "Registers the mapper once rather than from repeated page constructors"
+    timeout: 240
+
+  - name: "Migrate renderer event cleanup"
+    prompt: |
+      I have a Xamarin.Forms renderer that subscribes to native text-changed and
+      focus events in OnElementChanged and removes them in Dispose. Convert the
+      lifecycle idea to a MAUI custom handler.
+    assertions:
+      - type: "output_contains"
+        value: "ConnectHandler"
+      - type: "output_contains"
+        value: "DisconnectHandler"
+      - type: "output_matches"
+        pattern: "-=|unsubscribe|remove"
+      - type: "output_contains"
+        value: "PropertyMapper"
+    rubric:
+      - "Moves native event subscription/setup into ConnectHandler"
+      - "Moves unsubscription and owned native cleanup into DisconnectHandler"
+      - "Replaces OnElementPropertyChanged with PropertyMapper entries"
+      - "Avoids broad try/catch cleanup that hides lifecycle errors"
+    timeout: 240
+
+  - name: "Create handler with property and command mappers"
+    prompt: |
+      I am building a custom VideoPlayer MAUI control with Source, IsLooping,
+      and Play/Pause/Stop commands. What should the handler structure look like?
+    assertions:
+      - type: "output_contains"
+        value: "PropertyMapper"
+      - type: "output_contains"
+        value: "CommandMapper"
+      - type: "output_matches"
+        pattern: "ConfigureMauiHandlers|AddHandler"
+      - type: "output_matches"
+        pattern: "CreatePlatformView|ViewHandler"
+    rubric:
+      - "Defines bindable/cross-platform control API before native implementation"
+      - "Uses PropertyMapper for Source/IsLooping-style state"
+      - "Uses CommandMapper for Play/Pause/Stop-style actions"
+      - "Shows handler registration through ConfigureMauiHandlers"
+    timeout: 240

--- a/tests/dotnet-maui/maui-custom-handlers/eval.yaml
+++ b/tests/dotnet-maui/maui-custom-handlers/eval.yaml
@@ -8,7 +8,7 @@ scenarios:
       - type: "output_matches"
         pattern: "EntryHandler\\.Mapper\\.AppendToMapping|AppendToMapping"
       - type: "output_matches"
-        pattern: "is BorderlessEntry|as BorderlessEntry|== typeof\\(BorderlessEntry\\)"
+        pattern: "is\\s+(not\\s+)?BorderlessEntry|as BorderlessEntry|== typeof\\(BorderlessEntry\\)"
       - type: "output_matches"
         pattern: "#(if|elif)\\s+.*(ANDROID|IOS|MACCATALYST|WINDOWS)"
     rubric:

--- a/tests/dotnet-maui/maui-custom-handlers/eval.yaml
+++ b/tests/dotnet-maui/maui-custom-handlers/eval.yaml
@@ -10,7 +10,7 @@ scenarios:
       - type: "output_matches"
         pattern: "is BorderlessEntry|as BorderlessEntry|== typeof\\(BorderlessEntry\\)"
       - type: "output_matches"
-        pattern: "#if ANDROID|#elif IOS|#elif WINDOWS"
+        pattern: "#(if|elif)\\s+.*(ANDROID|IOS|MACCATALYST|WINDOWS)"
     rubric:
       - "Uses EntryHandler.Mapper.AppendToMapping or equivalent mapper customization"
       - "Scopes the customization to BorderlessEntry rather than all Entry controls"

--- a/tests/dotnet-maui/maui-essentials-ai/eval.yaml
+++ b/tests/dotnet-maui/maui-essentials-ai/eval.yaml
@@ -47,8 +47,9 @@ scenarios:
     prompt: |
       My local MAUI Essentials.AI chat assistant should be able to call app tools
       like searching
-      the user's garden catalog. How do I wire Microsoft.Extensions.AI tool
-      invocation, and when should I use the AI Attributes skill?
+      the user's garden catalog. How do I build the IChatClient pipeline with
+      UseFunctionInvocation and AdditionalTools, and when should I use the AI
+      Attributes skill?
     assertions:
       - type: "output_contains"
         value: "UseFunctionInvocation"

--- a/tests/dotnet-maui/maui-essentials-ai/eval.yaml
+++ b/tests/dotnet-maui/maui-essentials-ai/eval.yaml
@@ -1,7 +1,8 @@
 scenarios:
   - name: "Register local Apple Intelligence chat"
     prompt: |
-      I want my MAUI app to use local on-device chat on supported Apple devices
+      I want my MAUI app to use Microsoft.Maui.Essentials.AI local on-device chat
+      on supported Apple devices
       through Microsoft.Extensions.AI abstractions. What package and registration
       should I use, and what platform caveat should I show in the UI?
     assertions:
@@ -22,7 +23,8 @@ scenarios:
 
   - name: "Build local semantic search with embeddings"
     prompt: |
-      I have private notes in a MAUI app and want local semantic search without
+      I have private notes in a MAUI app and want local semantic search with
+      NLEmbeddingGenerator without
       sending them to a cloud model. How should I use the Essentials AI embedding
       generator and store/search the results?
     assertions:
@@ -43,7 +45,8 @@ scenarios:
 
   - name: "Add app tools to local chat client"
     prompt: |
-      My local MAUI chat assistant should be able to call app tools like searching
+      My local MAUI Essentials.AI chat assistant should be able to call app tools
+      like searching
       the user's garden catalog. How do I wire Microsoft.Extensions.AI tool
       invocation, and when should I use the AI Attributes skill?
     assertions:

--- a/tests/dotnet-maui/maui-essentials-ai/eval.yaml
+++ b/tests/dotnet-maui/maui-essentials-ai/eval.yaml
@@ -28,14 +28,14 @@ scenarios:
     assertions:
       - type: "output_contains"
         value: "NLEmbeddingGenerator"
-      - type: "output_contains"
-        value: "NLEmbeddingType.Sentence"
+      - type: "output_matches"
+        pattern: "new NLEmbeddingGenerator\\(\\)|NLLanguage|NLEmbedding\\b"
       - type: "output_matches"
         pattern: "cosine|similarity|nearest"
       - type: "output_matches"
         pattern: "metadata|snippet|source"
     rubric:
-      - "Uses NLEmbeddingGenerator with sentence embeddings for local semantic search"
+      - "Uses NLEmbeddingGenerator with its default English sentence embedding, or an explicit NLLanguage/NLEmbedding when needed"
       - "Stores embeddings with metadata/source snippets"
       - "Compares query embeddings with cosine similarity or a nearest-neighbor equivalent"
       - "Avoids regenerating the entire corpus on every query"

--- a/tests/dotnet-maui/maui-essentials-ai/eval.yaml
+++ b/tests/dotnet-maui/maui-essentials-ai/eval.yaml
@@ -26,8 +26,8 @@ scenarios:
       sending them to a cloud model. How should I use the Essentials AI embedding
       generator and store/search the results?
     assertions:
-      - type: "output_contains"
-        value: "NLEmbeddingGenerator"
+      - type: "output_matches"
+        pattern: "NLEmbeddingGenerator|IEmbeddingGenerator"
       - type: "output_matches"
         pattern: "new NLEmbeddingGenerator\\(\\)|NLLanguage|NLEmbedding\\b"
       - type: "output_matches"

--- a/tests/dotnet-maui/maui-essentials-ai/eval.yaml
+++ b/tests/dotnet-maui/maui-essentials-ai/eval.yaml
@@ -1,0 +1,63 @@
+scenarios:
+  - name: "Register local Apple Intelligence chat"
+    prompt: |
+      I want my MAUI app to use local on-device chat on supported Apple devices
+      through Microsoft.Extensions.AI abstractions. What package and registration
+      should I use, and what platform caveat should I show in the UI?
+    assertions:
+      - type: "output_contains"
+        value: "Microsoft.Maui.Essentials.AI"
+      - type: "output_contains"
+        value: "AppleIntelligenceChatClient"
+      - type: "output_contains"
+        value: "IChatClient"
+      - type: "output_matches"
+        pattern: "iOS 26|macOS 26|Mac Catalyst 26|unsupported"
+    rubric:
+      - "Installs Microsoft.Maui.Essentials.AI as a prerelease package"
+      - "Registers AppleIntelligenceChatClient as an IChatClient"
+      - "Mentions support on iOS/macOS/Mac Catalyst 26+ and fallback UI for unsupported platforms"
+      - "Keeps chat consumption behind DI/view models rather than page-only code"
+    timeout: 240
+
+  - name: "Build local semantic search with embeddings"
+    prompt: |
+      I have private notes in a MAUI app and want local semantic search without
+      sending them to a cloud model. How should I use the Essentials AI embedding
+      generator and store/search the results?
+    assertions:
+      - type: "output_contains"
+        value: "NLEmbeddingGenerator"
+      - type: "output_contains"
+        value: "NLEmbeddingType.Sentence"
+      - type: "output_matches"
+        pattern: "cosine|similarity|nearest"
+      - type: "output_matches"
+        pattern: "metadata|snippet|source"
+    rubric:
+      - "Uses NLEmbeddingGenerator with sentence embeddings for local semantic search"
+      - "Stores embeddings with metadata/source snippets"
+      - "Compares query embeddings with cosine similarity or a nearest-neighbor equivalent"
+      - "Avoids regenerating the entire corpus on every query"
+    timeout: 240
+
+  - name: "Add app tools to local chat client"
+    prompt: |
+      My local MAUI chat assistant should be able to call app tools like searching
+      the user's garden catalog. How do I wire Microsoft.Extensions.AI tool
+      invocation, and when should I use the AI Attributes skill?
+    assertions:
+      - type: "output_contains"
+        value: "UseFunctionInvocation"
+      - type: "output_matches"
+        pattern: "Tools|AdditionalTools"
+      - type: "output_matches"
+        pattern: "ExportAIFunction|maui-ai-tool-bindings|AIToolContext"
+      - type: "output_matches"
+        pattern: "approval|sensitive|mutat"
+    rubric:
+      - "Builds an IChatClient pipeline with UseFunctionInvocation"
+      - "Adds generated or curated tools through Tools/AdditionalTools"
+      - "Routes source-generated tool definitions to maui-ai-tool-bindings"
+      - "Calls out approval for sensitive or mutating tools"
+    timeout: 240

--- a/tests/dotnet-maui/maui-labs-platform-targeting/eval.yaml
+++ b/tests/dotnet-maui/maui-labs-platform-targeting/eval.yaml
@@ -51,12 +51,14 @@ scenarios:
       - type: "output_contains"
         value: "UseWPF"
       - type: "output_contains"
+        value: "UseMaui"
+      - type: "output_contains"
         value: "UseMauiAppWPF"
       - type: "output_contains"
         value: "UseWPFEssentials"
     rubric:
       - "Uses the WPF template/package and net10.0-windows target"
-      - "Includes UseWPF for manual projects"
+      - "Includes UseWPF and UseMaui for manual projects"
       - "Shows UseMauiAppWPF and UseWPFEssentials hosting setup"
       - "Frames this as consuming an experimental backend, not implementing backend handlers"
     timeout: 240

--- a/tests/dotnet-maui/maui-labs-platform-targeting/eval.yaml
+++ b/tests/dotnet-maui/maui-labs-platform-targeting/eval.yaml
@@ -1,0 +1,62 @@
+scenarios:
+  - name: "Add Linux GTK4 head project"
+    prompt: |
+      I have a normal MAUI app and want to try the experimental MAUI Labs Linux
+      GTK4 backend without pretending there is an official net10.0-linux MAUI
+      TFM. What project shape and commands should I use?
+    assertions:
+      - type: "output_contains"
+        value: "maui-linux-gtk4"
+      - type: "output_contains"
+        value: "UseMauiAppLinuxGtk4"
+      - type: "output_contains"
+        value: "ProjectReference"
+      - type: "output_matches"
+        pattern: "libgtk-4-dev|libwebkitgtk-6\\.0-dev|GtkApplication"
+    rubric:
+      - "Explains the separate Linux head project pattern"
+      - "Uses the Linux GTK4 template/package and UseMauiAppLinuxGtk4 hosting call"
+      - "References shared app code from the Linux head project"
+      - "Mentions GTK4/WebKitGTK native dependencies where relevant"
+    timeout: 240
+
+  - name: "Choose AppKit instead of Mac Catalyst"
+    prompt: |
+      Our desktop app needs native macOS AppKit behavior instead of Mac Catalyst.
+      How do we target the MAUI Labs AppKit backend and keep platform conditionals
+      straight?
+    assertions:
+      - type: "output_contains"
+        value: "maui-macos"
+      - type: "output_contains"
+        value: "net10.0-macos"
+      - type: "output_contains"
+        value: "UseMauiAppMacOS"
+      - type: "output_matches"
+        pattern: "MACOS|TargetPlatform|#if MAC|AddMacOSEssentials"
+    rubric:
+      - "Uses the AppKit template/package and net10.0-macos target"
+      - "Shows UseMauiAppMacOS and AddMacOSEssentials where appropriate"
+      - "Distinguishes AppKit macOS from Mac Catalyst/UIKit code paths"
+      - "Calls out experimental backend parity checks"
+    timeout: 240
+
+  - name: "Target WPF backend from MAUI Labs"
+    prompt: |
+      I want to run a MAUI app as a WPF desktop app using the MAUI Labs backend.
+      What template or manual project setup should I use?
+    assertions:
+      - type: "output_contains"
+        value: "maui-wpf"
+      - type: "output_contains"
+        value: "UseWPF"
+      - type: "output_contains"
+        value: "UseMauiAppWPF"
+      - type: "output_contains"
+        value: "UseWPFEssentials"
+    rubric:
+      - "Uses the WPF template/package and net10.0-windows target"
+      - "Includes UseWPF for manual projects"
+      - "Shows UseMauiAppWPF and UseWPFEssentials hosting setup"
+      - "Frames this as consuming an experimental backend, not implementing backend handlers"
+    timeout: 240

--- a/tests/dotnet-maui/maui-labs-platform-targeting/eval.yaml
+++ b/tests/dotnet-maui/maui-labs-platform-targeting/eval.yaml
@@ -1,7 +1,8 @@
 scenarios:
   - name: "Add Linux GTK4 head project"
     prompt: |
-      I have a normal MAUI app and want to try the experimental MAUI Labs Linux
+      I need MAUI Labs platform targeting guidance. I have a normal MAUI app and
+      want to try the experimental MAUI Labs Linux
       GTK4 backend without pretending there is an official net10.0-linux MAUI
       TFM. What project shape and commands should I use?
     assertions:
@@ -22,7 +23,8 @@ scenarios:
 
   - name: "Choose AppKit instead of Mac Catalyst"
     prompt: |
-      Our desktop app needs native macOS AppKit behavior instead of Mac Catalyst.
+      For MAUI Labs platform targeting, our desktop app needs native macOS AppKit
+      behavior instead of Mac Catalyst.
       How do we target the MAUI Labs AppKit backend and keep platform conditionals
       straight?
     assertions:
@@ -43,7 +45,8 @@ scenarios:
 
   - name: "Target WPF backend from MAUI Labs"
     prompt: |
-      I want to run a MAUI app as a WPF desktop app using the MAUI Labs backend.
+      For MAUI Labs platform targeting, I want to run a MAUI app as a WPF desktop
+      app using the MAUI Labs backend.
       What template or manual project setup should I use?
     assertions:
       - type: "output_contains"

--- a/tests/dotnet-maui/maui-labs-platform-targeting/eval.yaml
+++ b/tests/dotnet-maui/maui-labs-platform-targeting/eval.yaml
@@ -33,7 +33,7 @@ scenarios:
       - type: "output_contains"
         value: "UseMauiAppMacOS"
       - type: "output_matches"
-        pattern: "MACOS|TargetPlatform|#if MAC|AddMacOSEssentials"
+        pattern: "MACOS\\b|TargetPlatform|#if\\s+MACOS\\b|AddMacOSEssentials"
     rubric:
       - "Uses the AppKit template/package and net10.0-macos target"
       - "Shows UseMauiAppMacOS and AddMacOSEssentials where appropriate"

--- a/tests/dotnet-maui/maui-platform-invoke/eval.yaml
+++ b/tests/dotnet-maui/maui-platform-invoke/eval.yaml
@@ -28,7 +28,7 @@ scenarios:
       We are adding a MAUI platform service that invokes a small platform-specific
       camera metadata feature. What
       permission and platform file guidance should the MAUI implementation
-      include?
+      include in AndroidManifest.xml and Info.plist?
     assertions:
       - type: "output_contains"
         value: "Permissions.CheckStatusAsync"
@@ -50,7 +50,7 @@ scenarios:
       I need MAUI platform invoke lifecycle hooks to refresh native state when the
       MAUI app resumes on Android/iOS and
       configure the native Windows window when it is created. Where should this
-      code go?
+      code go in ConfigureLifecycleEvents with AddAndroid/AddiOS/AddWindows?
     assertions:
       - type: "output_contains"
         value: "ConfigureLifecycleEvents"

--- a/tests/dotnet-maui/maui-platform-invoke/eval.yaml
+++ b/tests/dotnet-maui/maui-platform-invoke/eval.yaml
@@ -5,12 +5,14 @@ scenarios:
       Android. I don't want platform-specific code scattered through view
       models. How should I structure it?
     assertions:
-      - type: "output_matches"
-        pattern: "interface|IAppReviewService"
+      - type: "output_contains"
+        value: "IAppReviewService"
       - type: "output_matches"
         pattern: "AddSingleton|AddTransient|AddScoped"
       - type: "output_matches"
-        pattern: "Platforms/Android|Platforms/iOS|#if ANDROID|#if IOS"
+        pattern: "Platforms/Android|#if\\s+ANDROID|#elif\\s+ANDROID"
+      - type: "output_matches"
+        pattern: "Platforms/iOS|Platforms/Ios|#if\\s+IOS\\b|#elif\\s+IOS\\b"
       - type: "output_matches"
         pattern: "inject|constructor"
     rubric:
@@ -49,10 +51,18 @@ scenarios:
     assertions:
       - type: "output_contains"
         value: "ConfigureLifecycleEvents"
-      - type: "output_matches"
-        pattern: "AddAndroid|AddiOS|AddWindows"
-      - type: "output_matches"
-        pattern: "OnResume|OnActivated|OnWindowCreated"
+      - type: "output_contains"
+        value: "AddAndroid"
+      - type: "output_contains"
+        value: "AddiOS"
+      - type: "output_contains"
+        value: "AddWindows"
+      - type: "output_contains"
+        value: "OnResume"
+      - type: "output_contains"
+        value: "OnActivated"
+      - type: "output_contains"
+        value: "OnWindowCreated"
       - type: "output_matches"
         pattern: "service|DI"
     rubric:

--- a/tests/dotnet-maui/maui-platform-invoke/eval.yaml
+++ b/tests/dotnet-maui/maui-platform-invoke/eval.yaml
@@ -1,0 +1,63 @@
+scenarios:
+  - name: "Wrap app review platform API behind DI"
+    prompt: |
+      My MAUI app needs to trigger the native app review prompt on iOS and
+      Android. I don't want platform-specific code scattered through view
+      models. How should I structure it?
+    assertions:
+      - type: "output_matches"
+        pattern: "interface|IAppReviewService"
+      - type: "output_matches"
+        pattern: "AddSingleton|AddTransient|AddScoped"
+      - type: "output_matches"
+        pattern: "Platforms/Android|Platforms/iOS|#if ANDROID|#if IOS"
+      - type: "output_matches"
+        pattern: "inject|constructor"
+    rubric:
+      - "Defines a shared interface for the platform API"
+      - "Implements per-platform classes/files and registers them in MauiProgram.cs"
+      - "Injects the abstraction into app services or view models"
+      - "Explains why this belongs in a platform service rather than a visual handler"
+    timeout: 240
+
+  - name: "Request permission before invoking native camera API"
+    prompt: |
+      We are adding a small platform-specific camera metadata feature. What
+      permission and platform file guidance should the MAUI implementation
+      include?
+    assertions:
+      - type: "output_contains"
+        value: "Permissions.CheckStatusAsync"
+      - type: "output_contains"
+        value: "Permissions.RequestAsync"
+      - type: "output_matches"
+        pattern: "AndroidManifest|Info\\.plist|entitlement|capabilit"
+      - type: "output_matches"
+        pattern: "PermissionStatus\\.Granted|denied|restricted"
+    rubric:
+      - "Checks and requests the camera permission before calling native APIs"
+      - "Mentions manifest/Info.plist/capability updates as required by platform"
+      - "Handles denied or restricted permission states explicitly"
+      - "Keeps native namespaces inside platform-specific files or compile guards"
+    timeout: 240
+
+  - name: "Use lifecycle hooks for native state"
+    prompt: |
+      I need to refresh native state when the MAUI app resumes on Android/iOS and
+      configure the native Windows window when it is created. Where should this
+      code go?
+    assertions:
+      - type: "output_contains"
+        value: "ConfigureLifecycleEvents"
+      - type: "output_matches"
+        pattern: "AddAndroid|AddiOS|AddWindows"
+      - type: "output_matches"
+        pattern: "OnResume|OnActivated|OnWindowCreated"
+      - type: "output_matches"
+        pattern: "service|DI"
+    rubric:
+      - "Uses ConfigureLifecycleEvents instead of page constructors for app/window lifecycle callbacks"
+      - "Shows platform-specific lifecycle registration for Android, iOS, and Windows"
+      - "Forwards shared state work into registered services when appropriate"
+      - "Keeps lifecycle callback bodies small and platform-scoped"
+    timeout: 240

--- a/tests/dotnet-maui/maui-platform-invoke/eval.yaml
+++ b/tests/dotnet-maui/maui-platform-invoke/eval.yaml
@@ -1,9 +1,10 @@
 scenarios:
   - name: "Wrap app review platform API behind DI"
     prompt: |
-      My MAUI app needs to trigger the native app review prompt on iOS and
+      For MAUI platform invoke, my MAUI app needs to trigger the native app
+      review prompt on iOS and
       Android. I don't want platform-specific code scattered through view
-      models. How should I structure it?
+      models. How should I structure it as a DI platform service abstraction?
     assertions:
       - type: "output_contains"
         value: "IAppReviewService"
@@ -24,7 +25,8 @@ scenarios:
 
   - name: "Request permission before invoking native camera API"
     prompt: |
-      We are adding a small platform-specific camera metadata feature. What
+      We are adding a MAUI platform service that invokes a small platform-specific
+      camera metadata feature. What
       permission and platform file guidance should the MAUI implementation
       include?
     assertions:
@@ -45,7 +47,8 @@ scenarios:
 
   - name: "Use lifecycle hooks for native state"
     prompt: |
-      I need to refresh native state when the MAUI app resumes on Android/iOS and
+      I need MAUI platform invoke lifecycle hooks to refresh native state when the
+      MAUI app resumes on Android/iOS and
       configure the native Windows window when it is created. Where should this
       code go?
     assertions:

--- a/tests/dotnet-maui/maui-release-notes/eval.yaml
+++ b/tests/dotnet-maui/maui-release-notes/eval.yaml
@@ -6,8 +6,8 @@ scenarios:
       requirements, and validation commands. What data collection and note shape
       should I use?
     assertions:
-      - type: "output_contains"
-        value: "dotnet-workload-info"
+      - type: "output_matches"
+        pattern: "workload set|manifest versions|WorkloadDependencies\\.json"
       - type: "output_contains"
         value: "WorkloadDependencies.json"
       - type: "output_matches"
@@ -28,7 +28,7 @@ scenarios:
       data. What conversion should I document?
     assertions:
       - type: "output_matches"
-        pattern: "\\d+\\.\\d+\\.\\d+"
+        pattern: "10\\.103\\.0|10\\.\\d+\\.0"
       - type: "output_matches"
         pattern: "Microsoft\\.NET\\.Workloads\\.\\d+\\.\\d+\\.\\d+"
       - type: "output_matches"
@@ -52,8 +52,8 @@ scenarios:
         pattern: "reject|omit|exclude|separate|do not include"
       - type: "output_matches"
         pattern: "known issues|breaking changes|requirements"
-      - type: "output_contains"
-        value: "dotnet-workload-info"
+      - type: "output_matches"
+        pattern: "WorkloadDependencies\\.json|WorkloadManifest|manifest data"
       - type: "output_matches"
         pattern: "WorkloadDependencies\\.json|WorkloadManifest|known issues"
     rubric:

--- a/tests/dotnet-maui/maui-release-notes/eval.yaml
+++ b/tests/dotnet-maui/maui-release-notes/eval.yaml
@@ -30,7 +30,7 @@ scenarios:
       - type: "output_matches"
         pattern: "10\\.103\\.0"
       - type: "output_matches"
-        pattern: "Microsoft\\.NET\\.Workloads\\.\\d+\\.\\d+\\.\\d+"
+        pattern: "Microsoft\\.NET\\.Workloads\\.10\\.0\\.100"
       - type: "output_matches"
         pattern: "SDK band|10\\.0\\.100"
       - type: "output_matches"
@@ -48,8 +48,6 @@ scenarios:
       they also pasted a sample mobile app's App Store changelog. How should I
       keep the workload notes focused?
     assertions:
-      - type: "output_matches"
-        pattern: "reject|omit|exclude|separate|do not include"
       - type: "output_matches"
         pattern: "known issues|breaking changes|requirements"
       - type: "output_matches"

--- a/tests/dotnet-maui/maui-release-notes/eval.yaml
+++ b/tests/dotnet-maui/maui-release-notes/eval.yaml
@@ -53,7 +53,7 @@ scenarios:
       - type: "output_matches"
         pattern: "WorkloadDependencies\\.json|WorkloadManifest|manifest data"
       - type: "output_matches"
-        pattern: "WorkloadDependencies\\.json|WorkloadManifest|known issues"
+        pattern: "(?i)app store.*(separate|out of scope|not workload)|(?:separate|out of scope|not workload).*app store|workload notes.*SDK consumers"
     rubric:
       - "Keeps release notes focused on MAUI workload/platform data for SDK consumers"
       - "Separates app-store or marketing changelog content from workload release notes"

--- a/tests/dotnet-maui/maui-release-notes/eval.yaml
+++ b/tests/dotnet-maui/maui-release-notes/eval.yaml
@@ -1,0 +1,64 @@
+scenarios:
+  - name: "Draft workload release notes from live data"
+    prompt: |
+      I need maintainer release notes for the current .NET 10 MAUI workload. I
+      care about workload set version, manifest versions, Xcode/JDK/Android SDK
+      requirements, and validation commands. What data collection and note shape
+      should I use?
+    assertions:
+      - type: "output_contains"
+        value: "dotnet-workload-info"
+      - type: "output_contains"
+        value: "WorkloadDependencies.json"
+      - type: "output_matches"
+        pattern: "known issues|breaking changes|installation|validation"
+      - type: "output_matches"
+        pattern: "manifest|workload set"
+    rubric:
+      - "Routes live workload discovery to dotnet-workload-info"
+      - "Collects workload set and manifest versions before drafting notes"
+      - "Gets platform requirements from WorkloadDependencies.json"
+      - "Includes install/update and validation sections in the release note shape"
+    timeout: 240
+
+  - name: "Convert workload set version for release note links"
+    prompt: |
+      The workload set CLI version for a release is 10.0.103. I need release
+      notes that include the NuGet package ID/version and a table of workload
+      data. What conversion should I document?
+    assertions:
+      - type: "output_matches"
+        pattern: "\\d+\\.\\d+\\.\\d+"
+      - type: "output_matches"
+        pattern: "Microsoft\\.NET\\.Workloads\\.\\d+\\.\\d+\\.\\d+"
+      - type: "output_matches"
+        pattern: "SDK band|10\\.0\\.100"
+      - type: "output_matches"
+        pattern: "markdown table|\\|.*\\||WorkloadManifest"
+    rubric:
+      - "Converts CLI version 10.0.103 to NuGet version 10.103.0"
+      - "Identifies Microsoft.NET.Workloads.10.0.100 as the workload set package ID"
+      - "Explains the SDK band relationship"
+      - "Places version data into a release-note table"
+    timeout: 240
+
+  - name: "Keep maintainer workload notes separate from app notes"
+    prompt: |
+      A teammate asked me to update MAUI release notes for SDK consumers, but
+      they also pasted a sample mobile app's App Store changelog. How should I
+      keep the workload notes focused?
+    assertions:
+      - type: "output_matches"
+        pattern: "reject|omit|exclude|separate|do not include"
+      - type: "output_matches"
+        pattern: "known issues|breaking changes|requirements"
+      - type: "output_contains"
+        value: "dotnet-workload-info"
+      - type: "output_matches"
+        pattern: "WorkloadDependencies\\.json|WorkloadManifest|known issues"
+    rubric:
+      - "Keeps release notes focused on MAUI workload/platform data for SDK consumers"
+      - "Separates app-store or marketing changelog content from workload release notes"
+      - "Uses live workload discovery for versions and requirements"
+      - "Includes known issues, breaking changes, and validation when data is available"
+    timeout: 240

--- a/tests/dotnet-maui/maui-release-notes/eval.yaml
+++ b/tests/dotnet-maui/maui-release-notes/eval.yaml
@@ -1,7 +1,8 @@
 scenarios:
   - name: "Summarize upgrade notes for a MAUI app team"
     prompt: |
-      Our .NET MAUI app is on .NET 9 today and we're considering the current
+      I need maui-release-notes guidance for an app team. Our .NET MAUI app is on
+      .NET 9 today and we're considering the current
       .NET 10 MAUI release. I need upgrade notes for the app team, not MAUI SDK
       maintainers. What should I extract from the release notes about breaking
       changes, Xcode/JDK/Android SDK requirements, CI changes, and post-upgrade
@@ -24,10 +25,11 @@ scenarios:
 
   - name: "Turn MAUI release notes into repo and CI action items"
     prompt: |
-      I own a MAUI app repo and need notes for upgrading our team from one MAUI
+      I own a MAUI app repo and need maui-release-notes guidance for upgrading our
+      team from one MAUI
       release to the next. We pin the SDK in global.json and install workloads in
       CI. What should the upgrade notes capture for app developers and build
-      engineers?
+      engineers, and when should I use dotnet-workload-info for exact versions?
     assertions:
       - type: "output_matches"
         pattern: "global\\.json|SDK"
@@ -46,7 +48,8 @@ scenarios:
 
   - name: "Keep framework upgrade notes separate from store changelog"
     prompt: |
-      A teammate mixed our shopping app's App Store release notes into a draft
+      In maui-release-notes scope, a teammate mixed our shopping app's App Store
+      release notes into a draft
       about upgrading the app to a new .NET MAUI release. How should I separate
       framework upgrade notes from customer-facing app release notes?
     assertions:

--- a/tests/dotnet-maui/maui-release-notes/eval.yaml
+++ b/tests/dotnet-maui/maui-release-notes/eval.yaml
@@ -28,7 +28,7 @@ scenarios:
       data. What conversion should I document?
     assertions:
       - type: "output_matches"
-        pattern: "10\\.103\\.0|10\\.\\d+\\.0"
+        pattern: "10\\.103\\.0"
       - type: "output_matches"
         pattern: "Microsoft\\.NET\\.Workloads\\.\\d+\\.\\d+\\.\\d+"
       - type: "output_matches"

--- a/tests/dotnet-maui/maui-release-notes/eval.yaml
+++ b/tests/dotnet-maui/maui-release-notes/eval.yaml
@@ -1,62 +1,64 @@
 scenarios:
-  - name: "Draft workload release notes from live data"
+  - name: "Summarize upgrade notes for a MAUI app team"
     prompt: |
-      I need maintainer release notes for the current .NET 10 MAUI workload. I
-      care about workload set version, manifest versions, Xcode/JDK/Android SDK
-      requirements, and validation commands. What data collection and note shape
-      should I use?
+      Our .NET MAUI app is on .NET 9 today and we're considering the current
+      .NET 10 MAUI release. I need upgrade notes for the app team, not MAUI SDK
+      maintainers. What should I extract from the release notes about breaking
+      changes, Xcode/JDK/Android SDK requirements, CI changes, and post-upgrade
+      validation?
     assertions:
       - type: "output_matches"
-        pattern: "workload set|manifest versions|WorkloadDependencies\\.json"
-      - type: "output_contains"
-        value: "WorkloadDependencies.json"
+        pattern: "breaking changes|known issues|upgrade"
       - type: "output_matches"
-        pattern: "known issues|breaking changes|installation|validation"
+        pattern: "Xcode|JDK|Android SDK|workload"
       - type: "output_matches"
-        pattern: "manifest|workload set"
+        pattern: "CI|global\\.json|pipeline|build"
+      - type: "output_matches"
+        pattern: "validation|smoke test|regression"
     rubric:
-      - "Routes live workload discovery to dotnet-workload-info"
-      - "Collects workload set and manifest versions before drafting notes"
-      - "Gets platform requirements from WorkloadDependencies.json"
-      - "Includes install/update and validation sections in the release note shape"
+      - "Frames the answer for an app team evaluating an upgrade, not for MAUI SDK maintainers"
+      - "Calls out app-facing breaking changes, environment requirements, and CI impact"
+      - "Uses dotnet-workload-info for exact live version or dependency requirements when needed"
+      - "Includes a concrete post-upgrade validation plan"
     timeout: 240
 
-  - name: "Convert workload set version for release note links"
+  - name: "Turn MAUI release notes into repo and CI action items"
     prompt: |
-      The workload set CLI version for a release is 10.0.103. I need release
-      notes that include the NuGet package ID/version and a table of workload
-      data. What conversion should I document?
+      I own a MAUI app repo and need notes for upgrading our team from one MAUI
+      release to the next. We pin the SDK in global.json and install workloads in
+      CI. What should the upgrade notes capture for app developers and build
+      engineers?
     assertions:
       - type: "output_matches"
-        pattern: "10\\.103\\.0"
+        pattern: "global\\.json|SDK"
       - type: "output_matches"
-        pattern: "Microsoft\\.NET\\.Workloads\\.10\\.0\\.100"
+        pattern: "dotnet workload (install|update)|workload set|CI"
       - type: "output_matches"
-        pattern: "SDK band|10\\.0\\.100"
+        pattern: "Xcode|JDK|Android SDK|tooling"
       - type: "output_matches"
-        pattern: "markdown table|\\|.*\\||WorkloadManifest"
+        pattern: "smoke test|device|simulator|validation"
     rubric:
-      - "Converts CLI version 10.0.103 to NuGet version 10.103.0"
-      - "Identifies Microsoft.NET.Workloads.10.0.100 as the workload set package ID"
-      - "Explains the SDK band relationship"
-      - "Places version data into a release-note table"
+      - "Translates framework release notes into repo and CI actions for an app team"
+      - "Mentions SDK pinning, workload updates, and environment/tooling changes"
+      - "Keeps the focus on app adoption guidance instead of manifest/package publishing details"
+      - "Includes validation steps for builds and critical app flows"
     timeout: 240
 
-  - name: "Keep maintainer workload notes separate from app notes"
+  - name: "Keep framework upgrade notes separate from store changelog"
     prompt: |
-      A teammate asked me to update MAUI release notes for SDK consumers, but
-      they also pasted a sample mobile app's App Store changelog. How should I
-      keep the workload notes focused?
+      A teammate mixed our shopping app's App Store release notes into a draft
+      about upgrading the app to a new .NET MAUI release. How should I separate
+      framework upgrade notes from customer-facing app release notes?
     assertions:
       - type: "output_matches"
-        pattern: "known issues|breaking changes|requirements"
+        pattern: "(?i)app store|play store|customer-facing"
       - type: "output_matches"
-        pattern: "WorkloadDependencies\\.json|WorkloadManifest|manifest data"
+        pattern: "(?i)separate|out of scope|different audience"
       - type: "output_matches"
-        pattern: "(?i)app store.*(separate|out of scope|not workload)|(?:separate|out of scope|not workload).*app store|workload notes.*SDK consumers"
+        pattern: "upgrade|breaking changes|requirements|validation|known issues"
     rubric:
-      - "Keeps release notes focused on MAUI workload/platform data for SDK consumers"
-      - "Separates app-store or marketing changelog content from workload release notes"
-      - "Uses live workload discovery for versions and requirements"
-      - "Includes known issues, breaking changes, and validation when data is available"
+      - "Separates customer-facing store notes from developer-facing framework upgrade guidance"
+      - "Keeps the upgrade notes focused on app risks, requirements, and testing"
+      - "Does not drift into MAUI SDK maintainer release-note structure"
+      - "Explains the distinct audiences and purposes of the two note types"
     timeout: 240

--- a/tests/dotnet-maui/maui-release-notes/eval.yaml
+++ b/tests/dotnet-maui/maui-release-notes/eval.yaml
@@ -1,7 +1,7 @@
 scenarios:
   - name: "Summarize upgrade notes for a MAUI app team"
     prompt: |
-      I need maui-release-notes guidance for an app team. Our .NET MAUI app is on
+      I need framework-upgrade guidance for an app team. Our .NET MAUI app is on
       .NET 9 today and we're considering the current
       .NET 10 MAUI release. I need upgrade notes for the app team, not MAUI SDK
       maintainers. What should I extract from the release notes about breaking
@@ -25,7 +25,7 @@ scenarios:
 
   - name: "Turn MAUI release notes into repo and CI action items"
     prompt: |
-      I own a MAUI app repo and need maui-release-notes guidance for upgrading our
+      I own a MAUI app repo and need framework-upgrade guidance for upgrading our
       team from one MAUI
       release to the next. We pin the SDK in global.json and install workloads in
       CI. What should the upgrade notes capture for app developers and build
@@ -48,7 +48,7 @@ scenarios:
 
   - name: "Keep framework upgrade notes separate from store changelog"
     prompt: |
-      In maui-release-notes scope, a teammate mixed our shopping app's App Store
+      In framework-upgrade planning scope, a teammate mixed our shopping app's App Store
       release notes into a draft
       about upgrading the app to a new .NET MAUI release. How should I separate
       framework upgrade notes from customer-facing app release notes?

--- a/tests/dotnet-maui/xamarin-forms-migration/eval.yaml
+++ b/tests/dotnet-maui/xamarin-forms-migration/eval.yaml
@@ -7,7 +7,7 @@ scenarios:
       MAUI.
     assertions:
       - type: "output_matches"
-        pattern: "DependencyService.*DI|DI.*DependencyService"
+        pattern: "DependencyService.*(DI|dependency injection)|(DI|dependency injection).*DependencyService"
       - type: "output_matches"
         pattern: "MessagingCenter.*WeakReferenceMessenger|WeakReferenceMessenger.*MessagingCenter|event aggregator|IObservable"
       - type: "output_matches"

--- a/tests/dotnet-maui/xamarin-forms-migration/eval.yaml
+++ b/tests/dotnet-maui/xamarin-forms-migration/eval.yaml
@@ -1,0 +1,64 @@
+scenarios:
+  - name: "Audit migration blockers before porting"
+    prompt: |
+      I inherited a Xamarin.Forms 5 app with DependencyService calls,
+      MessagingCenter messages, three custom renderers, and platform projects for
+      Android and iOS. I need an audit plan before we start moving code to .NET
+      MAUI.
+    assertions:
+      - type: "output_matches"
+        pattern: "DependencyService.*DI|DI.*DependencyService"
+      - type: "output_matches"
+        pattern: "MessagingCenter.*WeakReferenceMessenger|WeakReferenceMessenger.*MessagingCenter|event aggregator|IObservable"
+      - type: "output_matches"
+        pattern: "renderer|handler|PropertyMapper|ViewHandler"
+      - type: "output_matches"
+        pattern: "permissions|Info\\.plist|AndroidManifest|capabilit"
+    rubric:
+      - "Starts with a migration audit of packages, platform projects, renderers, DependencyService, MessagingCenter, permissions, and capabilities"
+      - "Plans DependencyService replacement through DI registration and constructor injection"
+      - "Plans MessagingCenter replacement with WeakReferenceMessenger, events, observable state, or explicit services"
+      - "Classifies custom renderers before choosing mapper customization or custom handlers"
+    timeout: 240
+
+  - name: "Move Xamarin.Forms app into a new MAUI project"
+    prompt: |
+      We are moving a Xamarin.Forms app to .NET MAUI and want to avoid dragging
+      old project file cruft forward. What new-project migration workflow should
+      we use, and what namespaces/APIs should we update while copying code?
+    assertions:
+      - type: "output_matches"
+        pattern: "new .NET MAUI project|new MAUI project|dotnet new maui"
+      - type: "output_contains"
+        value: "MauiProgram.cs"
+      - type: "output_contains"
+        value: "Microsoft.Maui.Controls"
+      - type: "output_matches"
+        pattern: "Microsoft\\.Maui\\.(ApplicationModel|Devices|Storage)"
+    rubric:
+      - "Recommends starting from a fresh MAUI project/solution rather than in-place project file edits"
+      - "Moves shared code/resources first and platform code later"
+      - "Replaces Xamarin.Forms and Xamarin.Essentials namespaces with MAUI namespaces"
+      - "Mentions MAUI startup through MauiProgram.cs and DI"
+    timeout: 240
+
+  - name: "Choose handlers, platform services, or slim bindings"
+    prompt: |
+      During migration we found a renderer that only removes an Entry underline,
+      another renderer that wraps a custom camera preview, and an iOS/Android
+      native payment SDK used by platform services. How should we split the work?
+    assertions:
+      - type: "output_matches"
+        pattern: "AppendToMapping|PropertyMapper"
+      - type: "output_matches"
+        pattern: "ViewHandler|custom handler|handler"
+      - type: "output_matches"
+        pattern: "DependencyInjection|AddSingleton|AddTransient|I[A-Za-z]+Service"
+      - type: "output_matches"
+        pattern: "slim binding|android-slim-bindings|ios-slim-bindings"
+    rubric:
+      - "Maps the simple Entry native property tweak to a scoped handler mapper customization"
+      - "Maps the camera preview visual surface to a custom handler"
+      - "Maps non-visual platform operations to DI platform services"
+      - "Routes the native payment SDK to slim bindings when the app needs a maintainable SDK surface"
+    timeout: 240

--- a/tests/dotnet-maui/xamarin-forms-migration/eval.yaml
+++ b/tests/dotnet-maui/xamarin-forms-migration/eval.yaml
@@ -1,7 +1,8 @@
 scenarios:
   - name: "Audit migration blockers before porting"
     prompt: |
-      I inherited a Xamarin.Forms 5 app with DependencyService calls,
+      I need a Xamarin.Forms migration audit before porting to .NET MAUI. I
+      inherited a Xamarin.Forms 5 app with DependencyService calls,
       MessagingCenter messages, three custom renderers, and platform projects for
       Android and iOS. I need an audit plan before we start moving code to .NET
       MAUI.
@@ -23,7 +24,8 @@ scenarios:
 
   - name: "Move Xamarin.Forms app into a new MAUI project"
     prompt: |
-      We are moving a Xamarin.Forms app to .NET MAUI and want to avoid dragging
+      We are doing a fresh-project Xamarin.Forms to .NET MAUI migration and want
+      to avoid dragging
       old project file cruft forward. What new-project migration workflow should
       we use, and what namespaces/APIs should we update while copying code?
     assertions:
@@ -44,7 +46,8 @@ scenarios:
 
   - name: "Choose handlers, platform services, or slim bindings"
     prompt: |
-      During migration we found a renderer that only removes an Entry underline,
+      During Xamarin.Forms migration we are doing renderer-to-handler triage. We
+      found a renderer that only removes an Entry underline,
       another renderer that wraps a custom camera preview, and an iOS/Android
       native payment SDK used by platform services. How should we split the work?
     assertions:


### PR DESCRIPTION
## Summary

Adds Phase 3 .NET MAUI app-building skills for advanced controls, migration, handlers, platform invoke, MAUI Labs platform targeting, on-device AI, AI tool bindings, and maintainer release notes.

Adds paired eval coverage for each new skill and updates the dotnet-maui plugin metadata to version 0.5.0.

## Stack

Stacked on Phase 2 PR #321 / `jfversluis/phase-2-maui-app-skills` after commit `0f3d05ff`.

## Validation

- `skill-validator check --plugin plugins/dotnet-maui --allowed-external-deps eng/allowed-external-deps.txt`
- YAML parse for all new eval files
- `git diff --cached --check`
- Multi-perspective persona review: enterprise app developer, indie app developer, migration consultant, accessibility/performance specialist, MAUI platform/runtime maintainer
- Separate eval-quality review with a different model

## Notes

Substantive review feedback was addressed before opening this PR. Remaining risk is normal preview churn for experimental MAUI Labs platform and AI packages.
