### PR TITLE
Fix API 37 system image parsing in Android provider

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -186,16 +186,8 @@ public class AndroidProviderTests
 		var provider = new FakeAndroidProvider
 		{
 			InstalledPackages = packages,
-			GetMostRecentSystemImageFunc = async ct =>
-			{
-				var pkgs = packages;
-				return pkgs
-					.Where(p => p.Path.StartsWith("system-images;android-", StringComparison.OrdinalIgnoreCase))
-					.Select(p => new { Package = p, ApiLevel = AndroidProvider.ExtractApiLevel(p.Path) })
-					.Where(x => x.ApiLevel > 0)
-					.OrderByDescending(x => x.ApiLevel)
-					.FirstOrDefault()?.Package.Path;
-			}
+			GetMostRecentSystemImageFunc = ct =>
+				Task.FromResult(AndroidProvider.FindMostRecentSystemImage(packages))
 		};
 
 		// Act
@@ -209,13 +201,9 @@ public class AndroidProviderTests
 	public async Task GetMostRecentSystemImageAsync_HandlesMinorRevisionSuffix()
 	{
 		// API 37 ships as "android-37.0" (with a minor revision suffix). Regression test
-		// ensuring such images are not silently dropped by API-level parsing.
-		//
-		// SdkManager is not mockable, so this mirrors the production filter from
-		// AndroidProvider.GetMostRecentSystemImageAsync while calling the real
-		// AndroidProvider.ExtractApiLevel. It is therefore an ExtractApiLevel integration
-		// test for the most-recent-image flow; ExtractApiLevel_ParsesApiLevel below covers
-		// the parser directly. Keep the filter here in sync with the production method.
+		// ensuring such images are not silently dropped by API-level parsing. Calls the real
+		// production selector (AndroidProvider.FindMostRecentSystemImage) so filter and sort
+		// logic stay covered.
 		var packages = new List<SdkPackage>
 		{
 			new SdkPackage { Path = "system-images;android-35;google_apis;arm64-v8a" },
@@ -226,12 +214,8 @@ public class AndroidProviderTests
 		var provider = new FakeAndroidProvider
 		{
 			InstalledPackages = packages,
-			GetMostRecentSystemImageFunc = ct => Task.FromResult(packages
-				.Where(p => p.Path.StartsWith("system-images;android-", StringComparison.OrdinalIgnoreCase))
-				.Select(p => new { Package = p, ApiLevel = AndroidProvider.ExtractApiLevel(p.Path) })
-				.Where(x => x.ApiLevel > 0)
-				.OrderByDescending(x => x.ApiLevel)
-				.FirstOrDefault()?.Package.Path)
+			GetMostRecentSystemImageFunc = ct =>
+				Task.FromResult(AndroidProvider.FindMostRecentSystemImage(packages))
 		};
 
 		// Act
@@ -241,16 +225,37 @@ public class AndroidProviderTests
 		Assert.Equal("system-images;android-37.0;google_apis_ps16k;arm64-v8a", result);
 	}
 
-	[Theory]
-	[InlineData("system-images;android-35;google_apis;arm64-v8a", 35)]
-	[InlineData("system-images;android-37.0;google_apis_ps16k;arm64-v8a", 37)]
-	[InlineData("system-images;android-37.0;google_apis_playstore_ps16k;x86_64", 37)]
-	[InlineData("platform-tools", 0)]
-	[InlineData("build-tools;34.0.0", 0)]
-	[InlineData("system-images;android-VanillaIceCream;google_apis;arm64-v8a", 0)]
-	public void ExtractApiLevel_ParsesApiLevel(string systemImagePath, int expected)
+	[Fact]
+	public void FindMostRecentSystemImage_PrefersHigherMinorRevision()
 	{
-		Assert.Equal(expected, AndroidProvider.ExtractApiLevel(systemImagePath));
+		// Two minor revisions of the same major API level can coexist. The newer revision
+		// must win regardless of input order — guards against a stable OrderByDescending
+		// leaving the older "37.0" ahead of "37.1" when both parse to the same major.
+		var packages = new List<SdkPackage>
+		{
+			new SdkPackage { Path = "system-images;android-37.0;google_apis_ps16k;arm64-v8a" },
+			new SdkPackage { Path = "system-images;android-37.1;google_apis_ps16k;arm64-v8a" },
+			new SdkPackage { Path = "system-images;android-36.1;google_apis;arm64-v8a" }
+		};
+
+		// Act
+		var result = AndroidProvider.FindMostRecentSystemImage(packages);
+
+		// Assert
+		Assert.Equal("system-images;android-37.1;google_apis_ps16k;arm64-v8a", result);
+	}
+
+	[Theory]
+	[InlineData("system-images;android-35;google_apis;arm64-v8a", "35.0")]
+	[InlineData("system-images;android-37.0;google_apis_ps16k;arm64-v8a", "37.0")]
+	[InlineData("system-images;android-37.0;google_apis_playstore_ps16k;x86_64", "37.0")]
+	[InlineData("system-images;android-37.1;google_apis_ps16k;arm64-v8a", "37.1")]
+	[InlineData("platform-tools", "0.0")]
+	[InlineData("build-tools;34.0.0", "0.0")]
+	[InlineData("system-images;android-VanillaIceCream;google_apis;arm64-v8a", "0.0")]
+	public void ExtractApiLevel_ParsesApiLevel(string systemImagePath, string expected)
+	{
+		Assert.Equal(Version.Parse(expected), AndroidProvider.ExtractApiLevel(systemImagePath));
 	}
 
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -210,6 +210,12 @@ public class AndroidProviderTests
 	{
 		// API 37 ships as "android-37.0" (with a minor revision suffix). Regression test
 		// ensuring such images are not silently dropped by API-level parsing.
+		//
+		// SdkManager is not mockable, so this mirrors the production filter from
+		// AndroidProvider.GetMostRecentSystemImageAsync while calling the real
+		// AndroidProvider.ExtractApiLevel. It is therefore an ExtractApiLevel integration
+		// test for the most-recent-image flow; ExtractApiLevel_ParsesApiLevel below covers
+		// the parser directly. Keep the filter here in sync with the production method.
 		var packages = new List<SdkPackage>
 		{
 			new SdkPackage { Path = "system-images;android-35;google_apis;arm64-v8a" },

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -245,6 +245,12 @@ public class AndroidProviderTests
 		Assert.Equal("system-images;android-37.1;google_apis_ps16k;arm64-v8a", result);
 	}
 
+	[Fact]
+	public void FindMostRecentSystemImage_Throws_WhenPackagesNull()
+	{
+		Assert.Throws<ArgumentNullException>(() => AndroidProvider.FindMostRecentSystemImage(null!));
+	}
+
 	[Theory]
 	[InlineData("system-images;android-35;google_apis;arm64-v8a", "35.0")]
 	[InlineData("system-images;android-37.0;google_apis_ps16k;arm64-v8a", "37.0")]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -191,7 +191,7 @@ public class AndroidProviderTests
 				var pkgs = packages;
 				return pkgs
 					.Where(p => p.Path.StartsWith("system-images;android-", StringComparison.OrdinalIgnoreCase))
-					.Select(p => new { Package = p, ApiLevel = ExtractApiLevel(p.Path) })
+					.Select(p => new { Package = p, ApiLevel = AndroidProvider.ExtractApiLevel(p.Path) })
 					.Where(x => x.ApiLevel > 0)
 					.OrderByDescending(x => x.ApiLevel)
 					.FirstOrDefault()?.Package.Path;
@@ -203,6 +203,48 @@ public class AndroidProviderTests
 
 		// Assert
 		Assert.Equal("system-images;android-35;google_apis;arm64-v8a", result);
+	}
+
+	[Fact]
+	public async Task GetMostRecentSystemImageAsync_HandlesMinorRevisionSuffix()
+	{
+		// API 37 ships as "android-37.0" (with a minor revision suffix). Regression test
+		// ensuring such images are not silently dropped by API-level parsing.
+		var packages = new List<SdkPackage>
+		{
+			new SdkPackage { Path = "system-images;android-35;google_apis;arm64-v8a" },
+			new SdkPackage { Path = "system-images;android-37.0;google_apis_ps16k;arm64-v8a" },
+			new SdkPackage { Path = "system-images;android-36;google_apis;arm64-v8a" }
+		};
+
+		var provider = new FakeAndroidProvider
+		{
+			InstalledPackages = packages,
+			GetMostRecentSystemImageFunc = ct => Task.FromResult(packages
+				.Where(p => p.Path.StartsWith("system-images;android-", StringComparison.OrdinalIgnoreCase))
+				.Select(p => new { Package = p, ApiLevel = AndroidProvider.ExtractApiLevel(p.Path) })
+				.Where(x => x.ApiLevel > 0)
+				.OrderByDescending(x => x.ApiLevel)
+				.FirstOrDefault()?.Package.Path)
+		};
+
+		// Act
+		var result = await provider.GetMostRecentSystemImageAsync();
+
+		// Assert
+		Assert.Equal("system-images;android-37.0;google_apis_ps16k;arm64-v8a", result);
+	}
+
+	[Theory]
+	[InlineData("system-images;android-35;google_apis;arm64-v8a", 35)]
+	[InlineData("system-images;android-37.0;google_apis_ps16k;arm64-v8a", 37)]
+	[InlineData("system-images;android-37.0;google_apis_playstore_ps16k;x86_64", 37)]
+	[InlineData("platform-tools", 0)]
+	[InlineData("build-tools;34.0.0", 0)]
+	[InlineData("system-images;android-VanillaIceCream;google_apis;arm64-v8a", 0)]
+	public void ExtractApiLevel_ParsesApiLevel(string systemImagePath, int expected)
+	{
+		Assert.Equal(expected, AndroidProvider.ExtractApiLevel(systemImagePath));
 	}
 
 	[Fact]
@@ -436,23 +478,6 @@ public class AndroidProviderTests
 		Assert.Equal(4, allPackages.Count);
 		Assert.Equal(2, allPackages.Count(p => p.IsInstalled));
 		Assert.Equal(2, allPackages.Count(p => !p.IsInstalled));
-	}
-
-	// Helper method to extract API level from system image path
-	private static int ExtractApiLevel(string systemImagePath)
-	{
-		var parts = systemImagePath.Split(';');
-		if (parts.Length >= 2)
-		{
-			var androidPart = parts[1];
-			if (androidPart.StartsWith("android-", StringComparison.OrdinalIgnoreCase))
-			{
-				var levelStr = androidPart.Substring(8);
-				if (int.TryParse(levelStr, out var level))
-					return level;
-			}
-		}
-		return 0;
 	}
 }
 

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -286,22 +286,24 @@ public class AndroidProvider : IAndroidProvider
 	public async Task<string?> GetMostRecentSystemImageAsync(CancellationToken cancellationToken = default)
 	{
 		var packages = await GetInstalledPackagesAsync(cancellationToken);
-
-		// Filter to system images and sort by Android API level (descending)
-		// System image format: system-images;android-XX;google_apis;arm64-v8a
-		var systemImages = packages
-			.Where(p => p.Path.StartsWith("system-images;android-", StringComparison.OrdinalIgnoreCase))
-			.Select(p => new { Package = p, ApiLevel = ExtractApiLevel(p.Path) })
-			.Where(x => x.ApiLevel > 0)
-			.OrderByDescending(x => x.ApiLevel)
-			.ToList();
-
-		return systemImages.FirstOrDefault()?.Package.Path;
+		return FindMostRecentSystemImage(packages);
 	}
 
