### PR TITLE
Add `maui android port` command group (issue #197, gap 4)

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidPortCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidPortCommandsTests.cs
@@ -4,7 +4,9 @@
 using Microsoft.Maui.Cli;
 using Microsoft.Maui.Cli.Commands;
 using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.Providers.Android;
 using Microsoft.Maui.Cli.UnitTests.Fakes;
+using Xamarin.Android.Tools;
 using Xunit;
 
 namespace Microsoft.Maui.Cli.UnitTests;
@@ -210,14 +212,16 @@ public class AndroidPortCommandsTests
 	{
 		var fake = WithOnlineDevice();
 		fake.ForwardPorts.Add(new AndroidPortMapping { Local = 8080, Remote = 9090 });
-		fake.ReversePorts.Add(new AndroidPortMapping { Local = 19223, Remote = 19223 });
+		// Distinct device/host ports so a device/host swap would be visible.
+		fake.ReversePorts.Add(new AndroidPortMapping { Local = 5000, Remote = 6000 });
 
 		var (exitCode, stdOut, _) = await InvokePortAsync(fake, "android port list --json");
 
 		Assert.Equal(0, exitCode);
 		Assert.Contains("emulator-5554", stdOut);
 		Assert.Contains("8080", stdOut);
-		Assert.Contains("19223", stdOut);
+		Assert.Contains("5000", stdOut);
+		Assert.Contains("6000", stdOut);
 	}
 
 	[Fact]
@@ -320,5 +324,68 @@ public class AndroidPortCommandsTests
 		Assert.Equal(0, exitCode);
 		var call = Assert.Single(fake.AddedForwardPorts);
 		Assert.Equal("emulator-5556", call.Serial);
+	}
+}
+
+/// <summary>
+/// Exercises the real <see cref="Adb"/> port-rule mapping against a stub <see cref="AdbRunner"/>.
+/// Upstream <see cref="AdbPortRule"/> normalizes BOTH forward and reverse rules so
+/// <c>rule.Local</c> is the host port and <c>rule.Remote</c> is the device port. The CLI keeps
+/// adb's per-direction convention: forward mappings are Local=host/Remote=device (no swap),
+/// reverse mappings are Local=device/Remote=host (axes swapped). These tests use DISTINCT ports
+/// so a missing swap is observable.
+/// </summary>
+public class AdbPortMappingTests
+{
+	sealed class StubRunner : AdbRunner
+	{
+		readonly IReadOnlyList<AdbPortRule> _forward;
+		readonly IReadOnlyList<AdbPortRule> _reverse;
+
+		public StubRunner(IReadOnlyList<AdbPortRule>? forward = null, IReadOnlyList<AdbPortRule>? reverse = null)
+			: base("adb")
+		{
+			_forward = forward ?? Array.Empty<AdbPortRule>();
+			_reverse = reverse ?? Array.Empty<AdbPortRule>();
+		}
+
+		public override Task<IReadOnlyList<AdbPortRule>> ListForwardPortsAsync(string serial, CancellationToken cancellationToken = default)
+			=> Task.FromResult(_forward);
+
+		public override Task<IReadOnlyList<AdbPortRule>> ListReversePortsAsync(string serial, CancellationToken cancellationToken = default)
+			=> Task.FromResult(_reverse);
+	}
+
+	// Upstream AdbPortRule is a record (Remote, Local). Both ParseForwardListOutput and
+	// ParseReverseListOutput normalize so that rule.Local is always the host port and
+	// rule.Remote is always the device port, regardless of direction.
+	static AdbPortRule Rule(int host, int device)
+		=> new(new AdbPortSpec(AdbProtocol.Tcp, device), new AdbPortSpec(AdbProtocol.Tcp, host));
+
+	[Fact]
+	public async Task ListForwardPorts_KeepsHostAsLocalAndDeviceAsRemote()
+	{
+		var adb = new Adb(new StubRunner(forward: new[] { Rule(host: 8080, device: 9090) }));
+
+		var result = await adb.ListForwardPortsAsync("emulator-5554");
+
+		var m = Assert.Single(result);
+		Assert.Equal(8080, m.Local);   // host
+		Assert.Equal(9090, m.Remote);  // device
+		Assert.Equal("tcp", m.Protocol);
+	}
+
+	[Fact]
+	public async Task ListReversePorts_SwapsToDeviceAsLocalAndHostAsRemote()
+	{
+		// adb reverse tcp:5000 (device) → tcp:6000 (host); upstream stores Local=host=6000, Remote=device=5000.
+		var adb = new Adb(new StubRunner(reverse: new[] { Rule(host: 6000, device: 5000) }));
+
+		var result = await adb.ListReversePortsAsync("emulator-5554");
+
+		var m = Assert.Single(result);
+		Assert.Equal(5000, m.Local);   // device
+		Assert.Equal(6000, m.Remote);  // host
+		Assert.Equal("tcp", m.Protocol);
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidPortCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidPortCommandsTests.cs
@@ -1,0 +1,324 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Maui.Cli;
+using Microsoft.Maui.Cli.Commands;
+using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.UnitTests.Fakes;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+[Collection("CLI")]
+public class AndroidPortCommandsTests
+{
+	// --- Parsing / structure ---
+
+	[Fact]
+	public void PortCommand_Exists()
+	{
+		var android = AndroidCommands.Create();
+		Assert.Contains(android.Subcommands, c => c.Name == "port");
+	}
+
+	[Theory]
+	[InlineData("list")]
+	[InlineData("forward")]
+	[InlineData("reverse")]
+	[InlineData("clear")]
+	public void PortCommand_HasSubcommand(string name)
+	{
+		var android = AndroidCommands.Create();
+		var port = android.Subcommands.First(c => c.Name == "port");
+		Assert.Contains(port.Subcommands, c => c.Name == name);
+	}
+
+	[Fact]
+	public void PortCommand_HasRecursiveDeviceOption()
+	{
+		var android = AndroidCommands.Create();
+		var port = android.Subcommands.First(c => c.Name == "port");
+		Assert.Contains(port.Options, o => o.Name == "--device");
+	}
+
+	[Fact]
+	public void ForwardCommand_HasAgentPortOption()
+	{
+		var android = AndroidCommands.Create();
+		var port = android.Subcommands.First(c => c.Name == "port");
+		var forward = port.Subcommands.First(c => c.Name == "forward");
+		Assert.Contains(forward.Options, o => o.Name == "--agent-port");
+	}
+
+	[Fact]
+	public void ReverseCommand_PortArgumentIsOptional()
+	{
+		var android = AndroidCommands.Create();
+		var rootPort = android.Subcommands.First(c => c.Name == "port");
+		var reverse = rootPort.Subcommands.First(c => c.Name == "reverse");
+
+		var parseResult = reverse.Parse("reverse");
+		Assert.Empty(parseResult.Errors);
+	}
+
+	// --- Handler-level tests ---
+
+	static FakeAndroidProvider WithOnlineDevice(string serial = "emulator-5554")
+		=> new()
+		{
+			Devices =
+			{
+				new Device
+				{
+					Name = serial,
+					Id = serial,
+					Platforms = new[] { "android" },
+					State = DeviceState.Connected
+				}
+			}
+		};
+
+	static async Task<(int ExitCode, string StdOut, FakeAndroidProvider Fake)> InvokePortAsync(
+		FakeAndroidProvider fake,
+		string args,
+		string? androidSerial = null)
+	{
+		var testProvider = ServiceConfiguration.CreateTestServiceProvider(androidProvider: fake);
+		var originalOut = Console.Out;
+		var originalSerial = Environment.GetEnvironmentVariable("ANDROID_SERIAL");
+		var stdOut = new StringWriter();
+		try
+		{
+			Environment.SetEnvironmentVariable("ANDROID_SERIAL", androidSerial);
+			Program.Services = testProvider;
+			Console.SetOut(stdOut);
+
+			var rootCommand = Program.BuildRootCommand();
+			var parseResult = rootCommand.Parse(args);
+			var exitCode = await parseResult.InvokeAsync();
+			return (exitCode, stdOut.ToString(), fake);
+		}
+		finally
+		{
+			Console.SetOut(originalOut);
+			Environment.SetEnvironmentVariable("ANDROID_SERIAL", originalSerial);
+			Program.ResetServices();
+		}
+	}
+
+	[Fact]
+	public async Task Forward_SinglePort_UsesSamePortOnBothSides()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 8080 --json");
+
+		Assert.Equal(0, exitCode);
+		var call = Assert.Single(fake.AddedForwardPorts);
+		Assert.Equal("emulator-5554", call.Serial);
+		Assert.Equal(8080, call.HostPort);
+		Assert.Equal(8080, call.DevicePort);
+	}
+
+	[Fact]
+	public async Task Forward_WithRemote_MapsHostToDevice()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 8080 9090 --json");
+
+		Assert.Equal(0, exitCode);
+		var call = Assert.Single(fake.AddedForwardPorts);
+		Assert.Equal(8080, call.HostPort);
+		Assert.Equal(9090, call.DevicePort);
+	}
+
+	[Fact]
+	public async Task Forward_AgentPort_ForwardsOnBothSides()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward --agent-port 19223 --json");
+
+		Assert.Equal(0, exitCode);
+		var call = Assert.Single(fake.AddedForwardPorts);
+		Assert.Equal(19223, call.HostPort);
+		Assert.Equal(19223, call.DevicePort);
+	}
+
+	[Fact]
+	public async Task Forward_PortAndAgentPort_IsRejected()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 8080 --agent-port 19223 --json");
+
+		Assert.Equal(1, exitCode);
+		Assert.Empty(fake.AddedForwardPorts);
+	}
+
+	[Fact]
+	public async Task Forward_MissingPort_IsRejected()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward --json");
+
+		Assert.Equal(1, exitCode);
+		Assert.Empty(fake.AddedForwardPorts);
+	}
+
+	[Fact]
+	public async Task Forward_InvalidPort_IsRejected()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 70000 --json");
+
+		Assert.Equal(1, exitCode);
+		Assert.Empty(fake.AddedForwardPorts);
+	}
+
+	[Fact]
+	public async Task Reverse_NoArgs_DefaultsToBrokerPort()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port reverse --json");
+
+		Assert.Equal(0, exitCode);
+		var call = Assert.Single(fake.AddedReversePorts);
+		Assert.Equal(19223, call.DevicePort);
+		Assert.Equal(19223, call.HostPort);
+	}
+
+	[Fact]
+	public async Task Reverse_WithPortAndHost_MapsDeviceToHost()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port reverse 5000 6000 --json");
+
+		Assert.Equal(0, exitCode);
+		var call = Assert.Single(fake.AddedReversePorts);
+		Assert.Equal(5000, call.DevicePort);
+		Assert.Equal(6000, call.HostPort);
+	}
+
+	[Fact]
+	public async Task List_Json_IncludesSerialAndMappings()
+	{
+		var fake = WithOnlineDevice();
+		fake.ForwardPorts.Add(new AndroidPortMapping { Local = 8080, Remote = 9090 });
+		fake.ReversePorts.Add(new AndroidPortMapping { Local = 19223, Remote = 19223 });
+
+		var (exitCode, stdOut, _) = await InvokePortAsync(fake, "android port list --json");
+
+		Assert.Equal(0, exitCode);
+		Assert.Contains("emulator-5554", stdOut);
+		Assert.Contains("8080", stdOut);
+		Assert.Contains("19223", stdOut);
+	}
+
+	[Fact]
+	public async Task Clear_NoFlags_ClearsBothDirections()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port clear --json");
+
+		Assert.Equal(0, exitCode);
+		Assert.Single(fake.ClearedForwardPorts);
+		Assert.Single(fake.ClearedReversePorts);
+	}
+
+	[Fact]
+	public async Task Clear_ForwardOnly_LeavesReverseUntouched()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port clear --forward --json");
+
+		Assert.Equal(0, exitCode);
+		Assert.Single(fake.ClearedForwardPorts);
+		Assert.Empty(fake.ClearedReversePorts);
+	}
+
+	[Fact]
+	public async Task Forward_NoOnlineDevice_Fails()
+	{
+		var fake = new FakeAndroidProvider();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 8080 --json");
+
+		Assert.Equal(1, exitCode);
+		Assert.Empty(fake.AddedForwardPorts);
+	}
+
+	[Fact]
+	public async Task Forward_MultipleDevicesWithoutSelector_Fails()
+	{
+		var fake = new FakeAndroidProvider
+		{
+			Devices =
+			{
+				new Device { Name = "a", Id = "emulator-5554", Platforms = new[] { "android" }, State = DeviceState.Connected },
+				new Device { Name = "b", Id = "emulator-5556", Platforms = new[] { "android" }, State = DeviceState.Booted }
+			}
+		};
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 8080 --json");
+
+		Assert.Equal(1, exitCode);
+		Assert.Empty(fake.AddedForwardPorts);
+	}
+
+	[Fact]
+	public async Task Forward_MultipleDevicesWithDeviceSelector_Succeeds()
+	{
+		var fake = new FakeAndroidProvider
+		{
+			Devices =
+			{
+				new Device { Name = "a", Id = "emulator-5554", Platforms = new[] { "android" }, State = DeviceState.Connected },
+				new Device { Name = "b", Id = "emulator-5556", Platforms = new[] { "android" }, State = DeviceState.Booted }
+			}
+		};
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 8080 --device emulator-5556 --json");
+
+		Assert.Equal(0, exitCode);
+		var call = Assert.Single(fake.AddedForwardPorts);
+		Assert.Equal("emulator-5556", call.Serial);
+	}
+
+	[Fact]
+	public async Task Forward_UnknownDeviceSelector_Fails()
+	{
+		var fake = WithOnlineDevice();
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 8080 --device does-not-exist --json");
+
+		Assert.Equal(1, exitCode);
+		Assert.Empty(fake.AddedForwardPorts);
+	}
+
+	[Fact]
+	public async Task Forward_AndroidSerialEnvVar_SelectsDevice()
+	{
+		var fake = new FakeAndroidProvider
+		{
+			Devices =
+			{
+				new Device { Name = "a", Id = "emulator-5554", Platforms = new[] { "android" }, State = DeviceState.Connected },
+				new Device { Name = "b", Id = "emulator-5556", Platforms = new[] { "android" }, State = DeviceState.Booted }
+			}
+		};
+
+		var (exitCode, _, _) = await InvokePortAsync(fake, "android port forward 8080 --json", androidSerial: "emulator-5556");
+
+		Assert.Equal(0, exitCode);
+		var call = Assert.Single(fake.AddedForwardPorts);
+		Assert.Equal("emulator-5556", call.Serial);
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
@@ -64,6 +64,16 @@ public class FakeAndroidProvider : IAndroidProvider
 	public List<int?> InstallJdkCalls { get; } = new();
 	public bool Disposed { get; private set; }
 
+	// --- Port management: configurable return values + call tracking ---
+
+	public List<AndroidPortMapping> ForwardPorts { get; set; } = new();
+	public List<AndroidPortMapping> ReversePorts { get; set; } = new();
+
+	public List<(string Serial, int HostPort, int DevicePort)> AddedForwardPorts { get; } = new();
+	public List<(string Serial, int DevicePort, int HostPort)> AddedReversePorts { get; } = new();
+	public List<string> ClearedForwardPorts { get; } = new();
+	public List<string> ClearedReversePorts { get; } = new();
+
 	// --- IAndroidProvider implementation ---
 
 	public Task<List<HealthCheck>> CheckHealthAsync(CancellationToken cancellationToken = default)
@@ -104,6 +114,36 @@ public class FakeAndroidProvider : IAndroidProvider
 	public Task StopEmulatorAsync(string deviceSerial, CancellationToken cancellationToken = default)
 	{
 		StoppedEmulators.Add(deviceSerial);
+		return Task.CompletedTask;
+	}
+
+	public Task<IReadOnlyList<AndroidPortMapping>> ListForwardPortsAsync(string deviceSerial, CancellationToken cancellationToken = default)
+		=> Task.FromResult<IReadOnlyList<AndroidPortMapping>>(ForwardPorts);
+
+	public Task<IReadOnlyList<AndroidPortMapping>> ListReversePortsAsync(string deviceSerial, CancellationToken cancellationToken = default)
+		=> Task.FromResult<IReadOnlyList<AndroidPortMapping>>(ReversePorts);
+
+	public Task AddForwardPortAsync(string deviceSerial, int hostPort, int devicePort, CancellationToken cancellationToken = default)
+	{
+		AddedForwardPorts.Add((deviceSerial, hostPort, devicePort));
+		return Task.CompletedTask;
+	}
+
+	public Task AddReversePortAsync(string deviceSerial, int devicePort, int hostPort, CancellationToken cancellationToken = default)
+	{
+		AddedReversePorts.Add((deviceSerial, devicePort, hostPort));
+		return Task.CompletedTask;
+	}
+
+	public Task ClearForwardPortsAsync(string deviceSerial, CancellationToken cancellationToken = default)
+	{
+		ClearedForwardPorts.Add(deviceSerial);
+		return Task.CompletedTask;
+	}
+
+	public Task ClearReversePortsAsync(string deviceSerial, CancellationToken cancellationToken = default)
+	{
+		ClearedReversePorts.Add(deviceSerial);
 		return Task.CompletedTask;
 	}
 

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Port.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Port.cs
@@ -13,27 +13,27 @@ namespace Microsoft.Maui.Cli.Commands;
 
 public static partial class AndroidCommands
 {
-	// Shared across all `port` subcommands. Recursive so subcommands inherit it.
-	static readonly Option<string> s_portDeviceOption = new("--device", "-s")
-	{
-		Description = "Target device serial. Defaults to the only online device, or the ANDROID_SERIAL environment variable.",
-		Recursive = true
-	};
-
 	static Command CreatePortCommand()
 	{
-		var command = new Command("port", "Manage adb forward/reverse port rules for a device");
-		command.Add(s_portDeviceOption);
+		// Shared across all `port` subcommands. Recursive so subcommands inherit it.
+		var deviceOption = new Option<string>("--device", "-s")
+		{
+			Description = "Target device serial. Defaults to the only online device, or the ANDROID_SERIAL environment variable.",
+			Recursive = true
+		};
 
-		command.Add(CreatePortListCommand());
-		command.Add(CreatePortForwardCommand());
-		command.Add(CreatePortReverseCommand());
-		command.Add(CreatePortClearCommand());
+		var command = new Command("port", "Manage adb forward/reverse port rules for a device");
+		command.Add(deviceOption);
+
+		command.Add(CreatePortListCommand(deviceOption));
+		command.Add(CreatePortForwardCommand(deviceOption));
+		command.Add(CreatePortReverseCommand(deviceOption));
+		command.Add(CreatePortClearCommand(deviceOption));
 
 		return command;
 	}
 
-	static Command CreatePortListCommand()
+	static Command CreatePortListCommand(Option<string> deviceOption)
 	{
 		var forwardFlag = new Option<bool>("--forward") { Description = "Show only forward (host → device) rules" };
 		var reverseFlag = new Option<bool>("--reverse") { Description = "Show only reverse (device → host) rules" };
@@ -52,7 +52,7 @@ public static partial class AndroidCommands
 
 			try
 			{
-				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(s_portDeviceOption), cancellationToken);
+				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(deviceOption), cancellationToken);
 
 				var showForward = parseResult.GetValue(forwardFlag);
 				var showReverse = parseResult.GetValue(reverseFlag);
@@ -115,7 +115,7 @@ public static partial class AndroidCommands
 		return listCommand;
 	}
 
-	static Command CreatePortForwardCommand()
+	static Command CreatePortForwardCommand(Option<string> deviceOption)
 	{
 		var portArg = new Argument<int?>("port")
 		{
@@ -163,7 +163,7 @@ public static partial class AndroidCommands
 				var devicePort = remote ?? hostPort.Value;
 				ValidatePort(devicePort);
 
-				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(s_portDeviceOption), cancellationToken);
+				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(deviceOption), cancellationToken);
 				await provider.AddForwardPortAsync(serial, hostPort.Value, devicePort, cancellationToken);
 
 				var message = $"Forwarding host tcp:{hostPort} → device tcp:{devicePort} on {serial}.";
@@ -195,7 +195,7 @@ public static partial class AndroidCommands
 		return forwardCommand;
 	}
 
