### PR TITLE
Update .NET SDK to 10.0.109

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -134,10 +134,7 @@ extends:
                     /p:TeamName=$(_TeamName)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
-            - task: UseDotNet@2
-              displayName: Install .NET SDK
-              inputs:
-                version: 10.0.105
+            - template: /eng/pipelines/install-dotnet-sdk.yml@self
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
@@ -158,10 +155,7 @@ extends:
                     /p:TeamName=$(_TeamName)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
-            - task: UseDotNet@2
-              displayName: Install .NET SDK
-              inputs:
-                version: 10.0.105
+            - template: /eng/pipelines/install-dotnet-sdk.yml@self
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
@@ -182,10 +176,7 @@ extends:
                     /p:TeamName=$(_TeamName)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
-            - task: UseDotNet@2
-              displayName: Install .NET SDK
-              inputs:
-                version: 10.0.105
+            - template: /eng/pipelines/install-dotnet-sdk.yml@self
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
@@ -210,10 +201,7 @@ extends:
                     /p:TeamName=$(_TeamName)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
-            - task: UseDotNet@2
-              displayName: Install .NET SDK
-              inputs:
-                version: 10.0.105
+            - template: /eng/pipelines/install-dotnet-sdk.yml@self
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
@@ -311,10 +299,7 @@ extends:
                 Release:
                   _BuildConfig: Release
             steps:
-            - task: UseDotNet@2
-              displayName: Install .NET SDK
-              inputs:
-                version: 10.0.105
+            - template: /eng/pipelines/install-dotnet-sdk.yml@self
             - script: |
                 sudo apt-get update
                 sudo apt-get install -y \

--- a/eng/pipelines/install-dotnet-sdk.yml
+++ b/eng/pipelines/install-dotnet-sdk.yml
@@ -14,4 +14,5 @@ steps:
 - task: UseDotNet@2
   displayName: Install .NET SDK
   inputs:
+    packageType: sdk
     version: $(DotNetSdkVersion)

--- a/eng/pipelines/install-dotnet-sdk.yml
+++ b/eng/pipelines/install-dotnet-sdk.yml
@@ -1,0 +1,17 @@
+steps:
+- pwsh: |
+    $globalJsonPath = Join-Path '$(Build.SourcesDirectory)' 'global.json'
+    $sdkVersion = (Get-Content $globalJsonPath -Raw | ConvertFrom-Json).sdk.version
+
+    if ([string]::IsNullOrWhiteSpace($sdkVersion)) {
+      throw "Unable to read the .NET SDK version from $globalJsonPath."
+    }
+
+    Write-Host "Using .NET SDK $sdkVersion from $globalJsonPath."
+    Write-Host "##vso[task.setvariable variable=DotNetSdkVersion]$sdkVersion"
+  displayName: Read .NET SDK version
+
+- task: UseDotNet@2
+  displayName: Install .NET SDK
+  inputs:
+    version: $(DotNetSdkVersion)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.108",
+    "version": "10.0.109",
     "paths": [
       ".dotnet",
       "$host$"
@@ -9,7 +9,7 @@
     "allowPrerelease": false
   },
   "tools": {
-    "dotnet": "10.0.108"
+    "dotnet": "10.0.109"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26302.116"


### PR DESCRIPTION
Updates the repo-root `global.json` SDK and tool versions to `10.0.109` so builds use the updated .NET 10 runtime/component set.

Also adds Dependabot monitoring for the repo-root .NET SDK and changes the Azure DevOps `UseDotNet@2` jobs to read the SDK version from the repo-root `global.json`, avoiding drift from future SDK bumps without enabling broad `useGlobalJson` search behavior.