### PR TITLE
Fix EssentialsAI macOS dotnet provisioning

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -211,6 +211,8 @@ extends:
 
           - job: EssentialsAI_macOS
             displayName: EssentialsAI - macOS (native build)
+            variables:
+              DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)/.dotnet
             pool:
               name: Azure Pipelines
               vmImage: macos-latest-internal


### PR DESCRIPTION
## Summary
- Force the EssentialsAI macOS native build to use the repo-local Arcade-provisioned `.dotnet` SDK path.
- Keep the existing `.dotnet/dotnet workload install` pipeline convention intact for the macOS job.

## Validation
- Parsed `eng/pipelines/devflow-official.yml` as YAML.
- Ran `git diff --check` for the pipeline change.