-	internal static int ExtractApiLevel(string systemImagePath)
+	// Selects the installed system image with the highest Android API level.
+	// System image format: system-images;android-XX;google_apis;arm64-v8a
+	internal static string? FindMostRecentSystemImage(IEnumerable<SdkPackage> packages)
 	{
-		// Parse "system-images;android-35;google_apis;arm64-v8a" -> 35
+		return packages
+			.Where(p => p.Path.StartsWith("system-images;android-", StringComparison.OrdinalIgnoreCase))
+			.Select(p => new { Package = p, ApiLevel = ExtractApiLevel(p.Path) })
+			.Where(x => x.ApiLevel > new Version(0, 0))
+			.OrderByDescending(x => x.ApiLevel)
+			.FirstOrDefault()?.Package.Path;
+	}
+
+	internal static Version ExtractApiLevel(string systemImagePath)
+	{
+		// Parse "system-images;android-35;google_apis;arm64-v8a" -> 35.0
 		var parts = systemImagePath.Split(';');
 		if (parts.Length >= 2)
 		{
@@ -310,21 +312,18 @@ public class AndroidProvider : IAndroidProvider
 			{
 				var levelStr = androidPart.Substring(8); // Remove "android-"
 
-				// Some platforms carry a minor revision suffix (e.g. "android-37.0");
-				// compare on the major component so the image isn't silently dropped.
-				// Two coexisting minor revisions (e.g. "37.0" and "37.1") both map to 37,
-				// so their relative ordering is input-order-dependent. Only ".0" has been
-				// observed in practice; if finer-grained ordering is ever required, switch
-				// to Version.TryParse on the full "major.minor" component.
-				var dotIndex = levelStr.IndexOf('.');
-				if (dotIndex >= 0)
-					levelStr = levelStr.Substring(0, dotIndex);
-
-				if (int.TryParse(levelStr, out var level))
-					return level;
+				// Platforms may carry a minor revision suffix (e.g. "android-37.0"); keep it
+				// so newer revisions sort ahead of older ones (37.1 > 37.0) rather than being
+				// silently dropped. Mirrors the parse ladder in AndroidCommands.Sdk.cs:
+				// "37.0" -> 37.0, plain "35" -> 35.0, and non-numeric codenames
+				// (e.g. "android-VanillaIceCream") -> 0.0 so they're excluded from auto-detect.
+				if (Version.TryParse(levelStr, out var version))
+					return version;
+				if (int.TryParse(levelStr, out var major))
+					return new Version(major, 0);
 			}
 		}
-		return 0;
+		return new Version(0, 0);
 	}
 
 	public async Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses = false,

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -312,6 +312,10 @@ public class AndroidProvider : IAndroidProvider
 
 				// Some platforms carry a minor revision suffix (e.g. "android-37.0");
 				// compare on the major component so the image isn't silently dropped.
