### PR TITLE
Add application menu inspection and invocation to DevFlow (#339)

### DIFF
--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -85,6 +85,7 @@ If the tool calls a new agent endpoint, add the client method in `Microsoft.Maui
 | `InvokeTools.cs` | `maui_list_actions`, `maui_invoke_action` | DevFlow Actions |
 | `JobTools.cs` | `maui_jobs_list`, `maui_jobs_run` | Background jobs |
 | `LogsTool.cs` | `maui_logs` | Log retrieval |
+| `MenuTools.cs` | `maui_menu_list`, `maui_menu_invoke` | Application menu inspection & invocation |
 | `NavigationTools.cs` | `maui_navigate`, `maui_back`, `maui_focus`, `maui_resize` | Navigation & window |
 | `NetworkTool.cs` | `maui_network`, `maui_network_detail`, `maui_network_clear` | Network inspection |
 | `PlatformTools.cs` | `maui_app_info`, `maui_device_info`, `maui_display_info`, `maui_battery_info`, `maui_connectivity`, `maui_geolocation` | Device/app info |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ Each product requires source setup **and** CI/CD configuration across two system
 
 ## DevFlow MCP Tools
 
-DevFlow exposes 67 MCP tools for AI agent integration (in `src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/`):
+DevFlow exposes 69 MCP tools for AI agent integration (in `src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/`):
 
 | Tool | Purpose |
 |------|---------|
@@ -260,6 +260,8 @@ DevFlow exposes 67 MCP tools for AI agent integration (in `src/Cli/Microsoft.Mau
 | `maui_list_actions` | List all registered DevFlow Actions |
 | `maui_list_agents` | List connected MAUI DevFlow agents (running apps) |
 | `maui_logs` | Retrieve app logs (ILogger + WebView console) |
+| `maui_menu_invoke` | Invoke an application menu item (MAUI or native macOS/Catalyst menu) |
+| `maui_menu_list` | Inspect the application menu bar (MAUI MenuBarItems + native menu) |
 | `maui_navigate` | Shell navigation to a route |
 | `maui_network` | List captured HTTP requests |
 | `maui_network_clear` | Clear captured request buffer |

--- a/docs/DevFlow/spec/examples/agent-status-response.json
+++ b/docs/DevFlow/spec/examples/agent-status-response.json
@@ -26,7 +26,8 @@
     "sensors": true,
     "storage": true,
     "profiler": true,
-    "jobs": true
+    "jobs": true,
+    "menus": true
   },
   "running": true,
   "uptime": "PT5M30S"

--- a/docs/DevFlow/spec/examples/capabilities-maui-response.json
+++ b/docs/DevFlow/spec/examples/capabilities-maui-response.json
@@ -18,6 +18,12 @@
       "version": 1,
       "features": ["element", "fullscreen", "selector"]
     },
+    "ui.menus": {
+      "version": 1,
+      "features": ["list", "invoke"],
+      "maui": true,
+      "native": true
+    },
     "webview": {
       "version": 1,
       "features": ["evaluate", "contexts", "source", "dom", "dom-query", "network", "console", "screenshot"]

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -284,6 +284,103 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/v1/ui/menus:
+    get:
+      operationId: listMenus
+      tags: [ui]
+      summary: List application menus
+      description: >
+        Returns the application menu bar: the cross-platform MAUI MenuBarItems
+        tree plus, where supported, the platform's native application menu
+        (macOS AppKit NSMenu or Mac Catalyst responder-chain key commands). The
+        native menu bar is not part of the MAUI visual tree returned by the tree
+        endpoint.
+      parameters:
+        - name: window
+          in: query
+          description: Window index to scope the MAUI menu walk. Defaults to all windows.
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        "200":
+          description: The application menus.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  platform:
+                    type: string
+                  mauiSupported:
+                    type: boolean
+                  nativeSupported:
+                    type: boolean
+                  menuBar:
+                    type: object
+                    description: The cross-platform MAUI MenuBarItems tree.
+                  native:
+                    description: The platform native menu, or null when unavailable.
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/v1/ui/menus/invoke:
+    post:
+      operationId: invokeMenu
+      tags: [ui]
+      summary: Invoke an application menu item
+      description: >
+        Invokes an application menu item identified by id, path (slash-joined
+        titles), title, or key plus modifiers. The target selects the menu
+        layer: auto (default, tries the MAUI menu then the native menu), maui,
+        or native.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Stable menu item id from the list endpoint.
+                path:
+                  type: string
+                  description: Slash-joined title path, e.g. "File/Save".
+                title:
+                  type: string
+                  description: Menu item title (first match).
+                key:
+                  type: string
+                  description: Key equivalent (combine with modifiers).
+                modifiers:
+                  type: string
+                  description: Comma or plus separated modifiers, e.g. "cmd,shift".
+                target:
+                  type: string
+                  enum: [auto, maui, native]
+                  default: auto
+      responses:
+        "200":
+          description: The menu item was invoked.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  source:
+                    type: string
+                  title:
+                    type: string
+                  path:
+                    type: string
+        "404":
+          $ref: "#/components/responses/ElementNotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   # ─────────────────────────── UI Actions ──────────────────────────────
   /api/v1/ui/actions/tap:
     post:

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -89,6 +89,15 @@
               "element"
             ]
           },
+          "ui.menus": {
+            "version": 1,
+            "features": [
+              "list",
+              "invoke"
+            ],
+            "maui": true,
+            "native": true
+          },
           "webview": {
             "version": 1,
             "features": [

--- a/docs/DevFlow/spec/schemas/agent-status.json
+++ b/docs/DevFlow/spec/schemas/agent-status.json
@@ -130,6 +130,10 @@
         "jobs": {
           "type": "boolean",
           "description": "Whether platform background jobs are supported by this agent."
+        },
+        "menus": {
+          "type": "boolean",
+          "description": "Whether application menu inspection and invocation are supported by this agent."
         }
       },
       "additionalProperties": true

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -1328,6 +1328,55 @@ public class DevFlowCommands
 
         platformCommand.Add(sensorsCommand);
 
+        // MAUI menu (application menu bar inspection + invocation)
+        var mauiMenuCmd = new Command("menu", "Inspect and invoke the application menu bar");
+
+        var menuListCmd = new Command("list", "List application menus (MAUI MenuBarItems + native menu)") { windowOption };
+        menuListCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var window = ctx.GetValue(windowOption);
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            await MauiMenuListAsync(host, port, isJson, window);
+        });
+        mauiMenuCmd.Add(menuListCmd);
+
+        var menuInvokeIdOption = new Option<string?>("--id") { Description = "Menu item id from 'menu list' (e.g. maui:w0/1/2 or native:1/3)" };
+        var menuInvokePathOption = new Option<string?>("--path") { Description = "Slash-joined title path, e.g. 'File/Save'" };
+        var menuInvokeTitleOption = new Option<string?>("--title") { Description = "Menu item title (first match)" };
+        var menuInvokeKeyOption = new Option<string?>("--key") { Description = "Key equivalent, e.g. 's' (combine with --modifiers)" };
+        var menuInvokeModifiersOption = new Option<string?>("--modifiers") { Description = "Comma/plus separated modifiers, e.g. 'cmd,shift'" };
+        var menuInvokeTargetOption = new Option<string?>("--target") { Description = "Menu layer: auto (default), maui, or native" };
+        var menuInvokeCmd = new Command("invoke", "Invoke an application menu item")
+        {
+            menuInvokeIdOption, menuInvokePathOption, menuInvokeTitleOption,
+            menuInvokeKeyOption, menuInvokeModifiersOption, menuInvokeTargetOption,
+            andScreenshotOption, andTreeOption, andTreeDepthOption,
+        };
+        menuInvokeCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            var id = ctx.GetValue(menuInvokeIdOption);
+            var path = ctx.GetValue(menuInvokePathOption);
+            var title = ctx.GetValue(menuInvokeTitleOption);
+            var key = ctx.GetValue(menuInvokeKeyOption);
+            var modifiers = ctx.GetValue(menuInvokeModifiersOption);
+            var target = ctx.GetValue(menuInvokeTargetOption);
+            var andScreenshot = ctx.GetValue(andScreenshotOption);
+            var hasAndScreenshot = ctx.GetResult(andScreenshotOption) != null;
+            var andTree = ctx.GetValue(andTreeOption);
+            var andTreeDepth = ctx.GetValue(andTreeDepthOption);
+            var invoked = await MauiMenuInvokeAsync(host, port, isJson, id, path, title, key, modifiers, target);
+            if (invoked)
+                await HandlePostActionFlags(host, port, isJson, hasAndScreenshot, andScreenshot, andTree, andTreeDepth);
+        });
+        mauiMenuCmd.Add(menuInvokeCmd);
+
+        mauiCommand.Add(mauiMenuCmd);
+
         devflowCommand.Add(mauiCommand);
 
         // ===== init / skills commands =====
