### PR TITLE
Bump Xamarin.Android.Tools.AndroidSdk to 1.0.192-ci.main.1652

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
     <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.)
          The package is built by dotnet/android which includes android-tools as a submodule. -->
-    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.189-preview.58">
+    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.192-ci.main.1652">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>2114bc81fed892c4d166aeff637ca2387b0fcd8a</Sha>
+      <Sha>be5272c91959d2d653b35603ba9b533886f7357c</Sha>
     </Dependency>
     <!-- dotnet/maui -->
     <Dependency Name="Microsoft.Maui.Controls" Version="10.0.41">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   </PropertyGroup>
   <!-- Android platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Android Tools">
-    <XamarinAndroidToolsAndroidSdkVersion>1.0.189-preview.58</XamarinAndroidToolsAndroidSdkVersion>
+    <XamarinAndroidToolsAndroidSdkVersion>1.0.192-ci.main.1652</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">


### PR DESCRIPTION
## Summary

Bumps `Xamarin.Android.Tools.AndroidSdk` via darc from the **`.NET 11.0.1xx SDK`** channel.

| | Version | SHA (dotnet/android) |
|---|---|---|
| Old | `1.0.189-preview.58` | `2114bc8` |
| New | `1.0.192-ci.main.1652` | `be5272c` |

**Channel:** `.NET 11.0.1xx SDK`

## Compare links

- `dotnet/android`: [`2114bc8…be5272c`](https://github.com/dotnet/android/compare/2114bc81fed892c4d166aeff637ca2387b0fcd8a...be5272c91959d2d653b35603ba9b533886f7357c)
- `dotnet/android-tools` submodule: [`132f790…367724d`](https://github.com/dotnet/android-tools/compare/132f790353413dcaef231e720e255364a310b3bd...367724d6ba93db20294681769de97b9cdecb58a0)

## Notable changes

The real API surface for the CLI lives in the `dotnet/android-tools` submodule (`SdkManager`, `AdbRunner`, `AvdManagerRunner`, `EmulatorRunner`, `JdkInfo`, `SdkBootstrap*`). The submodule pointer moved `132f790…367724d`, but those 3 commits only touch:

- `.github/**` CI/workflow files (AI reviewer → PAT pool)
- `Directory.Build.targets` (GitInfo `3.6.0 → 3.6.1` dependabot bump)

**No source or `PublicAPI.txt` changes** — no new, changed, or removed public API affecting the CLI. The bulk of the `dotnet/android` commit range is `Java.Interop`/`generator` work that is unrelated to the `Xamarin.Android.Tools.AndroidSdk` package the CLI consumes.

## CLI follow-up

**No CLI changes needed.** There are no API additions to adopt and no obsolete workarounds to remove, since the tooling API surface is unchanged across this bump.

## Build / test status

- `dotnet restore src/Cli/Cli.slnf` ✅ (new `ci.main` version resolves from a public feed)
- `dotnet build src/Cli/Cli.slnf -c Release` ✅ 0 warnings, 0 errors
- `dotnet test src/Cli/Microsoft.Maui.Cli.UnitTests/` ✅ 575 passed, 0 failed

---
🤖 Requesting review — please do not merge without approval.