### PR TITLE
Refactor AndroidDevFlowPortForwarder to use AdbRunner

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
@@ -8,6 +8,61 @@ namespace Microsoft.Maui.Cli.UnitTests;
 public class AndroidDevFlowPortForwarderTests
 {
 	[Fact]
+	public void Constructor_WithAdbPathButNullRunner_ThrowsArgumentNullException()
+	{
+		var provider = new FakeAndroidProvider();
+
+		var ex = Assert.Throws<ArgumentNullException>(() =>
+			new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", adbRunner: null));
+
+		Assert.Equal("adbRunner", ex.ParamName);
+	}
+
+	[Fact]
+	public async Task EnsureAsync_WhenCallerCancels_PropagatesOperationCanceledException()
+	{
+		var provider = CreateProvider(Device("emulator-5554"));
+		var runner = new FakeAdbRunner
+		{
+			OnReversePort = () => throw new OperationCanceledException()
+		};
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() => forwarder.EnsureAsync(
+			new AndroidDevFlowForwardingRequest
+			{
+				AgentPorts = [9223],
+				EnsureBrokerReverse = true,
+				Repair = true
+			},
+			cts.Token));
+	}
+
+	[Fact]
+	public async Task EnsureAsync_WhenAdbCallTimesOutInternally_ReportsErrorInsteadOfPropagating()
+	{
+		var provider = CreateProvider(Device("emulator-5554"));
+		var runner = new FakeAdbRunner
+		{
+			// Simulates the internal per-call timeout firing - not the caller's own token.
+			OnReversePort = () => throw new OperationCanceledException("adb reverse timed out")
+		};
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
+
+		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
+		{
+			AgentPorts = [9223],
+			EnsureBrokerReverse = true,
+			Repair = true
+		}, CancellationToken.None);
+
+		Assert.Equal(AndroidDevFlowForwardingStatus.Error, report.Status);
+		Assert.Contains("adb reverse tcp:19223 tcp:19223 failed", report.Message);
+	}
+
+	[Fact]
 	public async Task EnsureAsync_WithoutSdkPath_ReportsNoAdb()
 	{
 		var provider = new FakeAndroidProvider();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
@@ -18,6 +18,15 @@ public class AndroidDevFlowPortForwarderTests
 		Assert.Equal("adbRunner", ex.ParamName);
 	}
 
+	/// <summary>
+	/// Verifies that an <see cref="OperationCanceledException"/> raised while a runner call is in
+	/// flight propagates out of <see cref="AndroidDevFlowPortForwarder.EnsureAsync"/> untouched
+	/// (i.e. it isn't caught and reported as an error result). This is exercised via
+	/// <see cref="FakeAdbRunner.OnReversePort"/> throwing unconditionally, not by the pre-cancelled
+	/// <c>cts.Token</c> actually being observed - <see cref="FakeAdbRunner"/> accepts a
+	/// <see cref="CancellationToken"/> parameter on each call but never checks it, so this test does
+	/// not prove that a caller-supplied token threads through to cancel a real adb process.
+	/// </summary>
 	[Fact]
 	public async Task EnsureAsync_WhenCallerCancels_PropagatesOperationCanceledException()
 	{

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidDevFlowPortForwarderTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.UnitTests.Fakes;
-using Microsoft.Maui.Cli.Utils;
 using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
@@ -12,7 +11,7 @@ public class AndroidDevFlowPortForwarderTests
 	public async Task EnsureAsync_WithoutSdkPath_ReportsNoAdb()
 	{
 		var provider = new FakeAndroidProvider();
-		var forwarder = new AndroidDevFlowPortForwarder(provider, null, (_, _, _) => throw new InvalidOperationException("adb should not run"));
+		var forwarder = new AndroidDevFlowPortForwarder(provider, null, adbRunner: null);
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest { AgentPorts = [9223] });
 
@@ -27,19 +26,15 @@ public class AndroidDevFlowPortForwarderTests
 		var provider = CreateProvider(
 			Device("emulator-5554"),
 			Device("RZ8T123456A", isEmulator: false));
-		var commands = new List<string>();
-		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", (_, args, _) =>
-		{
-			commands.Add(string.Join(' ', args));
-			return Task.FromResult(new ProcessResult { ExitCode = 0 });
-		});
+		var runner = new FakeAdbRunner();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest { AgentPorts = [9223] });
 
 		Assert.Equal(AndroidDevFlowForwardingStatus.MultipleDevices, report.Status);
 		Assert.Null(report.SelectedSerial);
 		Assert.Equal("Multiple online Android devices or emulators were found. Specify --device or ANDROID_SERIAL.", report.Message);
-		Assert.Empty(commands);
+		Assert.Empty(runner.Commands);
 	}
 
 	[Fact]
@@ -50,7 +45,8 @@ public class AndroidDevFlowPortForwarderTests
 			Device("RZ8T123456A", isEmulator: false));
 		var forwardRules = new HashSet<int> { 9223 };
 		var reverseRules = new HashSet<int> { 19223 };
