### PR TITLE
Fix non-retryable macOS screenshot failure when window not frontmost

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -2914,7 +2914,18 @@ public class DevFlowCommands
             // Fall back to agent-based screenshot (or used for element-scoped captures)
             if (data == null)
             {
-                data = await client.ScreenshotAsync(window, id, selector, maxWidth, scale);
+                var result = await client.ScreenshotResultAsync(window, id, selector, maxWidth, scale);
+                if (!result.Success)
+                {
+                    Output.WriteError(
+                        result.Error ?? "Failed to capture screenshot",
+                        json,
+                        retryable: result.Retryable,
+                        suggestions: result.Suggestions?.ToArray());
+                    _errorOccurred = true;
+                    return;
+                }
+                data = result.Data;
             }
 
             if (data == null)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ScreenshotTool.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ScreenshotTool.cs
@@ -20,10 +20,17 @@ public sealed class ScreenshotTool
 		[Description("Scale mode: 'native' keeps full HiDPI resolution, default auto-scales to 1x logical pixels")] string? scale = null)
 	{
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var bytes = await agent.ScreenshotAsync(window, elementId, selector, maxWidth, scale);
-		if (bytes == null || bytes.Length == 0)
-			throw new McpException("Screenshot failed — no image data returned. Is the agent connected and the app visible?");
+		var result = await agent.ScreenshotResultAsync(window, elementId, selector, maxWidth, scale);
+		if (!result.Success || result.Data == null || result.Data.Length == 0)
+		{
+			var message = result.Error
+				?? "Screenshot failed — no image data returned. Is the agent connected and the app visible?";
+			if (result.Suggestions is { Count: > 0 })
+				message += " " + string.Join(" ", result.Suggestions);
+			throw new McpException(message);
+		}
 
+		var bytes = result.Data;
 		return [
 			new TextContentBlock { Text = $"Screenshot captured ({bytes.Length} bytes, PNG)" },
 			ImageContentBlock.FromBytes(bytes, "image/png")

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ScreenshotTool.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ScreenshotTool.cs
@@ -26,7 +26,7 @@ public sealed class ScreenshotTool
 			var message = result.Error
 				?? "Screenshot failed — no image data returned. Is the agent connected and the app visible?";
 			if (result.Suggestions is { Count: > 0 })
-				message += " " + string.Join(" ", result.Suggestions);
+				message += "\n" + string.Join("\n", result.Suggestions);
 			throw new McpException(message);
 		}
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentHttpServer.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/AgentHttpServer.cs
@@ -495,6 +495,7 @@ public class HttpResponse
                 403 => "Forbidden",
                 404 => "Not Found",
                 408 => "Request Timeout",
+                409 => "Conflict",
                 501 => "Not Implemented",
                 500 => "Internal Server Error",
                 _ => "Bad Request"

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -1292,11 +1292,22 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                 if (element == null)
                     return HttpResponse.Error($"Element '{elementId}' not found or not a VisualElement");
 
-                var pngData = await DispatchAsync(() => CaptureElementScreenshotAsync(element));
-                if (pngData == null)
-                    return HttpResponse.Error($"Capture returned null for element '{elementId}'");
+                var outcome = await DispatchAsync<ScreenshotCaptureOutcome>(async () =>
+                {
+                    var bytes = await CaptureElementScreenshotAsync(element);
+                    // Diagnose in the same UI-thread turn as the failed capture so the
+                    // reported window/app state matches the state at capture time.
+                    return new ScreenshotCaptureOutcome
+                    {
+                        Data = bytes,
+                        Failure = bytes == null ? DescribeScreenshotFailure() : null
+                    };
+                });
 
-                return HttpResponse.Png(ResizePngIfNeeded(pngData, maxWidth, density, autoScale));
+                if (outcome?.Data == null)
+                    return BuildScreenshotFailureResponse(outcome?.Failure, $"Capture returned null for element '{elementId}'");
+
+                return HttpResponse.Png(ResizePngIfNeeded(outcome.Data, maxWidth, density, autoScale));
             }
             catch (Exception ex)
             {
@@ -1327,11 +1338,22 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                 if (element == null)
                     return HttpResponse.Error($"Element '{matchId}' not found or not a VisualElement");
 
-                var pngData = await DispatchAsync(() => CaptureElementScreenshotAsync(element));
-                if (pngData == null)
-                    return HttpResponse.Error($"Capture returned null for element '{matchId}'");
+                var outcome = await DispatchAsync<ScreenshotCaptureOutcome>(async () =>
+                {
+                    var bytes = await CaptureElementScreenshotAsync(element);
+                    // Diagnose in the same UI-thread turn as the failed capture so the
+                    // reported window/app state matches the state at capture time.
+                    return new ScreenshotCaptureOutcome
+                    {
+                        Data = bytes,
+                        Failure = bytes == null ? DescribeScreenshotFailure() : null
+                    };
+                });
 
-                return HttpResponse.Png(ResizePngIfNeeded(pngData, maxWidth, density, autoScale));
+                if (outcome?.Data == null)
+                    return BuildScreenshotFailureResponse(outcome?.Failure, $"Capture returned null for element '{matchId}'");
+
+                return HttpResponse.Png(ResizePngIfNeeded(outcome.Data, maxWidth, density, autoScale));
             }
             catch (FormatException ex)
             {
@@ -1345,10 +1367,11 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
         try
         {
-            var pngData = await DispatchAsync(async () =>
+            var outcome = await DispatchAsync<ScreenshotCaptureOutcome>(async () =>
             {
                 var window = GetWindow(windowIndex);
-                if (window == null) return null;
+                if (window == null)
+                    return new ScreenshotCaptureOutcome { Failure = DescribeScreenshotFailure() };
 
                 // If a modal page is displayed, capture it instead of the underlying page
                 VisualElement? topModal = null;
@@ -1375,18 +1398,27 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     }
                 }
 
+                byte[]? bytes;
                 if (topModal != null)
-                    return await CaptureScreenshotAsync(topModal);
+                    bytes = await CaptureScreenshotAsync(topModal);
+                else if (window.Page is VisualElement rootElement)
+                    bytes = await CaptureScreenshotAsync(rootElement);
+                else
+                    bytes = null;
 
-                if (window.Page is not VisualElement rootElement) return null;
-
-                return await CaptureScreenshotAsync(rootElement);
+                // Diagnose in the same UI-thread turn as the failed capture so the
+                // reported window/app state matches the state at capture time.
+                return new ScreenshotCaptureOutcome
+                {
+                    Data = bytes,
+                    Failure = bytes == null ? DescribeScreenshotFailure() : null
+                };
             });
 
-            if (pngData == null)
-                return await BuildScreenshotFailureResponseAsync("Failed to capture screenshot");
+            if (outcome?.Data == null)
+                return BuildScreenshotFailureResponse(outcome?.Failure, "Failed to capture screenshot");
 
-            return HttpResponse.Png(ResizePngIfNeeded(pngData, maxWidth, density, autoScale));
+            return HttpResponse.Png(ResizePngIfNeeded(outcome.Data, maxWidth, density, autoScale));
         }
         catch (Exception ex)
         {
@@ -1423,28 +1455,36 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     }
 
     /// <summary>
