### PR TITLE
Wire Android cmdline-tools resolver API into maui CLI

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,7 @@
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet11-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json" protocolVersion="3" />
+    <add key="dotnet11-workloads" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-workloads/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
     <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.)
          The package is built by dotnet/android which includes android-tools as a submodule. -->
-    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.189-preview.58">
+    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="99.61.4269-preview.2131">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>2114bc81fed892c4d166aeff637ca2387b0fcd8a</Sha>
+      <Sha>d76473e37910077edea90389f8a0ce71d11a5651</Sha>
     </Dependency>
     <!-- dotnet/maui -->
     <Dependency Name="Microsoft.Maui.Controls" Version="10.0.41">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   </PropertyGroup>
   <!-- Android platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Android Tools">
-    <XamarinAndroidToolsAndroidSdkVersion>1.0.189-preview.58</XamarinAndroidToolsAndroidSdkVersion>
+    <XamarinAndroidToolsAndroidSdkVersion>99.61.4269-preview.2131</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidCommandsTests.cs
@@ -532,6 +532,71 @@ public class AndroidCommandsTests
 		Assert.DoesNotContain(installCommand.Options, o => o.Name == "--sdk-path");
 	}
 
+	// --- Handler-level tests for 'android sdk update-tools' (cmdline-tools resolver API) ---
+
+	[Fact]
+	public void SdkCommand_HasUpdateToolsSubcommand()
+	{
+		var androidCommand = AndroidCommands.Create();
+		var sdkCommand = androidCommand.Subcommands.First(c => c.Name == "sdk");
+
+		Assert.Contains(sdkCommand.Subcommands, c => c.Name == "update-tools");
+	}
+
+	[Fact]
+	public async Task SdkUpdateToolsCommand_Json_InvokesProvider_WithResolvedSdkPath()
+	{
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			SdkPath = Path.Combine(Path.GetTempPath(), "sdk-update-tools-test"),
+			EnsureLatestSdkToolsRevision = "19.0"
+		};
+
+		var testProvider = ServiceConfiguration.CreateTestServiceProvider(androidProvider: fakeAndroid);
+		try
+		{
+			Program.Services = testProvider;
+
+			var rootCommand = Program.BuildRootCommand();
+			var parseResult = rootCommand.Parse("android sdk update-tools --json");
+			var exitCode = await parseResult.InvokeAsync();
+
+			Assert.Equal(0, exitCode);
+			Assert.Single(fakeAndroid.EnsureLatestSdkToolsCalls);
+			Assert.Equal(fakeAndroid.SdkPath, fakeAndroid.EnsureLatestSdkToolsCalls[0]);
+		}
+		finally
+		{
+			Program.ResetServices();
+		}
+	}
+
+	[Fact]
+	public async Task SdkUpdateToolsCommand_DryRun_DoesNotInvokeProvider()
+	{
+		var fakeAndroid = new FakeAndroidProvider
+		{
+			SdkPath = Path.Combine(Path.GetTempPath(), "sdk-update-tools-dryrun-test")
+		};
+
+		var testProvider = ServiceConfiguration.CreateTestServiceProvider(androidProvider: fakeAndroid);
+		try
+		{
+			Program.Services = testProvider;
+
+			var rootCommand = Program.BuildRootCommand();
+			var parseResult = rootCommand.Parse("android sdk update-tools --json --dry-run");
+			var exitCode = await parseResult.InvokeAsync();
+
+			Assert.Equal(0, exitCode);
+			Assert.Empty(fakeAndroid.EnsureLatestSdkToolsCalls);
+		}
+		finally
+		{
+			Program.ResetServices();
+		}
+	}
+
 	// --- Handler-level tests for 'android sdk accept-licenses' exit code behaviour ---
 	// Verifies that the command returns non-zero when the user declines so that callers
 	// (e.g. the VS Code MAUI extension) can trust the exit code.

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/AndroidProviderTests.cs
@@ -103,6 +103,43 @@ public class SdkManagerTests : IDisposable
 
 		Assert.Null(SdkManager.ResolveSdkManagerPath(_tempDir));
 	}
