### PR TITLE
Stream live progress for `maui android install` package downloads

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
@@ -135,6 +135,18 @@ public class FakeAndroidProvider : IAndroidProvider
 		return Task.CompletedTask;
 	}
 
+	public Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses, Action<AndroidPackageInstallProgress>? onProgress, CancellationToken cancellationToken = default)
+	{
+		var pkgList = packages.ToList();
+		InstalledPackageSets.Add(pkgList);
+		if (onProgress is not null)
+		{
+			for (var i = 0; i < pkgList.Count; i++)
+				onProgress(new AndroidPackageInstallProgress(pkgList[i], i + 1, pkgList.Count, "Installing", 100));
+		}
+		return Task.CompletedTask;
+	}
+
 	public Task UninstallPackagesAsync(IEnumerable<string> packages, CancellationToken cancellationToken = default)
 	{
 		UninstalledPackageSets.Add(packages.ToList());

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/SdkManagerProgressParserTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/SdkManagerProgressParserTests.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Maui.Cli.Providers.Android;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="SdkManager.TryParseInstallProgressLine"/>, the pure parser that turns
+/// streamed <c>sdkmanager</c> stdout lines into (phase, percent) so the install progress bar
+/// reflects real download/extraction progress instead of appearing to hang.
+/// </summary>
+public class SdkManagerProgressParserTests
+{
+	[Fact]
+	public void TryParse_DownloadingLineWithPercent_ReturnsDownloadingAndPercent()
+	{
+		var ok = SdkManager.TryParseInstallProgressLine(
+			"[=========                    ] 33% Downloading system-image.zip",
+			out var phase, out var percent);
+
+		Assert.True(ok);
+		Assert.Equal("Downloading", phase);
+		Assert.Equal(33, percent);
+	}
+
+	[Fact]
+	public void TryParse_UnzippingLineWithPercent_ReturnsUnzippingAndPercent()
+	{
+		var ok = SdkManager.TryParseInstallProgressLine(
+			"[====================         ] 78% Unzipping... google_apis/arm64-v8a/system.img",
+			out var phase, out var percent);
+
+		Assert.True(ok);
+		Assert.Equal("Unzipping", phase);
+		Assert.Equal(78, percent);
+	}
+
+	[Fact]
+	public void TryParse_PercentWithoutSpaceBeforeSign_IsParsed()
+	{
+		var ok = SdkManager.TryParseInstallProgressLine("[=====] 5 % Downloading", out var phase, out var percent);
+
+		Assert.True(ok);
+		Assert.Equal("Downloading", phase);
+		Assert.Equal(5, percent);
+	}
+
+	[Fact]
+	public void TryParse_PercentWithUnknownTrailingText_ReturnsPercentWithEmptyPhase()
+	{
+		var ok = SdkManager.TryParseInstallProgressLine("[==========          ] 50%", out var phase, out var percent);
+
+		Assert.True(ok);
+		Assert.Equal(string.Empty, phase);
+		Assert.Equal(50, percent);
+	}
+
+	[Fact]
+	public void TryParse_PhaseOnlyLineWithoutPercent_ReturnsPhaseAndUnknownPercent()
+	{
+		var ok = SdkManager.TryParseInstallProgressLine("Downloading system-images;android-37.0 ...",
+			out var phase, out var percent);
+
+		Assert.True(ok);
+		Assert.Equal("Downloading", phase);
+		Assert.Equal(-1, percent);
+	}
+
+	[Fact]
+	public void TryParse_CarriageReturnInPlaceUpdates_UsesLastSegment()
+	{
+		// sdkmanager rewrites the bar in place using '\r'; the parser should read the latest state.
+		var ok = SdkManager.TryParseInstallProgressLine(
+			"[==        ] 10% Downloading\r[=====     ] 45% Downloading",
+			out var phase, out var percent);
+
+		Assert.True(ok);
+		Assert.Equal("Downloading", phase);
+		Assert.Equal(45, percent);
+	}
+
+	[Fact]
+	public void TryParse_PercentAboveOneHundred_IsClamped()
+	{
+		var ok = SdkManager.TryParseInstallProgressLine("[==========] 120% Unzipping", out var phase, out var percent);
+
+		Assert.True(ok);
+		Assert.Equal("Unzipping", phase);
+		Assert.Equal(100, percent);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("Warning: A newer version of the tools is available")]
+	[InlineData("Loading local repository...")]
+	[InlineData("[======================================] 100%")] // handled separately
+	public void TryParse_LinesWithNoProgress_ReturnFalseExceptBareBar(string? line)
+	{
+		var ok = SdkManager.TryParseInstallProgressLine(line, out var phase, out var percent);
+
+		if (line is not null && line.Contains('%'))
+		{
+			// A bare progress bar with a percentage is still progress, just without a named phase.
+			Assert.True(ok);
+			Assert.Equal(string.Empty, phase);
+			Assert.Equal(100, percent);
+		}
+		else
+		{
+			Assert.False(ok);
+			Assert.Equal(string.Empty, phase);
+			Assert.Equal(-1, percent);
+		}
+	}
+
+	[Fact]
+	public void TryParse_MalformedLine_ReturnsFalse()
+	{
+		var ok = SdkManager.TryParseInstallProgressLine("done.", out var phase, out var percent);
+
+		Assert.False(ok);
+		Assert.Equal(string.Empty, phase);
+		Assert.Equal(-1, percent);
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/SdkManagerProgressParserTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/SdkManagerProgressParserTests.cs
@@ -38,7 +38,7 @@ public class SdkManagerProgressParserTests
 	}
 
 	[Fact]
-	public void TryParse_PercentWithoutSpaceBeforeSign_IsParsed()
+	public void TryParse_PercentWithWhitespaceBeforeSign_IsParsed()
 	{
 		var ok = SdkManager.TryParseInstallProgressLine("[=====] 5 % Downloading", out var phase, out var percent);
 
@@ -97,30 +97,32 @@ public class SdkManagerProgressParserTests
 	[InlineData("   ")]
 	[InlineData("Warning: A newer version of the tools is available")]
 	[InlineData("Loading local repository...")]
-	[InlineData("[======================================] 100%")] // handled separately
-	public void TryParse_LinesWithNoProgress_ReturnFalseExceptBareBar(string? line)
+	[InlineData("done.")]
+	public void TryParse_LinesWithNoProgress_ReturnFalse(string? line)
 	{
 		var ok = SdkManager.TryParseInstallProgressLine(line, out var phase, out var percent);
 
-		if (line is not null && line.Contains('%'))
-		{
-			// A bare progress bar with a percentage is still progress, just without a named phase.
-			Assert.True(ok);
-			Assert.Equal(string.Empty, phase);
-			Assert.Equal(100, percent);
-		}
-		else
-		{
-			Assert.False(ok);
-			Assert.Equal(string.Empty, phase);
-			Assert.Equal(-1, percent);
-		}
+		Assert.False(ok);
+		Assert.Equal(string.Empty, phase);
+		Assert.Equal(-1, percent);
+	}
+
+	[Fact]
+	public void TryParse_BareProgressBarWithoutPhase_ReturnsPercentWithEmptyPhase()
+	{
+		// A bare progress bar with a percentage is still progress, just without a named phase.
+		var ok = SdkManager.TryParseInstallProgressLine(
+			"[======================================] 100%", out var phase, out var percent);
+
+		Assert.True(ok);
+		Assert.Equal(string.Empty, phase);
+		Assert.Equal(100, percent);
 	}
 
 	[Fact]
 	public void TryParse_MalformedLine_ReturnsFalse()
 	{
-		var ok = SdkManager.TryParseInstallProgressLine("done.", out var phase, out var percent);
+		var ok = SdkManager.TryParseInstallProgressLine("no progress here", out var phase, out var percent);
 
 		Assert.False(ok);
 		Assert.Equal(string.Empty, phase);

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -176,6 +176,11 @@ public static partial class AndroidCommands
 					{
 						var pkgTask = ctx.AddTask($"Installing packages (0/{pkgList.Count})");
 						pkgTask.Update(0, $"Installing packages (0/{pkgList.Count})...");
+
+						// Phase transitions reset the per-package percent (e.g. Downloading 100% →
+						// Unzipping 0%), which would make the overall bar jump backwards. Clamp it to a
+						// high-water mark so the bar only ever moves forward.
+						var highWater = 0.0;
 						await androidProvider.InstallPackagesAsync(pkgList, acceptLicenses,
 							onProgress: (AndroidPackageInstallProgress p) =>
 							{
@@ -184,6 +189,7 @@ public static partial class AndroidCommands
 								var completed = p.PackageIndex - 1;
 								var within = p.Percent >= 0 ? p.Percent / 100.0 : 0;
 								var overall = (completed + within) / p.PackageTotal * 100;
+								highWater = Math.Max(highWater, overall);
 
 								var label = string.IsNullOrEmpty(p.Phase)
 									? $"Installing {p.Package} ({p.PackageIndex}/{p.PackageTotal})"
@@ -191,7 +197,7 @@ public static partial class AndroidCommands
 										? $"{p.Phase} {p.Package} ({p.PackageIndex}/{p.PackageTotal}) — {p.Percent}%"
 										: $"{p.Phase} {p.Package} ({p.PackageIndex}/{p.PackageTotal})";
 
-								pkgTask.Update(overall, label);
+								pkgTask.Update(highWater, label);
 							},
 							cancellationToken);
 						pkgTask.Complete($"{pkgList.Count} packages installed");

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Install.cs
@@ -177,10 +177,21 @@ public static partial class AndroidCommands
 						var pkgTask = ctx.AddTask($"Installing packages (0/{pkgList.Count})");
 						pkgTask.Update(0, $"Installing packages (0/{pkgList.Count})...");
 						await androidProvider.InstallPackagesAsync(pkgList, acceptLicenses,
-							onProgress: (pkg, idx, total) =>
+							onProgress: (AndroidPackageInstallProgress p) =>
 							{
-								var pct = (double)idx / total * 100;
-								pkgTask.Update(pct, $"Installing {pkg} ({idx}/{total})");
+								// Map per-package phase/percent onto the overall bar so large
+								// downloads/extractions show real movement instead of sitting at 100%.
+								var completed = p.PackageIndex - 1;
+								var within = p.Percent >= 0 ? p.Percent / 100.0 : 0;
+								var overall = (completed + within) / p.PackageTotal * 100;
+
+								var label = string.IsNullOrEmpty(p.Phase)
+									? $"Installing {p.Package} ({p.PackageIndex}/{p.PackageTotal})"
+									: p.Percent >= 0
+										? $"{p.Phase} {p.Package} ({p.PackageIndex}/{p.PackageTotal}) — {p.Percent}%"
+										: $"{p.Phase} {p.Package} ({p.PackageIndex}/{p.PackageTotal})";
+
+								pkgTask.Update(overall, label);
 							},
 							cancellationToken);
 						pkgTask.Complete($"{pkgList.Count} packages installed");

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -328,6 +328,12 @@ public class AndroidProvider : IAndroidProvider
 		await _sdkManager.InstallPackagesAsync(packages, acceptLicenses, onProgress, cancellationToken);
 	}
 
+	public async Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses,
+		Action<AndroidPackageInstallProgress>? onProgress, CancellationToken cancellationToken = default)
+	{
+		await _sdkManager.InstallPackagesAsync(packages, acceptLicenses, onProgress, cancellationToken);
+	}
+
 	public async Task UninstallPackagesAsync(IEnumerable<string> packages, CancellationToken cancellationToken = default)
 	{
 		await _sdkManager.UninstallPackagesAsync(packages, cancellationToken);

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
@@ -97,6 +97,12 @@ public interface IAndroidProvider : IDisposable
 	Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses, Action<string, int, int>? onProgress, CancellationToken cancellationToken = default);
 
 	/// <summary>
+	/// Installs SDK packages with live per-package progress (phase + percent) streamed from
+	/// <c>sdkmanager</c> so large downloads/extractions surface real progress instead of appearing to hang.
+	/// </summary>
+	Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses, Action<AndroidPackageInstallProgress>? onProgress, CancellationToken cancellationToken = default);
+
+	/// <summary>
 	/// Uninstalls SDK packages.
 	/// </summary>
 	Task UninstallPackagesAsync(IEnumerable<string> packages, CancellationToken cancellationToken = default);
@@ -191,3 +197,19 @@ public record SdkPackage
 	public string? Location { get; init; }
 	public bool IsInstalled { get; init; }
 }
+
+/// <summary>
+/// Live progress for a single SDK package install, surfaced from the streamed
+/// <c>sdkmanager</c> stdout so long downloads/extractions don't appear to hang.
+/// </summary>
+/// <param name="Package">The package being installed (e.g. <c>system-images;android-37.0;google_apis_ps16k;arm64-v8a</c>).</param>
+/// <param name="PackageIndex">1-based index of this package within the overall batch.</param>
+/// <param name="PackageTotal">Total number of packages in the batch.</param>
+/// <param name="Phase">Human-readable phase parsed from sdkmanager output (e.g. <c>Downloading</c>, <c>Unzipping</c>), or empty when unknown.</param>
+/// <param name="Percent">Percent (0-100) for the current package, or -1 when sdkmanager has not reported a percentage yet.</param>
+public record AndroidPackageInstallProgress(
+	string Package,
+	int PackageIndex,
+	int PackageTotal,
+	string Phase,
+	int Percent);

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
@@ -192,20 +192,20 @@ public partial class SdkManager : IDisposable
 
 		try
 		{
-			// Streaming the live progress requires answering any per-package license prompt on
-			// stdin. Without auto-accept, a prompt would deadlock behind the redirected stdout
-			// (the prompt text is parsed as progress and dropped). When we can't auto-accept,
-			// fall back to the upstream buffered install — it trades live progress for safety.
-			if (onProgress is null || !acceptLicenses)
+			// No progress requested: install everything in one buffered upstream call.
+			if (onProgress is null)
 			{
 				await _sdkManager.InstallAsync(packageList, acceptLicenses, cancellationToken);
 				return;
 			}
 
-			var sdkManagerPath = SdkManagerPath!; // EnsureAvailable guarantees this is non-null.
+			// Reuse the already-synced sdkPath to resolve the sdkmanager path once (avoids the
+			// extra SyncPaths() call the SdkManagerPath property would trigger). EnsureAvailable()
+			// above guarantees this resolves to a non-null path.
+			var sdkManagerPath = ResolveSdkManagerPath(sdkPath) ?? _sdkManager.FindSdkManagerPath()!;
 
-			// Install one package at a time so we can stream live progress for each. Installing
-			// individually also keeps the progress percentage meaningful (it resets per package).
+			// Install one package at a time so we can report per-package progress. Installing
+			// individually also keeps the streamed percentage meaningful (it resets per package).
 			for (var i = 0; i < packageList.Count; i++)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
@@ -216,11 +216,22 @@ public partial class SdkManager : IDisposable
 				// before sdkmanager prints its first progress line.
 				onProgress(new AndroidPackageInstallProgress(package, index, packageList.Count, string.Empty, -1));
 
-				await RunSdkManagerInstallAsync(
-					sdkManagerPath, package, acceptLicenses, sdkPath, jdkPath,
-					(phase, percent) => onProgress(
-						new AndroidPackageInstallProgress(package, index, packageList.Count, phase, percent)),
-					cancellationToken);
+				// Live streaming needs stdin to auto-accept per-package license prompts; without
+				// auto-accept a prompt would deadlock behind the redirected stdout. When we can't
+				// auto-accept, fall back to the buffered upstream install for this package — the
+				// seed callback above still gives coarse per-package progress.
+				if (acceptLicenses)
+				{
+					await RunSdkManagerInstallAsync(
+						sdkManagerPath, package, acceptLicenses, sdkPath, jdkPath,
+						(phase, percent) => onProgress(
+							new AndroidPackageInstallProgress(package, index, packageList.Count, phase, percent)),
+						cancellationToken);
+				}
+				else
+				{
+					await _sdkManager.InstallAsync(new[] { package }, acceptLicenses, cancellationToken);
+				}
 			}
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
@@ -246,14 +257,33 @@ public partial class SdkManager : IDisposable
 	{
 		var psi = new ProcessStartInfo
 		{
-			FileName = sdkManagerPath,
 			UseShellExecute = false,
 			CreateNoWindow = true,
 			RedirectStandardOutput = true,
 			RedirectStandardError = true,
 			RedirectStandardInput = acceptLicenses,
 		};
+
+		// On Windows, sdkmanager resolves to a .bat wrapper. Executing a .bat with
+		// UseShellExecute=false is not universally reliable (it is not a PE image), so run it
+		// through cmd.exe /c. Other platforms exec the shell script directly.
+		if (OperatingSystem.IsWindows() && sdkManagerPath.EndsWith(".bat", StringComparison.OrdinalIgnoreCase))
+		{
+			psi.FileName = "cmd.exe";
+			psi.ArgumentList.Add("/c");
+			psi.ArgumentList.Add(sdkManagerPath);
+		}
+		else
+		{
+			psi.FileName = sdkManagerPath;
+		}
+
 		psi.ArgumentList.Add(package);
+
+		// The upstream wrapper passes --sdk_root explicitly; mirror that so the install targets the
+		// resolved SDK even when ANDROID_HOME/ANDROID_SDK_ROOT aren't set in the ambient environment.
+		if (!string.IsNullOrEmpty(sdkPath))
+			psi.ArgumentList.Add($"--sdk_root={sdkPath}");
 
 		foreach (var kvp in AndroidEnvironment.BuildEnvironmentVariables(sdkPath, jdkPath))
 			psi.Environment[kvp.Key] = kvp.Value;
@@ -264,8 +294,8 @@ public partial class SdkManager : IDisposable
 		if (!process.Start())
 			throw new InvalidOperationException($"Failed to start sdkmanager for package '{package}'.");
 
-		// Stops the auto-accept loop deterministically once the process exits (independent of the
-		// caller's token) so it never races teardown and touches a disposed process.
+		// Stops the auto-accept loop deterministically once the process exits or the caller cancels.
+		// Linked to the caller's token so cancellation also tears the loop down.
 		using var stopAccept = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
 		using var registration = cancellationToken.Register(() =>
@@ -298,7 +328,18 @@ public partial class SdkManager : IDisposable
 
 		try
 		{
-			await process.WaitForExitAsync(cancellationToken);
+			// Race the process exit against the stdout reader. If onProgress throws, stdoutTask
+			// faults and stops draining stdout; sdkmanager would then block once the OS pipe buffer
+			// fills, hanging WaitForExitAsync forever. Detecting the faulted reader lets us kill the
+			// process so the fault surfaces instead of deadlocking.
+			var exitTask = process.WaitForExitAsync(cancellationToken);
+			var finished = await Task.WhenAny(exitTask, stdoutTask);
+			if (finished == stdoutTask && stdoutTask.IsFaulted)
+			{
+				try { if (!process.HasExited) process.Kill(entireProcessTree: true); }
+				catch { /* Best-effort: process may have already exited. */ }
+			}
+			await SafeAwait(exitTask);
 		}
 		finally
 		{

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Text.RegularExpressions;
 using Microsoft.Maui.Cli.Errors;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Utils;
@@ -14,7 +16,7 @@ namespace Microsoft.Maui.Cli.Providers.Android;
 /// Wrapper for Android SDK Manager operations.
 /// Delegates to Xamarin.Android.Tools.SdkManager for core functionality.
 /// </summary>
-public class SdkManager : IDisposable
+public partial class SdkManager : IDisposable
 {
 	readonly Func<string?> _getSdkPath;
 	readonly Func<string?> _getJdkPath;
@@ -162,11 +164,20 @@ public class SdkManager : IDisposable
 	public async Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses,
 		Action<string, int, int>? onProgress, CancellationToken cancellationToken = default)
 	{
-		// Adapt the coarse (package, index, total) callback onto the richer streaming
-		// overload so existing callers keep working while still driving one update per package.
+		// Adapt the coarse (package, index, total) callback onto the richer streaming overload.
+		// The streaming overload fires many times per package (once per progress line); collapse
+		// those back to a single call per package so this legacy callback keeps its original
+		// one-call-per-package contract (the seed update is the first event for each package).
+		var lastIndex = 0;
 		Action<AndroidPackageInstallProgress>? adapter = onProgress is null
 			? null
-			: p => onProgress(p.Package, p.PackageIndex, p.PackageTotal);
+			: p =>
+			{
+				if (p.PackageIndex == lastIndex)
+					return;
+				lastIndex = p.PackageIndex;
+				onProgress(p.Package, p.PackageIndex, p.PackageTotal);
+			};
 
 		await InstallPackagesAsync(packages, acceptLicenses, adapter, cancellationToken);
 	}
@@ -181,17 +192,17 @@ public class SdkManager : IDisposable
 
 		try
 		{
-			if (onProgress is null)
+			// Streaming the live progress requires answering any per-package license prompt on
+			// stdin. Without auto-accept, a prompt would deadlock behind the redirected stdout
+			// (the prompt text is parsed as progress and dropped). When we can't auto-accept,
+			// fall back to the upstream buffered install — it trades live progress for safety.
+			if (onProgress is null || !acceptLicenses)
 			{
 				await _sdkManager.InstallAsync(packageList, acceptLicenses, cancellationToken);
 				return;
 			}
 
-			var sdkManagerPath = SdkManagerPath
-				?? throw MauiToolException.AutoFixable(
-					ErrorCodes.AndroidSdkManagerNotFound,
-					"SDK Manager not found. Run 'maui android install' first.",
-					"maui android install");
+			var sdkManagerPath = SdkManagerPath!; // EnsureAvailable guarantees this is non-null.
 
 			// Install one package at a time so we can stream live progress for each. Installing
 			// individually also keeps the progress percentage meaningful (it resets per package).
@@ -303,6 +314,15 @@ public class SdkManager : IDisposable
 		// exit code; surface that as cancellation rather than a spurious install failure.
 		cancellationToken.ThrowIfCancellationRequested();
 
+		// On a clean (non-cancelled) exit, a faulted stdout reader means the progress callback threw
+		// (e.g. the live renderer was disposed). Surface it instead of reporting a false success.
+		if (stdoutTask.IsFaulted)
+		{
+			var fault = stdoutTask.Exception?.InnerException ?? stdoutTask.Exception;
+			if (fault is not null and not OperationCanceledException)
+				ExceptionDispatchInfo.Capture(fault).Throw();
+		}
+
 		if (process.ExitCode != 0)
 		{
 			throw new InvalidOperationException(
@@ -344,8 +364,7 @@ public class SdkManager : IDisposable
 			buffer.Append(chunk, 0, count);
 	}
 
-	static readonly (string Keyword, string Canonical)[] KnownPhases =
-	{
+	static readonly (string Keyword, string Canonical)[] KnownPhases =	{
 		("Downloading", "Downloading"),
 		("Unzipping", "Unzipping"),
 		("Installing", "Installing"),
@@ -369,7 +388,9 @@ public class SdkManager : IDisposable
 		if (string.IsNullOrWhiteSpace(line))
 			return false;
 
-		// sdkmanager rewrites the progress bar in place using '\r'; take the last segment.
+		// Defensive handling for direct callers (e.g. unit tests) that may pass a raw '\r'-joined
+		// buffer: take the last in-place segment. The streaming path never reaches here with a '\r'
+		// because ReadProgressStreamAsync already splits on it via ReadLineAsync.
 		var trimmed = line.Replace('\r', '\n');
 		var lastNewline = trimmed.LastIndexOf('\n');
 		if (lastNewline >= 0)
@@ -379,7 +400,7 @@ public class SdkManager : IDisposable
 		if (trimmed.Length == 0)
 			return false;
 
-		var match = System.Text.RegularExpressions.Regex.Match(trimmed, @"(\d{1,3})\s*%");
+		var match = PercentRegex().Match(trimmed);
 		if (match.Success)
 		{
 			if (int.TryParse(match.Groups[1].Value, out var p))
@@ -400,6 +421,9 @@ public class SdkManager : IDisposable
 
 		return false;
 	}
+
+	[GeneratedRegex(@"(\d{1,3})\s*%")]
+	private static partial Regex PercentRegex();
 
 	static string ExtractPhase(string text)
 	{

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
@@ -156,13 +156,25 @@ public class SdkManager : IDisposable
 	public async Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses = false,
 		CancellationToken cancellationToken = default)
 	{
-		await InstallPackagesAsync(packages, acceptLicenses, onProgress: null, cancellationToken);
+		await InstallPackagesAsync(packages, acceptLicenses, (Action<AndroidPackageInstallProgress>?)null, cancellationToken);
 	}
 
 	public async Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses,
 		Action<string, int, int>? onProgress, CancellationToken cancellationToken = default)
 	{
-		SyncPaths();
+		// Adapt the coarse (package, index, total) callback onto the richer streaming
+		// overload so existing callers keep working while still driving one update per package.
+		Action<AndroidPackageInstallProgress>? adapter = onProgress is null
+			? null
+			: p => onProgress(p.Package, p.PackageIndex, p.PackageTotal);
+
+		await InstallPackagesAsync(packages, acceptLicenses, adapter, cancellationToken);
+	}
+
+	public async Task InstallPackagesAsync(IEnumerable<string> packages, bool acceptLicenses,
+		Action<AndroidPackageInstallProgress>? onProgress, CancellationToken cancellationToken = default)
+	{
+		var (sdkPath, jdkPath) = SyncPaths();
 		EnsureAvailable();
 
 		var packageList = packages.ToList();
@@ -172,16 +184,32 @@ public class SdkManager : IDisposable
 			if (onProgress is null)
 			{
 				await _sdkManager.InstallAsync(packageList, acceptLicenses, cancellationToken);
+				return;
 			}
-			else
+
+			var sdkManagerPath = SdkManagerPath
+				?? throw MauiToolException.AutoFixable(
+					ErrorCodes.AndroidSdkManagerNotFound,
+					"SDK Manager not found. Run 'maui android install' first.",
+					"maui android install");
+
+			// Install one package at a time so we can stream live progress for each. Installing
+			// individually also keeps the progress percentage meaningful (it resets per package).
+			for (var i = 0; i < packageList.Count; i++)
 			{
-				// Install one at a time so we can report per-package progress
-				for (var i = 0; i < packageList.Count; i++)
-				{
-					cancellationToken.ThrowIfCancellationRequested();
-					onProgress(packageList[i], i + 1, packageList.Count);
-					await _sdkManager.InstallAsync(new[] { packageList[i] }, acceptLicenses, cancellationToken);
-				}
+				cancellationToken.ThrowIfCancellationRequested();
+				var package = packageList[i];
+				var index = i + 1;
+
+				// Seed an initial update so the UI immediately reflects which package is starting,
+				// before sdkmanager prints its first progress line.
+				onProgress(new AndroidPackageInstallProgress(package, index, packageList.Count, string.Empty, -1));
+
+				await RunSdkManagerInstallAsync(
+					sdkManagerPath, package, acceptLicenses, sdkPath, jdkPath,
+					(phase, percent) => onProgress(
+						new AndroidPackageInstallProgress(package, index, packageList.Count, phase, percent)),
+					cancellationToken);
 			}
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
@@ -194,6 +222,197 @@ public class SdkManager : IDisposable
 				$"Failed to install packages: {ex.Message}",
 				nativeError: ex.Message);
 		}
+	}
+
+	/// <summary>
+	/// Runs <c>sdkmanager &lt;package&gt;</c> directly (instead of going through the upstream wrapper,
+	/// which buffers stdout) so we can stream live download/extraction progress to <paramref name="onProgress"/>.
+	/// When <paramref name="acceptLicenses"/> is true, writes <c>y</c> to stdin every 500ms to mirror
+	/// the upstream auto-accept loop and keep the install non-interactive.
+	/// </summary>
+	async Task RunSdkManagerInstallAsync(string sdkManagerPath, string package, bool acceptLicenses,
+		string? sdkPath, string? jdkPath, Action<string, int> onProgress, CancellationToken cancellationToken)
+	{
+		var psi = new ProcessStartInfo
+		{
+			FileName = sdkManagerPath,
+			UseShellExecute = false,
+			CreateNoWindow = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			RedirectStandardInput = acceptLicenses,
+		};
+		psi.ArgumentList.Add(package);
+
+		foreach (var kvp in AndroidEnvironment.BuildEnvironmentVariables(sdkPath, jdkPath))
+			psi.Environment[kvp.Key] = kvp.Value;
+
+		using var process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+		var stderr = new System.Text.StringBuilder();
+
+		if (!process.Start())
+			throw new InvalidOperationException($"Failed to start sdkmanager for package '{package}'.");
+
+		// Stops the auto-accept loop deterministically once the process exits (independent of the
+		// caller's token) so it never races teardown and touches a disposed process.
+		using var stopAccept = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+		using var registration = cancellationToken.Register(() =>
+		{
+			try { if (!process.HasExited) process.Kill(entireProcessTree: true); }
+			catch { /* Best-effort: process may have already exited. */ }
+		});
+
+		// Auto-accept any per-package license prompt without blocking on stdin.
+		Task acceptTask = Task.CompletedTask;
+		if (acceptLicenses)
+		{
+			acceptTask = Task.Run(async () =>
+			{
+				try
+				{
+					while (!process.HasExited && !stopAccept.IsCancellationRequested)
+					{
+						await process.StandardInput.WriteLineAsync("y");
+						await process.StandardInput.FlushAsync();
+						await Task.Delay(500, stopAccept.Token);
+					}
+				}
+				catch { /* Process exited, stdin closed, or stop requested; nothing more to accept. */ }
+			}, stopAccept.Token);
+		}
+
+		var stdoutTask = ReadProgressStreamAsync(process.StandardOutput, onProgress, cancellationToken);
+		var stderrTask = ReadIntoBufferAsync(process.StandardError, stderr, cancellationToken);
+
+		try
+		{
+			await process.WaitForExitAsync(cancellationToken);
+		}
+		finally
+		{
+			// Always stop the auto-accept loop and drain the reader tasks before the process is
+			// disposed, so no task is left observing a disposed stream (avoids UnobservedTaskException).
+			stopAccept.Cancel();
+			await SafeAwait(acceptTask);
+			await SafeAwait(stdoutTask);
+			await SafeAwait(stderrTask);
+		}
+
+		// A kill triggered by cancellation makes WaitForExitAsync complete normally with a non-zero
+		// exit code; surface that as cancellation rather than a spurious install failure.
+		cancellationToken.ThrowIfCancellationRequested();
+
+		if (process.ExitCode != 0)
+		{
+			throw new InvalidOperationException(
+				$"Package installation ({package}) failed with exit code {process.ExitCode}: {stderr.ToString().Trim()}");
+		}
+	}
+
+	/// <summary>
+	/// Awaits a task while swallowing cancellation and teardown faults from the streaming/stdin
+	/// helpers. The exit code and the caller's cancellation token are the source of truth for the
+	/// install result, so faults from drained background reads must not mask them.
+	/// </summary>
+	static async Task SafeAwait(Task task)
+	{
+		try { await task; }
+		catch { /* Background read/stdin task faulted during teardown; ignore. */ }
+	}
+
+	/// <summary>
+	/// Reads sdkmanager stdout line by line and reports parsed progress. <see cref="TextReader.ReadLineAsync()"/>
+	/// treats a lone carriage return as a line terminator, so the in-place <c>[====] NN%</c> updates
+	/// sdkmanager emits each surface as their own line.
+	/// </summary>
+	static async Task ReadProgressStreamAsync(StreamReader reader, Action<string, int> onProgress, CancellationToken cancellationToken)
+	{
+		string? line;
+		while ((line = await reader.ReadLineAsync(cancellationToken)) != null)
+		{
+			if (TryParseInstallProgressLine(line, out var phase, out var percent))
+				onProgress(phase, percent);
+		}
+	}
+
+	static async Task ReadIntoBufferAsync(StreamReader reader, System.Text.StringBuilder buffer, CancellationToken cancellationToken)
+	{
+		var chunk = new char[4096];
+		int count;
+		while ((count = await reader.ReadAsync(chunk, cancellationToken)) > 0)
+			buffer.Append(chunk, 0, count);
+	}
+
+	static readonly (string Keyword, string Canonical)[] KnownPhases =
+	{
+		("Downloading", "Downloading"),
+		("Unzipping", "Unzipping"),
+		("Installing", "Installing"),
+		("Fetching", "Fetching"),
+		("Verifying", "Verifying"),
+		("Preparing", "Preparing"),
+		("Computing", "Computing updates"),
+	};
+
+	/// <summary>
+	/// Parses a single line of <c>sdkmanager</c> stdout into a (phase, percent) pair.
+	/// Tolerant of progress-bar prefixes (<c>[====   ]</c>), carriage-return in-place updates,
+	/// phase-only lines (no percentage), and lines that carry no progress at all.
+	/// Returns <see langword="false"/> when the line carries neither a percentage nor a known phase.
+	/// </summary>
+	internal static bool TryParseInstallProgressLine(string? line, out string phase, out int percent)
+	{
+		phase = string.Empty;
+		percent = -1;
+
+		if (string.IsNullOrWhiteSpace(line))
+			return false;
+
+		// sdkmanager rewrites the progress bar in place using '\r'; take the last segment.
+		var trimmed = line.Replace('\r', '\n');
+		var lastNewline = trimmed.LastIndexOf('\n');
+		if (lastNewline >= 0)
+			trimmed = trimmed[(lastNewline + 1)..];
+		trimmed = trimmed.Trim();
+
+		if (trimmed.Length == 0)
+			return false;
+
+		var match = System.Text.RegularExpressions.Regex.Match(trimmed, @"(\d{1,3})\s*%");
+		if (match.Success)
+		{
+			if (int.TryParse(match.Groups[1].Value, out var p))
+				percent = Math.Clamp(p, 0, 100);
+
+			var after = trimmed[(match.Index + match.Length)..].Trim();
+			phase = ExtractPhase(after);
+			return true;
+		}
+
+		// No percentage — only treat as progress if it names a known phase (e.g. "Downloading foo.zip").
+		var phaseOnly = ExtractPhase(trimmed);
+		if (phaseOnly.Length > 0)
+		{
+			phase = phaseOnly;
+			return true;
+		}
+
+		return false;
+	}
+
+	static string ExtractPhase(string text)
+	{
+		if (string.IsNullOrWhiteSpace(text))
+			return string.Empty;
+
+		foreach (var (keyword, canonical) in KnownPhases)
+		{
+			if (text.StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
+				return canonical;
+		}
+
+		return string.Empty;
 	}
 
 	public async Task AcceptLicensesAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Problem

Running e.g.:

```
maui android install --ci --accept-licenses --packages "...,system-images;android-37.0;google_apis_ps16k;arm64-v8a"
```

made the install **appear to hang**: the Spectre progress bar froze at `Installing system-images;... (6/6) 100%` for many minutes. It was *not* actually hung — the ~1.5GB system-image zip was downloading the whole time (verified: the temp zip under `~/Library/Android/sdk/.temp/` grew steadily and the `sdkmanager` java process stayed in `R` state). It only **looked** hung because no progress was surfaced.

Two root causes:

1. **`SdkManager.InstallPackagesAsync` reported progress too early.** It called `onProgress(pkg, i+1, total)` *before* awaiting the install, so the bar jumped to the package's slot at 100% the instant the install *started*, then sat there until it finished.
2. **The upstream library buffers output.** `Xamarin.Android.Tools.SdkManager` (NuGet `Xamarin.Android.Tools.AndroidSdk`) runs `sdkmanager <pkg>` and captures stdout/stderr into in-memory `StringWriter`s (its private `RunSdkManagerAsync`). It never streams the live `[=====   ] 45% Downloading …` / `… Unzipping …` lines, so our wrapper had nothing to surface. (Confirmed by decompiling the assembly — only the bootstrap/download path exposes `SdkBootstrapProgress`; package installs route through the buffered path.)

## Approach

Add a **streaming** `InstallPackagesAsync` overload in our own `SdkManager` wrapper that keeps the fix entirely in this repo (no upstream release required):

- Resolves the `sdkmanager` path the same way the wrapper already does (`SdkManagerPath`).
- Invokes `sdkmanager <pkg>` directly, one package at a time, with stdout/stderr redirected.
- Streams stdout line-by-line (`ReadLineAsync` treats a lone `\r` as a line terminator, so the in-place progress-bar updates each surface as their own line) and parses each line into `(phase, percent)`.
- Reports a real per-package percentage + phase via a new `AndroidPackageInstallProgress` callback, which drives the existing Spectre live progress bar (Step 4 of `AndroidCommands.Install.cs`). The overall bar now advances as `(completedPackages + currentPackage%) / total`.
- When `acceptLicenses` is `true`, auto-writes `y` to stdin every ~500ms (mirroring the upstream auto-accept loop) so the install stays **non-interactive** with `--accept-licenses`.
- On cancellation, kills the process tree and propagates `OperationCanceledException` (not a wrapped `MauiToolException`); background stdin/stdout/stderr tasks are deterministically stopped and drained before the process is disposed.

JSON / non-interactive mode is untouched (it routes through the existing buffered `InstallAsync`).

## Parser

`SdkManager.TryParseInstallProgressLine(line, out phase, out percent)` is a small pure function, tolerant of:
- progress-bar prefixes `[====   ]`
- carriage-return in-place updates (uses the last segment)
- phase-only lines with no percentage (e.g. `Downloading foo.zip` → percent `-1`)
- percentages clamped to 0–100
- malformed / non-progress lines (returns `false`)

## Public API changes

- **New** `AndroidPackageInstallProgress` record and a new `InstallPackagesAsync(..., Action<AndroidPackageInstallProgress>?, …)` overload on `IAndroidProvider` / `AndroidProvider` / `SdkManager`.
- The existing `Action<string,int,int>` overload is **preserved** (it now delegates to the richer one), so existing callers and tests are unaffected.
- **No shipped NuGet break:** `AgentClient` (the `Microsoft.Maui.DevFlow.Driver` public surface) does not expose package installs. `IAndroidProvider` lives inside the `maui` global tool, not a shipped library.

## Tests

`SdkManagerProgressParserTests` (xUnit, `src/Cli/Microsoft.Maui.Cli.UnitTests/`) covers download %, unzip %, percent-without-phase, phase-without-percent, `\r` in-place updates, clamping, and malformed/no-progress lines. **No network access.**

```
dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/
Passed!  - Failed: 0, Passed: 589, Skipped: 0, Total: 589
```

A `code-review` pass flagged three process-handling issues (cancellation race wrapping OCE, the stdin loop not being awaited, and abandoned reader tasks on cancel); all three were fixed and re-verified before commit.

## Notes for reviewers

- Draft — please review the streaming/process teardown in `SdkManager.RunSdkManagerInstallAsync` and the overall-bar math in `AndroidCommands.Install.cs`.
- Manual end-to-end verification of a live ~1.5GB system-image download on macOS is still recommended before merge (not exercised by unit tests, by design).