### PR TITLE
Bump EssentialsAI preview version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -84,7 +84,7 @@
     <EssentialsAIMinorVersion>0</EssentialsAIMinorVersion>
     <EssentialsAIPatchVersion>0</EssentialsAIPatchVersion>
     <EssentialsAIPreReleaseVersionLabel>preview</EssentialsAIPreReleaseVersionLabel>
-    <EssentialsAIPreviewVersionIteration>5</EssentialsAIPreviewVersionIteration>
+    <EssentialsAIPreviewVersionIteration>6</EssentialsAIPreviewVersionIteration>
     <!-- Microsoft Extensions AI -->
     <MicrosoftExtensionsAIAbstractionsVersion>10.4.1</MicrosoftExtensionsAIAbstractionsVersion>
     <!-- Microsoft Agents AI (sample only) -->


### PR DESCRIPTION
## Summary
- Bump EssentialsAI from preview.5 to preview.6
- Ensures the next NuGet.org release from this repo is clearly newer than the accidental preview.5 release from the previous repository

## Validation
- Evaluated the EssentialsAI package version with MSBuild using an official-build-like id; it now resolves to `11.0.0-preview.6.26358.1`