+
+	[Fact]
+	public void FindCommandLineTools_ReturnsPathAndRevision_FromSourceProperties()
+	{
+		var toolDir = Path.Combine(_tempDir, "cmdline-tools", "latest");
+		var sdkManagerPath = Path.Combine(toolDir, "bin",
+			OperatingSystem.IsWindows() ? "sdkmanager.bat" : "sdkmanager");
+		Directory.CreateDirectory(Path.GetDirectoryName(sdkManagerPath)!);
+		File.WriteAllText(sdkManagerPath, string.Empty);
+		File.WriteAllText(Path.Combine(toolDir, "source.properties"),
+			"Pkg.Revision=19.0\nPkg.Path=cmdline-tools;latest\n");
+
+		using var sdkManager = new SdkManager(() => _tempDir, () => null);
+
+		var tool = sdkManager.FindCommandLineTools();
+
+		Assert.NotNull(tool);
+		Assert.Equal(sdkManagerPath, tool!.Path);
+		Assert.Equal("19.0", tool.Revision);
+	}
+
+	[Fact]
+	public void FindCommandLineTools_ReturnsNull_WhenSdkPathIsNull()
+	{
+		using var sdkManager = new SdkManager(() => null, () => null);
+
+		Assert.Null(sdkManager.FindCommandLineTools());
+	}
+
+	[Fact]
+	public async Task EnsureLatestCommandLineToolsAsync_Throws_OnEmptyTargetPath()
+	{
+		using var sdkManager = new SdkManager(() => _tempDir, () => null);
+
+		await Assert.ThrowsAsync<ArgumentNullException>(
+			() => sdkManager.EnsureLatestCommandLineToolsAsync(string.Empty));
+	}
 }
 
 [Collection("AndroidEnvironment")]

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
@@ -61,6 +61,8 @@ public class FakeAndroidProvider : IAndroidProvider
 	public int AcceptLicensesCalled { get; private set; }
 	public List<(string? SdkPath, string? JdkPath, int? JdkVersion, List<string>? AdditionalPackages)> InstallCalls { get; } = new();
 	public List<string> InstallSdkToolsCalls { get; } = new();
+	public List<string> EnsureLatestSdkToolsCalls { get; } = new();
+	public string? EnsureLatestSdkToolsRevision { get; set; }
 	public List<int?> InstallJdkCalls { get; } = new();
 	public bool Disposed { get; private set; }
 
@@ -192,6 +194,12 @@ public class FakeAndroidProvider : IAndroidProvider
 	{
 		InstallSdkToolsCalls.Add(targetPath);
 		return Task.CompletedTask;
+	}
+
+	public Task<string?> EnsureLatestSdkToolsAsync(string targetPath, Action<string, int, string>? onProgress = null, CancellationToken cancellationToken = default)
+	{
+		EnsureLatestSdkToolsCalls.Add(targetPath);
+		return Task.FromResult(EnsureLatestSdkToolsRevision);
 	}
 
 	public void OverrideSdkPath(string path) => SdkPath = path;

--- a/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/AndroidCommands.Sdk.cs
@@ -475,10 +475,86 @@ public static partial class AndroidCommands
 			}
 		});
 
