### PR TITLE
Fix preferences list to enumerate the native store (issue #344)

### DIFF
--- a/samples/DevFlow.Sample/MauiProgram.cs
+++ b/samples/DevFlow.Sample/MauiProgram.cs
@@ -49,7 +49,7 @@ public static class MauiProgram
 				"com.example.diagnostics",
 				"Sample diagnostics extension",
 				"1.0.0",
-				new[] { "build_info", "echo" });
+				new[] { "build_info", "echo", "seed_pref" });
 
 			diagnostics.MapTool(
 				"build_info",
@@ -109,6 +109,66 @@ public static class MauiProgram
 				annotations: new ExtensionToolAnnotations
 				{
 					Idempotent = true,
+					Category = "diagnostics"
+				});
+
+			// Writes a preference directly via Microsoft.Maui.Storage.Preferences,
+			// bypassing DevFlow's /preferences endpoints (so the key is NOT recorded
+			// in DevFlow's tracked-key registry). Reproduces issue #344: such keys must
+			// still appear in `preferences list` via native store enumeration.
+			diagnostics.MapTool(
+				"seed_pref",
+				"Writes a preference directly via the app's Preferences store, bypassing DevFlow tracking.",
+				"POST",
+				"seed-pref",
+				request =>
+				{
+					using var document = JsonDocument.Parse(string.IsNullOrWhiteSpace(request.Body) ? "{}" : request.Body);
+					var root = document.RootElement;
+					var key = root.TryGetProperty("key", out var keyElement) ? keyElement.GetString() : null;
+					if (string.IsNullOrEmpty(key))
+						return Task.FromResult(HttpResponse.Error("'key' is required."));
+
+					var value = root.TryGetProperty("value", out var valueElement) ? valueElement.GetString() : null;
+					var sharedName = root.TryGetProperty("sharedName", out var sharedElement) ? sharedElement.GetString() : null;
+
+					if (string.IsNullOrEmpty(sharedName))
+						Microsoft.Maui.Storage.Preferences.Default.Set(key, value ?? string.Empty);
+					else
+						Microsoft.Maui.Storage.Preferences.Default.Set(key, value ?? string.Empty, sharedName);
+
+					return Task.FromResult(HttpResponse.Json(new
+					{
+						key,
+						value = value ?? string.Empty,
+						sharedName,
+						seeded = true
+					}));
+				},
+				parameters: JsonDocument.Parse("""
+				{
+				  "type": "object",
+				  "properties": {
+				    "key": { "type": "string" },
+				    "value": { "type": "string" },
+				    "sharedName": { "type": "string" }
+				  },
+				  "required": ["key"]
+				}
+				""").RootElement.Clone(),
+				returns: JsonDocument.Parse("""
+				{
+				  "type": "object",
+				  "properties": {
+				    "key": { "type": "string" },
+				    "value": { "type": "string" },
+				    "sharedName": { "type": "string" },
+				    "seeded": { "type": "boolean" }
+				  }
+				}
+				""").RootElement.Clone(),
+				annotations: new ExtensionToolAnnotations
+				{
 					Category = "diagnostics"
 				});
 		});

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -903,7 +903,7 @@ public class DevFlowCommands
 
         var prefsSharedNameOption = new Option<string?>("--sharedName") { Description = "Shared preferences container name" };
 