-	static Command CreatePortReverseCommand()
+	static Command CreatePortReverseCommand(Option<string> deviceOption)
 	{
 		var portArg = new Argument<int?>("port")
 		{
@@ -227,7 +227,7 @@ public static partial class AndroidCommands
 				var hostPort = parseResult.GetValue(hostArg) ?? devicePort;
 				ValidatePort(hostPort);
 
-				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(s_portDeviceOption), cancellationToken);
+				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(deviceOption), cancellationToken);
 				await provider.AddReversePortAsync(serial, devicePort, hostPort, cancellationToken);
 
 				var message = $"Reversing device tcp:{devicePort} → host tcp:{hostPort} on {serial}.";
@@ -259,7 +259,7 @@ public static partial class AndroidCommands
 		return reverseCommand;
 	}
 
-	static Command CreatePortClearCommand()
+	static Command CreatePortClearCommand(Option<string> deviceOption)
 	{
 		var forwardFlag = new Option<bool>("--forward") { Description = "Clear only forward (host → device) rules" };
 		var reverseFlag = new Option<bool>("--reverse") { Description = "Clear only reverse (device → host) rules" };
@@ -283,7 +283,7 @@ public static partial class AndroidCommands
 				if (!clearForward && !clearReverse)
 					clearForward = clearReverse = true;
 
-				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(s_portDeviceOption), cancellationToken);
+				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(deviceOption), cancellationToken);
 
 				if (clearForward)
 					await provider.ClearForwardPortsAsync(serial, cancellationToken);

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Port.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Port.cs
@@ -1,0 +1,370 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Microsoft.Maui.Cli.DevFlow.Broker;
+using Microsoft.Maui.Cli.Errors;
+using Microsoft.Maui.Cli.Models;
+using Microsoft.Maui.Cli.Output;
+using Microsoft.Maui.Cli.Providers.Android;
+
+namespace Microsoft.Maui.Cli.Commands;
+
+public static partial class AndroidCommands
+{
+	// Shared across all `port` subcommands. Recursive so subcommands inherit it.
+	static readonly Option<string> s_portDeviceOption = new("--device", "-s")
+	{
+		Description = "Target device serial. Defaults to the only online device, or the ANDROID_SERIAL environment variable.",
+		Recursive = true
+	};
+
+	static Command CreatePortCommand()
+	{
+		var command = new Command("port", "Manage adb forward/reverse port rules for a device");
+		command.Add(s_portDeviceOption);
+
+		command.Add(CreatePortListCommand());
+		command.Add(CreatePortForwardCommand());
+		command.Add(CreatePortReverseCommand());
+		command.Add(CreatePortClearCommand());
+
+		return command;
+	}
+
+	static Command CreatePortListCommand()
+	{
+		var forwardFlag = new Option<bool>("--forward") { Description = "Show only forward (host → device) rules" };
+		var reverseFlag = new Option<bool>("--reverse") { Description = "Show only reverse (device → host) rules" };
+
+		var listCommand = new Command("list", "List active adb forward/reverse port rules")
+		{
+			forwardFlag,
+			reverseFlag
+		};
+
+		listCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var provider = GetAndroidProvider(parseResult);
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+
+			try
+			{
+				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(s_portDeviceOption), cancellationToken);
+
+				var showForward = parseResult.GetValue(forwardFlag);
+				var showReverse = parseResult.GetValue(reverseFlag);
+				if (!showForward && !showReverse)
+					showForward = showReverse = true;
+
+				IReadOnlyList<AndroidPortMapping> forward = showForward
+					? await provider.ListForwardPortsAsync(serial, cancellationToken)
+					: Array.Empty<AndroidPortMapping>();
+				IReadOnlyList<AndroidPortMapping> reverse = showReverse
+					? await provider.ListReversePortsAsync(serial, cancellationToken)
+					: Array.Empty<AndroidPortMapping>();
+
+				if (useJson)
+				{
+					formatter.Write(new AndroidPortListResult
+					{
+						Serial = serial,
+						Forward = forward.ToList(),
+						Reverse = reverse.ToList()
+					});
+				}
+				else
+				{
+					if (showForward)
+					{
+						formatter.WriteInfo($"Forward (host → device) — {serial}");
+						if (forward.Count == 0)
+							formatter.WriteInfo("  (none)");
+						else
+							formatter.WriteTable(
+								forward,
+								("Host", m => m.Local.ToString()),
+								("Device", m => m.Remote.ToString()),
+								("Protocol", m => m.Protocol));
+					}
+
+					if (showReverse)
+					{
+						formatter.WriteInfo($"Reverse (device → host) — {serial}");
+						if (reverse.Count == 0)
+							formatter.WriteInfo("  (none)");
+						else
+							formatter.WriteTable(
+								reverse,
+								("Device", m => m.Local.ToString()),
+								("Host", m => m.Remote.ToString()),
+								("Protocol", m => m.Protocol));
+					}
+				}
+
+				return 0;
+			}
+			catch (Exception ex)
+			{
+				return Program.HandleCommandException(formatter, ex);
+			}
+		});
+
+		return listCommand;
+	}
+
+	static Command CreatePortForwardCommand()
+	{
+		var portArg = new Argument<int?>("port")
+		{
+			Description = "Host port to forward from (tcp)",
+			Arity = ArgumentArity.ZeroOrOne
+		};
+		var remoteArg = new Argument<int?>("remote")
+		{
+			Description = "Device port to forward to (tcp). Defaults to <port>.",
+			Arity = ArgumentArity.ZeroOrOne
+		};
+		var agentPortOption = new Option<int?>("--agent-port")
+		{
+			Description = "DevFlow shortcut: forward the agent port on both host and device sides"
+		};
+
+		var forwardCommand = new Command("forward", "Forward a host port to a device port (adb forward)")
+		{
+			portArg,
+			remoteArg,
+			agentPortOption
+		};
+
+		forwardCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var provider = GetAndroidProvider(parseResult);
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+
+			try
+			{
+				var port = parseResult.GetValue(portArg);
+				var remote = parseResult.GetValue(remoteArg);
+				var agentPort = parseResult.GetValue(agentPortOption);
+
+				if (port is not null && agentPort is not null)
+					throw new MauiToolException(ErrorCodes.InvalidArgument, "Specify either a <port> argument or --agent-port, not both.");
+
+				var hostPort = port ?? agentPort;
+				if (hostPort is null)
+					throw new MauiToolException(ErrorCodes.InvalidArgument,
+						"Specify a host port to forward, e.g. 'maui android port forward 8080' or '--agent-port 19223'.");
+
+				ValidatePort(hostPort.Value);
+				var devicePort = remote ?? hostPort.Value;
+				ValidatePort(devicePort);
+
+				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(s_portDeviceOption), cancellationToken);
+				await provider.AddForwardPortAsync(serial, hostPort.Value, devicePort, cancellationToken);
+
+				var message = $"Forwarding host tcp:{hostPort} → device tcp:{devicePort} on {serial}.";
+				if (useJson)
+				{
+					formatter.Write(new AndroidPortActionResult
+					{
+						Action = "forward",
+						Serial = serial,
+						Local = hostPort,
+						Remote = devicePort,
+						Protocol = "tcp",
+						Message = message
+					});
+				}
+				else
+				{
+					formatter.WriteSuccess(message);
+				}
+
+				return 0;
+			}
+			catch (Exception ex)
+			{
+				return Program.HandleCommandException(formatter, ex);
+			}
+		});
+
+		return forwardCommand;
+	}
+
+	static Command CreatePortReverseCommand()
+	{
+		var portArg = new Argument<int?>("port")
+		{
+			Description = $"Device port to reverse (tcp). Defaults to the broker port {BrokerServer.DefaultPort}.",
+			Arity = ArgumentArity.ZeroOrOne
+		};
+		var hostArg = new Argument<int?>("host")
+		{
+			Description = "Host port to reverse to (tcp). Defaults to <port>.",
+			Arity = ArgumentArity.ZeroOrOne
+		};
+
+		var reverseCommand = new Command("reverse", "Reverse a device port to a host port (adb reverse)")
+		{
+			portArg,
+			hostArg
+		};
+
+		reverseCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var provider = GetAndroidProvider(parseResult);
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+
+			try
+			{
+				var devicePort = parseResult.GetValue(portArg) ?? BrokerServer.DefaultPort;
+				ValidatePort(devicePort);
+				var hostPort = parseResult.GetValue(hostArg) ?? devicePort;
+				ValidatePort(hostPort);
+
+				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(s_portDeviceOption), cancellationToken);
+				await provider.AddReversePortAsync(serial, devicePort, hostPort, cancellationToken);
+
+				var message = $"Reversing device tcp:{devicePort} → host tcp:{hostPort} on {serial}.";
+				if (useJson)
+				{
+					formatter.Write(new AndroidPortActionResult
+					{
+						Action = "reverse",
+						Serial = serial,
+						Local = devicePort,
+						Remote = hostPort,
+						Protocol = "tcp",
+						Message = message
+					});
+				}
+				else
+				{
+					formatter.WriteSuccess(message);
+				}
+
+				return 0;
+			}
+			catch (Exception ex)
+			{
+				return Program.HandleCommandException(formatter, ex);
+			}
+		});
+
+		return reverseCommand;
+	}
+
+	static Command CreatePortClearCommand()
+	{
+		var forwardFlag = new Option<bool>("--forward") { Description = "Clear only forward (host → device) rules" };
+		var reverseFlag = new Option<bool>("--reverse") { Description = "Clear only reverse (device → host) rules" };
+
+		var clearCommand = new Command("clear", "Remove all adb forward/reverse rules for a device")
+		{
+			forwardFlag,
+			reverseFlag
+		};
+
+		clearCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var provider = GetAndroidProvider(parseResult);
+			var formatter = Program.GetFormatter(parseResult);
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+
+			try
+			{
+				var clearForward = parseResult.GetValue(forwardFlag);
+				var clearReverse = parseResult.GetValue(reverseFlag);
+				if (!clearForward && !clearReverse)
+					clearForward = clearReverse = true;
+
+				var serial = await ResolveDeviceSerialAsync(provider, parseResult.GetValue(s_portDeviceOption), cancellationToken);
+
+				if (clearForward)
+					await provider.ClearForwardPortsAsync(serial, cancellationToken);
+				if (clearReverse)
+					await provider.ClearReversePortsAsync(serial, cancellationToken);
+
+				var cleared = (clearForward, clearReverse) switch
+				{
+					(true, true) => "forward and reverse",
+					(true, false) => "forward",
+					_ => "reverse"
+				};
+				var message = $"Cleared {cleared} port rules on {serial}.";
+
+				if (useJson)
+				{
+					formatter.Write(new AndroidPortActionResult
+					{
+						Action = "clear",
+						Serial = serial,
+						ClearedForward = clearForward,
+						ClearedReverse = clearReverse,
+						Message = message
+					});
+				}
+				else
+				{
+					formatter.WriteSuccess(message);
+				}
+
+				return 0;
+			}
+			catch (Exception ex)
+			{
+				return Program.HandleCommandException(formatter, ex);
+			}
+		});
+
+		return clearCommand;
+	}
+
+	/// <summary>
+	/// Resolves the target device serial: an explicit <c>--device</c> value (falling back to the
+	/// <c>ANDROID_SERIAL</c> environment variable) must match an online device; otherwise the single
+	/// online Android device is used. Throws when none, multiple (without a selector), or the requested
+	/// device is not online.
+	/// </summary>
+	static async Task<string> ResolveDeviceSerialAsync(IAndroidProvider provider, string? requested, CancellationToken cancellationToken)
+	{
+		var target = !string.IsNullOrWhiteSpace(requested)
+			? requested
+			: Environment.GetEnvironmentVariable("ANDROID_SERIAL");
+
+		var devices = await provider.GetDevicesAsync(cancellationToken);
+		var online = devices
+			.Where(d => d.Platforms.Any(p => p.Equals("android", StringComparison.OrdinalIgnoreCase)))
+			.Where(d => d.State is DeviceState.Connected or DeviceState.Booted)
+			.ToList();
+
+		if (!string.IsNullOrWhiteSpace(target))
+		{
+			var match = online.FirstOrDefault(d => d.Id.Equals(target, StringComparison.OrdinalIgnoreCase));
+			if (match is null)
+				throw new MauiToolException(ErrorCodes.AndroidDeviceNotFound,
+					$"Android device '{target}' is not connected and online.");
+			return match.Id;
+		}
+
+		return online.Count switch
+		{
+			0 => throw new MauiToolException(ErrorCodes.AndroidDeviceNotFound,
+				"No online Android devices or emulators were found."),
+			1 => online[0].Id,
+			_ => throw new MauiToolException(ErrorCodes.InvalidArgument,
+				"Multiple online Android devices or emulators were found. Specify --device or ANDROID_SERIAL.")
+		};
+	}
+
+	static void ValidatePort(int port)
+	{
+		if (port is < 1 or > 65535)
+			throw new MauiToolException(ErrorCodes.InvalidArgument, $"Port must be between 1 and 65535, got {port}.");
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.cs
@@ -39,6 +39,7 @@ public static partial class AndroidCommands
 		command.Add(CreateJdkCommand());
 		command.Add(CreateSdkCommand());
 		command.Add(CreateEmulatorCommand());
+		command.Add(CreatePortCommand());
 
 		return command;
 	}

