### PR TITLE
eng: publish Microsoft.Maui.ProfilingHelper from official pipeline

### DIFF
--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -470,6 +470,7 @@ extends:
           - powershell: |
               New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/CliPackages'
               Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Cli.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose
+              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.ProfilingHelper.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose -ErrorAction Stop
               Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.StartupProfiling.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose -ErrorAction Stop
             displayName: Filter Cli packages
 

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -471,7 +471,6 @@ extends:
               New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/CliPackages'
               Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Cli.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose
               Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.ProfilingHelper.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose -ErrorAction Stop
-              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.StartupProfiling.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose -ErrorAction Stop
             displayName: Filter Cli packages
 
         - job: PublishNuGet


### PR DESCRIPTION
## Summary
Include `Microsoft.Maui.ProfilingHelper` in the CLI NuGet publish artifact filter in `eng/pipelines/devflow-official.yml`.

## Change
Added this copy step in the `publish_cli_nuget` stage:

`Copy-Item ''$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.ProfilingHelper.*.nupkg'' ''$(Pipeline.Workspace)/CliPackages/'' -Verbose -ErrorAction Stop`

This ensures the package is included in `CliPackages` and pushed by the existing `1ES.PublishNuget@1` task.

## Why
`Microsoft.Maui.ProfilingHelper` is a shipping package in the CLI product and is referenced in docs, but it was not being copied into the publish artifact set for the CLI NuGet publish stage.