-		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules));
+		var runner = new FakeAdbRunner(forwardRules, reverseRules);
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
 		{
@@ -71,8 +67,8 @@ public class AndroidDevFlowPortForwarderTests
 		var provider = CreateProvider(Device("emulator-5554"));
 		var forwardRules = new HashSet<int> { 9223 };
 		var reverseRules = new HashSet<int> { 19223 };
-		var commands = new List<string>();
-		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules, commands));
+		var runner = new FakeAdbRunner(forwardRules, reverseRules);
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
 		{
@@ -83,18 +79,16 @@ public class AndroidDevFlowPortForwarderTests
 
 		Assert.Equal(AndroidDevFlowForwardingStatus.Ok, report.Status);
 		Assert.False(report.BrokerReverseAdded);
-		Assert.DoesNotContain("-s emulator-5554 reverse tcp:19223 tcp:19223", commands);
-		Assert.DoesNotContain("-s emulator-5554 forward tcp:9223 tcp:9223", commands);
+		Assert.DoesNotContain("-s emulator-5554 reverse tcp:19223 tcp:19223", runner.Commands);
+		Assert.DoesNotContain("-s emulator-5554 forward tcp:9223 tcp:9223", runner.Commands);
 	}
 
 	[Fact]
 	public async Task EnsureAsync_WithRepair_AddsMissingReverseAndForward()
 	{
 		var provider = CreateProvider(Device("emulator-5554"));
-		var forwardRules = new HashSet<int>();
-		var reverseRules = new HashSet<int>();
-		var commands = new List<string>();
-		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules, commands));
+		var runner = new FakeAdbRunner();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
 		{
@@ -107,15 +101,15 @@ public class AndroidDevFlowPortForwarderTests
 		Assert.True(report.BrokerReversePresent);
 		Assert.True(report.BrokerReverseAdded);
 		Assert.True(report.AgentForwards.Single(f => f.Port == 9223).PresentAfter);
-		Assert.Contains("-s emulator-5554 reverse tcp:19223 tcp:19223", commands);
-		Assert.Contains("-s emulator-5554 forward tcp:9223 tcp:9223", commands);
+		Assert.Contains("-s emulator-5554 reverse tcp:19223 tcp:19223", runner.Commands);
+		Assert.Contains("-s emulator-5554 forward tcp:9223 tcp:9223", runner.Commands);
 	}
 
 	[Fact]
 	public async Task EnsureAsync_WithoutRepair_ReportsMissingMappings()
 	{
 		var provider = CreateProvider(Device("emulator-5554"));
-		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner([], []));
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", new FakeAdbRunner());
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
 		{
@@ -135,10 +129,8 @@ public class AndroidDevFlowPortForwarderTests
 	public async Task EnsureAsync_WithCustomBrokerPort_UsesProvidedPortForReverse()
 	{
 		var provider = CreateProvider(Device("emulator-5554"));
-		var forwardRules = new HashSet<int>();
-		var reverseRules = new HashSet<int>();
-		var commands = new List<string>();
-		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules, commands));
+		var runner = new FakeAdbRunner();
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
 		{
@@ -151,15 +143,15 @@ public class AndroidDevFlowPortForwarderTests
 		Assert.Equal(AndroidDevFlowForwardingStatus.Repaired, report.Status);
 		Assert.Equal(19225, report.BrokerPort);
 		Assert.True(report.BrokerReversePresent);
-		Assert.Contains("-s emulator-5554 reverse tcp:19225 tcp:19225", commands);
-		Assert.DoesNotContain("-s emulator-5554 reverse tcp:19223 tcp:19223", commands);
+		Assert.Contains("-s emulator-5554 reverse tcp:19225 tcp:19225", runner.Commands);
+		Assert.DoesNotContain("-s emulator-5554 reverse tcp:19223 tcp:19223", runner.Commands);
 	}
 
 	[Fact]
 	public async Task EnsureAsync_WithCustomBrokerPortAndMissingReverse_SuggestsCustomPort()
 	{
 		var provider = CreateProvider(Device("emulator-5554"));
-		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner([], []));
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", new FakeAdbRunner());
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
 		{
@@ -179,8 +171,8 @@ public class AndroidDevFlowPortForwarderTests
 		var provider = CreateProvider(Device("emulator-5554"));
 		var forwardRules = new HashSet<int> { 9223 };
 		var reverseRules = new HashSet<int> { 19223 };
-		var commands = new List<string>();
-		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", CreateAdbRunner(forwardRules, reverseRules, commands));
+		var runner = new FakeAdbRunner(forwardRules, reverseRules);
+		var forwarder = new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
 
 		var report = await forwarder.EnsureAsync(new AndroidDevFlowForwardingRequest
 		{
@@ -192,7 +184,7 @@ public class AndroidDevFlowPortForwarderTests
 		Assert.Equal(AndroidDevFlowForwardingStatus.Ok, report.Status);
 		Assert.False(report.BrokerReverseChecked);
 		Assert.False(report.BrokerReversePresent);
-		Assert.DoesNotContain("-s emulator-5554 reverse --list", commands);
+		Assert.DoesNotContain("-s emulator-5554 reverse --list", runner.Commands);
 	}
 
 	static FakeAndroidProvider CreateProvider(params Device[] devices)
@@ -214,55 +206,4 @@ public class AndroidDevFlowPortForwarderTests
 			IsEmulator = isEmulator,
 			IsRunning = true
 		};
-
-	static Func<string, string[], CancellationToken, Task<ProcessResult>> CreateAdbRunner(
-		HashSet<int> forwardRules,
-		HashSet<int> reverseRules,
-		List<string>? commands = null)
-		=> (_, args, _) =>
-		{
-			commands?.Add(string.Join(' ', args));
-
-			if (args is ["-s", var forwardListSerial, "forward", "--list"])
-			{
-				var output = string.Join(Environment.NewLine, forwardRules.Select(port => $"{forwardListSerial} tcp:{port} tcp:{port}"));
-				return Task.FromResult(new ProcessResult { ExitCode = 0, StandardOutput = output });
-			}
-
-			if (args is ["-s", var reverseListSerial, "reverse", "--list"])
-			{
-				var output = string.Join(Environment.NewLine, reverseRules.Select(port => $"{reverseListSerial} tcp:{port} tcp:{port}"));
-				return Task.FromResult(new ProcessResult { ExitCode = 0, StandardOutput = output });
-			}
-
-			if (args is ["-s", _, "forward", var forwardLocal, var forwardRemote] &&
-				TryParseTcpPort(forwardLocal, out var forwardLocalPort) &&
-				TryParseTcpPort(forwardRemote, out var forwardRemotePort) &&
-				forwardLocalPort == forwardRemotePort)
-			{
-				forwardRules.Add(forwardLocalPort);
-				return Task.FromResult(new ProcessResult { ExitCode = 0 });
-			}
-
-			if (args is ["-s", _, "reverse", var reverseLocal, var reverseRemote] &&
-				TryParseTcpPort(reverseLocal, out var reverseLocalPort) &&
-				TryParseTcpPort(reverseRemote, out var reverseRemotePort) &&
-				reverseLocalPort == reverseRemotePort)
-			{
-				reverseRules.Add(reverseLocalPort);
-				return Task.FromResult(new ProcessResult { ExitCode = 0 });
-			}
-
-			return Task.FromResult(new ProcessResult { ExitCode = 1, StandardError = $"Unexpected adb command: {string.Join(' ', args)}" });
-		};
-
-	static bool TryParseTcpPort(string value, out int port)
-	{
-		const string Prefix = "tcp:";
-		if (value.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
-			return int.TryParse(value[Prefix.Length..], out port);
-
-		port = 0;
-		return false;
-	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliIntegrationTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Maui.Cli.DevFlow.Broker;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.UnitTests.Fixtures;
 using Microsoft.Maui.Cli.UnitTests.Fakes;
-using Microsoft.Maui.Cli.Utils;
 using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
@@ -199,7 +198,7 @@ public class DevFlowCliIntegrationTests
         var cli = new CliTestHarness(mockAgentPort: 9223);
         var tempDir = Directory.CreateTempSubdirectory("maui-devflow-diagnose-");
         var originalCurrentDirectory = Directory.GetCurrentDirectory();
-        var commands = new List<string>();
+        var runner = new FakeAdbRunner(forwardPorts: [9223], reversePorts: [19223]);
 
         DevFlowCommands.ResolveRunningBrokerPortAsync = () => Task.FromResult<int?>(19223);
         DevFlowCommands.ListBrokerAgentsAsync = _ => Task.FromResult<AgentRegistration[]?>(
@@ -238,20 +237,7 @@ public class DevFlowCliIntegrationTests
                 ]
             };
 
-            return new AndroidDevFlowPortForwarder(
-                provider,
-                "/android-sdk/platform-tools/adb",
-                (_, args, _) =>
-                {
-                    commands.Add(string.Join(' ', args));
-                    var output = args[2] switch
-                    {
-                        "reverse" => "emulator-5554 tcp:19223 tcp:19223",
-                        "forward" => "emulator-5554 tcp:9223 tcp:9223",
-                        _ => ""
-                    };
-                    return Task.FromResult(new ProcessResult { ExitCode = 0, StandardOutput = output });
-                });
+            return new AndroidDevFlowPortForwarder(provider, "/android-sdk/platform-tools/adb", runner);
         };
 
         try
@@ -268,8 +254,8 @@ public class DevFlowCliIntegrationTests
             var forward = Assert.Single(android.GetProperty("agent_forwards").EnumerateArray());
             Assert.Equal(9223, forward.GetProperty("port").GetInt32());
             Assert.True(forward.GetProperty("present_after").GetBoolean());
-            Assert.Contains("-s emulator-5554 reverse --list", commands);
-            Assert.Contains("-s emulator-5554 forward --list", commands);
+            Assert.Contains("-s emulator-5554 reverse --list", runner.Commands);
+            Assert.Contains("-s emulator-5554 forward --list", runner.Commands);
         }
         finally
         {
@@ -330,16 +316,7 @@ public class DevFlowCliIntegrationTests
             return new AndroidDevFlowPortForwarder(
                 provider,
                 "/android-sdk/platform-tools/adb",
-                (_, args, _) =>
-                {
-                    var output = args[2] switch
-                    {
-                        "reverse" => "emulator-5554 tcp:19225 tcp:19225",
-                        "forward" => "emulator-5554 tcp:9223 tcp:9223",
-                        _ => ""
-                    };
-                    return Task.FromResult(new ProcessResult { ExitCode = 0, StandardOutput = output });
-                });
+                new FakeAdbRunner(forwardPorts: [9223], reversePorts: [19225]));
         };
 
         try

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAdbRunner.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAdbRunner.cs
@@ -57,8 +57,11 @@ public sealed class FakeAdbRunner : AdbRunner
 
 	public override Task ForwardPortAsync(string serial, AdbPortSpec local, AdbPortSpec remote, CancellationToken cancellationToken = default)
 	{
-		Commands.Add($"-s {serial} forward {local.ToSocketSpec()} {remote.ToSocketSpec()}");
+		// The hook runs first so a simulated failure (throwing from OnForwardPort) prevents the
+		// command from being recorded as "attempted" - Commands should only ever reflect calls
+		// that actually completed, matching what a real adb invocation would have logged.
 		OnForwardPort?.Invoke();
+		Commands.Add($"-s {serial} forward {local.ToSocketSpec()} {remote.ToSocketSpec()}");
 		if (local.Port == remote.Port)
 			_forwardPorts.Add(local.Port);
 		return Task.CompletedTask;
@@ -66,8 +69,10 @@ public sealed class FakeAdbRunner : AdbRunner
 
 	public override Task ReversePortAsync(string serial, AdbPortSpec remote, AdbPortSpec local, CancellationToken cancellationToken = default)
 	{
-		Commands.Add($"-s {serial} reverse {remote.ToSocketSpec()} {local.ToSocketSpec()}");
+		// See the comment in ForwardPortAsync: the hook runs first so a simulated failure keeps
+		// Commands limited to calls that actually completed.
 		OnReversePort?.Invoke();
+		Commands.Add($"-s {serial} reverse {remote.ToSocketSpec()} {local.ToSocketSpec()}");
 		if (local.Port == remote.Port)
 			_reversePorts.Add(local.Port);
 		return Task.CompletedTask;

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAdbRunner.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAdbRunner.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xamarin.Android.Tools;
+
+namespace Microsoft.Maui.Cli.UnitTests.Fakes;
+
+/// <summary>
+/// In-memory fake for <see cref="AdbRunner"/> used to test <see cref="Microsoft.Maui.Cli.DevFlow.Android.AndroidDevFlowPortForwarder"/>
+/// without shelling out to a real <c>adb</c> binary. Only the members the forwarder actually calls
+/// (<see cref="ListForwardPortsAsync"/>, <see cref="ListReversePortsAsync"/>, <see cref="ForwardPortAsync"/>,
+/// <see cref="ReversePortAsync"/>) are overridden. Port state is intentionally not keyed by serial - the
+/// forwarder always targets a single selected device per call, and per-serial fidelity is <see cref="AdbRunner"/>'s
+/// own concern, not something this fake needs to reproduce.
+/// </summary>
+public sealed class FakeAdbRunner : AdbRunner
+{
+	readonly HashSet<int> _forwardPorts;
+	readonly HashSet<int> _reversePorts;
+
+	public List<string> Commands { get; } = [];
+
+	public FakeAdbRunner(HashSet<int>? forwardPorts = null, HashSet<int>? reversePorts = null)
+		: base("adb")
+	{
+		_forwardPorts = forwardPorts ?? [];
+		_reversePorts = reversePorts ?? [];
+	}
+
+	public override Task<IReadOnlyList<AdbPortRule>> ListForwardPortsAsync(string serial, CancellationToken cancellationToken = default)
+	{
+		Commands.Add($"-s {serial} forward --list");
+		return Task.FromResult(ToRules(_forwardPorts));
+	}
+
+	public override Task<IReadOnlyList<AdbPortRule>> ListReversePortsAsync(string serial, CancellationToken cancellationToken = default)
+	{
+		Commands.Add($"-s {serial} reverse --list");
+		return Task.FromResult(ToRules(_reversePorts));
+	}
+
+	public override Task ForwardPortAsync(string serial, AdbPortSpec local, AdbPortSpec remote, CancellationToken cancellationToken = default)
+	{
+		Commands.Add($"-s {serial} forward {local.ToSocketSpec()} {remote.ToSocketSpec()}");
+		if (local.Port == remote.Port)
+			_forwardPorts.Add(local.Port);
+		return Task.CompletedTask;
+	}
+
+	public override Task ReversePortAsync(string serial, AdbPortSpec remote, AdbPortSpec local, CancellationToken cancellationToken = default)
+	{
+		Commands.Add($"-s {serial} reverse {remote.ToSocketSpec()} {local.ToSocketSpec()}");
+		if (local.Port == remote.Port)
+			_reversePorts.Add(local.Port);
+		return Task.CompletedTask;
+	}
+
+	static IReadOnlyList<AdbPortRule> ToRules(HashSet<int> ports)
+		=> ports
+			.Select(port => new AdbPortRule(new AdbPortSpec(AdbProtocol.Tcp, port), new AdbPortSpec(AdbProtocol.Tcp, port)))
+			.ToArray();
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAdbRunner.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAdbRunner.cs
@@ -20,6 +20,22 @@ public sealed class FakeAdbRunner : AdbRunner
 
 	public List<string> Commands { get; } = [];
 
+	/// <summary>
+	/// Optional hook invoked before <see cref="ReversePortAsync"/> performs its normal
+	/// work. Throw from this delegate to simulate an <c>adb</c> failure. Throwing an
+	/// <see cref="OperationCanceledException"/> here simulates an internal per-call
+	/// timeout (as opposed to the caller's own <see cref="CancellationToken"/> firing).
+	/// </summary>
+	public Action? OnReversePort { get; set; }
+
+	/// <summary>
+	/// Optional hook invoked before <see cref="ForwardPortAsync"/> performs its normal
+	/// work. Throw from this delegate to simulate an <c>adb</c> failure. Throwing an
+	/// <see cref="OperationCanceledException"/> here simulates an internal per-call
+	/// timeout (as opposed to the caller's own <see cref="CancellationToken"/> firing).
+	/// </summary>
+	public Action? OnForwardPort { get; set; }
+
 	public FakeAdbRunner(HashSet<int>? forwardPorts = null, HashSet<int>? reversePorts = null)
 		: base("adb")
 	{
@@ -42,6 +58,7 @@ public sealed class FakeAdbRunner : AdbRunner
 	public override Task ForwardPortAsync(string serial, AdbPortSpec local, AdbPortSpec remote, CancellationToken cancellationToken = default)
 	{
 		Commands.Add($"-s {serial} forward {local.ToSocketSpec()} {remote.ToSocketSpec()}");
+		OnForwardPort?.Invoke();
 		if (local.Port == remote.Port)
 			_forwardPorts.Add(local.Port);
 		return Task.CompletedTask;
@@ -50,6 +67,7 @@ public sealed class FakeAdbRunner : AdbRunner
 	public override Task ReversePortAsync(string serial, AdbPortSpec remote, AdbPortSpec local, CancellationToken cancellationToken = default)
 	{
 		Commands.Add($"-s {serial} reverse {remote.ToSocketSpec()} {local.ToSocketSpec()}");
+		OnReversePort?.Invoke();
 		if (local.Port == remote.Port)
 			_reversePorts.Add(local.Port);
 		return Task.CompletedTask;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
@@ -335,7 +335,9 @@ internal sealed class AndroidDevFlowPortForwarder
     }
 
     static bool ContainsMapping(IEnumerable<AdbPortRule> mappings, int port)
-        => mappings.Any(m => m.Local.Port == port && m.Remote.Port == port);
+        => mappings.Any(m =>
+            m.Local.Protocol == AdbProtocol.Tcp && m.Local.Port == port
+            && m.Remote.Protocol == AdbProtocol.Tcp && m.Remote.Port == port);
 
     static string[] BuildMappingSuggestions(string serial, bool brokerReverseMissing, int brokerPort, int[] missingAgentForwards)
     {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
@@ -10,6 +10,8 @@ internal sealed class AndroidDevFlowPortForwarder
 {
     public const int DefaultBrokerPort = BrokerServer.DefaultPort;
 
+    static readonly TimeSpan AdbCallTimeout = TimeSpan.FromSeconds(15);
+
     readonly IAndroidProvider _androidProvider;
     readonly string? _adbPath;
     readonly AdbRunner? _adbRunner;
@@ -19,6 +21,9 @@ internal sealed class AndroidDevFlowPortForwarder
         string? adbPath,
         AdbRunner? adbRunner)
     {
+        if (adbPath != null && adbRunner == null)
+            throw new ArgumentNullException(nameof(adbRunner), "adbRunner is required when adbPath is provided");
+
         _androidProvider = androidProvider;
         _adbPath = adbPath;
         _adbRunner = adbRunner;
@@ -84,7 +89,7 @@ internal sealed class AndroidDevFlowPortForwarder
         {
             devices = await _androidProvider.GetDevicesAsync(cancellationToken);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return report with
             {
@@ -141,8 +146,16 @@ internal sealed class AndroidDevFlowPortForwarder
             try
             {
                 var spec = new AdbPortSpec(AdbProtocol.Tcp, brokerPort);
-                await _adbRunner!.ReversePortAsync(report.SelectedSerial, spec, spec, cancellationToken);
+                using var timeoutCts = CreateAdbCallTimeoutSource(cancellationToken);
+                await _adbRunner!.ReversePortAsync(report.SelectedSerial, spec, spec, timeoutCts.Token);
                 brokerReverseAdded = true;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Caller-initiated cancellation (Ctrl+C, etc.) must propagate. Cancellation
+                // originating from the internal per-call timeout below falls through to the
+                // general catch so a single slow adb invocation is reported as an error.
+                throw;
             }
             catch (Exception ex)
             {
@@ -160,8 +173,13 @@ internal sealed class AndroidDevFlowPortForwarder
                 try
                 {
                     var spec = new AdbPortSpec(AdbProtocol.Tcp, port);
-                    await _adbRunner!.ForwardPortAsync(report.SelectedSerial, spec, spec, cancellationToken);
+                    using var timeoutCts = CreateAdbCallTimeoutSource(cancellationToken);
+                    await _adbRunner!.ForwardPortAsync(report.SelectedSerial, spec, spec, timeoutCts.Token);
                     added = true;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
                 }
                 catch (Exception ex)
                 {
@@ -285,16 +303,35 @@ internal sealed class AndroidDevFlowPortForwarder
     {
         try
         {
+            using var timeoutCts = CreateAdbCallTimeoutSource(cancellationToken);
             var rules = reverse
-                ? await _adbRunner!.ListReversePortsAsync(serial, cancellationToken)
-                : await _adbRunner!.ListForwardPortsAsync(serial, cancellationToken);
+                ? await _adbRunner!.ListReversePortsAsync(serial, timeoutCts.Token)
+                : await _adbRunner!.ListForwardPortsAsync(serial, timeoutCts.Token);
             return AndroidPortMappingList.Ok(rules);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             var command = reverse ? "adb reverse --list" : "adb forward --list";
             return AndroidPortMappingList.Failed($"{command} failed: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Creates a linked <see cref="CancellationTokenSource"/> that caps a single
+    /// <c>adb</c> invocation at <see cref="AdbCallTimeout"/>, while still observing the
+    /// caller's <paramref name="cancellationToken"/>. Callers distinguish the two by
+    /// checking <c>cancellationToken.IsCancellationRequested</c> in their catch block:
+    /// only the caller's own token should cause the whole operation to abort.
+    /// </summary>
+    static CancellationTokenSource CreateAdbCallTimeoutSource(CancellationToken cancellationToken)
+    {
+        var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(AdbCallTimeout);
+        return timeoutCts;
     }
 
     static bool ContainsMapping(IEnumerable<AdbPortRule> mappings, int port)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Android/AndroidDevFlowPortForwarder.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Maui.Cli.DevFlow.Broker;
 using Microsoft.Maui.Cli.Models;
 using Microsoft.Maui.Cli.Providers.Android;
-using Microsoft.Maui.Cli.Utils;
+using Xamarin.Android.Tools;
 
 namespace Microsoft.Maui.Cli.DevFlow.Android;
 
@@ -12,16 +12,16 @@ internal sealed class AndroidDevFlowPortForwarder
 
     readonly IAndroidProvider _androidProvider;
     readonly string? _adbPath;
-    readonly Func<string, string[], CancellationToken, Task<ProcessResult>> _runAdbAsync;
+    readonly AdbRunner? _adbRunner;
 
     public AndroidDevFlowPortForwarder(
         IAndroidProvider androidProvider,
         string? adbPath,
-        Func<string, string[], CancellationToken, Task<ProcessResult>> runAdbAsync)
+        AdbRunner? adbRunner)
     {
         _androidProvider = androidProvider;
         _adbPath = adbPath;
-        _runAdbAsync = runAdbAsync;
+        _adbRunner = adbRunner;
     }
 
     public static AndroidDevFlowPortForwarder CreateDefault()
@@ -30,15 +30,7 @@ internal sealed class AndroidDevFlowPortForwarder
         var environment = AndroidEnvironment.BuildEnvironmentVariables(provider.SdkPath, provider.JdkPath);
         var adb = new Adb(() => provider.SdkPath, environment);
 
-        return new AndroidDevFlowPortForwarder(
-            provider,
-            adb.AdbPath,
-            (adbPath, args, cancellationToken) => ProcessRunner.RunAsync(
-                adbPath,
-                args,
-                environmentVariables: environment,
-                timeout: TimeSpan.FromSeconds(15),
-                cancellationToken: cancellationToken));
+        return new AndroidDevFlowPortForwarder(provider, adb.AdbPath, adb.Runner);
     }
 
     /// <summary>
@@ -141,30 +133,40 @@ internal sealed class AndroidDevFlowPortForwarder
 
         var errors = new List<string>();
         var brokerReverseBefore = request.EnsureBrokerReverse
-            && ContainsMapping(reverseBefore.Mappings, report.SelectedSerial, brokerPort);
+            && ContainsMapping(reverseBefore.Mappings, brokerPort);
         var brokerReverseAdded = false;
 
         if (request.EnsureBrokerReverse && !brokerReverseBefore && request.Repair)
         {
-            var result = await RunAdbAsync(report.SelectedSerial, ["reverse", $"tcp:{brokerPort}", $"tcp:{brokerPort}"], cancellationToken);
-            if (result.Success)
+            try
+            {
+                var spec = new AdbPortSpec(AdbProtocol.Tcp, brokerPort);
+                await _adbRunner!.ReversePortAsync(report.SelectedSerial, spec, spec, cancellationToken);
                 brokerReverseAdded = true;
-            else
-                errors.Add($"adb reverse tcp:{brokerPort} tcp:{brokerPort} failed: {GetProcessError(result)}");
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"adb reverse tcp:{brokerPort} tcp:{brokerPort} failed: {ex.Message}");
+            }
         }
 
         var agentForwards = new List<AndroidDevFlowPortForward>();
         foreach (var port in report.AgentPorts)
         {
-            var presentBefore = ContainsMapping(forwardBefore.Mappings, report.SelectedSerial, port);
+            var presentBefore = ContainsMapping(forwardBefore.Mappings, port);
             var added = false;
             if (!presentBefore && request.Repair)
             {
-                var result = await RunAdbAsync(report.SelectedSerial, ["forward", $"tcp:{port}", $"tcp:{port}"], cancellationToken);
-                if (result.Success)
+                try
+                {
+                    var spec = new AdbPortSpec(AdbProtocol.Tcp, port);
+                    await _adbRunner!.ForwardPortAsync(report.SelectedSerial, spec, spec, cancellationToken);
                     added = true;
-                else
-                    errors.Add($"adb forward tcp:{port} tcp:{port} failed: {GetProcessError(result)}");
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"adb forward tcp:{port} tcp:{port} failed: {ex.Message}");
+                }
             }
 
             agentForwards.Add(new AndroidDevFlowPortForward
@@ -192,12 +194,12 @@ internal sealed class AndroidDevFlowPortForwarder
 
         var brokerReversePresent = request.EnsureBrokerReverse
             && reverseAfter.Success
-            && ContainsMapping(reverseAfter.Mappings, report.SelectedSerial, brokerPort);
+            && ContainsMapping(reverseAfter.Mappings, brokerPort);
 
         agentForwards = agentForwards
             .Select(f => f with
             {
-                PresentAfter = forwardAfter.Success && ContainsMapping(forwardAfter.Mappings, report.SelectedSerial, f.Port)
+                PresentAfter = forwardAfter.Success && ContainsMapping(forwardAfter.Mappings, f.Port)
             })
             .ToList();
 
@@ -281,68 +283,22 @@ internal sealed class AndroidDevFlowPortForwarder
 
     async Task<AndroidPortMappingList> ListMappingsAsync(string serial, bool reverse, CancellationToken cancellationToken)
     {
-        var result = await RunAdbAsync(serial, [reverse ? "reverse" : "forward", "--list"], cancellationToken);
-        if (!result.Success)
+        try
+        {
+            var rules = reverse
+                ? await _adbRunner!.ListReversePortsAsync(serial, cancellationToken)
+                : await _adbRunner!.ListForwardPortsAsync(serial, cancellationToken);
+            return AndroidPortMappingList.Ok(rules);
+        }
+        catch (Exception ex)
         {
             var command = reverse ? "adb reverse --list" : "adb forward --list";
-            return AndroidPortMappingList.Failed($"{command} failed: {GetProcessError(result)}");
+            return AndroidPortMappingList.Failed($"{command} failed: {ex.Message}");
         }
-
-        return AndroidPortMappingList.Ok(ParsePortMappings(result.StandardOutput));
     }
 
-    Task<ProcessResult> RunAdbAsync(string serial, string[] args, CancellationToken cancellationToken)
-    {
-        var fullArgs = new List<string> { "-s", serial };
-        fullArgs.AddRange(args);
-        return _runAdbAsync(_adbPath!, fullArgs.ToArray(), cancellationToken);
-    }
-
-    internal static AndroidDevFlowPortMapping[] ParsePortMappings(string output)
-    {
-        var mappings = new List<AndroidDevFlowPortMapping>();
-        foreach (var rawLine in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
-        {
-            var parts = rawLine.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length >= 3)
-            {
-                mappings.Add(new AndroidDevFlowPortMapping
-                {
-                    Serial = parts[0],
-                    Local = parts[1],
-                    Remote = parts[2]
-                });
-            }
-            else if (parts.Length == 2)
-            {
-                mappings.Add(new AndroidDevFlowPortMapping
-                {
-                    Local = parts[0],
-                    Remote = parts[1]
-                });
-            }
-        }
-
-        return mappings.ToArray();
-    }
-
-    static bool ContainsMapping(IEnumerable<AndroidDevFlowPortMapping> mappings, string serial, int port)
-    {
-        var endpoint = $"tcp:{port}";
-        return mappings.Any(m =>
-            (string.IsNullOrWhiteSpace(m.Serial) || m.Serial.Equals(serial, StringComparison.OrdinalIgnoreCase)) &&
-            m.Local.Equals(endpoint, StringComparison.OrdinalIgnoreCase) &&
-            m.Remote.Equals(endpoint, StringComparison.OrdinalIgnoreCase));
-    }
-
-    static string GetProcessError(ProcessResult result)
-    {
-        var error = !string.IsNullOrWhiteSpace(result.StandardError)
-            ? result.StandardError.Trim()
-            : result.StandardOutput.Trim();
-
-        return string.IsNullOrWhiteSpace(error) ? $"exit code {result.ExitCode}" : error;
-    }
+    static bool ContainsMapping(IEnumerable<AdbPortRule> mappings, int port)
+        => mappings.Any(m => m.Local.Port == port && m.Remote.Port == port);
 
     static string[] BuildMappingSuggestions(string serial, bool brokerReverseMissing, int brokerPort, int[] missingAgentForwards)
     {
@@ -362,9 +318,9 @@ internal sealed class AndroidDevFlowPortForwarder
             => new(status, null, message, suggestions);
     }
 
-    sealed record AndroidPortMappingList(bool Success, AndroidDevFlowPortMapping[] Mappings, string? Error)
+    sealed record AndroidPortMappingList(bool Success, IReadOnlyList<AdbPortRule> Mappings, string? Error)
     {
-        public static AndroidPortMappingList Ok(AndroidDevFlowPortMapping[] mappings) => new(true, mappings, null);
+        public static AndroidPortMappingList Ok(IReadOnlyList<AdbPortRule> mappings) => new(true, mappings, null);
 
         public static AndroidPortMappingList Failed(string error) => new(false, [], error);
     }
@@ -484,19 +440,6 @@ internal sealed record AndroidDevFlowDevice
             IsEmulator = device.IsEmulator,
             IsOnline = device.State is DeviceState.Connected or DeviceState.Booted
         };
-}
-
-internal sealed record AndroidDevFlowPortMapping
-{
-    [JsonPropertyName("serial")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Serial { get; init; }
-
-    [JsonPropertyName("local")]
-    public string Local { get; init; } = "";
-
-    [JsonPropertyName("remote")]
-    public string Remote { get; init; } = "";
 }
 
 internal sealed record AndroidDevFlowPortForward


### PR DESCRIPTION
## Summary

Replaces hand-rolled `adb reverse`/`adb forward` process calls and manual stdout parsing in `AndroidDevFlowPortForwarder` with the typed `AdbRunner` API introduced in `Xamarin.Android.Tools.AndroidSdk` `1.0.189-preview.58` (bumped in #305).

This API was added upstream specifically in [dotnet/android-tools#351](https://github.com/dotnet/android-tools/pull/351), which was filed to close **this repo's issue #197** ("adb reverse/forward" tracked as a CLI gap). Now that the typed API is available, we no longer need to build `adb` argument arrays by hand or parse `reverse --list`/`forward --list` output ourselves.

## Changes

- `AndroidDevFlowPortForwarder`'s constructor now takes an `AdbRunner?` instead of a raw `Func<string, string[], CancellationToken, Task<ProcessResult>>` process-run delegate.
- `CreateDefault()` reuses `Adb`'s existing internal `Runner` property instead of building a new `ProcessRunner`-backed delegate.
- Reverse/forward repair logic now calls `ReversePortAsync`/`ForwardPortAsync` directly, wrapped in try/catch.
- Listing mappings now calls `ListReversePortsAsync`/`ListForwardPortsAsync` directly, returning typed `AdbPortRule` records instead of hand-parsed strings.
- `ContainsMapping` simplified to compare `AdbPortRule.Local.Port`/`.Remote.Port` (dropped the now-unnecessary `serial` parameter).
- Removed now-dead code: `RunAdbAsync` helper, `ParsePortMappings`, `GetProcessError`, and the `AndroidDevFlowPortMapping` record.

## Tests

- Added `Fakes/FakeAdbRunner.cs` — an in-memory `AdbRunner` subclass overriding the 4 virtual methods the forwarder calls, with a `Commands` log for assertions.
- Rewrote `AndroidDevFlowPortForwarderTests.cs` to construct `FakeAdbRunner` directly instead of a raw process-arg-matching delegate; all 9 original test scenarios preserved with equivalent assertions.
- Updated 2 additional call sites in `DevFlowCliIntegrationTests.cs` that also constructed `AndroidDevFlowPortForwarder` directly.
- Full suite: **664/664 tests passing**, build has 0 warnings/errors.

## Out of scope

`ProfileCommandPortRouter.cs` (used by `maui profile startup`) has similar raw `adb reverse`/`forward` logic, but it's structurally independent (its own `adb` path resolution and its own stderr-based conflict detection for `DiagnosticPortRoutingConflictException`). Left untouched here — could be a good follow-up candidate for the same `AdbRunner`-based refactor.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>