### PR TITLE
Check GTK version at startup

### DIFF
--- a/platforms/Linux.Gtk4/README.md
+++ b/platforms/Linux.Gtk4/README.md
@@ -107,7 +107,7 @@ https://github.com/user-attachments/assets/70f2a910-94b3-437c-945a-6b71223c5cd3
 | Requirement | Version |
 |---|---|
 | .NET SDK | 10.0+ |
-| GTK 4 libraries | 4.x (system package) |
+| GTK 4 libraries | 4.12+ (system package) |
 | WebKitGTK *(Blazor only)* | 6.x (system package) |
 
 ### Install GTK4 & WebKitGTK (Debian / Ubuntu)

--- a/platforms/Linux.Gtk4/docs/appimage-packaging.md
+++ b/platforms/Linux.Gtk4/docs/appimage-packaging.md
@@ -14,7 +14,7 @@ This produces `YourApp-1.0.0-x86_64.AppImage` in the publish output parent direc
 
 - **Build host**: Linux x86_64 or ARM64 (matching your target)
 - **curl**: For automatic `appimagetool` download (first build only)
-- **Target system**: GTK4 installed (the AppImage checks for this at launch)
+- **Target system**: GTK 4.12+ installed (the AppImage checks for this at launch)
 
 ## How It Works
 