-    /// Describes why the most recent screenshot capture returned null, when the platform
-    /// can determine an actionable, often-retryable cause (e.g. the app window is not the
-    /// frontmost application on macOS). Returns <c>null</c> when no specific cause is known,
-    /// in which case the caller falls back to a generic error.
-    /// Called on the UI thread.
+    /// Describes why a screenshot capture returned null, when the platform can determine an
+    /// actionable, often-retryable cause (e.g. the app window is not the frontmost application
+    /// on macOS). Returns <c>null</c> when no specific cause is known, in which case the caller
+    /// falls back to a generic error.
+    /// <para>
+    /// Invoked on the UI thread within the same dispatch as the failed capture (see
+    /// <see cref="ScreenshotCaptureOutcome"/>), so the probed window/app state reflects the
+    /// state at capture time rather than a later re-probe. The result is best-effort/advisory.
+    /// </para>
     /// </summary>
     protected virtual ScreenshotCaptureFailure? DescribeScreenshotFailure() => null;
 
     /// <summary>
+    /// Carries the outcome of a screenshot capture attempt: the PNG bytes on success, or the
+    /// platform-described <see cref="ScreenshotCaptureFailure"/> (probed atomically in the same
+    /// UI dispatch as the capture) on failure.
+    /// </summary>
+    private sealed class ScreenshotCaptureOutcome
+    {
+        public byte[]? Data { get; init; }
+        public ScreenshotCaptureFailure? Failure { get; init; }
+    }
+
+    /// <summary>
     /// Builds an HTTP error response for a failed screenshot capture, enriching it with an
-    /// actionable, retryable cause when the platform can describe one (see
+    /// actionable, retryable cause when the platform described one (see
     /// <see cref="DescribeScreenshotFailure"/>). Falls back to <paramref name="defaultMessage"/>.
     /// </summary>
