### PR TITLE
Fix EssentialsAI macOS SDK path without job variables

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -211,8 +211,6 @@ extends:
 
           - job: EssentialsAI_macOS
             displayName: EssentialsAI - macOS (native build)
-            variables:
-              DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)/.dotnet
             pool:
               name: Azure Pipelines
               vmImage: macos-latest-internal
@@ -231,10 +229,14 @@ extends:
             - script: |
                 eng/common/dotnet.sh --info
               displayName: Provision .NET SDK via Arcade
+              env:
+                DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)/.dotnet
             - script: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
               displayName: Select Xcode 26.3
             - script: .dotnet/dotnet workload install maui ios maccatalyst macos maui-tizen --version 10.0.203
               displayName: Install MAUI workloads
+              env:
+                DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)/.dotnet
             - script: |
                 ./eng/common/build.sh \
                   --configuration $(_BuildConfig) \
@@ -244,6 +246,8 @@ extends:
                   --ci \
                   --projects $(Build.SourcesDirectory)/src/AI/EssentialsAI.slnf
               displayName: Build EssentialsAI (macOS)
+              env:
+                DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)/.dotnet
             - task: CopyFiles@2
               displayName: Copy Native Binaries
               inputs:

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -230,13 +230,14 @@ extends:
                 eng/common/dotnet.sh --info
               displayName: Provision .NET SDK via Arcade
               env:
+                # Hosted macOS sets DOTNET_INSTALL_DIR to /Users/runner/.dotnet.
+                # Force Arcade to provision repo-local .dotnet because the next
+                # step invokes .dotnet/dotnet directly.
                 DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)/.dotnet
             - script: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
               displayName: Select Xcode 26.3
             - script: .dotnet/dotnet workload install maui ios maccatalyst macos maui-tizen --version 10.0.203
               displayName: Install MAUI workloads
-              env:
-                DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)/.dotnet
             - script: |
                 ./eng/common/build.sh \
                   --configuration $(_BuildConfig) \
@@ -247,6 +248,7 @@ extends:
                   --projects $(Build.SourcesDirectory)/src/AI/EssentialsAI.slnf
               displayName: Build EssentialsAI (macOS)
               env:
+                # Use the same SDK root that received the workload installation.
                 DOTNET_INSTALL_DIR: $(Build.SourcesDirectory)/.dotnet
             - task: CopyFiles@2
               displayName: Copy Native Binaries


### PR DESCRIPTION
## Summary
- Move the EssentialsAI macOS repo-local `.dotnet` override to script-step `env` blocks.
- Avoid job-level `variables`, which the Arcade/1ES job template rejects during Azure Pipelines expansion.
- Keep the existing `.dotnet/dotnet` workload install convention intact.

## Validation
- Parsed `eng/pipelines/devflow-official.yml` as YAML.
- Ran `git diff --check` for the pipeline change.