### PR TITLE
Fix GTK action sheet button handling

### DIFF
--- a/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkAlertManager.cs
+++ b/platforms/Linux.Gtk4/src/Linux.Gtk4/Platform/GtkAlertManager.cs
@@ -206,7 +206,7 @@ var sheetArgs = args[1]!;
 var title = GetProp<string>(sheetArgs, "Title") ?? "";
 var cancel = GetProp<string>(sheetArgs, "Cancel") ?? "Cancel";
 var destruction = GetProp<string>(sheetArgs, "Destruction");
-var buttons = GetProp<string[]>(sheetArgs, "Buttons");
+var buttons = GetProp<IEnumerable<string>>(sheetArgs, "Buttons")?.ToArray() ?? Array.Empty<string>();
 var result = GetProp<object>(sheetArgs, "Result");
 var trySetResult = result?.GetType().GetMethod("TrySetResult");
 


### PR DESCRIPTION
## Summary
- Fix `DisplayActionSheet` on Linux GTK4 by reading MAUI action sheet buttons as `IEnumerable<string>` instead of `string[]`
- Materialize the enumerable before rendering GTK dialog buttons so MAUI's filtered iterator does not throw `InvalidCastException`

Fixes #358.

## Validation
- `dotnet build platforms/Linux.Gtk4/src/Linux.Gtk4/Linux.Gtk4.csproj --verbosity minimal`
- `dotnet build platforms/Linux.Gtk4/Linux.Gtk4.slnx --verbosity minimal`