+				// Two coexisting minor revisions (e.g. "37.0" and "37.1") both map to 37,
+				// so their relative ordering is input-order-dependent. Only ".0" has been
+				// observed in practice; if finer-grained ordering is ever required, switch
+				// to Version.TryParse on the full "major.minor" component.
 				var dotIndex = levelStr.IndexOf('.');
 				if (dotIndex >= 0)
 					levelStr = levelStr.Substring(0, dotIndex);

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -299,16 +299,23 @@ public class AndroidProvider : IAndroidProvider
 		return systemImages.FirstOrDefault()?.Package.Path;
 	}
 
-	static int ExtractApiLevel(string systemImagePath)
+	internal static int ExtractApiLevel(string systemImagePath)
 	{
 		// Parse "system-images;android-35;google_apis;arm64-v8a" -> 35
 		var parts = systemImagePath.Split(';');
 		if (parts.Length >= 2)
 		{
-			var androidPart = parts[1]; // "android-35"
+			var androidPart = parts[1]; // "android-35" or "android-37.0"
 			if (androidPart.StartsWith("android-", StringComparison.OrdinalIgnoreCase))
 			{
 				var levelStr = androidPart.Substring(8); // Remove "android-"
+
+				// Some platforms carry a minor revision suffix (e.g. "android-37.0");
+				// compare on the major component so the image isn't silently dropped.
+				var dotIndex = levelStr.IndexOf('.');
+				if (dotIndex >= 0)
+					levelStr = levelStr.Substring(0, dotIndex);
+
 				if (int.TryParse(levelStr, out var level))
 					return level;
 			}

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -32,6 +32,10 @@ public class AndroidProvider : IAndroidProvider
 	internal static string DefaultSystemImagePackage =>
 		$"system-images;android-{DefaultAndroidApiLevel};google_apis;{(PlatformDetector.IsArm64 ? "arm64-v8a" : "x86_64")}";
 
+	// Sentinel returned by ExtractApiLevel for non-numeric ids (e.g. codenames); such
+	// images are excluded from auto-detect. Hoisted to avoid a per-element allocation.
+	static readonly Version NoApiLevel = new(0, 0);
+
 	public string? SdkPath => _sdkPath ??= PlatformDetector.Paths.GetAndroidSdkPath();
 	public string? JdkPath => _jdkPath ??= _jdkManager.DetectedJdkPath ?? PlatformDetector.Paths.GetJdkPath();
 
@@ -293,10 +297,12 @@ public class AndroidProvider : IAndroidProvider
 	// System image format: system-images;android-XX;google_apis;arm64-v8a
 	internal static string? FindMostRecentSystemImage(IEnumerable<SdkPackage> packages)
 	{
+		ArgumentNullException.ThrowIfNull(packages);
+
 		return packages
 			.Where(p => p.Path.StartsWith("system-images;android-", StringComparison.OrdinalIgnoreCase))
 			.Select(p => new { Package = p, ApiLevel = ExtractApiLevel(p.Path) })
-			.Where(x => x.ApiLevel > new Version(0, 0))
+			.Where(x => x.ApiLevel > NoApiLevel)
 			.OrderByDescending(x => x.ApiLevel)
 			.FirstOrDefault()?.Package.Path;
 	}
@@ -310,7 +316,7 @@ public class AndroidProvider : IAndroidProvider
 			var androidPart = parts[1]; // "android-35" or "android-37.0"
 			if (androidPart.StartsWith("android-", StringComparison.OrdinalIgnoreCase))
 			{
-				var levelStr = androidPart.Substring(8); // Remove "android-"
+				var levelStr = androidPart.Substring("android-".Length);
 
 				// Platforms may carry a minor revision suffix (e.g. "android-37.0"); keep it
 				// so newer revisions sort ahead of older ones (37.1 > 37.0) rather than being
@@ -323,7 +329,7 @@ public class AndroidProvider : IAndroidProvider
 					return new Version(major, 0);
 			}
 		}
-		return new Version(0, 0);
+		return NoApiLevel;
 	}
 
 	public async Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses = false,