@@ -2839,6 +2888,127 @@ public class DevFlowCommands
                 Console.WriteLine(result);
         }
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
+    }
+
+    private static async Task MauiMenuListAsync(string host, int port, bool json, int? window)
+    {
+        try
+        {
+            using var client = await CreateAgentClientAsync(host, port);
+            var menus = await client.GetMenusAsync(window);
+            if (menus.ValueKind == JsonValueKind.Undefined)
+            {
+                Output.WriteError("Failed to retrieve menus", json);
+                _errorOccurred = true;
+                return;
+            }
+
+            if (json)
+            {
+                Console.WriteLine(FormatJson(menus));
+                return;
+            }
+
+            PrintMenus(menus);
+        }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
+    }
+
+    private static async Task<bool> MauiMenuInvokeAsync(string host, int port, bool json, string? id, string? path, string? title, string? key, string? modifiers, string? target)
+    {
+        if (string.IsNullOrWhiteSpace(id) && string.IsNullOrWhiteSpace(path) &&
+            string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(key))
+        {
+            Output.WriteError("Provide one of: --id, --path, --title, or --key", json, "InvocationError");
+            _errorOccurred = true;
+            return false;
+        }
+
+        try
+        {
+            using var client = await CreateAgentClientAsync(host, port);
+            var result = await client.InvokeMenuAsync(id, path, title, key, modifiers, target);
+
+            var success = result.ValueKind == JsonValueKind.Object &&
+                          result.TryGetProperty("success", out var s) && s.ValueKind == JsonValueKind.True;
+
+            if (json)
+            {
+                Console.WriteLine(result.ValueKind == JsonValueKind.Undefined ? "{\"success\":false}" : FormatJson(result));
+            }
+            else
+            {
+                var label = id ?? path ?? title ?? key;
+                Console.WriteLine(success ? $"Invoked: {label}" : $"Failed to invoke menu item: {label}");
+            }
+
+            if (!success) _errorOccurred = true;
+            return success;
+        }
+        catch (Exception ex)
+        {
+            Output.WriteError(ex.Message, json, suggestions: new[] { "Run 'ui menu list' to see available menu items" });
+            _errorOccurred = true;
+            return false;
+        }
+    }
+
+    private static void PrintMenus(JsonElement menus)
+    {
+        if (menus.TryGetProperty("platform", out var platform))
+            Console.WriteLine($"Platform: {platform.GetString()}");
+
+        if (menus.TryGetProperty("menuBar", out var menuBar) && menuBar.ValueKind == JsonValueKind.Object &&
+            menuBar.TryGetProperty("items", out var mauiItems) && mauiItems.ValueKind == JsonValueKind.Array &&
+            mauiItems.GetArrayLength() > 0)
+        {
+            Console.WriteLine("MAUI menu bar:");
+            foreach (var item in mauiItems.EnumerateArray())
+                PrintMenuNode(item, 1);
+        }
+
+        if (menus.TryGetProperty("native", out var native) && native.ValueKind == JsonValueKind.Object &&
+            native.TryGetProperty("items", out var nativeItems) && nativeItems.ValueKind == JsonValueKind.Array)
+        {
+            var source = native.TryGetProperty("source", out var src) ? src.GetString() : "native";
+            Console.WriteLine($"Native menu ({source}):");
+            foreach (var item in nativeItems.EnumerateArray())
+                PrintMenuNode(item, 1);
+        }
+    }
+
+    private static void PrintMenuNode(JsonElement node, int depth)
+    {
+        var indent = new string(' ', depth * 2);
+
+        if (node.TryGetProperty("separator", out var sep) && sep.ValueKind == JsonValueKind.True)
+        {
+            Console.WriteLine($"{indent}--------");
+            return;
+        }
+
+        var title = node.TryGetProperty("title", out var t) ? t.GetString() : "";
+        var line = $"{indent}{title}";
+
+        if (node.TryGetProperty("key", out var key) && key.ValueKind == JsonValueKind.String)
+        {
+            var mods = "";
+            if (node.TryGetProperty("modifiers", out var m) && m.ValueKind == JsonValueKind.Array)
+                mods = string.Join("+", m.EnumerateArray().Select(x => x.GetString()));
+            line += string.IsNullOrEmpty(mods) ? $"  [{key.GetString()}]" : $"  [{mods}+{key.GetString()}]";
+        }
+
+        if (node.TryGetProperty("enabled", out var en) && en.ValueKind == JsonValueKind.False)
+            line += "  (disabled)";
+
+        if (node.TryGetProperty("id", out var id) && id.ValueKind == JsonValueKind.String)
+            line += $"  {id.GetString()}";
+
+        Console.WriteLine(line);
+
+        if (node.TryGetProperty("items", out var items) && items.ValueKind == JsonValueKind.Array)
+            foreach (var child in items.EnumerateArray())
+                PrintMenuNode(child, depth + 1);
     }
 
     private static async Task MauiTapAsync(string host, int port, bool json, string elementId)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -46,6 +46,7 @@ public static class McpServerHost
 			.WithTools<ThemeTools>()
 			.WithTools<SensorTools>()
 			.WithTools<JobTools>()