@@ -75,7 +75,7 @@ All properties are optional (except `ApplicationId` which is required by MAUI co
 
 The generated AppImage automatically checks for required system libraries at launch:
 
-- **GTK4** (`libgtk-4.so`) — always checked
+- **GTK 4.12+** (`libgtk-4.so`, verified via the 4.12-only `gtk_css_provider_load_from_string` symbol) — always checked
 - **WebKitGTK 6.0** (`libwebkitgtk-6.0.so`) — checked only when `Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView` is referenced
 
 If libraries are missing, the user sees a friendly error message with install commands for Ubuntu/Debian, Fedora, and Arch Linux. If `zenity` is available, a graphical error dialog is also shown.

--- a/platforms/Linux.Gtk4/docs/deb-packaging.md
+++ b/platforms/Linux.Gtk4/docs/deb-packaging.md
@@ -50,7 +50,7 @@ When `CreateDeb=true` is set during `dotnet publish`, the build:
 | `DebSection` | Package section | `utils` |
 | `DebPriority` | Package priority | `optional` |
 | `DebMaintainer` | Maintainer field | `$(Authors)` |
-| `DebDepends` | Dependency list | Auto-detected (GTK4 + optional WebKitGTK) |
+| `DebDepends` | Dependency list | Auto-detected (GTK 4.12+ + optional WebKitGTK) |
 | `DebHomepage` | Homepage URL | `$(PackageProjectUrl)` |
 | `DebDescription` | Package description | `$(Description)` |
 | `DebCategories` | `.desktop` Categories | `Utility;` |
@@ -66,7 +66,7 @@ When `CreateDeb=true` is set during `dotnet publish`, the build:
   <ApplicationTitle>My App</ApplicationTitle>
   <ApplicationDisplayVersion>2.1.0</ApplicationDisplayVersion>
   <DebSection>office</DebSection>
-  <DebDepends>libgtk-4-1, libwebkitgtk-6.0-4, libsqlite3-0</DebDepends>
+  <DebDepends>libgtk-4-1 (&gt;= 4.12.0), libwebkitgtk-6.0-4, libsqlite3-0</DebDepends>
   <DebMaintainer>My Name &lt;me@example.com&gt;</DebMaintainer>
 </PropertyGroup>
 ```
@@ -75,7 +75,7 @@ When `CreateDeb=true` is set during `dotnet publish`, the build:
 
 The `Depends` field in `DEBIAN/control` is automatically populated:
 
-- **GTK4** (`libgtk-4-1`) — always included
+- **GTK 4.12+** (`libgtk-4-1 (>= 4.12.0)`) — always included
 - **WebKitGTK** (`libwebkitgtk-6.0-4`) — included when `Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView` is referenced
 
 Override with `DebDepends` if your app has additional system dependencies.
@@ -136,6 +136,11 @@ If your app needs additional system libraries, set `DebDepends`:
 
 ```xml
 <PropertyGroup>
-  <DebDepends>libgtk-4-1, libcurl4, libsqlite3-0</DebDepends>
+  <DebDepends>libgtk-4-1 (&gt;= 4.12.0), libcurl4, libsqlite3-0</DebDepends>
 </PropertyGroup>
 ```
+
+> **Note:** `DebDepends` *replaces* the auto-detected dependency list, so keep the
+> GTK floor `libgtk-4-1 (>= 4.12.0)` (and `libwebkitgtk-6.0-4` if you use Blazor)
+> in your override — otherwise the package will install on GTK older than 4.12
+> and only fail at launch.

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/GtkBlazorWebView.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4.BlazorWebView/GtkBlazorWebView.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 using WebKit;
 using WebView = WebKit.WebView;
 
@@ -58,6 +59,10 @@ public sealed class GtkBlazorWebView : IDisposable
 	public static void InitializeWebKit()
 	{
 		if (Interlocked.Exchange(ref _moduleInitialized, 1) != 0) return;
+
+		// Fail fast with a friendly message if GTK is missing or too old, before any
+		// GirCore GTK/WebKit native initialization happens below.
+		GtkRuntime.EnsureSupported();
 
 		WebKitSandboxHelper.ConfigureSandbox();
 

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkMauiApplication.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkMauiApplication.cs
@@ -12,15 +12,6 @@ public abstract class GtkMauiApplication : IPlatformApplication
 	private const string DefaultApplicationId = "com.maui.linux";
 	private const string MauiApplicationIdMetadataKey = "MauiApplicationId";
 
-	// The backend calls gtk_css_provider_load_from_string (GTK 4.12+) and uses
-	// Gtk.FileDialog (GTK 4.10+). On older GTK these resolve to missing native
-	// entry points and the app crashes with a cryptic EntryPointNotFoundException.
-	private const uint MinimumGtkMajor = 4;
-	private const uint MinimumGtkMinor = 12;
-
-	// Log prefix derived from the assembly name instead of a hardcoded string.
-	private static readonly string LogPrefix = $"[{typeof(GtkMauiApplication).Assembly.GetName().Name}]";
-
 	private Gtk.Application _gtkApp = null!;
 	private IApplication _mauiApp = null!;
 	private GtkMauiContext _applicationContext = null!;
@@ -43,22 +34,11 @@ public abstract class GtkMauiApplication : IPlatformApplication
 
 	public void Run(string[] args)
 	{
+		// Fail fast with a friendly message before any GirCore GTK initialization.
+		GtkRuntime.EnsureSupported();
+
 		var applicationId = string.IsNullOrWhiteSpace(ApplicationId) ? null : ApplicationId;
-
-		try
-		{
-			_gtkApp = Gtk.Application.New(applicationId, Gio.ApplicationFlags.DefaultFlags);
-		}
-		catch (Exception ex) when (IsGtkLibraryMissing(ex))
-		{
-			var notFound = "GTK 4 was not found. Please install GTK 4.12 or newer and try again.";
-			Console.Error.WriteLine($"{LogPrefix} {notFound}");
-			throw new PlatformNotSupportedException(notFound, ex);
-		}
-
-		// Application.New succeeded, so GirCore is initialized and its native calls
-		// resolve — only now is it safe to query the runtime GTK version.
-		EnsureSupportedGtkVersion();
+		_gtkApp = Gtk.Application.New(applicationId, Gio.ApplicationFlags.DefaultFlags);
 
 		_gtkApp.OnActivate += OnActivate;
 		_gtkApp.OnShutdown += OnShutdown;
@@ -66,37 +46,6 @@ public abstract class GtkMauiApplication : IPlatformApplication
 		var exitCode = _gtkApp.Run(args);
 		Environment.ExitCode = exitCode;
 	}
-
-	/// <summary>
-	/// Verifies the GTK runtime is new enough for this backend and fails fast with
-	/// an actionable message otherwise. Without this, an old GTK produces a cryptic
-	/// <c>EntryPointNotFoundException</c> deep inside the first handler that loads CSS.
-	/// </summary>
-	/// <remarks>
-	/// Must be called after <c>Gtk.Application.New</c> has succeeded — that
-	/// initializes GirCore so the version functions resolve.
-	/// </remarks>
-	private static void EnsureSupportedGtkVersion()
-	{
-		var major = Gtk.Functions.GetMajorVersion();
-		var minor = Gtk.Functions.GetMinorVersion();
-
-		if (major > MinimumGtkMajor || (major == MinimumGtkMajor && minor >= MinimumGtkMinor))
-			return;
-
-		var micro = Gtk.Functions.GetMicroVersion();
-		var message =
-			$"This app needs GTK {MinimumGtkMajor}.{MinimumGtkMinor} or newer, but the installed " +
-			$"version is {major}.{minor}.{micro}. Please update GTK and try again.";
-
-		Console.Error.WriteLine($"{LogPrefix} {message}");
-		throw new PlatformNotSupportedException(message);
-	}
-
-	// A missing libgtk surfaces either directly as DllNotFoundException or wrapped
-	// in a TypeInitializationException when thrown from GirCore's type initializer.
-	private static bool IsGtkLibraryMissing(Exception ex) =>
-		ex is DllNotFoundException || ex.InnerException is DllNotFoundException;
 
 	private void OnActivate(Gio.Application sender, EventArgs args)
 	{

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkMauiApplication.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkMauiApplication.cs
@@ -11,6 +11,16 @@ public abstract class GtkMauiApplication : IPlatformApplication
 {
 	private const string DefaultApplicationId = "com.maui.linux";
 	private const string MauiApplicationIdMetadataKey = "MauiApplicationId";
+
+	// The backend calls gtk_css_provider_load_from_string (GTK 4.12+) and uses
+	// Gtk.FileDialog (GTK 4.10+). On older GTK these resolve to missing native
+	// entry points and the app crashes with a cryptic EntryPointNotFoundException.
+	private const uint MinimumGtkMajor = 4;
+	private const uint MinimumGtkMinor = 12;
+
+	// Log prefix derived from the assembly name instead of a hardcoded string.
+	private static readonly string LogPrefix = $"[{typeof(GtkMauiApplication).Assembly.GetName().Name}]";
+
 	private Gtk.Application _gtkApp = null!;
 	private IApplication _mauiApp = null!;
 	private GtkMauiContext _applicationContext = null!;
@@ -34,7 +44,21 @@ public abstract class GtkMauiApplication : IPlatformApplication
 	public void Run(string[] args)
 	{
 		var applicationId = string.IsNullOrWhiteSpace(ApplicationId) ? null : ApplicationId;
-		_gtkApp = Gtk.Application.New(applicationId, Gio.ApplicationFlags.DefaultFlags);
+
+		try
+		{
+			_gtkApp = Gtk.Application.New(applicationId, Gio.ApplicationFlags.DefaultFlags);
+		}
+		catch (Exception ex) when (IsGtkLibraryMissing(ex))
+		{
+			var notFound = "GTK 4 was not found. Please install GTK 4.12 or newer and try again.";
+			Console.Error.WriteLine($"{LogPrefix} {notFound}");
+			throw new PlatformNotSupportedException(notFound, ex);
+		}
+
+		// Application.New succeeded, so GirCore is initialized and its native calls
+		// resolve — only now is it safe to query the runtime GTK version.
+		EnsureSupportedGtkVersion();
 
 		_gtkApp.OnActivate += OnActivate;
 		_gtkApp.OnShutdown += OnShutdown;
@@ -42,6 +66,37 @@ public abstract class GtkMauiApplication : IPlatformApplication
 		var exitCode = _gtkApp.Run(args);
 		Environment.ExitCode = exitCode;
 	}
+
+	/// <summary>
+	/// Verifies the GTK runtime is new enough for this backend and fails fast with
+	/// an actionable message otherwise. Without this, an old GTK produces a cryptic
+	/// <c>EntryPointNotFoundException</c> deep inside the first handler that loads CSS.
+	/// </summary>
+	/// <remarks>
+	/// Must be called after <c>Gtk.Application.New</c> has succeeded — that
+	/// initializes GirCore so the version functions resolve.
+	/// </remarks>
+	private static void EnsureSupportedGtkVersion()
+	{
+		var major = Gtk.Functions.GetMajorVersion();
+		var minor = Gtk.Functions.GetMinorVersion();
+
+		if (major > MinimumGtkMajor || (major == MinimumGtkMajor && minor >= MinimumGtkMinor))
+			return;
+
+		var micro = Gtk.Functions.GetMicroVersion();
+		var message =
+			$"This app needs GTK {MinimumGtkMajor}.{MinimumGtkMinor} or newer, but the installed " +
+			$"version is {major}.{minor}.{micro}. Please update GTK and try again.";
+
+		Console.Error.WriteLine($"{LogPrefix} {message}");
+		throw new PlatformNotSupportedException(message);
+	}
+
+	// A missing libgtk surfaces either directly as DllNotFoundException or wrapped
+	// in a TypeInitializationException when thrown from GirCore's type initializer.
+	private static bool IsGtkLibraryMissing(Exception ex) =>
+		ex is DllNotFoundException || ex.InnerException is DllNotFoundException;
 
 	private void OnActivate(Gio.Application sender, EventArgs args)
 	{

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkRuntime.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkRuntime.cs
@@ -1,0 +1,83 @@
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+
+/// <summary>
+/// Guards against running on an unsupported GTK runtime. Every supported startup
+/// path (<see cref="GtkMauiApplication.Run"/> and
+/// <c>GtkBlazorWebView.InitializeWebKit</c>) calls <see cref="EnsureSupported"/>
+/// before any GirCore GTK/WebKit initialization.
+/// </summary>
+/// <remarks>
+/// The version is read by P/Invoking GTK's own stable ABI directly
+/// (<c>gtk_get_*_version</c>, present since GTK 4.0; soname <c>libgtk-4.so.1</c>),
+/// so the check is independent of GirCore's initialization order — it can run
+/// before the WebKit/GTK GirCore modules are initialized.
+/// </remarks>
+internal static class GtkRuntime
+{
+	// The backend calls gtk_css_provider_load_from_string (GTK 4.12+) and uses
+	// Gtk.FileDialog (GTK 4.10+). On older GTK these resolve to missing native
+	// entry points and the app crashes with a cryptic EntryPointNotFoundException.
+	private const uint MinimumGtkMajor = 4;
+	private const uint MinimumGtkMinor = 12;
+
+	// Log prefix derived from the assembly name instead of a hardcoded string.
+	private static readonly string LogPrefix = $"[{typeof(GtkRuntime).Assembly.GetName().Name}]";
+
+	private static bool _verified;
+
+	/// <summary>
+	/// Throws <see cref="PlatformNotSupportedException"/> with a friendly, logged
+	/// message if GTK is missing or older than the minimum supported version
+	/// (currently 4.12). Safe to call from multiple entry points; only the first
+	/// call performs the check.
+	/// </summary>
+	internal static void EnsureSupported()
+	{
+		if (_verified)
+			return;
+
+		uint major, minor, micro;
+		try
+		{
+			major = gtk_get_major_version();
+			minor = gtk_get_minor_version();
+			micro = gtk_get_micro_version();
+		}
+		catch (DllNotFoundException ex)
+		{
+			Fail("GTK 4 was not found. Please install GTK 4.12 or newer and try again.", ex);
+			return; // unreachable; keeps definite-assignment analysis happy
+		}
+
+		if (major < MinimumGtkMajor || (major == MinimumGtkMajor && minor < MinimumGtkMinor))
+		{
+			Fail(
+				$"This app needs GTK {MinimumGtkMajor}.{MinimumGtkMinor} or newer, but the installed " +
+				$"version is {major}.{minor}.{micro}. Please update GTK and try again.",
+				inner: null);
+		}
+
+		_verified = true;
+	}
+
+	private static void Fail(string message, Exception? inner)
+	{
+		Console.Error.WriteLine($"{LogPrefix} {message}");
+		throw inner is null
+			? new PlatformNotSupportedException(message)
+			: new PlatformNotSupportedException(message, inner);
+	}
+
+	private const string GtkLibrary = "libgtk-4.so.1";
+
+	[DllImport(GtkLibrary)]
+	private static extern uint gtk_get_major_version();
+
+	[DllImport(GtkLibrary)]
+	private static extern uint gtk_get_minor_version();
+
+	[DllImport(GtkLibrary)]
+	private static extern uint gtk_get_micro_version();
+}

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/buildTransitive/Microsoft.Maui.Platforms.Linux.Gtk4.AppImage.targets
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/buildTransitive/Microsoft.Maui.Platforms.Linux.Gtk4.AppImage.targets
@@ -190,9 +190,12 @@ HERE=&quot;%24(dirname &quot;%24(readlink -f &quot;%240&quot;)&quot;)&quot;
 # --- System dependency checks ---
 MISSING=&quot;&quot;
 
-# GTK4 (required)
-if ! ldconfig -p 2>/dev/null | grep -q &quot;libgtk-4.so&quot;; then
-  MISSING=&quot;%24{MISSING}  - GTK4 (libgtk-4-1 / gtk4)\n&quot;
+# GTK 4.12+ (required) — detected via the 4.12-only symbol gtk_css_provider_load_from_string
+_GTK_LIB=&quot;%24(ldconfig -p 2>/dev/null | grep -m1 &quot;libgtk-4.so&quot; | awk '{print %24NF}')&quot;
+if [ -z &quot;%24_GTK_LIB&quot; ]; then
+  MISSING=&quot;%24{MISSING}  - GTK 4.12+ (libgtk-4-1 / gtk4)\n&quot;
+elif ! grep -aq &quot;gtk_css_provider_load_from_string&quot; &quot;%24_GTK_LIB&quot; 2>/dev/null; then
+  MISSING=&quot;%24{MISSING}  - GTK 4.12+ (found older GTK 4.x; update to 4.12 or newer)\n&quot;
 fi
 
 # WebKitGTK 6.0 (required for Blazor WebView)
@@ -228,9 +231,12 @@ HERE=&quot;%24(dirname &quot;%24(readlink -f &quot;%240&quot;)&quot;)&quot;
 # --- System dependency checks ---
 MISSING=&quot;&quot;
 
-# GTK4 (required)
-if ! ldconfig -p 2>/dev/null | grep -q &quot;libgtk-4.so&quot;; then
-  MISSING=&quot;%24{MISSING}  - GTK4 (libgtk-4-1 / gtk4)\n&quot;
+# GTK 4.12+ (required) — detected via the 4.12-only symbol gtk_css_provider_load_from_string
+_GTK_LIB=&quot;%24(ldconfig -p 2>/dev/null | grep -m1 &quot;libgtk-4.so&quot; | awk '{print %24NF}')&quot;
+if [ -z &quot;%24_GTK_LIB&quot; ]; then
+  MISSING=&quot;%24{MISSING}  - GTK 4.12+ (libgtk-4-1 / gtk4)\n&quot;
+elif ! grep -aq &quot;gtk_css_provider_load_from_string&quot; &quot;%24_GTK_LIB&quot; 2>/dev/null; then
+  MISSING=&quot;%24{MISSING}  - GTK 4.12+ (found older GTK 4.x; update to 4.12 or newer)\n&quot;
 fi
 
 if [ -n &quot;%24MISSING&quot; ]; then

--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/buildTransitive/Microsoft.Maui.Platforms.Linux.Gtk4.Deb.targets
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/buildTransitive/Microsoft.Maui.Platforms.Linux.Gtk4.Deb.targets
@@ -86,8 +86,8 @@
 
     <!-- Build the Depends field -->
     <PropertyGroup>
-      <DebDepends Condition="'$(DebDepends)' == '' and '$(_DebNeedsWebKit)' == 'true'">libgtk-4-1, libwebkitgtk-6.0-4</DebDepends>
-      <DebDepends Condition="'$(DebDepends)' == ''">libgtk-4-1</DebDepends>
+      <DebDepends Condition="'$(DebDepends)' == '' and '$(_DebNeedsWebKit)' == 'true'">libgtk-4-1 (&gt;= 4.12.0), libwebkitgtk-6.0-4</DebDepends>
+      <DebDepends Condition="'$(DebDepends)' == ''">libgtk-4-1 (&gt;= 4.12.0)</DebDepends>
     </PropertyGroup>
 
     <Message Importance="normal" Text="Deb: Dependencies: $(DebDepends)"  />


### PR DESCRIPTION
The Linux GTK4 backend uses APIs that only exist in newer GTK releases — gtk_css_provider_load_from_string (GTK 4.12+) and Gtk.FileDialog (GTK 4.10+). On older GTK runtimes these resolve to missing native entry points, so the app crashes with a cryptic EntryPointNotFoundException deep inside the first handler that loads CSS.

This PR adds a fast, fail-early version check in GtkMauiApplication.Run that validates the installed GTK runtime before any handlers run.