### PR DESCRIPTION
## Summary

Fixes a latent bug in the `maui` CLI Android provider where **API 37+ system images are silently dropped** from emulator auto-detection.

## Root cause

Android API 37 publishes its platform and system images with a **minor-revision suffix** in the package id (verified via `sdkmanager --list`):

- `platforms;android-37.0`
- `system-images;android-37.0;google_apis_ps16k;arm64-v8a`

All prior API levels used a plain integer (e.g. `android-35`). `AndroidProvider.ExtractApiLevel` parsed the level with `int.TryParse("37.0")`, which **fails and returns 0**. `GetMostRecentSystemImageAsync` then filters `.Where(x => x.ApiLevel > 0)`, so an installed API‑37 image (and also `android-36.1`) is silently dropped and never picked.

**Scope:** the bug only manifests in **emulator auto-detect** (`AndroidCommands.Emulator.cs` → `GetMostRecentSystemImageAsync`, used when no `--package` is supplied). Explicit `install --packages "...android-37.0..."` and an explicit `emulator create --package` are unaffected — those ids pass straight to `sdkmanager` and no API-level parsing happens. That's why the released CLI works for explicit installs.

## The fix

- `ExtractApiLevel` now returns a `System.Version` instead of an `int`, reusing the exact `Version.TryParse` → `int.TryParse` → `Version(0,0)` parse ladder already used in `AndroidCommands.Sdk.cs` (and mirrored in `AppleProvider.cs`):
  - `android-37.0` → `37.0`
  - `android-35` → `35.0`
  - codenames like `android-VanillaIceCream` → `0.0` (excluded from auto-detect, as before)