+		// sdk update-tools
+		var updateToolsCommand = new Command("update-tools",
+			"Ensure the latest Android SDK command-line tools (cmdline-tools;latest) are installed");
+		updateToolsCommand.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+		{
+			var androidProvider = GetAndroidProvider(parseResult);
+
+			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
+			var dryRun = parseResult.GetValue(GlobalOptions.DryRunOption);
+			var formatter = Program.GetFormatter(parseResult);
+
+			var targetPath = androidProvider.SdkPath ?? PlatformDetector.Paths.DefaultAndroidSdkPath;
+
+			try
+			{
+				if (dryRun)
+				{
+					formatter.WriteInfo($"[dry-run] Would ensure latest command-line tools at: {targetPath}");
+					return 0;
+				}
+
+				string? revision = null;
+				if (!useJson && formatter is SpectreOutputFormatter spectre)
+				{
+					await spectre.LiveProgressAsync(async (ctx) =>
+					{
+						var task = ctx.AddTask("Updating command-line tools");
+						revision = await androidProvider.EnsureLatestSdkToolsAsync(targetPath,
+							onProgress: (phase, pct, msg) =>
+							{
+								var label = phase switch
+								{
+									"CheckingForUpdates" => "Checking for updates...",
+									"Downloading" => $"Downloading: {msg}",
+									"Verifying" => "Verifying checksum...",
+									"Extracting" => "Extracting...",
+									"Installing" => "Installing...",
+									"Complete" => "Command-line tools updated",
+									_ => msg
+								};
+								task.Update(Math.Max(0, pct), label);
+							},
+							cancellationToken);
+						task.Complete(revision is null ? "Command-line tools up to date" : $"cmdline-tools {revision}");
+					});
+				}
+				else
+				{
+					revision = await androidProvider.EnsureLatestSdkToolsAsync(targetPath, onProgress: null, cancellationToken);
+				}
+
+				if (useJson)
+				{
+					formatter.Write(new CliCommandResult
+					{
+						Success = true,
+						Status = "updated",
+						Message = revision is null ? "command-line tools up to date" : $"command-line tools {revision}",
+						Path = targetPath
+					});
+				}
+				else
+				{
+					formatter.WriteSuccess(revision is null
+						? "Command-line tools are up to date"
+						: $"Command-line tools updated to revision {revision}");
+				}
+				return 0;
+			}
+			catch (Exception ex)
+			{
+				return Program.HandleCommandException(formatter, ex);
+			}
+		});
+
 		command.Add(checkCommand);
 		command.Add(installCommand);
 		command.Add(listCommand);
 		command.Add(acceptLicensesCommand);
+		command.Add(updateToolsCommand);
 		command.Add(CreateSdkUninstallCommand());
 
 		return command;

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -129,11 +129,24 @@ public class AndroidProvider : IAndroidProvider
 		}
 		else
 		{
+			// Surface the resolved command-line tools revision (new in the android-tools
+			// resolver API) so `maui doctor` reports which cmdline-tools build is in use.
+			var commandLineTools = _sdkManager.FindCommandLineTools();
 			checks.Add(new HealthCheck
 			{
 				Category = "android",
 				Name = "SDK Manager",
-				Status = CheckStatus.Ok
+				Status = CheckStatus.Ok,
+				Message = commandLineTools?.Revision is { Length: > 0 } rev
+					? $"command-line tools {rev}"
+					: null,
+				Details = commandLineTools is not null
+					? new JsonObject
+					{
+						["path"] = commandLineTools.Path,
+						["revision"] = commandLineTools.Revision
+					}
+					: null
 			});
 
 			// Check licenses
@@ -473,6 +486,16 @@ public class AndroidProvider : IAndroidProvider
 			onProgress: (phase, pct, msg) => onProgress?.Invoke(phase.ToString(), pct, msg),
 			cancellationToken);
 		_sdkPath = targetPath;
