### PR TITLE
Enable major roll-forward for the MAUI CLI tool

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -21,6 +21,11 @@
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <!-- Let the latest packaged tool TFM run on newer major runtimes. -->
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />


### PR DESCRIPTION
## Summary
- enable `RollForward=Major` for the packaged MAUI CLI tool on its latest supported TFM (`net10.0`)

## Why
- Enabling roll forward allows the tool to run on .NET 11 preview builds when no matching runtime is available, whether that is because the local installation only has preview builds or because the targeted runtime is not installed on the machine at all.
- Microsoft documents this guidance in [Whats new in the SDK and tooling for .NET 9 - .NET tool roll-forward](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/sdk#net-tool-roll-forward), which calls out that tool authors can opt in by setting the `RollForward` MSBuild property.
- Even though `dotnet tool install` and `dotnet tool run` now let users override this with `--allow-roll-forward`, it is still much easier to support it in the tool itself. Users would have to know that the option exists and how to use it correctly, and the default failure mode does not make that discoverable.