- The system-image filter+sort is extracted into a single `internal static FindMostRecentSystemImage(...)` (single source of truth), called by `GetMostRecentSystemImageAsync`.
- Made testable via the existing `InternalsVisibleTo` for `Microsoft.Maui.Cli.UnitTests`.

## Cross-model review follow-up

A two-model code review (GPT‑5.5 + Gemini 3.1 Pro) plus the earlier Expert Review converged on a real ordering defect: collapsing the minor revision to the major level let LINQ's **stable** `OrderByDescending` return the *older* image when two minor revisions of the same API coexist (e.g. `37.0` chosen over `37.1`, since both keyed to `37` and `sdkmanager` lists `37.0` first). Returning a full `Version` fixes this so `37.1` correctly sorts ahead of `37.0`. The same refactor lets the unit tests call the **real** production selector instead of a duplicated LINQ mirror.

## Tests

`dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/ --filter "FullyQualifiedName~AndroidProvider"` → **32 passed**.

- `ExtractApiLevel_ParsesApiLevel` `[Theory]` — `android-35`→`35.0`, `android-37.0` (both `google_apis_ps16k` / `google_apis_playstore_ps16k`)→`37.0`, `android-37.1`→`37.1`, `platform-tools`→`0.0`, `build-tools;34.0.0`→`0.0`, `android-VanillaIceCream`→`0.0`.
- `GetMostRecentSystemImageAsync_HandlesMinorRevisionSuffix` `[Fact]` — given `android-35`, `android-37.0`, `android-36`, returns `android-37.0`.
- `FindMostRecentSystemImage_PrefersHigherMinorRevision` `[Fact]` — given coexisting `37.0`, `37.1`, `36.1`, returns `37.1` regardless of input order.

## Manual verification (real SDK, macOS)

- **Before (released `maui`):** emulator auto-detect wrongly selected `android-35` with `35`, `36.1`, `37.0` installed — both `36.1` and `37.0` dropped. Bug reproduced.
- **After (this branch):** auto-detect correctly selected `android-37.0`.
- Explicit `android-35` create still works.

## Out of scope

The interactive `android install` flow in `AndroidCommands.cs` has a separate, pre-existing mishandling of `android-37.0` (invalid `build-tools;37.0.0.0`, hardcoded `google_apis`). Tracked in #338 — not addressed here.

---
🤖 Draft — do not merge.