-    private async Task<HttpResponse> BuildScreenshotFailureResponseAsync(string defaultMessage)
+    private static HttpResponse BuildScreenshotFailureResponse(ScreenshotCaptureFailure? failure, string defaultMessage)
     {
-        ScreenshotCaptureFailure? failure = null;
-        try
-        {
-            failure = await DispatchAsync(() => DescribeScreenshotFailure());
-        }
-        catch { }
-
         if (failure == null)
             return HttpResponse.Error(defaultMessage);
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -1384,7 +1384,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             });
 
             if (pngData == null)
-                return HttpResponse.Error("Failed to capture screenshot");
+                return await BuildScreenshotFailureResponseAsync("Failed to capture screenshot");
 
             return HttpResponse.Png(ResizePngIfNeeded(pngData, maxWidth, density, autoScale));
         }
@@ -1420,6 +1420,50 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     protected virtual Task<byte[]?> CaptureFullScreenAsync()
     {
         return Task.FromResult<byte[]?>(null);
+    }
+
+    /// <summary>
+    /// Describes why the most recent screenshot capture returned null, when the platform
+    /// can determine an actionable, often-retryable cause (e.g. the app window is not the
+    /// frontmost application on macOS). Returns <c>null</c> when no specific cause is known,
+    /// in which case the caller falls back to a generic error.
+    /// Called on the UI thread.
+    /// </summary>
+    protected virtual ScreenshotCaptureFailure? DescribeScreenshotFailure() => null;
+
+    /// <summary>
+    /// Builds an HTTP error response for a failed screenshot capture, enriching it with an
+    /// actionable, retryable cause when the platform can describe one (see
+    /// <see cref="DescribeScreenshotFailure"/>). Falls back to <paramref name="defaultMessage"/>.
+    /// </summary>
+    private async Task<HttpResponse> BuildScreenshotFailureResponseAsync(string defaultMessage)
+    {
+        ScreenshotCaptureFailure? failure = null;
+        try
+        {
+            failure = await DispatchAsync(() => DescribeScreenshotFailure());
+        }
+        catch { }
+
+        if (failure == null)
+            return HttpResponse.Error(defaultMessage);
+
+        var details = new Dictionary<string, object?>
+        {
+            ["retryable"] = failure.Retryable
+        };
+        if (failure.Suggestions is { Length: > 0 })
+            details["suggestions"] = failure.Suggestions;
+
+        var message = string.IsNullOrWhiteSpace(failure.Message) ? defaultMessage : failure.Message;
+
+        // 409 Conflict signals a transient, retryable precondition (window focus/visibility);
+        // the structured body carries the authoritative retryable flag for clients.
+        return HttpResponse.Error(
+            message,
+            statusCode: failure.Retryable ? 409 : 400,
+            reason: failure.Reason,
+            details: details);
     }
 
     /// <summary>
@@ -6875,6 +6919,34 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
 
         return HttpResponse.Json(result);
     }