+			.WithTools<MenuTools>()
 			.WithTools<FileTools>()
 			.WithTools<BatchTools>()
 			.WithTools<InvokeTools>()

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/MenuTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/MenuTools.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Microsoft.Maui.Cli.DevFlow.Mcp;
+
+namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class MenuTools
+{
+	[McpServerTool(Name = "maui_menu_list"), Description("Inspect the application menu bar. Returns the cross-platform MAUI MenuBarItems tree plus, where supported, the platform's native application menu (macOS AppKit NSMenu, or Mac Catalyst responder-chain key commands). Use this to discover menu titles, paths, key equivalents, and enabled state — the native app menu is not part of the visual tree returned by maui_tree.")]
+	public static async Task<string> ListMenus(
+		McpAgentSession session,
+		[Description("Optional window index to scope the MAUI menu walk to a single window")] int? window = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.GetMenusAsync(window);
+		return result.ValueKind == JsonValueKind.Undefined ? "Failed to list menus." : result.ToString();
+	}
+
+	[McpServerTool(Name = "maui_menu_invoke"), Description("Invoke an application menu item. Identify the item by id (from maui_menu_list), path (slash-joined titles such as 'File/Save'), title, or key + modifiers (e.g. key 'l', modifiers 'cmd,shift'). The target selects the menu layer: 'auto' (default — tries the MAUI menu, then the native menu), 'maui', or 'native'. On macOS this performs the native NSMenu item; cross-platform MAUI menu items execute their Command and fire Clicked.")]
+	public static async Task<string> InvokeMenu(
+		McpAgentSession session,
+		[Description("Stable menu item id from maui_menu_list (e.g. 'maui:w0/1/2' or 'native:1/3')")] string? id = null,
+		[Description("Slash-joined title path, e.g. 'Account/Log Out'")] string? path = null,
+		[Description("Menu item title (first match)")] string? title = null,
+		[Description("Key equivalent for the item, e.g. 'l' or 's'. Combine with modifiers.")] string? key = null,
+		[Description("Comma or plus separated modifiers for the key, e.g. 'cmd,shift'")] string? modifiers = null,
+		[Description("Menu layer to target: 'auto' (default), 'maui', or 'native'")] string? target = null,
+		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null)
+	{
+		if (string.IsNullOrWhiteSpace(id) && string.IsNullOrWhiteSpace(path) &&
+			string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(key))
+		{
+			return "Provide one of: id, path, title, or key.";
+		}
+
+		var agent = await session.GetAgentClientAsync(agentPort);
+		var result = await agent.InvokeMenuAsync(id, path, title, key, modifiers, target);
+		return result.ValueKind == JsonValueKind.Undefined
+			? "Failed to invoke menu item (not found or unsupported)."
+			: result.ToString();
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/MenuTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/MenuTools.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class MenuTools
 {
-	[McpServerTool(Name = "maui_menu_list"), Description("Inspect the application menu bar. Returns the cross-platform MAUI MenuBarItems tree plus, where supported, the platform's native application menu (macOS AppKit NSMenu, or Mac Catalyst responder-chain key commands). Use this to discover menu titles, paths, key equivalents, and enabled state — the native app menu is not part of the visual tree returned by maui_tree.")]
+	[McpServerTool(Name = "maui_menu_list"), Description("Inspect the application menu bar. Returns the cross-platform MAUI MenuBarItems tree plus, where supported, the platform's native application menu (macOS AppKit NSMenu, or Mac Catalyst responder-chain key commands). Use this to discover menu titles, paths, key equivalents, and enabled state — the native app menu is not part of the visual tree returned by maui_tree. On Mac Catalyst, native 'native:N' ids are ephemeral (derived from responder-chain order at call time) and should only be used within the same automation step; prefer key + modifiers for stable invocation on Catalyst. macOS AppKit ids are stable.")]
 	public static async Task<string> ListMenus(
 		McpAgentSession session,
 		[Description("Optional window index to scope the MAUI menu walk to a single window")] int? window = null,
@@ -19,11 +19,11 @@ public sealed class MenuTools
 		return result.ValueKind == JsonValueKind.Undefined ? "Failed to list menus." : result.ToString();
 	}
 
-	[McpServerTool(Name = "maui_menu_invoke"), Description("Invoke an application menu item. Identify the item by id (from maui_menu_list), path (slash-joined titles such as 'File/Save'), title, or key + modifiers (e.g. key 'l', modifiers 'cmd,shift'). The target selects the menu layer: 'auto' (default — tries the MAUI menu, then the native menu), 'maui', or 'native'. On macOS this performs the native NSMenu item; cross-platform MAUI menu items execute their Command and fire Clicked.")]
+	[McpServerTool(Name = "maui_menu_invoke"), Description("Invoke an application menu item. Identify the item by id (from maui_menu_list), path (slash-joined titles such as 'File/Save'), title, or key + modifiers (e.g. key 'l', modifiers 'cmd,shift'). The target selects the menu layer: 'auto' (default — tries the MAUI menu, then the native menu), 'maui', or 'native'. On macOS this performs the native NSMenu item; cross-platform MAUI menu items execute their Command and fire Clicked. Note: paths are slash-joined titles and do not escape '/', so a menu title that itself contains '/' is ambiguous for path matching - identify such items by their stable id from maui_menu_list instead.")]
 	public static async Task<string> InvokeMenu(
 		McpAgentSession session,
-		[Description("Stable menu item id from maui_menu_list (e.g. 'maui:w0/1/2' or 'native:1/3')")] string? id = null,
-		[Description("Slash-joined title path, e.g. 'Account/Log Out'")] string? path = null,
+		[Description("Menu item id from maui_menu_list (e.g. 'maui:w0/1/2' or 'native:1/3'). MAUI and macOS ids are stable; Mac Catalyst 'native:N' ids are ephemeral - prefer key + modifiers there.")] string? id = null,
+		[Description("Slash-joined title path, e.g. 'Account/Log Out'. If a title itself contains '/', use id instead.")] string? path = null,
 		[Description("Menu item title (first match)")] string? title = null,
 		[Description("Key equivalent for the item, e.g. 'l' or 's'. Combine with modifiers.")] string? key = null,
 		[Description("Comma or plus separated modifiers for the key, e.g. 'cmd,shift'")] string? modifiers = null,

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.Menus.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.Menus.cs
@@ -1,0 +1,448 @@
+using System.Linq;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.DevFlow.Agent.Core;
+
+// Application menu inspection & invocation.
+//
+// Surfaces two layers of menus:
+//   1. Cross-platform MAUI menus defined via Page.MenuBarItems (MenuBarItem /
+//      MenuFlyoutItem / MenuFlyoutSubItem / MenuFlyoutSeparator). Inspectable and
+//      invokable on every platform straight from Agent.Core.
+//   2. The platform's native application menu (macOS NSMenu, Mac Catalyst UIKit menus)
+//      via the IsNativeMenusSupported / GetNativeMenusAsync / InvokeNativeMenuAsync hooks,
+//      which platform agents override.
+public partial class DevFlowAgentService
+{
+    // ── Platform extensibility hooks ──
+
+    /// <summary>
+    /// Whether the platform exposes a native application menu (macOS AppKit NSMenu,
+    /// Mac Catalyst UIKit menus). Override in platform-specific agents.
+    /// </summary>
+    protected virtual bool IsNativeMenusSupported => false;
+
+    /// <summary>
+    /// Returns the native application-menu payload, or <c>null</c> when the platform has
+    /// no inspectable native menu. Override in platform agents (macOS AppKit / Mac Catalyst).
+    /// </summary>
+    protected virtual Task<object?> GetNativeMenusAsync() => Task.FromResult<object?>(null);
+
+    /// <summary>
+    /// Invokes a native menu item identified by the request. Returns a result object on
+    /// success, or <c>null</c> when no matching native item was found (or the platform
+    /// does not support native menu invocation). Override in platform agents.
+    /// </summary>
+    protected virtual Task<object?> InvokeNativeMenuAsync(MenuInvokeRequest request)
+        => Task.FromResult<object?>(null);
+
+    // ── HTTP handlers ──
+
+    private async Task<HttpResponse> HandleMenusList(HttpRequest request)
+    {
+        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+
+        var windowIndex = ParseWindowIndex(request);
+
+        var menuBar = await DispatchAsync(() => BuildMauiMenuBar(windowIndex));
+        var native = IsNativeMenusSupported ? await GetNativeMenusAsync() : null;
+
+        return HttpResponse.Json(new
+        {
+            platform = PlatformName,
+            mauiSupported = true,
+            nativeSupported = IsNativeMenusSupported,
+            menuBar,
+            native,
+        });
+    }
+
+    private async Task<HttpResponse> HandleMenuInvoke(HttpRequest request)
+    {
+        if (_app == null) return HttpResponse.Error("Agent not bound to app");
+
+        var body = request.BodyAs<MenuInvokeRequest>();
+        if (body == null ||
+            (string.IsNullOrWhiteSpace(body.Id) &&
+             string.IsNullOrWhiteSpace(body.Path) &&
+             string.IsNullOrWhiteSpace(body.Title) &&
+             string.IsNullOrWhiteSpace(body.Key)))
+        {
+            return HttpResponse.Error("One of id, path, title, or key is required");
+        }
+
+        var target = (body.Target ?? "auto").Trim().ToLowerInvariant();
+        if (target is not ("auto" or "maui" or "native"))
+            return HttpResponse.Error("target must be 'auto', 'maui', or 'native'");
+
+        var startedAtUtc = DateTime.UtcNow;
+        var label = body.Id ?? body.Path ?? body.Title ?? body.Key;
+
+        // Layer 1: cross-platform MAUI MenuBarItems.
+        if (target is "auto" or "maui")
+        {
+            var mauiResult = await DispatchAsync(() => TryInvokeMauiMenu(body));
+            if (mauiResult.Success)
+            {
+                PublishUiOperationSpan("action.menu", startedAtUtc, true, null, label, new { source = "maui" });
+                return HttpResponse.Json(new { success = true, source = "maui", title = mauiResult.Title, path = mauiResult.Path });
+            }
+
+            if (target == "maui")
+            {
+                PublishUiOperationSpan("action.menu", startedAtUtc, false, mauiResult.Error, label, new { source = "maui" });
+                return HttpResponse.Error(mauiResult.Error ?? "Menu item not found", 404, "not-found");
+            }
+        }
+
+        // Layer 2: native platform menu.
+        if (target is "auto" or "native")
+        {
+            if (IsNativeMenusSupported)
+            {
+                var nativeResult = await InvokeNativeMenuAsync(body);
+                if (nativeResult != null)
+                {
+                    PublishUiOperationSpan("action.menu", startedAtUtc, true, null, label, new { source = "native" });
+                    return HttpResponse.Json(nativeResult);
+                }
+            }
+            else if (target == "native")
+            {
+                return HttpResponse.Error($"Native menu invocation is not supported on {PlatformName}", 501, "unsupported-capability");
+            }
+        }
+
+        PublishUiOperationSpan("action.menu", startedAtUtc, false, "not found", label, new { target });
+        return HttpResponse.Error("Menu item not found", 404, "not-found");
+    }
+
+    // ── MAUI menu walk ──
+
+    private object BuildMauiMenuBar(int? windowIndex)
+    {
+        var groups = new List<object>();
+
+        foreach (var (window, wIndex) in ResolveMenuWindows(windowIndex))
+        {
+            var barItems = GetMenuBarItemsForWindow(window);
+            if (barItems == null) continue;
+
+            for (var b = 0; b < barItems.Count; b++)
+            {
+                var bar = barItems[b];
+                if (bar == null) continue;
+
+                var id = $"maui:w{wIndex}/{b}";
+                var title = bar.Text ?? string.Empty;
+                groups.Add(new Dictionary<string, object?>
+                {
+                    ["id"] = id,
+                    ["title"] = title,
+                    ["path"] = title,
+                    ["enabled"] = true,
+                    ["separator"] = false,
+                    ["hasSubmenu"] = true,
+                    ["items"] = BuildMauiChildren(bar, id, title),
+                });
+            }
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["source"] = "maui",
+            ["items"] = groups,
+        };
+    }
+
+    private List<object> BuildMauiChildren(IEnumerable<IMenuElement> elements, string idPrefix, string pathPrefix)
+    {
+        var items = new List<object>();
+        var i = 0;
+        foreach (var element in elements)
+        {
+            var id = $"{idPrefix}/{i}";
+            i++;
+
+            switch (element)
+            {
+                case MenuFlyoutSeparator:
+                    items.Add(new Dictionary<string, object?> { ["id"] = id, ["separator"] = true });
+                    break;
+
+                case MenuFlyoutSubItem sub:
+                {
+                    var title = sub.Text ?? string.Empty;
+                    var path = CombineMenuPath(pathPrefix, title);
+                    items.Add(new Dictionary<string, object?>
+                    {
+                        ["id"] = id,
+                        ["title"] = title,
+                        ["path"] = path,
+                        ["enabled"] = sub.IsEnabled,
+                        ["separator"] = false,
+                        ["hasSubmenu"] = true,
+                        ["items"] = BuildMauiChildren(sub, id, path),
+                    });
+                    break;
+                }
+
+                case MenuFlyoutItem flyout:
+                {
+                    var title = flyout.Text ?? string.Empty;
+                    var (key, mods) = GetAcceleratorInfo(flyout);
+                    items.Add(new Dictionary<string, object?>
+                    {
+                        ["id"] = id,
+                        ["title"] = title,
+                        ["path"] = CombineMenuPath(pathPrefix, title),
+                        ["enabled"] = flyout.IsEnabled,
+                        ["separator"] = false,
+                        ["hasSubmenu"] = false,
+                        ["key"] = key,
+                        ["modifiers"] = mods,
+                    });
+                    break;
+                }
+
+                case MenuItem menuItem:
+                {
+                    var title = menuItem.Text ?? string.Empty;
+                    items.Add(new Dictionary<string, object?>
+                    {
+                        ["id"] = id,
+                        ["title"] = title,
+                        ["path"] = CombineMenuPath(pathPrefix, title),
+                        ["enabled"] = menuItem.IsEnabled,
+                        ["separator"] = false,
+                        ["hasSubmenu"] = false,
+                    });
+                    break;
+                }
+            }
+        }
+
+        return items;
+    }
+
+    private MenuInvokeResult TryInvokeMauiMenu(MenuInvokeRequest request)
+    {
+        foreach (var (window, wIndex) in ResolveMenuWindows(null))
+        {
+            var barItems = GetMenuBarItemsForWindow(window);
+            if (barItems == null) continue;
+
+            for (var b = 0; b < barItems.Count; b++)
+            {
+                var bar = barItems[b];
+                if (bar == null) continue;
+
+                var match = FindMauiMatch(bar, $"maui:w{wIndex}/{b}", bar.Text ?? string.Empty, request);
+                if (match == null) continue;
+
+                var (item, path) = match.Value;
+                if (!item.IsEnabled)
+                    return new MenuInvokeResult { Success = false, Error = $"Menu item '{path}' is disabled" };
+
+                ((IMenuItemController)item).Activate();
+                return new MenuInvokeResult { Success = true, Title = item.Text, Path = path };
+            }
+        }
+
+        return new MenuInvokeResult { Success = false, Error = "Menu item not found" };
+    }
+
+    private (MenuItem item, string path)? FindMauiMatch(IEnumerable<IMenuElement> elements, string idPrefix, string pathPrefix, MenuInvokeRequest request)
+    {
+        var i = 0;
+        foreach (var element in elements)
+        {
+            var id = $"{idPrefix}/{i}";
+            i++;
+
+            switch (element)
+            {
+                case MenuFlyoutSeparator:
+                    break;
+
+                case MenuFlyoutSubItem sub:
+                {
+                    var nested = FindMauiMatch(sub, id, CombineMenuPath(pathPrefix, sub.Text ?? string.Empty), request);
+                    if (nested != null) return nested;
+                    break;
+                }
+
+                case MenuItem menuItem:
+                {
+                    var path = CombineMenuPath(pathPrefix, menuItem.Text ?? string.Empty);
+                    if (MauiItemMatches(menuItem, id, path, request))
+                        return (menuItem, path);
+                    break;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool MauiItemMatches(MenuItem item, string id, string path, MenuInvokeRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.Id))
+            return string.Equals(request.Id.Trim(), id, StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(request.Path))
+            return string.Equals(NormalizeMenuPath(request.Path), path, StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(request.Title))
+            return string.Equals(request.Title.Trim(), item.Text?.Trim(), StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(request.Key))
+        {
+            if (item is not MenuFlyoutItem flyout) return false;
+            var (key, mods) = GetAcceleratorInfo(flyout);
+            if (key == null || !string.Equals(key, request.Key.Trim(), StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var requested = ParseModifierList(request.Modifiers);
+            var actual = new HashSet<string>(mods ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+            return requested.SetEquals(actual);
+        }
+
+        return false;
+    }
+
+    // ── Helpers ──
+
+    private IEnumerable<(Window window, int index)> ResolveMenuWindows(int? windowIndex)
+    {
+        if (_app == null) yield break;
+
+        if (windowIndex.HasValue)
+        {
+            if (windowIndex.Value >= 0 && windowIndex.Value < _app.Windows.Count && _app.Windows[windowIndex.Value] is Window scoped)
+                yield return (scoped, windowIndex.Value);
+            yield break;
+        }
+
+        for (var i = 0; i < _app.Windows.Count; i++)
+            if (_app.Windows[i] is Window window)
+                yield return (window, i);
+    }
+
+    private static IList<MenuBarItem>? GetMenuBarItemsForWindow(Window window)
+    {
+        var active = ResolveActiveMenuPage(window);
+        var items = active?.MenuBarItems;
+        if ((items == null || items.Count == 0) && window.Page is Page root && !ReferenceEquals(root, active))
+            items = root.MenuBarItems;
+        return items;
+    }
+
+    private static Page? ResolveActiveMenuPage(Window window)
+    {
+        var page = window.Page;
+        if (page == null) return null;
+
+        try
+        {
+            var modalStack = page.Navigation?.ModalStack;
+            if (modalStack is { Count: > 0 } && modalStack[^1] is Page modal)
+                return modal;
+        }
+        catch { }
+
+        if (page is Shell shell && shell.CurrentPage is Page shellPage)
+            return shellPage;
+
+        try
+        {
+            var navStack = page.Navigation?.NavigationStack;
+            if (navStack is { Count: > 0 } && navStack[^1] is Page navPage)
+                return navPage;
+        }
+        catch { }
+
+        return page;
+    }
+
+    private static (string? key, List<string>? modifiers) GetAcceleratorInfo(MenuFlyoutItem item)
+    {
+        var accelerator = item.KeyboardAccelerators?.FirstOrDefault();
+        if (accelerator == null) return (null, null);
+
+        var mods = ModifiersToList(accelerator.Modifiers);
+        return (string.IsNullOrEmpty(accelerator.Key) ? null : accelerator.Key, mods.Count > 0 ? mods : null);
+    }
+
+    private static List<string> ModifiersToList(KeyboardAcceleratorModifiers modifiers)
+    {
+        var list = new List<string>();
+        if (modifiers.HasFlag(KeyboardAcceleratorModifiers.Cmd)) list.Add("cmd");
+        if (modifiers.HasFlag(KeyboardAcceleratorModifiers.Ctrl)) list.Add("ctrl");
+        if (modifiers.HasFlag(KeyboardAcceleratorModifiers.Alt)) list.Add("alt");
+        if (modifiers.HasFlag(KeyboardAcceleratorModifiers.Shift)) list.Add("shift");
+        if (modifiers.HasFlag(KeyboardAcceleratorModifiers.Windows)) list.Add("windows");
+        return list;
+    }
+
+    private static HashSet<string> ParseModifierList(string? modifiers)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(modifiers)) return set;
+
+        foreach (var raw in modifiers.Split(new[] { ',', '+', ' ', '|' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var normalized = NormalizeModifier(raw);
+            if (normalized != null) set.Add(normalized);
+        }
+
+        return set;
+    }
+
+    private static string? NormalizeModifier(string modifier) => modifier.ToLowerInvariant() switch
+    {
+        "cmd" or "command" or "meta" or "super" => "cmd",
+        "ctrl" or "control" => "ctrl",
+        "alt" or "option" or "opt" => "alt",
+        "shift" => "shift",
+        "win" or "windows" => "windows",
+        _ => null,
+    };
+
+    private static string CombineMenuPath(string prefix, string title)
+        => string.IsNullOrEmpty(prefix) ? title : $"{prefix}/{title}";
+
+    private static string NormalizeMenuPath(string path)
+        => path.Replace('\\', '/').Trim().Trim('/');
+}
+
+/// <summary>Request body for invoking an application menu item.</summary>
+public class MenuInvokeRequest
+{
+    /// <summary>Stable id from the menu listing (e.g. <c>maui:w0/1/2</c>).</summary>
+    public string? Id { get; set; }
+
+    /// <summary>Slash-joined title path (e.g. <c>Account/Log Out</c>).</summary>
+    public string? Path { get; set; }
+
+    /// <summary>Menu item title (first match).</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Key equivalent (e.g. <c>l</c>) used with <see cref="Modifiers"/>.</summary>
+    public string? Key { get; set; }
+
+    /// <summary>Comma/plus separated modifiers (e.g. <c>cmd,shift</c>).</summary>
+    public string? Modifiers { get; set; }
+
+    /// <summary>Which menu layer to target: <c>auto</c> (default), <c>maui</c>, or <c>native</c>.</summary>
+    public string? Target { get; set; }
+}
+
+internal sealed class MenuInvokeResult
+{
+    public bool Success { get; set; }
+    public string? Title { get; set; }
+    public string? Path { get; set; }
+    public string? Error { get; set; }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.Menus.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.Menus.cs
@@ -23,6 +23,11 @@ public partial class DevFlowAgentService
     /// </summary>
     protected virtual bool IsNativeMenusSupported => false;
 
+    // The cross-platform MAUI MenuBarItems backbone works on every platform (returning a
+    // valid, possibly-empty tree), so the menus capability is advertised everywhere. Per-layer
+    // fidelity (native vs. MAUI) is reported by the ui.menus capability's maui/native flags.
+    protected virtual bool IsMenusSupported => true;
+
     /// <summary>
     /// Returns the native application-menu payload, or <c>null</c> when the platform has
     /// no inspectable native menu. Override in platform agents (macOS AppKit / Mac Catalyst).
@@ -418,7 +423,7 @@ public partial class DevFlowAgentService
 }
 
 /// <summary>Request body for invoking an application menu item.</summary>
-public class MenuInvokeRequest
+public sealed class MenuInvokeRequest
 {
     /// <summary>Stable id from the menu listing (e.g. <c>maui:w0/1/2</c>).</summary>
     public string? Id { get; set; }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -656,7 +656,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     storage = true,
                     profiler = IsProfilerFeatureAvailable,
                     jobs = IsJobsSupported,
-                    menus = true,
+                    menus = IsMenusSupported,
                     theme = true,
                 },
                 running = _app != null,

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/DevFlowAgentService.cs
@@ -546,6 +546,10 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         _server.MapPut("/api/v1/storage/files/{path}", HandleFileUpload);
         _server.MapDelete("/api/v1/storage/files/{path}", HandleFileDelete);
 
+        // Application menus (MAUI MenuBarItems + native NSMenu / UIKit menus)
+        _server.MapGet("/api/v1/ui/menus", HandleMenusList);
+        _server.MapPost("/api/v1/ui/menus/invoke", HandleMenuInvoke);
+
         // Invoke / reflection
         _server.MapGet("/api/v1/invoke/actions", HandleListActions);
         _server.MapPost("/api/v1/invoke/actions/{name}", HandleInvokeAction);
@@ -652,6 +656,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     storage = true,
                     profiler = IsProfilerFeatureAvailable,
                     jobs = IsJobsSupported,
+                    menus = true,
                     theme = true,
                 },
                 running = _app != null,
@@ -692,6 +697,13 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
         capabilities["ui.tree"] = new { version = 1, features = new[] { "css-selector", "type", "text", "accessibility-id" } };
         capabilities["ui.actions"] = new { version = 1, features = new[] { "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "properties" } };
         capabilities["ui.screenshot"] = new { version = 1, features = new[] { "element", "fullscreen", "selector" } };
+        capabilities["ui.menus"] = new
+        {
+            version = 1,
+            features = new[] { "list", "invoke" },
+            maui = true,
+            native = IsNativeMenusSupported,
+        };
 
         if (_cdpWebViews.Count > 0)
             capabilities["webview"] = new { version = 1, features = new[] { "evaluate", "contexts", "source", "dom", "dom-query", "network", "console", "screenshot" } };

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.Menus.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.Menus.cs
@@ -110,6 +110,16 @@ public partial class PlatformAgentService
 
             if (NativeItemMatches(item, id, path, request))
             {
+                if (!item.Enabled)
+                    return new
+                    {
+                        success = false,
+                        source = "appkit",
+                        title = item.Title,
+                        path,
+                        error = "disabled",
+                    };
+
                 var invoked = PerformNativeMenuItem(menu, item, i);
                 return new
                 {
@@ -253,6 +263,10 @@ public partial class PlatformAgentService
             else if (!string.IsNullOrWhiteSpace(request.Title) || !string.IsNullOrWhiteSpace(request.Path))
             {
                 var wanted = (request.Title ?? request.Path)!.Trim();
+                // On Catalyst the responder-chain key commands are flat (path == title), so a
+                // hierarchical path like "File/Save" is matched by its last segment.
+                if (string.IsNullOrWhiteSpace(request.Title) && wanted.Contains('/'))
+                    wanted = wanted[(wanted.LastIndexOf('/') + 1)..].Trim();
                 matches = string.Equals(wanted, command.Title?.Trim(), StringComparison.OrdinalIgnoreCase);
             }
             else if (!string.IsNullOrWhiteSpace(request.Key))

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.Menus.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.Menus.cs
@@ -1,0 +1,365 @@
+using Microsoft.Maui.DevFlow.Agent.Core;
+#if MACOS
+using AppKit;
+using Foundation;
+using ObjCRuntime;
+#endif
+#if MACCATALYST
+using UIKit;
+using Foundation;
+using ObjCRuntime;
+#endif
+
+namespace Microsoft.Maui.DevFlow.Agent;
+
+public partial class PlatformAgentService
+{
+#if MACOS
+    // macOS AppKit exposes the application menu bar as a global NSMenu tree, which is not
+    // part of the MAUI visual tree. Walk and invoke it directly via AppKit.
+    protected override bool IsNativeMenusSupported => true;
+
+    protected override Task<object?> GetNativeMenusAsync()
+        => DispatchAsync(() => BuildNativeMainMenu());
+
+    protected override Task<object?> InvokeNativeMenuAsync(MenuInvokeRequest request)
+        => DispatchAsync(() => InvokeNativeMenuItem(request));
+
+    private object? BuildNativeMainMenu()
+    {
+        var mainMenu = NSApplication.SharedApplication.MainMenu;
+        if (mainMenu == null) return null;
+
+        return new Dictionary<string, object?>
+        {
+            ["source"] = "appkit",
+            ["title"] = mainMenu.Title ?? string.Empty,
+            ["items"] = BuildNativeMenuItems(mainMenu, "native:", string.Empty),
+        };
+    }
+
+    private List<object> BuildNativeMenuItems(NSMenu menu, string idPrefix, string pathPrefix)
+    {
+        var items = new List<object>();
+        for (nint i = 0; i < menu.Count; i++)
+        {
+            var item = menu.ItemAt(i);
+            if (item == null) continue;
+
+            var id = $"{idPrefix}{i}";
+            if (item.IsSeparatorItem)
+            {
+                items.Add(new Dictionary<string, object?> { ["id"] = id, ["separator"] = true });
+                continue;
+            }
+
+            var title = item.Title ?? string.Empty;
+            var path = CombineNativePath(pathPrefix, title);
+            var node = new Dictionary<string, object?>
+            {
+                ["id"] = id,
+                ["title"] = title,
+                ["path"] = path,
+                ["enabled"] = item.Enabled,
+                ["hidden"] = item.Hidden,
+                ["separator"] = false,
+                ["state"] = NativeStateToString(item.State),
+                ["action"] = item.Action?.Name,
+            };
+
+            var key = item.KeyEquivalent;
+            if (!string.IsNullOrEmpty(key))
+            {
+                node["key"] = key;
+                node["modifiers"] = NativeModifiersToList(item.KeyEquivalentModifierMask);
+            }
+
+            if (item.Submenu is NSMenu submenu)
+            {
+                node["hasSubmenu"] = true;
+                node["items"] = BuildNativeMenuItems(submenu, $"{id}/", path);
+            }
+            else
+            {
+                node["hasSubmenu"] = false;
+            }
+
+            items.Add(node);
+        }
+
+        return items;
+    }
+
+    private object? InvokeNativeMenuItem(MenuInvokeRequest request)
+    {
+        var mainMenu = NSApplication.SharedApplication.MainMenu;
+        if (mainMenu == null) return null;
+
+        return FindAndInvokeNative(mainMenu, "native:", string.Empty, request);
+    }
+
+    private object? FindAndInvokeNative(NSMenu menu, string idPrefix, string pathPrefix, MenuInvokeRequest request)
+    {
+        for (nint i = 0; i < menu.Count; i++)
+        {
+            var item = menu.ItemAt(i);
+            if (item == null || item.IsSeparatorItem) continue;
+
+            var id = $"{idPrefix}{i}";
+            var path = CombineNativePath(pathPrefix, item.Title ?? string.Empty);
+
+            if (NativeItemMatches(item, id, path, request))
+            {
+                var invoked = PerformNativeMenuItem(menu, item, i);
+                return new
+                {
+                    success = invoked,
+                    source = "appkit",
+                    title = item.Title,
+                    path,
+                    action = item.Action?.Name,
+                };
+            }
+
+            if (item.Submenu is NSMenu submenu)
+            {
+                var nested = FindAndInvokeNative(submenu, $"{id}/", path, request);
+                if (nested != null) return nested;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool PerformNativeMenuItem(NSMenu menu, NSMenuItem item, nint index)
+    {
+        try
+        {
+            menu.PerformActionForItem(index);
+            return true;
+        }
+        catch { }
+
+        try
+        {
+            if (item.Action is Selector action)
+                return NSApplication.SharedApplication.SendAction(action, item.Target, item);
+        }
+        catch { }
+
+        return false;
+    }
+
+    private static bool NativeItemMatches(NSMenuItem item, string id, string path, MenuInvokeRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.Id))
+            return string.Equals(request.Id.Trim(), id, StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(request.Path))
+            return string.Equals(NormalizeNativePath(request.Path), path, StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(request.Title))
+            return string.Equals(request.Title.Trim(), item.Title?.Trim(), StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(request.Key))
+        {
+            var key = item.KeyEquivalent;
+            if (string.IsNullOrEmpty(key) || !string.Equals(key, request.Key.Trim(), StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var requested = ParseNativeModifierSet(request.Modifiers);
+            var actual = new HashSet<string>(NativeModifiersToList(item.KeyEquivalentModifierMask), StringComparer.OrdinalIgnoreCase);
+            return requested.SetEquals(actual);
+        }
+
+        return false;
+    }
+
+    private static List<string> NativeModifiersToList(NSEventModifierMask mask)
+    {
+        var list = new List<string>();
+        if (mask.HasFlag(NSEventModifierMask.CommandKeyMask)) list.Add("cmd");
+        if (mask.HasFlag(NSEventModifierMask.ControlKeyMask)) list.Add("ctrl");
+        if (mask.HasFlag(NSEventModifierMask.AlternateKeyMask)) list.Add("alt");
+        if (mask.HasFlag(NSEventModifierMask.ShiftKeyMask)) list.Add("shift");
+        return list;
+    }
+
+    private static string? NativeStateToString(NSCellStateValue state) => state switch
+    {
+        NSCellStateValue.On => "on",
+        NSCellStateValue.Mixed => "mixed",
+        _ => null,
+    };
+#endif
+
+#if MACCATALYST
+    // Mac Catalyst exposes menus through UIKit. UIKit has no public runtime API to read the
+    // built main menu tree (UIMenuBuilder is build-time only), so we surface the responder
+    // chain's UIKeyCommands as a best-effort inspection surface and invoke through the
+    // responder chain via SendAction. MAUI-defined menus are covered by the cross-platform
+    // MAUI backbone in Agent.Core.
+    protected override bool IsNativeMenusSupported => true;
+
+    protected override Task<object?> GetNativeMenusAsync()
+        => DispatchAsync(() => BuildCatalystKeyCommands());
+
+    protected override Task<object?> InvokeNativeMenuAsync(MenuInvokeRequest request)
+        => DispatchAsync(() => InvokeCatalystKeyCommand(request));
+
+    private object? BuildCatalystKeyCommands()
+    {
+        var commands = CollectKeyCommands();
+        var items = new List<object>();
+        var index = 0;
+        foreach (var command in commands)
+        {
+            items.Add(new Dictionary<string, object?>
+            {
+                ["id"] = $"native:{index}",
+                ["title"] = command.Title,
+                ["path"] = command.Title,
+                ["separator"] = false,
+                ["hasSubmenu"] = false,
+                ["key"] = string.IsNullOrEmpty(command.Input) ? null : command.Input,
+                ["modifiers"] = CatalystModifiersToList(command.ModifierFlags),
+                ["action"] = command.Action?.Name,
+            });
+            index++;
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["source"] = "uikit",
+            ["note"] = "UIKit exposes only responder-chain key commands at runtime; use the MAUI menuBar for the full menu definition.",
+            ["items"] = items,
+        };
+    }
+
+    private object? InvokeCatalystKeyCommand(MenuInvokeRequest request)
+    {
+        var commands = CollectKeyCommands();
+        var requestedModifiers = ParseNativeModifierSet(request.Modifiers);
+
+        var index = 0;
+        foreach (var command in commands)
+        {
+            var id = $"native:{index}";
+            index++;
+
+            var matches = false;
+            if (!string.IsNullOrWhiteSpace(request.Id))
+                matches = string.Equals(request.Id.Trim(), id, StringComparison.OrdinalIgnoreCase);
+            else if (!string.IsNullOrWhiteSpace(request.Title) || !string.IsNullOrWhiteSpace(request.Path))
+            {
+                var wanted = (request.Title ?? request.Path)!.Trim();
+                matches = string.Equals(wanted, command.Title?.Trim(), StringComparison.OrdinalIgnoreCase);
+            }
+            else if (!string.IsNullOrWhiteSpace(request.Key))
+            {
+                if (string.Equals(command.Input, request.Key.Trim(), StringComparison.OrdinalIgnoreCase))
+                {
+                    var actual = new HashSet<string>(CatalystModifiersToList(command.ModifierFlags), StringComparer.OrdinalIgnoreCase);
+                    matches = requestedModifiers.SetEquals(actual);
+                }
+            }
+
+            if (!matches || command.Action == null) continue;
+
+            var invoked = UIApplication.SharedApplication.SendAction(command.Action, null, null, null);
+            return new
+            {
+                success = invoked,
+                source = "uikit",
+                title = command.Title,
+                action = command.Action.Name,
+            };
+        }
+
+        return null;
+    }
+
+    private static List<UIKeyCommand> CollectKeyCommands()
+    {
+        var collected = new List<UIKeyCommand>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        void Add(UIResponder? responder)
+        {
+            try
+            {
+                if (responder?.KeyCommands is { } keyCommands)
+                {
+                    foreach (var command in keyCommands)
+                    {
+                        var key = $"{command.Title}|{command.Input}|{(long)command.ModifierFlags}|{command.Action?.Name}";
+                        if (seen.Add(key)) collected.Add(command);
+                    }
+                }
+            }
+            catch { }
+        }
+
+        try
+        {
+            Add(UIApplication.SharedApplication);
+
+            foreach (var window in UIApplication.SharedApplication.Windows ?? Array.Empty<UIWindow>())
+            {
+                Add(window);
+                var controller = window.RootViewController;
+                while (controller != null)
+                {
+                    Add(controller);
+                    foreach (var child in controller.ChildViewControllers ?? Array.Empty<UIViewController>())
+                        Add(child);
+                    if (controller.View != null) Add(controller.View);
+                    controller = controller.PresentedViewController;
+                }
+            }
+        }
+        catch { }
+
+        return collected;
+    }
+
+    private static List<string> CatalystModifiersToList(UIKeyModifierFlags flags)
+    {
+        var list = new List<string>();
+        if (flags.HasFlag(UIKeyModifierFlags.Command)) list.Add("cmd");
+        if (flags.HasFlag(UIKeyModifierFlags.Control)) list.Add("ctrl");
+        if (flags.HasFlag(UIKeyModifierFlags.Alternate)) list.Add("alt");
+        if (flags.HasFlag(UIKeyModifierFlags.Shift)) list.Add("shift");
+        return list;
+    }
+#endif
+
+#if MACOS || MACCATALYST
+    private static HashSet<string> ParseNativeModifierSet(string? modifiers)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(modifiers)) return set;
+
+        foreach (var raw in modifiers.Split(new[] { ',', '+', ' ', '|' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var normalized = raw.ToLowerInvariant() switch
+            {
+                "cmd" or "command" or "meta" or "super" => "cmd",
+                "ctrl" or "control" => "ctrl",
+                "alt" or "option" or "opt" => "alt",
+                "shift" => "shift",
+                _ => null,
+            };
+            if (normalized != null) set.Add(normalized);
+        }
+
+        return set;
+    }
+
+    private static string CombineNativePath(string prefix, string title)
+        => string.IsNullOrEmpty(prefix) ? title : $"{prefix}/{title}";
+
+    private static string NormalizeNativePath(string path)
+        => path.Replace('\\', '/').Trim().Trim('/');
+#endif
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.DevFlow.Agent;
 /// Platform-specific agent service that provides native tap and screenshot
 /// implementations for Android, iOS, Mac Catalyst, Windows, and macOS AppKit.
 /// </summary>
-public class PlatformAgentService : DevFlowAgentService
+public partial class PlatformAgentService : DevFlowAgentService
 {
     public PlatformAgentService(AgentOptions? options = null) : base(options) { }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -961,6 +961,56 @@ public class AgentClient : IDisposable
         catch (Exception ex) when (IsExpectedClientException(ex)) { return default; }
     }
 
+    // ── Menus ──
+
+    /// <summary>
+    /// Lists the application menus: the cross-platform MAUI <c>MenuBarItems</c> tree plus,
+    /// where supported, the platform's native application menu (macOS NSMenu / Mac Catalyst
+    /// key commands).
+    /// </summary>
+    public async Task<JsonElement> GetMenusAsync(int? window = null)
+    {
+        var path = window.HasValue ? $"{UiApi}/menus?window={window.Value}" : $"{UiApi}/menus";
+        return await GetJsonAsync(path);
+    }
+
+    /// <summary>
+    /// Invokes an application menu item. Identify the item by <paramref name="id"/>,
+    /// <paramref name="path"/> (slash-joined titles), <paramref name="title"/>, or
+    /// <paramref name="key"/> + <paramref name="modifiers"/>. <paramref name="target"/>
+    /// selects the menu layer: <c>auto</c> (default), <c>maui</c>, or <c>native</c>.
+    /// </summary>
+    public async Task<JsonElement> InvokeMenuAsync(
+        string? id = null,
+        string? path = null,
+        string? title = null,
+        string? key = null,
+        string? modifiers = null,
+        string? target = null)
+    {
+        var payload = new JsonObject();
+        if (!string.IsNullOrWhiteSpace(id)) payload["id"] = id;
+        if (!string.IsNullOrWhiteSpace(path)) payload["path"] = path;
+        if (!string.IsNullOrWhiteSpace(title)) payload["title"] = title;
+        if (!string.IsNullOrWhiteSpace(key)) payload["key"] = key;
+        if (!string.IsNullOrWhiteSpace(modifiers)) payload["modifiers"] = modifiers;
+        if (!string.IsNullOrWhiteSpace(target)) payload["target"] = target;
+
+        try
+        {
+            using var response = await SendWithTransientRetriesAsync(HttpMethod.Post, async () =>
+            {
+                using var content = DriverJson.CreateJsonContent(payload);
+                return await _http.PostAsync($"{_baseUrl}{UiApi}/menus/invoke", content);
+            });
+            var responseBody = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(responseBody))
+                return default;
+            return DriverJson.ParseElement(responseBody);
+        }
+        catch (Exception ex) when (IsExpectedClientException(ex)) { return default; }
+    }
+
     // ── Files ──
 
     public async Task<JsonElement> ListStorageRootsAsync()
@@ -1169,6 +1219,8 @@ public class AgentCapabilities
     public bool Profiler { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("jobs")]
     public bool Jobs { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("menus")]
+    public bool Menus { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("theme")]
     public bool Theme { get; set; }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MenuTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/MenuTests.cs
@@ -1,0 +1,296 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Windows.Input;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.DevFlow.Agent.Core;
+using Microsoft.Maui.DevFlow.Driver;
+using Microsoft.Maui.Dispatching;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class MenuTests
+{
+    [Fact]
+    public async Task GetMenus_ReturnsMauiMenuBar_WithTitlesKeysAndModifiers()
+    {
+        using var harness = await MenuTestHarness.CreateAsync(() => BuildMenuPage(null));
+
+        var menus = await harness.Client.GetMenusAsync();
+
+        Assert.Equal(JsonValueKind.Object, menus.ValueKind);
+        Assert.True(menus.GetProperty("mauiSupported").GetBoolean());
+
+        var groups = menus.GetProperty("menuBar").GetProperty("items");
+        Assert.Equal(JsonValueKind.Array, groups.ValueKind);
+
+        var titles = groups.EnumerateArray().Select(g => g.GetProperty("title").GetString()).ToList();
+        Assert.Contains("File", titles);
+        Assert.Contains("Account", titles);
+
+        var account = groups.EnumerateArray().First(g => g.GetProperty("title").GetString() == "Account");
+        var logout = account.GetProperty("items").EnumerateArray().First(i => i.GetProperty("title").GetString() == "Log Out");
+        Assert.Equal("l", logout.GetProperty("key").GetString());
+        var mods = logout.GetProperty("modifiers").EnumerateArray().Select(m => m.GetString()).ToList();
+        Assert.Contains("cmd", mods);
+        Assert.Contains("shift", mods);
+    }
+
+    [Fact]
+    public async Task GetMenus_IncludesNestedSubItems()
+    {
+        using var harness = await MenuTestHarness.CreateAsync(() => BuildMenuPage(null));
+
+        var menus = await harness.Client.GetMenusAsync();
+        var file = menus.GetProperty("menuBar").GetProperty("items").EnumerateArray()
+            .First(g => g.GetProperty("title").GetString() == "File");
+
+        var recent = file.GetProperty("items").EnumerateArray()
+            .First(i => i.TryGetProperty("title", out var t) && t.GetString() == "Recent");
+        Assert.True(recent.GetProperty("hasSubmenu").GetBoolean());
+        var clear = recent.GetProperty("items").EnumerateArray()
+            .First(i => i.GetProperty("title").GetString() == "Clear");
+        Assert.Equal("File/Recent/Clear", clear.GetProperty("path").GetString());
+    }
+
+    [Fact]
+    public async Task InvokeMenu_ByPath_ExecutesCommand()
+    {
+        var loggedOut = false;
+        using var harness = await MenuTestHarness.CreateAsync(() => BuildMenuPage(() => loggedOut = true));
+
+        var result = await harness.Client.InvokeMenuAsync(path: "Account/Log Out");
+
+        Assert.True(result.GetProperty("success").GetBoolean());
+        Assert.Equal("maui", result.GetProperty("source").GetString());
+        Assert.True(loggedOut);
+    }
+
+    [Fact]
+    public async Task InvokeMenu_ByKeyAndModifiers_ExecutesCommand()
+    {
+        var loggedOut = false;
+        using var harness = await MenuTestHarness.CreateAsync(() => BuildMenuPage(() => loggedOut = true));
+
+        var result = await harness.Client.InvokeMenuAsync(key: "l", modifiers: "cmd+shift");
+
+        Assert.True(result.GetProperty("success").GetBoolean());
+        Assert.True(loggedOut);
+    }
+
+    [Fact]
+    public async Task InvokeMenu_ByTitle_ExecutesCommand()
+    {
+        var loggedOut = false;
+        using var harness = await MenuTestHarness.CreateAsync(() => BuildMenuPage(() => loggedOut = true));
+
+        var result = await harness.Client.InvokeMenuAsync(title: "Log Out");
+
+        Assert.True(result.GetProperty("success").GetBoolean());
+        Assert.True(loggedOut);
+    }
+
+    [Fact]
+    public async Task InvokeMenu_UnknownItem_ReturnsNotFound()
+    {
+        using var harness = await MenuTestHarness.CreateAsync(() => BuildMenuPage(null));
+
+        var result = await harness.Client.InvokeMenuAsync(path: "Account/Does Not Exist");
+
+        // Driver returns the error body; assert it did not report success.
+        var success = result.ValueKind == JsonValueKind.Object &&
+                      result.TryGetProperty("success", out var s) && s.ValueKind == JsonValueKind.True;
+        Assert.False(success);
+    }
+
+    [Fact]
+    public async Task InvokeMenu_DisabledItem_DoesNotExecute()
+    {
+        var clicked = false;
+        using var harness = await MenuTestHarness.CreateAsync(() =>
+        {
+            var page = new ContentPage();
+            var bar = new MenuBarItem { Text = "Edit" };
+            bar.Add(new MenuFlyoutItem { Text = "Paste", IsEnabled = false, Command = new RelayCommand(() => clicked = true) });
+            page.MenuBarItems.Add(bar);
+            return page;
+        });
+
+        var result = await harness.Client.InvokeMenuAsync(path: "Edit/Paste", target: "maui");
+        var success = result.ValueKind == JsonValueKind.Object &&
+                      result.TryGetProperty("success", out var s) && s.ValueKind == JsonValueKind.True;
+        Assert.False(success);
+        Assert.False(clicked);
+    }
+
+    [Fact]
+    public async Task MenusEndpoints_UseV1Paths_ViaMockListener()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var acceptTask = Task.Run(async () =>
+        {
+            for (var i = 0; i < 2; i++)
+            {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                var buffer = new byte[8192];
+                var read = await stream.ReadAsync(buffer);
+                var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+                if (request.Contains("GET /api/v1/ui/menus", StringComparison.Ordinal))
+                {
+                    var body = """
+                    {
+                      "platform": "macOS",
+                      "mauiSupported": true,
+                      "nativeSupported": true,
+                      "menuBar": { "source": "maui", "items": [] },
+                      "native": { "source": "appkit", "items": [ { "title": "File", "path": "File" } ] }
+                    }
+                    """;
+                    var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+                    await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+                    continue;
+                }
+
+                if (request.Contains("POST /api/v1/ui/menus/invoke", StringComparison.Ordinal))
+                {
+                    Assert.Contains("\"path\":\"File/Save\"", request);
+                    var body = """{"success":true,"source":"appkit","title":"Save","path":"File/Save"}""";
+                    var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {Encoding.UTF8.GetByteCount(body)}\r\nConnection: close\r\n\r\n{body}";
+                    await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+                    continue;
+                }
+
+                throw new InvalidOperationException($"Unexpected request: {request}");
+            }
+        });
+
+        using var agentClient = new AgentClient("localhost", port);
+
+        var menus = await agentClient.GetMenusAsync();
+        Assert.True(menus.GetProperty("nativeSupported").GetBoolean());
+        Assert.Equal("appkit", menus.GetProperty("native").GetProperty("source").GetString());
+
+        var invoke = await agentClient.InvokeMenuAsync(path: "File/Save", target: "native");
+        Assert.True(invoke.GetProperty("success").GetBoolean());
+        Assert.Equal("Save", invoke.GetProperty("title").GetString());
+
+        await acceptTask;
+        listener.Stop();
+    }
+
+    private static ContentPage BuildMenuPage(Action? onLogout)
+    {
+        var page = new ContentPage();
+
+        var file = new MenuBarItem { Text = "File" };
+        file.Add(new MenuFlyoutItem { Text = "New" });
+        file.Add(new MenuFlyoutSeparator());
+        var recent = new MenuFlyoutSubItem { Text = "Recent" };
+        recent.Add(new MenuFlyoutItem { Text = "Clear" });
+        file.Add(recent);
+
+        var account = new MenuBarItem { Text = "Account" };
+        var logout = new MenuFlyoutItem { Text = "Log Out", Command = new RelayCommand(() => onLogout?.Invoke()) };
+        logout.KeyboardAccelerators.Add(new KeyboardAccelerator
+        {
+            Key = "l",
+            Modifiers = KeyboardAcceleratorModifiers.Cmd | KeyboardAcceleratorModifiers.Shift,
+        });
+        account.Add(logout);
+
+        page.MenuBarItems.Add(file);
+        page.MenuBarItems.Add(account);
+        return page;
+    }
+
+    private sealed class RelayCommand : ICommand
+    {
+        private readonly Action _execute;
+        public RelayCommand(Action execute) => _execute = execute;
+        public event EventHandler? CanExecuteChanged { add { } remove { } }
+        public bool CanExecute(object? parameter) => true;
+        public void Execute(object? parameter) => _execute();
+    }
+
+    private sealed class MenuTestHarness : IDisposable
+    {
+        private readonly DevFlowAgentService _service;
+        public AgentClient Client { get; }
+
+        private MenuTestHarness(DevFlowAgentService service, AgentClient client)
+        {
+            _service = service;
+            Client = client;
+        }
+
+        public static async Task<MenuTestHarness> CreateAsync(Func<Page> pageFactory)
+        {
+            var app = new Application();
+            var service = new DevFlowAgentService(new AgentOptions { Port = GetFreePort() });
+            var client = new AgentClient("localhost", service.Port);
+
+            service.StartServerOnly(new ImmediateDispatcher());
+            AddWindow(app, new Window(pageFactory()));
+            service.BindApp(app);
+
+            for (var i = 0; i < 20; i++)
+            {
+                var status = await client.GetStatusAsync();
+                if (status != null)
+                    return new MenuTestHarness(service, client);
+                await Task.Delay(100);
+            }
+
+            throw new InvalidOperationException("Agent did not start in time");
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _service.Dispose();
+        }
+
+        private static int GetFreePort()
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+
+        private static void AddWindow(Application app, Window window)
+        {
+            // Application.AddWindow is internal; at runtime the platform handler registers
+            // windows. In a headless test we register the window directly so the agent can
+            // enumerate Application.Windows.
+            var method = typeof(Application).GetMethod(
+                "AddWindow",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            method!.Invoke(app, new object[] { window });
+        }
+    }
+
+    private sealed class ImmediateDispatcher : IDispatcher
+    {
+        public bool IsDispatchRequired => false;
+        public bool Dispatch(Action action) { action(); return true; }
+        public bool DispatchDelayed(TimeSpan delay, Action action) { action(); return true; }
+        public IDispatcherTimer CreateTimer() => new ImmediateDispatcherTimer();
+    }
+
+    private sealed class ImmediateDispatcherTimer : IDispatcherTimer
+    {
+        public bool IsRepeating { get; set; }
+        public TimeSpan Interval { get; set; }
+        public bool IsRunning { get; private set; }
+        public event EventHandler? Tick { add { } remove { } }
+        public void Start() => IsRunning = true;
+        public void Stop() => IsRunning = false;
+    }
+}

--- a/src/DevFlow/README.md
+++ b/src/DevFlow/README.md
@@ -101,6 +101,7 @@ The same value can also be supplied via the `MAUI_DEVFLOW_SESSION_ID` environmen
 
 - **Visual Tree Inspection** — query the full MAUI visual tree via HTTP API or CLI
 - **Element Interaction** — tap, fill, scroll, navigate, focus, resize, and mutate properties
+- **Application Menus** — inspect and invoke the app menu bar: the cross-platform MAUI `MenuBarItems` tree plus the native macOS AppKit `NSMenu` and Mac Catalyst key commands
 - **Screenshots** — capture PNG screenshots from any platform (full window or per-element)
 - **Screen Recording** — start/stop video recording of app sessions
 - **Network Monitoring** — intercept and inspect HTTP requests/responses
@@ -122,7 +123,7 @@ All DevFlow commands are available under `maui devflow`. Run `maui devflow <comm
 
 | Command Group | Description |
 |---------------|-------------|
-| `ui` | Visual tree, element interaction, screenshots, alerts, assertions |
+| `ui` | Visual tree, element interaction, screenshots, alerts, assertions, application menus |
 | `recording` | Start, stop, and manage screen recordings of app sessions |
 | `webview` | Blazor WebView automation — DOM, JS eval, navigation, input, screenshots |
 | `logs` | Fetch and stream application logs |


### PR DESCRIPTION
## Summary

Fixes #339. On the macOS AppKit head, the native application menu bar (`NSMenu`) is not part of the MAUI visual tree, so DevFlow UI automation could neither **inspect** nor **invoke** menu items — `ui tree` showed only the `Window` node, `ui query` couldn't find menu items, and there was no way to trigger a menu command or key equivalent. The same gap existed on Mac Catalyst.

This adds a new `ui.menus` capability with `list` and `invoke` endpoints, wired through every tier.

## Layered approach

1. **MAUI menu backbone (cross-platform, Agent.Core).** Walks `Window.Page.MenuBarItems` / Shell menus (`MenuFlyoutItem` / `MenuFlyoutSubItem` / `MenuFlyoutSeparator`) into a serializable tree with stable ids. Invokes by id / path / title / key+modifiers via `IMenuItemController.Activate()` (respects `IsEnabled`). Works on all platforms and is unit-testable on `net10.0`.
2. **macOS AppKit native (full).** Walks `NSApplication.MainMenu` recursively (title, key equivalent + modifier mask, enabled, state, hidden, separator, submenu, action). Invokes via `NSMenu.PerformActionForItem` with `SendAction` fallback. This is the primary fix for the reported scenario.
3. **Mac Catalyst native (best-effort).** UIKit exposes no public runtime menu-tree read API, so it collects responder-chain `UIKeyCommand`s for inspection and invokes via `SendAction`. The MAUI backbone covers MAUI-defined menus reliably; the limitation is documented in the payload.

## API

- `GET /api/v1/ui/menus?window=N` → `{ platform, mauiSupported, nativeSupported, menuBar, native }`
- `POST /api/v1/ui/menus/invoke` → `{ id?, path?, title?, key?, modifiers?, target? }` where `target` = `auto` (default) | `maui` | `native`
- Capability `ui.menus` + status `capabilities.menus`

## Layers touched

- **Agent.Core** — `DevFlowAgentService.Menus.cs`: MAUI walk/invoke, native virtuals, handlers, DTOs; routes + capability/status flags.
- **Agent** — `DevFlowAgentService.Menus.cs`: `#if MACOS` NSMenu and `#if MACCATALYST` UIKeyCommand overrides.
- **Driver** — `AgentClient.GetMenusAsync` / `InvokeMenuAsync`; `AgentCapabilities.Menus`.
- **MCP** — `maui_menu_list`, `maui_menu_invoke` (tool count 67 → 69).
- **CLI** — `ui menu list` / `ui menu invoke`.
- **Docs** — README / AGENTS / MCP instructions; OpenAPI paths + capability/status schemas and examples.

## Testing

- 8 new menu tests (real MAUI menus end-to-end + a Driver integration test). Full DevFlow suite: **225/225 pass**.
- `DevFlow.slnf` and `Cli.slnf`: **0 warnings, 0 errors**. Agent compiles for `net10.0-macos` and `net10.0-maccatalyst`.

> Note: the `Microsoft.Maui.DevFlow.Driver` public API gained `GetMenusAsync` / `InvokeMenuAsync` and `AgentCapabilities.Menus` (additive; repo is `0.1.0-preview`).