-        var prefsListCmd = new Command("list", "List all known preference keys") { prefsSharedNameOption };
+        var prefsListCmd = new Command("list", "List preference keys (enumerates the native store where supported; response includes source and complete fields)") { prefsSharedNameOption };
         prefsListCmd.SetAction(async (ctx, ct) =>
         {
             var host = ctx.GetValue(agentHostOption)!;
@@ -2546,7 +2546,7 @@ public class DevFlowCommands
         new("network list", "List recent network requests", false),
         new("network detail", "Show full network request details", false),
         new("network clear", "Clear network request buffer", true),
-        new("storage preferences list", "List all known preference keys", false),
+        new("storage preferences list", "List preference keys (native enumeration where supported)", false),
         new("storage preferences get", "Get a preference value by key", false),
         new("storage preferences set", "Set a preference value", true),
         new("storage preferences delete", "Remove a preference", true),

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/PreferencesTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/PreferencesTools.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class PreferencesTools
 {
-	[McpServerTool(Name = "maui_preferences_list"), Description("List all known preference keys from the app's key-value store.")]
+	[McpServerTool(Name = "maui_preferences_list"), Description("List preference keys from the app's key-value store. Where the platform store can be enumerated (macOS/iOS/MacCatalyst/Android/Windows/Linux/WPF), all persisted keys are returned and the response reports source=\"native\" with complete=true. If enumeration is unsupported, only DevFlow-tracked keys are returned with source=\"registry\" and complete=false (app-written keys may be missing).")]
 	public static async Task<string> ListPreferences(
 		McpAgentSession session,
 		[Description("Shared preferences name (optional, for shared containers)")] string? sharedName = null,

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -5567,19 +5567,58 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
             SaveKnownPreferenceKeys(keys, sharedName);
     }
 
+    /// <summary>
+    /// Enumerate the preference keys actually present in the platform's backing
+    /// store (e.g. <c>NSUserDefaults</c>, Android <c>SharedPreferences</c>,
+    /// Windows <c>LocalSettings</c>) for the given <paramref name="sharedName"/>.
+    /// </summary>
+    /// <returns>
+    /// The keys present in the store (possibly empty) when the platform can
+    /// enumerate it, or <c>null</c> when it cannot. When <c>null</c> is returned,
+    /// <see cref="HandlePreferencesList"/> falls back to DevFlow's best-effort
+    /// tracked-key registry and reports the result as incomplete so callers know
+    /// app-written keys may be missing.
+    /// </returns>
+    protected virtual IReadOnlyCollection<string>? EnumerateNativePreferenceKeys(string? sharedName) => null;
+
     private Task<HttpResponse> HandlePreferencesList(HttpRequest request)
     {
         try
         {
             request.QueryParams.TryGetValue("sharedName", out var sharedName);
-            var keys = GetKnownPreferenceKeys(sharedName);
+
+            var registryKeys = GetKnownPreferenceKeys(sharedName);
+
+            IReadOnlyCollection<string>? nativeKeys;
+            try
+            {
+                nativeKeys = EnumerateNativePreferenceKeys(sharedName);
+            }
+            catch
+            {
+                // Best-effort: any platform failure degrades to registry-only.
+                nativeKeys = null;
+            }
+
+            var merged = PreferenceKeyMerger.Merge(
+                registryKeys,
+                nativeKeys,
+                excludeKeys: new[] { PreferencesKeyRegistryKey });
+
             var entries = new List<object>();
-            foreach (var key in keys.OrderBy(k => k))
+            foreach (var key in merged.Keys)
             {
                 var (value, type) = ReadPreferenceValue(key, sharedName);
                 entries.Add(new { key, value, type, sharedName });
             }
-            return Task.FromResult(HttpResponse.Json(new { keys = entries }));
+
+            return Task.FromResult(HttpResponse.Json(new
+            {
+                keys = entries,
+                source = merged.Source,
+                complete = merged.Complete,
+                sharedName
+            }));
         }
         catch (Exception ex)
         {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/PreferenceKeyMerger.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/PreferenceKeyMerger.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Maui.DevFlow.Agent.Core;
+
+/// <summary>
+/// The result of merging DevFlow's tracked preference-key registry with the
+/// keys enumerated from the platform's backing store.
+/// </summary>
+/// <param name="Keys">The ordered, de-duplicated set of preference keys.</param>
+/// <param name="Source">
+/// <c>"native"</c> when the platform store was enumerated (authoritative), or
+/// <c>"registry"</c> when only DevFlow-tracked keys are available (best-effort).
+/// </param>
+/// <param name="Complete">
+/// <c>true</c> when the list reflects the full backing store; <c>false</c> when
+/// it only reflects keys DevFlow itself wrote (app-set keys may be missing).
+/// </param>
+internal readonly record struct PreferenceKeySet(
+    IReadOnlyList<string> Keys,
+    string Source,
+    bool Complete);
+
+/// <summary>
+/// Pure (platform-free) helper that combines DevFlow's tracked preference-key
+/// registry with platform-enumerated keys and reports how complete the result
+/// is. Kept free of any MAUI/platform dependency so it can be unit tested.
+/// </summary>
+internal static class PreferenceKeyMerger
+{
+    public const string SourceNative = "native";
+    public const string SourceRegistry = "registry";
+
+    /// <summary>
+    /// Merge the registry keys with the (optional) native keys.
+    /// </summary>
+    /// <param name="registryKeys">Keys DevFlow has tracked via set/delete.</param>
+    /// <param name="nativeKeys">
+    /// Keys enumerated from the platform store, or <c>null</c> when the platform
+    /// cannot enumerate its store. When non-null, the result is marked complete.
+    /// </param>
+    /// <param name="excludeKeys">Internal keys to omit (e.g. DevFlow's registry key).</param>
+    public static PreferenceKeySet Merge(
+        IEnumerable<string> registryKeys,
+        IReadOnlyCollection<string>? nativeKeys,
+        IEnumerable<string>? excludeKeys = null)
+    {
+        var exclude = excludeKeys is null
+            ? new HashSet<string>(System.StringComparer.Ordinal)
+            : new HashSet<string>(excludeKeys, System.StringComparer.Ordinal);
+
+        var set = new HashSet<string>(System.StringComparer.Ordinal);
+        var nativeSupported = nativeKeys is not null;
+
+        if (nativeSupported)
+        {
+            foreach (var key in nativeKeys!)
+            {
+                if (!string.IsNullOrEmpty(key))
+                    set.Add(key);
+            }
+        }
+
+        // Always union the tracked registry so previously-listed keys never regress.
+        if (registryKeys is not null)
+        {
+            foreach (var key in registryKeys)
+            {
+                if (!string.IsNullOrEmpty(key))
+                    set.Add(key);
+            }
+        }
+
+        set.ExceptWith(exclude);
+
+        var ordered = set.OrderBy(k => k, System.StringComparer.Ordinal).ToList();
+        return new PreferenceKeySet(
+            ordered,
+            nativeSupported ? SourceNative : SourceRegistry,
+            nativeSupported);
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/GtkAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/GtkAgentService.cs
@@ -23,6 +23,11 @@ public class GtkAgentService : DevFlowAgentService
     {
         try
         {
+            // Guard against path traversal: sharedName becomes part of a file name.
+            if (!string.IsNullOrEmpty(sharedName) &&
+                (sharedName.Contains('/') || sharedName.Contains('\\') || sharedName.Contains("..")))
+                return null;
+
             // Mirror LinuxPreferences' on-disk layout:
             // $XDG_CONFIG_HOME (or ~/.config) / {FriendlyName} / preferences[.{shared}].json
             var configDir = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
@@ -49,6 +54,9 @@ public class GtkAgentService : DevFlowAgentService
         if (!global::System.IO.File.Exists(path))
             return new List<string>();
 
+        // Best-effort read: not synchronized with LinuxPreferences.Save, so a
+        // concurrent write may yield partial JSON. The caller's catch treats a
+        // parse failure as "cannot enumerate" (degrades to complete=false).
         var json = global::System.IO.File.ReadAllText(path);
         if (string.IsNullOrWhiteSpace(json))
             return new List<string>();

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/GtkAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Gtk/GtkAgentService.cs
@@ -19,6 +19,50 @@ public class GtkAgentService : DevFlowAgentService
     protected override string DeviceTypeName => "Virtual";
     protected override string IdiomName => "Desktop";
 
+    protected override IReadOnlyCollection<string>? EnumerateNativePreferenceKeys(string? sharedName)
+    {
+        try
+        {
+            // Mirror LinuxPreferences' on-disk layout:
+            // $XDG_CONFIG_HOME (or ~/.config) / {FriendlyName} / preferences[.{shared}].json
+            var configDir = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            if (string.IsNullOrEmpty(configDir))
+                configDir = global::System.IO.Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config");
+
+            var appDir = global::System.IO.Path.Combine(configDir, AppDomain.CurrentDomain.FriendlyName);
+            var fileName = string.IsNullOrEmpty(sharedName)
+                ? "preferences.json"
+                : $"preferences.{sharedName}.json";
+            var path = global::System.IO.Path.Combine(appDir, fileName);
+
+            return ReadJsonObjectKeys(path);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static IReadOnlyCollection<string>? ReadJsonObjectKeys(string path)
+    {
+        if (!global::System.IO.File.Exists(path))
+            return new List<string>();
+
+        var json = global::System.IO.File.ReadAllText(path);
+        if (string.IsNullOrWhiteSpace(json))
+            return new List<string>();
+
+        using var doc = global::System.Text.Json.JsonDocument.Parse(json);
+        if (doc.RootElement.ValueKind != global::System.Text.Json.JsonValueKind.Object)
+            return new List<string>();
+
+        var keys = new List<string>();
+        foreach (var prop in doc.RootElement.EnumerateObject())
+            keys.Add(prop.Name);
+        return keys;
+    }
+
     protected override double GetWindowDisplayDensity(IWindow? window)
     {
         try

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/PreferencesTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/PreferencesTests.cs
@@ -49,6 +49,36 @@ public class PreferencesTests : IntegrationTestBase
         await Client.DeletePreferenceAsync(key);
     }
 
+    // Regression test for issue #344: a preference written directly by the app
+    // (here via the sample's `seed_pref` diagnostics tool, which calls
+    // Preferences.Default.Set bypassing DevFlow's /preferences endpoints) must
+    // still be enumerated by `preferences list` via the native backing store,
+    // not just keys DevFlow itself tracked. The response must also report
+    // native enumeration as complete.
+    [Fact]
+    public async Task List_IncludesKeyWrittenDirectlyByApp()
+    {
+        var key = $"{TestKeyPrefix}app_written";
+
+        try
+        {
+            await Client.CallExtensionToolAsync(
+                "POST",
+                "/api/v1/ext/com.example.diagnostics/seed-pref",
+                JsonSerializer.SerializeToElement(new { key, value = "app_written_value" }));
+
+            var list = await Client.GetPreferencesAsync();
+
+            Assert.Contains(key, list.ToString());
+            Assert.Equal("native", list.GetProperty("source").GetString());
+            Assert.True(list.GetProperty("complete").GetBoolean());
+        }
+        finally
+        {
+            await Client.DeletePreferenceAsync(key);
+        }
+    }
+
     [Fact]
     public async Task Delete_RemovesKey()
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/PreferencesTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/PreferencesTests.cs
@@ -44,7 +44,9 @@ public class PreferencesTests : IntegrationTestBase
         await Client.SetPreferenceAsync(key, "list_value");
 
         var list = await Client.GetPreferencesAsync();
-        Assert.Contains(key, list.ToString());
+        var listedKeys = list.GetProperty("keys").EnumerateArray()
+            .Select(e => e.GetProperty("key").GetString());
+        Assert.Contains(key, listedKeys);
 
         await Client.DeletePreferenceAsync(key);
     }
@@ -69,7 +71,9 @@ public class PreferencesTests : IntegrationTestBase
 
             var list = await Client.GetPreferencesAsync();
 
-            Assert.Contains(key, list.ToString());
+            var listedKeys = list.GetProperty("keys").EnumerateArray()
+                .Select(e => e.GetProperty("key").GetString());
+            Assert.Contains(key, listedKeys);
             Assert.Equal("native", list.GetProperty("source").GetString());
             Assert.True(list.GetProperty("complete").GetBoolean());
         }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.WPF/WpfAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.WPF/WpfAgentService.cs
@@ -25,6 +25,39 @@ public class WpfAgentService : DevFlowAgentService
     protected override string DeviceTypeName => "Virtual";
     protected override string IdiomName => "Desktop";
 
+    protected override IReadOnlyCollection<string>? EnumerateNativePreferenceKeys(string? sharedName)
+    {
+        try
+        {
+            // Mirror WPFPreferences' on-disk layout:
+            // LocalApplicationData / {FriendlyName} / preferences / {shared|default}.json
+            var prefsDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                AppDomain.CurrentDomain.FriendlyName, "preferences");
+            var path = Path.Combine(prefsDir, (sharedName ?? "default") + ".json");
+
+            if (!File.Exists(path))
+                return new List<string>();
+
+            var json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+                return new List<string>();
+
+            using var doc = global::System.Text.Json.JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != global::System.Text.Json.JsonValueKind.Object)
+                return new List<string>();
+
+            var keys = new List<string>();
+            foreach (var prop in doc.RootElement.EnumerateObject())
+                keys.Add(prop.Name);
+            return keys;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     protected override double GetWindowDisplayDensity(IWindow? window)
     {
         try

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.WPF/WpfAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.WPF/WpfAgentService.cs
@@ -29,6 +29,11 @@ public class WpfAgentService : DevFlowAgentService
     {
         try
         {
+            // Guard against path traversal: sharedName becomes part of a file name.
+            if (!string.IsNullOrEmpty(sharedName) &&
+                (sharedName.Contains('/') || sharedName.Contains('\\') || sharedName.Contains("..")))
+                return null;
+
             // Mirror WPFPreferences' on-disk layout:
             // LocalApplicationData / {FriendlyName} / preferences / {shared|default}.json
             var prefsDir = Path.Combine(
@@ -39,6 +44,7 @@ public class WpfAgentService : DevFlowAgentService
             if (!File.Exists(path))
                 return new List<string>();
 
+            // Best-effort read; parse failures degrade to complete=false.
             var json = File.ReadAllText(path);
             if (string.IsNullOrWhiteSpace(json))
                 return new List<string>();

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -60,6 +60,110 @@ public class PlatformAgentService : DevFlowAgentService
         }
     }
 
+    protected override IReadOnlyCollection<string>? EnumerateNativePreferenceKeys(string? sharedName)
+    {
+        try
+        {
+#if IOS || MACCATALYST || MACOS
+            // NSUserDefaults: enumerate the app's persistent domain so we return
+            // only the app's own keys, not the global/system defaults search list.
+            var domain = !string.IsNullOrWhiteSpace(sharedName)
+                ? sharedName!
+                : NSBundle.MainBundle.BundleIdentifier;
+            if (string.IsNullOrEmpty(domain))
+                return null;
+
+            var representation = NSUserDefaults.StandardUserDefaults.PersistentDomainForName(domain);
+            if (representation is null)
+                return new List<string>();
+
+            var keys = new List<string>();
+            foreach (var key in representation.Keys)
+            {
+                var name = key?.ToString();
+                if (!string.IsNullOrEmpty(name))
+                    keys.Add(name!);
+            }
+            return keys;
+#elif ANDROID
+            // Mirror MAUI Essentials' store selection: default uses the default
+            // SharedPreferences, a sharedName uses a private named file.
+            var context = global::Android.App.Application.Context;
+            using var prefs = string.IsNullOrWhiteSpace(sharedName)
+#pragma warning disable CS0618 // GetDefaultSharedPreferences is the store Essentials uses
+                ? global::Android.Preferences.PreferenceManager.GetDefaultSharedPreferences(context)
+#pragma warning restore CS0618
+                : context.GetSharedPreferences(sharedName, global::Android.Content.FileCreationMode.Private);
+            var all = prefs?.All;
+            if (all is null)
+                return new List<string>();
+            return new List<string>(all.Keys);
+#elif WINDOWS
+            try
+            {
+                var localSettings = global::Windows.Storage.ApplicationData.Current.LocalSettings;
+                global::Windows.Storage.ApplicationDataContainer? container;
+                if (string.IsNullOrWhiteSpace(sharedName))
+                    container = localSettings;
+                else
+                    container = localSettings.Containers.ContainsKey(sharedName)
+                        ? localSettings.Containers[sharedName]
+                        : null;
+
+                if (container is null)
+                    return new List<string>();
+                return new List<string>(container.Values.Keys);
+            }
+            catch
+            {
+                // Unpackaged apps throw on ApplicationData.Current — fall back to the
+                // preferences.dat file MAUI Essentials writes for unpackaged apps.
+                return EnumerateUnpackagedWindowsPreferenceKeys(sharedName);
+            }
+#else
+            return base.EnumerateNativePreferenceKeys(sharedName);
+#endif
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+#if WINDOWS
+    private static IReadOnlyCollection<string>? EnumerateUnpackagedWindowsPreferenceKeys(string? sharedName)
+    {
+        try
+        {
+            var path = global::System.IO.Path.Combine(
+                Microsoft.Maui.Storage.FileSystem.AppDataDirectory, "..", "Settings", "preferences.dat");
+            if (!global::System.IO.File.Exists(path))
+                return new List<string>();
+
+            var json = global::System.IO.File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+                return new List<string>();
+
+            using var doc = global::System.Text.Json.JsonDocument.Parse(json);
+            var bucket = sharedName ?? string.Empty;
+            if (doc.RootElement.ValueKind == global::System.Text.Json.JsonValueKind.Object &&
+                doc.RootElement.TryGetProperty(bucket, out var inner) &&
+                inner.ValueKind == global::System.Text.Json.JsonValueKind.Object)
+            {
+                var keys = new List<string>();
+                foreach (var prop in inner.EnumerateObject())
+                    keys.Add(prop.Name);
+                return keys;
+            }
+            return new List<string>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+#endif
+
     protected override Task<bool> TryNativeScroll(VisualElement element, double deltaX, double deltaY)
     {
         try

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/PreferenceKeyMergerTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/PreferenceKeyMergerTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Maui.DevFlow.Agent.Core;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class PreferenceKeyMergerTests
+{
+    [Fact]
+    public void Merge_NoNativeSupport_ReturnsRegistryOnlyAndIncomplete()
+    {
+        var result = PreferenceKeyMerger.Merge(
+            registryKeys: new[] { "b", "a" },
+            nativeKeys: null);
+
+        Assert.Equal(PreferenceKeyMerger.SourceRegistry, result.Source);
+        Assert.False(result.Complete);
+        Assert.Equal(new[] { "a", "b" }, result.Keys);
+    }
+
+    [Fact]
+    public void Merge_NativeSupported_ReturnsNativeAndComplete()
+    {
+        var result = PreferenceKeyMerger.Merge(
+            registryKeys: Array.Empty<string>(),
+            nativeKeys: new[] { "session", "theme" });
+
+        Assert.Equal(PreferenceKeyMerger.SourceNative, result.Source);
+        Assert.True(result.Complete);
+        Assert.Equal(new[] { "session", "theme" }, result.Keys);
+    }
+
+    [Fact]
+    public void Merge_NativeSupported_UnionsRegistryKeysWithoutRegression()
+    {
+        // A key DevFlow tracked but that the native enumeration somehow missed
+        // must still be listed (no regression vs. registry-only behavior).
+        var result = PreferenceKeyMerger.Merge(
+            registryKeys: new[] { "tracked_only" },
+            nativeKeys: new[] { "app_written" });
+
+        Assert.True(result.Complete);
+        Assert.Equal(new[] { "app_written", "tracked_only" }, result.Keys);
+    }
+
+    [Fact]
+    public void Merge_Deduplicates_OverlappingKeys()
+    {
+        var result = PreferenceKeyMerger.Merge(
+            registryKeys: new[] { "shared", "reg" },
+            nativeKeys: new[] { "shared", "nat" });
+
+        Assert.Equal(new[] { "nat", "reg", "shared" }, result.Keys);
+    }
+
+    [Fact]
+    public void Merge_ExcludesInternalKeys()
+    {
+        const string registryKey = "__devflow_known_keys";
+        var result = PreferenceKeyMerger.Merge(
+            registryKeys: new[] { "user_key" },
+            nativeKeys: new[] { "user_key", registryKey },
+            excludeKeys: new[] { registryKey });
+
+        Assert.DoesNotContain(registryKey, result.Keys);
+        Assert.Equal(new[] { "user_key" }, result.Keys);
+    }
+
+    [Fact]
+    public void Merge_NativeEmpty_IsCompleteWithNoKeys()
+    {
+        var result = PreferenceKeyMerger.Merge(
+            registryKeys: Array.Empty<string>(),
+            nativeKeys: Array.Empty<string>());
+
+        Assert.Equal(PreferenceKeyMerger.SourceNative, result.Source);
+        Assert.True(result.Complete);
+        Assert.Empty(result.Keys);
+    }
+
+    [Fact]
+    public void Merge_IgnoresNullAndEmptyKeys()
+    {
+        var result = PreferenceKeyMerger.Merge(
+            registryKeys: new[] { "", "a" },
+            nativeKeys: new[] { "b", "", null! });
+
+        Assert.Equal(new[] { "a", "b" }, result.Keys);
+    }
+
+    [Fact]
+    public void Merge_KeysAreOrdinallySorted()
+    {
+        var result = PreferenceKeyMerger.Merge(
+            registryKeys: new[] { "Zebra", "apple", "Banana" },
+            nativeKeys: null);
+
+        // Ordinal: uppercase letters sort before lowercase.
+        Assert.Equal(new[] { "Banana", "Zebra", "apple" }, result.Keys);
+    }
+}


### PR DESCRIPTION
Fixes #344.

## Problem

On the macOS AppKit head (and in fact every platform), `maui devflow storage preferences list` returned `{"keys":[]}` even when the app had persisted preferences — e.g. a signed-in session restored across launches.

### Root cause

`HandlePreferencesList` only enumerated DevFlow's own **tracked-key registry** (`__devflow_known_keys`), which is populated *only* when a preference is set **through** the agent (`HandlePreferencesSet` → `TrackPreferenceKey`). Preferences the app writes directly via `Microsoft.Maui.Storage.Preferences` are never tracked, so they were invisible to `list`. The backing stores were all actually enumerable — we just weren't reading them.

## Approach

- **Core** (`Agent.Core`): added a virtual `EnumerateNativePreferenceKeys(sharedName)` hook (returns `null` when a platform can't enumerate its store) and a pure, unit-tested `PreferenceKeyMerger` that unions native keys with the tracked registry. `HandlePreferencesList` now merges both and returns additive `source` (`native`/`registry`), `complete`, and `sharedName` fields so registry-only fallbacks are explicit (matches the issue's "Expected behavior").
- **Platform overrides** enumerate each backing store:
  - Apple (macOS / iOS / MacCatalyst): `NSUserDefaults.PersistentDomainForName` (app domain only — excludes system/global defaults)
  - Android: `SharedPreferences.All.Keys` (mirrors Essentials' store selection)
  - Windows: `ApplicationData.LocalSettings` / containers, with a `preferences.dat` fallback for unpackaged apps
  - Linux GTK and WPF: their respective JSON preference files
- Any platform failure degrades to registry-only (`complete:false`) so listing never throws. Always unions the registry so previously-listed keys never regress.
- Updated the `maui_preferences_list` MCP tool and CLI help text.

## Tests

- 8 unit tests for `PreferenceKeyMerger` (registry-only vs native, dedupe/union, internal-key exclusion, ordering, completeness/source).
- Integration repro: a new `seed_pref` diagnostics tool in `samples/DevFlow.Sample` writes a preference **directly** (bypassing DevFlow tracking); `PreferencesTests.List_IncludesKeyWrittenDirectlyByApp` asserts the key appears in `list` with `source=native`, `complete=true`.

## Notes

- Response is **additive** (`source`, `complete`, `sharedName`); the existing `keys` array shape is preserved. Repo is `0.1.0-preview`.
- Validated by build across TFMs (Agent.Core, Apple/Android/iOS platform heads, GTK, sample maccatalyst) and unit tests. WPF (`net10.0-windows`) builds on the CI Windows runner; reviewed for correctness.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>