--- a/src/Cli/Microsoft.Maui.Cli/Models/AndroidPortMapping.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Models/AndroidPortMapping.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.Cli.Models;
+
+/// <summary>
+/// A single adb port mapping rule. <see cref="Local"/> and <see cref="Remote"/> mirror
+/// adb's own <c>LOCAL</c>/<c>REMOTE</c> socket specs:
+/// for a forward rule <see cref="Local"/> is the host port and <see cref="Remote"/> is the device port;
+/// for a reverse rule <see cref="Local"/> is the device port and <see cref="Remote"/> is the host port.
+/// </summary>
+public sealed record AndroidPortMapping
+{
+	[JsonPropertyName("local")]
+	public int Local { get; init; }
+
+	[JsonPropertyName("remote")]
+	public int Remote { get; init; }
+
+	[JsonPropertyName("protocol")]
+	public string Protocol { get; init; } = "tcp";
+}
+
+/// <summary>
+/// Result of <c>maui android port list</c>.
+/// </summary>
+public sealed record AndroidPortListResult
+{
+	[JsonPropertyName("serial")]
+	public string Serial { get; init; } = string.Empty;
+
+	[JsonPropertyName("forward")]
+	public List<AndroidPortMapping> Forward { get; init; } = [];
+
+	[JsonPropertyName("reverse")]
+	public List<AndroidPortMapping> Reverse { get; init; } = [];
+}
+
+/// <summary>
+/// Result of a mutating <c>maui android port</c> action (forward, reverse, or clear).
+/// </summary>
+public sealed record AndroidPortActionResult
+{
+	[JsonPropertyName("success")]
+	public bool Success { get; init; } = true;
+
+	[JsonPropertyName("serial")]
+	public string Serial { get; init; } = string.Empty;
+
+	/// <summary>The action performed: <c>forward</c>, <c>reverse</c>, or <c>clear</c>.</summary>
+	[JsonPropertyName("action")]
+	public required string Action { get; init; }
+
+	[JsonPropertyName("local")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public int? Local { get; init; }
+
+	[JsonPropertyName("remote")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public int? Remote { get; init; }
+
+	[JsonPropertyName("protocol")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Protocol { get; init; }
+
+	[JsonPropertyName("cleared_forward")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public bool? ClearedForward { get; init; }
+
+	[JsonPropertyName("cleared_reverse")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public bool? ClearedReverse { get; init; }
+
+	[JsonPropertyName("message")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Message { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Output/MauiCliJsonContext.cs
@@ -74,4 +74,7 @@ namespace Microsoft.Maui.Cli.Output;
 [JsonSerializable(typeof(SimulatorScreenshotResult))]
 [JsonSerializable(typeof(SimulatorRecordingStartedResult))]
 [JsonSerializable(typeof(SimulatorRecordingResult))]
+[JsonSerializable(typeof(AndroidPortMapping))]
+[JsonSerializable(typeof(AndroidPortListResult))]
+[JsonSerializable(typeof(AndroidPortActionResult))]
 internal sealed partial class MauiCliJsonContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
@@ -25,6 +25,16 @@ public class Adb
 		_environmentVariables = environmentVariables;
 	}
 
+	/// <summary>
+	/// Test-only constructor that injects a preconfigured <see cref="AdbRunner"/> so the
+	/// port-rule mapping can be exercised without a real <c>adb</c> binary.
+	/// </summary>
+	internal Adb(AdbRunner runner)
+	{
+		_runner = runner ?? throw new ArgumentNullException(nameof(runner));
+		_adbPath = "adb";
+	}
+
 	public string? AdbPath => _adbPath;
 
 	public bool IsAvailable => _adbPath != null;
@@ -141,7 +151,7 @@ public class Adb
 	{
 		var runner = RequireRunner();
 		var rules = await runner.ListReversePortsAsync(deviceSerial, cancellationToken);
-		return rules.Select(MapPortRule).ToList();
+		return rules.Select(MapReversePortRule).ToList();
 	}
 
 	/// <summary>Adds an <c>adb forward tcp:hostPort tcp:devicePort</c> rule.</summary>
@@ -183,10 +193,22 @@ public class Adb
 	AdbRunner RequireRunner() =>
 		Runner ?? throw new MauiToolException(ErrorCodes.AndroidAdbNotFound, "ADB not found");
 
+	// Upstream AdbPortRule normalizes both forward AND reverse rules so that
+	// rule.Local is always the host port and rule.Remote is always the device port.
+	// AndroidPortMapping keeps adb's own per-direction convention: for a forward rule
+	// Local=host/Remote=device (no swap), but for a reverse rule Local=device/Remote=host,
+	// matching what 'port reverse' emits — so reverse rules must be mapped with axes swapped.
 	static AndroidPortMapping MapPortRule(AdbPortRule rule) => new()
 	{
 		Local = rule.Local.Port,
 		Remote = rule.Remote.Port,
+		Protocol = rule.Local.Protocol.ToString().ToLowerInvariant(),
+	};
+
+	static AndroidPortMapping MapReversePortRule(AdbPortRule rule) => new()
+	{
+		Local = rule.Remote.Port,   // device
+		Remote = rule.Local.Port,   // host
 		Protocol = rule.Local.Protocol.ToString().ToLowerInvariant(),
 	};
 

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
@@ -128,4 +128,66 @@ public class Adb
 		await runner.StopEmulatorAsync(deviceSerial, cancellationToken);
 	}
 
+	/// <summary>Lists active <c>adb forward</c> (host → device) port rules for a device.</summary>
+	public async Task<IReadOnlyList<AndroidPortMapping>> ListForwardPortsAsync(string deviceSerial, CancellationToken cancellationToken = default)
+	{
+		var runner = RequireRunner();
+		var rules = await runner.ListForwardPortsAsync(deviceSerial, cancellationToken);
+		return rules.Select(MapPortRule).ToList();
+	}
+
+	/// <summary>Lists active <c>adb reverse</c> (device → host) port rules for a device.</summary>
+	public async Task<IReadOnlyList<AndroidPortMapping>> ListReversePortsAsync(string deviceSerial, CancellationToken cancellationToken = default)
+	{
+		var runner = RequireRunner();
+		var rules = await runner.ListReversePortsAsync(deviceSerial, cancellationToken);
+		return rules.Select(MapPortRule).ToList();
+	}
+
+	/// <summary>Adds an <c>adb forward tcp:hostPort tcp:devicePort</c> rule.</summary>
+	public async Task AddForwardPortAsync(string deviceSerial, int hostPort, int devicePort, CancellationToken cancellationToken = default)
+	{
+		var runner = RequireRunner();
+		await runner.ForwardPortAsync(
+			deviceSerial,
+			new AdbPortSpec(AdbProtocol.Tcp, hostPort),
+			new AdbPortSpec(AdbProtocol.Tcp, devicePort),
+			cancellationToken);
+	}
+
+	/// <summary>Adds an <c>adb reverse tcp:devicePort tcp:hostPort</c> rule.</summary>
+	public async Task AddReversePortAsync(string deviceSerial, int devicePort, int hostPort, CancellationToken cancellationToken = default)
+	{
+		var runner = RequireRunner();
+		await runner.ReversePortAsync(
+			deviceSerial,
+			new AdbPortSpec(AdbProtocol.Tcp, devicePort),
+			new AdbPortSpec(AdbProtocol.Tcp, hostPort),
+			cancellationToken);
+	}
+
+	/// <summary>Removes all <c>adb forward</c> rules for a device.</summary>
+	public async Task ClearForwardPortsAsync(string deviceSerial, CancellationToken cancellationToken = default)
+	{
+		var runner = RequireRunner();
+		await runner.RemoveAllForwardPortsAsync(deviceSerial, cancellationToken);
+	}
+
+	/// <summary>Removes all <c>adb reverse</c> rules for a device.</summary>
+	public async Task ClearReversePortsAsync(string deviceSerial, CancellationToken cancellationToken = default)
+	{
+		var runner = RequireRunner();
+		await runner.RemoveAllReversePortsAsync(deviceSerial, cancellationToken);
+	}
+
+	AdbRunner RequireRunner() =>
+		Runner ?? throw new MauiToolException(ErrorCodes.AndroidAdbNotFound, "ADB not found");
+
+	static AndroidPortMapping MapPortRule(AdbPortRule rule) => new()
+	{
+		Local = rule.Local.Port,
+		Remote = rule.Remote.Port,
+		Protocol = rule.Local.Protocol.ToString().ToLowerInvariant(),
+	};
+
 }

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/Adb.cs
@@ -209,7 +209,7 @@ public class Adb
 	{
 		Local = rule.Remote.Port,   // device
 		Remote = rule.Local.Port,   // host
-		Protocol = rule.Local.Protocol.ToString().ToLowerInvariant(),
+		Protocol = rule.Remote.Protocol.ToString().ToLowerInvariant(),   // same side as Local
 	};
 
 }

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -282,6 +282,24 @@ public class AndroidProvider : IAndroidProvider
 			EmulatorProcessHelper.KillProcessIds(childPids);
 	}
 
+	public Task<IReadOnlyList<AndroidPortMapping>> ListForwardPortsAsync(string deviceSerial, CancellationToken cancellationToken = default) =>
+		_adb.ListForwardPortsAsync(deviceSerial, cancellationToken);
+
+	public Task<IReadOnlyList<AndroidPortMapping>> ListReversePortsAsync(string deviceSerial, CancellationToken cancellationToken = default) =>
+		_adb.ListReversePortsAsync(deviceSerial, cancellationToken);
+
+	public Task AddForwardPortAsync(string deviceSerial, int hostPort, int devicePort, CancellationToken cancellationToken = default) =>
+		_adb.AddForwardPortAsync(deviceSerial, hostPort, devicePort, cancellationToken);
+
+	public Task AddReversePortAsync(string deviceSerial, int devicePort, int hostPort, CancellationToken cancellationToken = default) =>
+		_adb.AddReversePortAsync(deviceSerial, devicePort, hostPort, cancellationToken);
+
+	public Task ClearForwardPortsAsync(string deviceSerial, CancellationToken cancellationToken = default) =>
+		_adb.ClearForwardPortsAsync(deviceSerial, cancellationToken);
+
+	public Task ClearReversePortsAsync(string deviceSerial, CancellationToken cancellationToken = default) =>
+		_adb.ClearReversePortsAsync(deviceSerial, cancellationToken);
+
 	public async Task<List<SdkPackage>> GetInstalledPackagesAsync(CancellationToken cancellationToken = default)
 	{
 		return await _sdkManager.GetInstalledPackagesAsync(cancellationToken);

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
@@ -78,6 +78,36 @@ public interface IAndroidProvider : IDisposable
 	Task StopEmulatorAsync(string deviceSerial, CancellationToken cancellationToken = default);
 
 	/// <summary>
+	/// Lists active <c>adb forward</c> (host → device) port rules for a device.
+	/// </summary>
+	Task<IReadOnlyList<AndroidPortMapping>> ListForwardPortsAsync(string deviceSerial, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Lists active <c>adb reverse</c> (device → host) port rules for a device.
+	/// </summary>
+	Task<IReadOnlyList<AndroidPortMapping>> ListReversePortsAsync(string deviceSerial, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Adds an <c>adb forward tcp:hostPort tcp:devicePort</c> rule.
+	/// </summary>
+	Task AddForwardPortAsync(string deviceSerial, int hostPort, int devicePort, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Adds an <c>adb reverse tcp:devicePort tcp:hostPort</c> rule.
+	/// </summary>
+	Task AddReversePortAsync(string deviceSerial, int devicePort, int hostPort, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Removes all <c>adb forward</c> rules for a device.
+	/// </summary>
+	Task ClearForwardPortsAsync(string deviceSerial, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Removes all <c>adb reverse</c> rules for a device.
+	/// </summary>
+	Task ClearReversePortsAsync(string deviceSerial, CancellationToken cancellationToken = default);
+
+	/// <summary>
 	/// Lists installed SDK packages.
 	/// </summary>
 	Task<List<SdkPackage>> GetInstalledPackagesAsync(CancellationToken cancellationToken = default);


### PR DESCRIPTION
## Summary

Extends the unified `maui` CLI with a new `maui android port` command group that wraps `adb forward`/`adb reverse` via the existing `Xamarin.Android.Tools.AdbRunner`, so DevFlow agent skills can drop their raw `adb forward`/`adb reverse` fallbacks. Closes gap 4 from the issue #197 backlog.

## New commands

- `maui android port list [--forward] [--reverse] [-s|--device <serial>]` — lists active forward/reverse rules (both by default).
- `maui android port forward <port> [<remote>] [--agent-port <p>] [-s|--device <serial>]` — `adb forward tcp:port tcp:remote`; `remote` defaults to `<port>`. `--agent-port` is a self-documenting DevFlow shortcut that forwards the agent port on both sides.
- `maui android port reverse [<port>] [<host>] [-s|--device <serial>]` — `adb reverse tcp:port tcp:host`; `<port>` defaults to the broker port **19223** (`BrokerServer.DefaultPort`); `<host>` defaults to `<port>`.
- `maui android port clear [--forward] [--reverse] [-s|--device <serial>]` — removes all forward/reverse rules (both by default).

## Conventions followed

- System.CommandLine command wiring; `--json` via `OutputWriter` + the source-generated `MauiCliJsonContext`.
- Errors via `MauiToolException` + `ErrorCodes` (`AndroidAdbNotFound`, `AndroidDeviceNotFound`, `InvalidArgument`).
- Provider delegation pattern: `IAndroidProvider` → `AndroidProvider` → `Adb` → `AdbRunner`, mirroring existing `StopEmulatorAsync`/`GetDevicesAsync`.
- Device selection mirrors `AndroidDevFlowPortForwarder.SelectDevice`: resolves the single online device, honors `--device`/`ANDROID_SERIAL`, and errors on none / multiple / not-found.

## Tests

Adds `AndroidPortCommandsTests` (24 xUnit cases): command structure/parsing, forward/reverse/clear behavior and defaults, `--agent-port` handling, port validation, and device-selection errors. Full CLI suite green (775 passed); `dotnet build src/Cli/Cli.slnf` clean.

## Deferred (documented)

Issue #197 gaps 5–7 (`android device install|uninstall|launch|stop`, `logcat`, `screenshot|screenrecord`) remain **deferred**: the pinned android-tools `AdbRunner` exposes no `install`/`exec-out`/`pull`/streaming APIs to back them, so they'd require an upstream package bump rather than guessing at non-existent APIs. Apple simulator backlog items (create/erase/install/launch/privacy/appearance/openurl/push/location/addmedia/screenshot) and `maui port check` were found already implemented during investigation.