+	}
+
+	public async Task<string?> EnsureLatestSdkToolsAsync(string targetPath,
+		Action<string, int, string>? onProgress = null, CancellationToken cancellationToken = default)
+	{
+		var tool = await _sdkManager.EnsureLatestCommandLineToolsAsync(targetPath,
+			onProgress: (phase, pct, msg) => onProgress?.Invoke(phase.ToString(), pct, msg),
+			cancellationToken);
+		_sdkPath = targetPath;
+		return tool.Revision;
 	}
 
 	public void OverrideSdkPath(string path)

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
@@ -153,6 +153,14 @@ public interface IAndroidProvider : IDisposable
 	Task InstallSdkToolsAsync(string targetPath, Action<string, int, string>? onProgress = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
+	/// Ensures the Android SDK at <paramref name="targetPath"/> contains the latest
+	/// <c>cmdline-tools;latest</c> package, bootstrapping and/or updating from the Google
+	/// catalog as needed. Returns the resolved command-line tools revision, or
+	/// <see langword="null"/> when the revision could not be determined.
+	/// </summary>
+	Task<string?> EnsureLatestSdkToolsAsync(string targetPath, Action<string, int, string>? onProgress = null, CancellationToken cancellationToken = default);
+
+	/// <summary>
 	/// Overrides the Android SDK path for the current session.
 	/// Rebuilds downstream tool wrappers (SdkManager, AvdManager, Adb) to use the new path.
 	/// </summary>

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/SdkManager.cs
@@ -543,6 +543,32 @@ public partial class SdkManager : IDisposable
 		await _sdkManager.BootstrapAsync(targetPath, bootstrapProgress, cancellationToken);
 	}
 
+	/// <summary>
+	/// Resolves the installed command-line tools (sdkmanager path + revision) from the highest
+	/// <c>cmdline-tools</c> revision reported by <c>source.properties</c>. Returns
+	/// <see langword="null"/> when no SDK path is configured or no sdkmanager is installed.
+	/// </summary>
+	public Xamarin.Android.Tools.CommandLineTool? FindCommandLineTools()
+	{
+		SyncPaths();
+		return _sdkManager.FindSdkManager();
+	}
+
+	/// <summary>
+	/// Ensures the Android SDK at <paramref name="targetPath"/> contains the latest
+	/// <c>cmdline-tools;latest</c> package, bootstrapping and/or updating from the Google
+	/// catalog as needed. Returns the resolved sdkmanager executable and installed revision.
+	/// </summary>
+	public async Task<Xamarin.Android.Tools.CommandLineTool> EnsureLatestCommandLineToolsAsync(
+		string targetPath,
+		Action<Xamarin.Android.Tools.SdkBootstrapPhase, int, string>? onProgress = null,
+		CancellationToken cancellationToken = default)
+	{
+		var bootstrapProgress = new Progress<Xamarin.Android.Tools.SdkBootstrapProgress>(p =>
+			onProgress?.Invoke(p.Phase, p.PercentComplete, p.Message));
+		return await _sdkManager.EnsureLatestCommandLineToolsAsync(targetPath, bootstrapProgress, cancellationToken);
+	}
+
 	void EnsureAvailable()
 	{
 		if (!IsAvailable)


### PR DESCRIPTION
## What & why

Bumps `Xamarin.Android.Tools.AndroidSdk` `1.0.189-preview.58` → `99.61.4266-ci.main.2128` to pick up the new **command-line tools resolver API**, and actually consumes it in the `maui` CLI.

## Changes

- **SdkManager wrappers** — `FindCommandLineTools()` and `EnsureLatestCommandLineToolsAsync()` over the upstream `FindSdkManager()` / `EnsureLatestCommandLineToolsAsync()`.
- **`maui doctor`** — the *SDK Manager* check now surfaces the resolved cmdline-tools **revision + path**.
- **New command** — `maui android sdk update-tools` (`--json` / `--dry-run`, live progress) ensures `cmdline-tools;latest`.
- **Provider API** — `EnsureLatestSdkToolsAsync` added to `IAndroidProvider` / `AndroidProvider` (+ test fake).
- **Tests** — 6 new (SdkManager resolver + command-level); **757/757** green.

## Notes / risks

- `99.61.4266-ci.main.2128` is a rolling **main-channel CI build** served only from the `dotnet11-transport` feed (transport feeds prune old builds; there is no Maestro subscription, so it's a manual pin). The prior `.58` pin was also transport-only, so this isn't a new dependency class — but it's less stable than a preview-channel version. **Kept as draft pending a decision on this pin.**

Single commit, based directly on `main`. Local validation: `Microsoft.Maui.Cli` builds clean; `Microsoft.Maui.Cli.UnitTests` 757/757 pass.