+}
+
+/// <summary>
+/// Describes an actionable cause for a failed screenshot capture, used to return a clear,
+/// often-retryable error to clients instead of a generic failure. See
+/// <see cref="DevFlowAgentService.DescribeScreenshotFailure"/>.
+/// </summary>
+public sealed class ScreenshotCaptureFailure
+{
+    public ScreenshotCaptureFailure(string message, string reason, bool retryable, string[]? suggestions = null)
+    {
+        Message = message;
+        Reason = reason;
+        Retryable = retryable;
+        Suggestions = suggestions;
+    }
+
+    /// <summary>Human-readable, actionable error message.</summary>
+    public string Message { get; }
+
+    /// <summary>Machine-readable cause identifier (e.g. <c>window-not-frontmost</c>).</summary>
+    public string Reason { get; }
+
+    /// <summary>Whether retrying (e.g. after foregrounding the app) may succeed.</summary>
+    public bool Retryable { get; }
+
+    /// <summary>Optional actionable suggestions for the caller.</summary>
+    public string[]? Suggestions { get; }
 }
 
 // Request DTOs

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -605,13 +605,14 @@ public class PlatformAgentService : DevFlowAgentService
                         var pdfData = contentView.DataWithPdfInsideRect(bounds);
                         if (pdfData != null)
                         {
-                            var image = new NSImage(pdfData);
+                            using var image = new NSImage(pdfData);
                             var tiffData = image.AsTiff();
                             if (tiffData != null)
                             {
-                                var bitmapRep = new NSBitmapImageRep(tiffData);
+                                using var bitmapRep = new NSBitmapImageRep(tiffData);
+                                using var pngProperties = new NSDictionary();
                                 var pngData = bitmapRep.RepresentationUsingTypeProperties(
-                                    NSBitmapImageFileType.Png, new NSDictionary());
+                                    NSBitmapImageFileType.Png, pngProperties);
                                 return pngData?.ToArray();
                             }
                         }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -570,45 +570,50 @@ public class PlatformAgentService : DevFlowAgentService
     {
         try
         {
-            // Get the window - try KeyWindow first, then find any visible window via MAUI
-            var window = NSApplication.SharedApplication.KeyWindow;
-            if (window == null)
-            {
-                var mauiWindow = Microsoft.Maui.Controls.Application.Current?.Windows.FirstOrDefault();
-                if (mauiWindow?.Handler?.PlatformView is NSWindow nsWindow)
-                    window = nsWindow;
-            }
+            // Resolve the window without depending on the app being frontmost.
+            // NSApplication.KeyWindow is null when the app is not the active application,
+            // so prefer the NSWindow that actually owns the element being captured.
+            var window = ResolveCaptureWindow(rootElement);
 
             // If a modal sheet is attached, capture it instead of the main window
             if (window?.AttachedSheet is NSWindow sheet)
                 window = sheet;
 
-            // Use CGWindowListCreateImage for composited capture including layer-backed controls
             if (window != null)
             {
+                // Primary: CGWindowListCreateImage gives a composited capture including
+                // layer-backed controls and WebView content. This can return null when the
+                // window is not frontmost / fully occluded (the window server may have purged
+                // its backing store), so we fall through to occlusion-independent paths below.
                 var pngBytes = CaptureWindowViaCG(window);
                 if (pngBytes != null)
                     return pngBytes;
-            }
 
-            // Fallback: DataWithPdfInsideRect (misses layer-backed controls like NSButton, NSSlider)
-            var contentView = window?.ContentView;
-            if (contentView != null)
-            {
-                var bounds = contentView.Bounds;
-                if (bounds.Width > 0 && bounds.Height > 0)
+                var contentView = window.ContentView;
+                if (contentView != null)
                 {
-                    var pdfData = contentView.DataWithPdfInsideRect(bounds);
-                    if (pdfData != null)
+                    // Occlusion-independent fallback: CacheDisplay re-renders the view
+                    // hierarchy directly, so it works even when the window is not frontmost.
+                    var cached = CaptureNSView(contentView);
+                    if (cached != null)
+                        return cached;
+
+                    // Last resort: DataWithPdfInsideRect (misses layer-backed controls like NSButton, NSSlider)
+                    var bounds = contentView.Bounds;
+                    if (bounds.Width > 0 && bounds.Height > 0)
                     {
-                        var image = new NSImage(pdfData);
-                        var tiffData = image.AsTiff();
-                        if (tiffData != null)
+                        var pdfData = contentView.DataWithPdfInsideRect(bounds);
+                        if (pdfData != null)
                         {
-                            var bitmapRep = new NSBitmapImageRep(tiffData);
-                            var pngData = bitmapRep.RepresentationUsingTypeProperties(
-                                NSBitmapImageFileType.Png, new NSDictionary());
-                            return pngData?.ToArray();
+                            var image = new NSImage(pdfData);
+                            var tiffData = image.AsTiff();
+                            if (tiffData != null)
+                            {
+                                var bitmapRep = new NSBitmapImageRep(tiffData);
+                                var pngData = bitmapRep.RepresentationUsingTypeProperties(
+                                    NSBitmapImageFileType.Png, new NSDictionary());
+                                return pngData?.ToArray();
+                            }
                         }
                     }
                 }
@@ -617,6 +622,99 @@ public class PlatformAgentService : DevFlowAgentService
         catch { }
 
         return await base.CaptureScreenshotAsync(rootElement);
+    }
+
+    /// <summary>
+    /// Resolves the NSWindow to capture without requiring the app to be frontmost.
+    /// Prefers the window that owns the element being captured (via its NSView), then the
+    /// MAUI application window's platform view, then key/main windows, and finally any
+    /// visible on-screen window.
+    /// </summary>
+    private static NSWindow? ResolveCaptureWindow(VisualElement rootElement)
+    {
+        // 1. The NSWindow that actually hosts the element's native view (focus-independent).
+        if (rootElement.Handler?.PlatformView is NSView elementView && elementView.Window is NSWindow ownerWindow)
+            return ownerWindow;
+
+        // 2. The MAUI application window's platform view.
+        var mauiWindow = Microsoft.Maui.Controls.Application.Current?.Windows.FirstOrDefault();
+        if (NSWindowFromPlatformView(mauiWindow?.Handler?.PlatformView) is NSWindow mauiNsWindow)
+            return mauiNsWindow;
+
+        // 3. Key / main window (only non-null when the app is active).
+        var app = NSApplication.SharedApplication;
+        if (app.KeyWindow is NSWindow keyWindow)
+            return keyWindow;
+        if (app.MainWindow is NSWindow mainWindow)
+            return mainWindow;
+
+        // 4. Any visible, on-screen window owned by the app (fall back to the first window).
+        var appWindows = app.DangerousWindows;
+        if (appWindows != null)
+        {
+            NSWindow? firstWindow = null;
+            foreach (var candidate in appWindows)
+            {
+                if (candidate == null)
+                    continue;
+                firstWindow ??= candidate;
+                if (candidate.IsVisible && candidate.WindowNumber > 0)
+                    return candidate;
+            }
+
+            return firstWindow;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts an NSWindow from a MAUI platform view, which may be an NSWindow directly,
+    /// an NSView (use its Window), an NSWindowController, or an NSViewController.
+    /// </summary>
+    private static NSWindow? NSWindowFromPlatformView(object? platformView) => platformView switch
+    {
+        NSWindow window => window,
+        NSView view => view.Window,
+        NSWindowController controller => controller.Window,
+        NSViewController viewController => viewController.View?.Window,
+        _ => null
+    };
+
+    /// <summary>
+    /// On macOS, reports an actionable cause when a screenshot fails because the app window
+    /// is not the frontmost application (a common reason CGWindowListCreateImage returns null).
+    /// </summary>
+    protected override ScreenshotCaptureFailure? DescribeScreenshotFailure()
+    {
+        try
+        {
+            var app = NSApplication.SharedApplication;
+
+            var mauiWindow = Microsoft.Maui.Controls.Application.Current?.Windows.FirstOrDefault();
+            var nsWindow = NSWindowFromPlatformView(mauiWindow?.Handler?.PlatformView)
+                ?? app.KeyWindow ?? app.MainWindow;
+
+            var appActive = app.Active;
+            var windowVisible = nsWindow == null || nsWindow.IsVisible;
+
+            if (!appActive || !windowVisible)
+            {
+                return new ScreenshotCaptureFailure(
+                    "Failed to capture screenshot because the app window is not frontmost (the app is not the active application). " +
+                    "Bring the app to the foreground and retry.",
+                    "window-not-frontmost",
+                    retryable: true,
+                    suggestions: new[]
+                    {
+                        "Bring the MAUI app window to the foreground (click it or use the app switcher / Cmd+Tab), then retry.",
+                        "Ensure the app window is visible and not minimized."
+                    });
+            }
+        }
+        catch { }
+
+        return null;
     }
 
     protected override Task<byte[]?> CaptureElementScreenshotAsync(VisualElement element)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -328,6 +328,18 @@ public class AgentClient : IDisposable
     /// </summary>
     public async Task<byte[]?> ScreenshotAsync(int? window = null, string? elementId = null, string? selector = null, int? maxWidth = null, string? scale = null)
     {
+        var result = await ScreenshotResultAsync(window, elementId, selector, maxWidth, scale);
+        return result.Success ? result.Data : null;
+    }
+
+    /// <summary>
+    /// Captures a screenshot and returns a structured <see cref="ScreenshotResult"/>. On failure,
+    /// the result carries the agent-provided error message, machine-readable reason, retryable
+    /// flag, and any actionable suggestions (e.g. the macOS app window not being frontmost),
+    /// instead of collapsing every failure into <c>null</c> as <see cref="ScreenshotAsync"/> does.
+    /// </summary>
+    public async Task<ScreenshotResult> ScreenshotResultAsync(int? window = null, string? elementId = null, string? selector = null, int? maxWidth = null, string? scale = null)
+    {
         try
         {
             var queryParams = new List<string>();
@@ -342,10 +354,58 @@ public class AgentClient : IDisposable
                 : $"{_baseUrl}{UiApi}/screenshot";
 
             using var response = await SendWithTransientRetriesAsync(() => _http.GetAsync(url));
-            if (!response.IsSuccessStatusCode) return null;
-            return await response.Content.ReadAsByteArrayAsync();
+            if (response.IsSuccessStatusCode)
+                return ScreenshotResult.Ok(await response.Content.ReadAsByteArrayAsync());
+
+            var body = await response.Content.ReadAsStringAsync();
+            return ParseScreenshotError(body);
         }
-        catch (Exception ex) when (IsExpectedClientException(ex)) { return null; }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return ScreenshotResult.Failure(null); }
+    }
+
+    private static ScreenshotResult ParseScreenshotError(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return ScreenshotResult.Failure(null);
+
+        try
+        {
+            var json = DriverJson.ParseElement(body);
+            if (json.ValueKind != JsonValueKind.Object)
+                return ScreenshotResult.Failure(null);
+
+            var error = json.TryGetProperty("error", out var e) && e.ValueKind == JsonValueKind.String
+                ? e.GetString() : null;
+            var reason = json.TryGetProperty("reason", out var r) && r.ValueKind == JsonValueKind.String
+                ? r.GetString() : null;
+
+            var retryable = false;
+            IReadOnlyList<string>? suggestions = null;
+
+            if (json.TryGetProperty("details", out var details) && details.ValueKind == JsonValueKind.Object)
+            {
+                if (details.TryGetProperty("retryable", out var ret) &&
+                    (ret.ValueKind == JsonValueKind.True || ret.ValueKind == JsonValueKind.False))
+                    retryable = ret.GetBoolean();
+
+                if (details.TryGetProperty("suggestions", out var sugg) && sugg.ValueKind == JsonValueKind.Array)
+                {
+                    var list = new List<string>();
+                    foreach (var item in sugg.EnumerateArray())
+                    {
+                        if (item.ValueKind == JsonValueKind.String && item.GetString() is { } s)
+                            list.Add(s);
+                    }
+                    if (list.Count > 0) suggestions = list;
+                }
+            }
+
+            return ScreenshotResult.Failure(error, reason, retryable, suggestions);
+        }
+        catch
+        {
+            return ScreenshotResult.Failure(null);
+        }
     }
 
     /// <summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ScreenshotResult.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ScreenshotResult.cs
@@ -1,0 +1,46 @@
+namespace Microsoft.Maui.DevFlow.Driver;
+
+/// <summary>
+/// Result of a screenshot capture request made through <see cref="AgentClient.ScreenshotResultAsync"/>.
+/// On success, <see cref="Data"/> holds the captured PNG bytes. On failure, <see cref="Error"/>,
+/// <see cref="Reason"/>, <see cref="Retryable"/>, and <see cref="Suggestions"/> describe an
+/// actionable cause when the agent could provide one (for example, the macOS app window not
+/// being the frontmost application).
+/// </summary>
+public sealed class ScreenshotResult
+{
+    /// <summary>Whether the capture succeeded.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>Captured PNG bytes when <see cref="Success"/> is <c>true</c>.</summary>
+    public byte[]? Data { get; init; }
+
+    /// <summary>Human-readable, actionable error message when the capture failed.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>Machine-readable cause identifier (e.g. <c>window-not-frontmost</c>) when available.</summary>
+    public string? Reason { get; init; }
+
+    /// <summary>Whether retrying (e.g. after foregrounding the app) may succeed.</summary>
+    public bool Retryable { get; init; }
+
+    /// <summary>Optional actionable suggestions surfaced by the agent.</summary>
+    public IReadOnlyList<string>? Suggestions { get; init; }
+
+    public static ScreenshotResult Ok(byte[] data) =>
+        new() { Success = true, Data = data };
+
+    public static ScreenshotResult Failure(
+        string? error,
+        string? reason = null,
+        bool retryable = false,
+        IReadOnlyList<string>? suggestions = null) =>
+        new()
+        {
+            Success = false,
+            Error = error,
+            Reason = reason,
+            Retryable = retryable,
+            Suggestions = suggestions
+        };
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ScreenshotAgentClientTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ScreenshotAgentClientTests.cs
@@ -7,6 +7,10 @@ namespace Microsoft.Maui.DevFlow.Tests;
 
 public class ScreenshotAgentClientTests
 {
+    // Guards the test server's accept call so a missed client connection fails fast
+    // instead of hanging CI indefinitely.
+    private static readonly TimeSpan AcceptTimeout = TimeSpan.FromSeconds(10);
+
     private static readonly byte[] SamplePng =
     {
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x01, 0x02, 0x03, 0x04
@@ -21,7 +25,7 @@ public class ScreenshotAgentClientTests
 
         var serverTask = Task.Run(async () =>
         {
-            using var client = await listener.AcceptTcpClientAsync();
+            using var client = await AcceptAsync(listener);
             using var stream = client.GetStream();
             var request = await ReadRequestAsync(stream);
             Assert.Contains("GET /api/v1/ui/screenshot", request, StringComparison.Ordinal);
@@ -65,7 +69,7 @@ public class ScreenshotAgentClientTests
 
         var serverTask = Task.Run(async () =>
         {
-            using var client = await listener.AcceptTcpClientAsync();
+            using var client = await AcceptAsync(listener);
             using var stream = client.GetStream();
             await ReadRequestAsync(stream);
             await WriteResponseAsync(stream, 409, "Conflict", "application/json", Encoding.UTF8.GetBytes(body));
@@ -101,7 +105,7 @@ public class ScreenshotAgentClientTests
 
         var serverTask = Task.Run(async () =>
         {
-            using var client = await listener.AcceptTcpClientAsync();
+            using var client = await AcceptAsync(listener);
             using var stream = client.GetStream();
             await ReadRequestAsync(stream);
             await WriteResponseAsync(stream, 409, "Conflict", "application/json", Encoding.UTF8.GetBytes(body));
@@ -125,7 +129,7 @@ public class ScreenshotAgentClientTests
 
         var serverTask = Task.Run(async () =>
         {
-            using var client = await listener.AcceptTcpClientAsync();
+            using var client = await AcceptAsync(listener);
             using var stream = client.GetStream();
             await ReadRequestAsync(stream);
             await WriteResponseAsync(stream, 200, "OK", "image/png", SamplePng);
@@ -139,6 +143,12 @@ public class ScreenshotAgentClientTests
         Assert.Equal(SamplePng, data);
 
         await serverTask;
+    }
+
+    private static async Task<TcpClient> AcceptAsync(TcpListener listener)
+    {
+        using var cts = new CancellationTokenSource(AcceptTimeout);
+        return await listener.AcceptTcpClientAsync(cts.Token);
     }
 
     private static async Task<string> ReadRequestAsync(NetworkStream stream)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ScreenshotAgentClientTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ScreenshotAgentClientTests.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class ScreenshotAgentClientTests
+{
+    private static readonly byte[] SamplePng =
+    {
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x01, 0x02, 0x03, 0x04
+    };
+
+    [Fact]
+    public async Task ScreenshotResultAsync_SuccessfulCapture_ReturnsPngBytes()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var request = await ReadRequestAsync(stream);
+            Assert.Contains("GET /api/v1/ui/screenshot", request, StringComparison.Ordinal);
+            await WriteResponseAsync(stream, 200, "OK", "image/png", SamplePng);
+        });
+
+        using var agent = new AgentClient("localhost", port);
+
+        var result = await agent.ScreenshotResultAsync();
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal(SamplePng, result.Data);
+        Assert.Null(result.Error);
+        Assert.False(result.Retryable);
+
+        await serverTask;
+    }
+
+    [Fact]
+    public async Task ScreenshotResultAsync_WindowNotFrontmost_ReturnsRetryableFailureWithSuggestions()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        const string body = """
+        {
+          "success": false,
+          "error": "Failed to capture screenshot because the app window is not frontmost (the app is not the active application). Bring the app to the foreground and retry.",
+          "reason": "window-not-frontmost",
+          "details": {
+            "retryable": true,
+            "suggestions": [
+              "Bring the MAUI app window to the foreground (click it or use the app switcher / Cmd+Tab), then retry.",
+              "Ensure the app window is visible and not minimized."
+            ]
+          }
+        }
+        """;
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            await ReadRequestAsync(stream);
+            await WriteResponseAsync(stream, 409, "Conflict", "application/json", Encoding.UTF8.GetBytes(body));
+        });
+
+        using var agent = new AgentClient("localhost", port);
+
+        var result = await agent.ScreenshotResultAsync();
+
+        Assert.False(result.Success);
+        Assert.Null(result.Data);
+        Assert.Equal("window-not-frontmost", result.Reason);
+        Assert.True(result.Retryable);
+        Assert.NotNull(result.Error);
+        Assert.Contains("not frontmost", result.Error!, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(result.Suggestions);
+        Assert.Equal(2, result.Suggestions!.Count);
+        Assert.Contains(result.Suggestions, s => s.Contains("foreground", StringComparison.OrdinalIgnoreCase));
+
+        await serverTask;
+    }
+
+    [Fact]
+    public async Task ScreenshotAsync_OnError_ReturnsNullForBackCompat()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        const string body = """
+        { "success": false, "error": "Failed to capture screenshot", "reason": "window-not-frontmost", "details": { "retryable": true } }
+        """;
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            await ReadRequestAsync(stream);
+            await WriteResponseAsync(stream, 409, "Conflict", "application/json", Encoding.UTF8.GetBytes(body));
+        });
+
+        using var agent = new AgentClient("localhost", port);
+
+        var data = await agent.ScreenshotAsync();
+
+        Assert.Null(data);
+
+        await serverTask;
+    }
+
+    [Fact]
+    public async Task ScreenshotAsync_OnSuccess_ReturnsBytesForBackCompat()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            await ReadRequestAsync(stream);
+            await WriteResponseAsync(stream, 200, "OK", "image/png", SamplePng);
+        });
+
+        using var agent = new AgentClient("localhost", port);
+
+        var data = await agent.ScreenshotAsync();
+
+        Assert.NotNull(data);
+        Assert.Equal(SamplePng, data);
+
+        await serverTask;
+    }
+
+    private static async Task<string> ReadRequestAsync(NetworkStream stream)
+    {
+        var buffer = new byte[1024];
+        using var request = new MemoryStream();
+
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer);
+            if (read == 0)
+                break;
+
+            request.Write(buffer, 0, read);
+            var bytes = request.ToArray();
+
+            // GET requests have no body; stop once headers are fully received.
+            if (IndexOf(bytes, HeaderTerminator) >= 0)
+                break;
+        }
+
+        return Encoding.UTF8.GetString(request.ToArray());
+    }
+
+    private static readonly byte[] HeaderTerminator = Encoding.ASCII.GetBytes("\r\n\r\n");
+
+    private static int IndexOf(byte[] source, byte[] pattern)
+    {
+        for (var i = 0; i <= source.Length - pattern.Length; i++)
+        {
+            var found = true;
+            for (var j = 0; j < pattern.Length; j++)
+            {
+                if (source[i + j] != pattern[j])
+                {
+                    found = false;
+                    break;
+                }
+            }
+
+            if (found)
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static async Task WriteResponseAsync(NetworkStream stream, int statusCode, string statusText, string contentType, byte[] body)
+    {
+        var header = Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 {statusCode} {statusText}\r\nContent-Type: {contentType}\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n");
+        await stream.WriteAsync(header);
+        await stream.WriteAsync(body);
+    }
+}


### PR DESCRIPTION
Fixes #340

## Problem

On the macOS **AppKit** head, `ui screenshot` (page capture) returned a generic, non-retryable error whenever the app window was not the frontmost application:

```json
{"error":"Failed to capture screenshot","type":"RuntimeError","retryable":false}
```

Bringing the app to the foreground made it succeed. The error was generic and `retryable:false`, which sent debugging the wrong way.

### Root cause

In the macOS `#if MACOS` override of `CaptureScreenshotAsync`:
1. Window resolution started with `NSApplication.SharedApplication.KeyWindow`, which is **null when the app is not the active/frontmost app**. The fallback only accepted a `PlatformView` that was exactly an `NSWindow`.
2. `CGWindowListCreateImage` can return `IntPtr.Zero` for a non-frontmost / occluded window whose backing store the window server purged.
3. When all native paths failed, the error detail was **lost**: `AgentClient.ScreenshotAsync` discarded the response body on non-2xx and returned `null`; the CLI printed a hard-coded generic `retryable:false` error.

## Approach — defense in depth

### Part A — make macOS capture work when not frontmost
`src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs` (`#if MACOS`):
- New `ResolveCaptureWindow` resolves the `NSWindow` **independent of `KeyWindow`**: prefers the window that owns the captured element's `NSView`, then the MAUI app window's platform view, then key/main windows, then any visible on-screen window.
- Added an occlusion-independent `CacheDisplay` fallback (re-renders the view hierarchy regardless of frontmost/occlusion state) **before** the existing `DataWithPdfInsideRect` last resort.

### Part B — actionable, retryable error end-to-end (fallback)
- **Core** (`Agent.Core/DevFlowAgentService.cs`): added `ScreenshotCaptureFailure` type, a `protected virtual ScreenshotCaptureFailure? DescribeScreenshotFailure()` hook, and `BuildScreenshotFailureResponseAsync()` which returns `409` with `reason` + `details.retryable` + `details.suggestions` when a cause is known.
- **macOS**: overrides `DescribeScreenshotFailure()` → `reason = window-not-frontmost`, `retryable = true`, with actionable suggestions.
- **Driver** (`Driver/AgentClient.cs`): added additive `ScreenshotResult` + `ScreenshotResultAsync()` that parses the structured error body. `ScreenshotAsync()` is now a **non-breaking** thin wrapper.
- **CLI / MCP**: surface the agent-provided message, retryable flag, and suggestions instead of the hard-coded generic error.

## Tests
New `src/DevFlow/Microsoft.Maui.DevFlow.Tests/ScreenshotAgentClientTests.cs` (TCP-listener harness):
- `ScreenshotResultAsync` returns `Success=true` with PNG bytes on 200.
- `ScreenshotResultAsync` parses a structured retryable error (`error`, `reason`, `details.retryable`, `details.suggestions`).
- `ScreenshotAsync` back-compat: still returns bytes on success, `null` on error.

## Verification
- `net10.0-macos` and `net10.0-maccatalyst` Agent targets build clean.
- Core / Driver / CLI compile.
- **221/221** DevFlow tests pass (including the 4 new ones).

## Notes
- Driver changes are **additive** — `ScreenshotAsync` signature is unchanged, so no breaking change for NuGet consumers.
- Platform `#if MACOS` capture code itself isn't unit-testable (needs a device); CI on macOS/Windows builds it. Tests cover the Core→Driver→CLI contract.