### PR TITLE
Expose Apple Intelligence token usage through M.E.AI

### DIFF
--- a/src/AI/AppleNative/ApiDefinitions.cs
+++ b/src/AI/AppleNative/ApiDefinitions.cs
@@ -185,10 +185,44 @@ interface ChatResponseNative
 	[Export("messages", ArgumentSemantic.Copy)]
 	ChatMessageNative[] Messages { get; set; }
 
+	// @property (nonatomic, readonly, strong) UsageDetailsNative * _Nullable usage;
+	[NullAllowed, Export("usage", ArgumentSemantic.Strong)]
+	UsageDetailsNative Usage { get; }
+
 	// - (nonnull instancetype)initWithMessages:(NSArray<ChatMessageNative *> * _Nonnull)messages OBJC_DESIGNATED_INITIALIZER;
 	[Export("initWithMessages:")]
 	[DesignatedInitializer]
 	NativeHandle Constructor(ChatMessageNative[] messages);
+
+	// - (nonnull instancetype)initWithMessages:(NSArray<ChatMessageNative *> * _Nonnull)messages usage:(UsageDetailsNative * _Nullable)usage OBJC_DESIGNATED_INITIALIZER;
+	[Export("initWithMessages:usage:")]
+	[DesignatedInitializer]
+	NativeHandle Constructor(ChatMessageNative[] messages, [NullAllowed] UsageDetailsNative usage);
+}
+
+// @interface UsageDetailsNative : NSObject
+[Introduced(PlatformName.iOS, 26, 0)]
+[Introduced(PlatformName.MacCatalyst, 26, 0)]
+[Introduced(PlatformName.MacOSX, 26, 0)]
+[BaseType(typeof(NSObject))]
+[DisableDefaultCtor]
+[Internal]
+interface UsageDetailsNative
+{
+	[Export("inputTokenCount")]
+	nint InputTokenCount { get; }
+
+	[Export("outputTokenCount")]
+	nint OutputTokenCount { get; }
+
+	[Export("totalTokenCount")]
+	nint TotalTokenCount { get; }
+
+	[Export("cachedInputTokenCount")]
+	nint CachedInputTokenCount { get; }
+
+	[Export("reasoningTokenCount")]
+	nint ReasoningTokenCount { get; }
 }
 
 // @interface FunctionCallContentNative : AIContentNative

--- a/src/AI/AppleNative/EssentialsAI/ChatClient.swift
+++ b/src/AI/AppleNative/EssentialsAI/ChatClient.swift
@@ -103,7 +103,7 @@ public class ChatClientNative: NSObject {
                     log("[\(methodName)] Stream collected, content length: \(response.content.jsonString.count)")
                 }
 #endif
-                return (response.content.jsonString, response.transcriptEntries)
+                return (response.content.jsonString, response.transcriptEntries, self.toUsageDetailsNative(response))
             } else {
 #if APPLE_INTELLIGENCE_LOGGING_ENABLED
                 if let log = AppleIntelligenceLogger.log {
@@ -132,7 +132,7 @@ public class ChatClientNative: NSObject {
                     log("[\(methodName)] Stream collected, content length: \(response.content.count)")
                 }
 #endif
-                return (response.content, response.transcriptEntries)
+                return (response.content, response.transcriptEntries, self.toUsageDetailsNative(response))
             }
         }
 
@@ -202,7 +202,7 @@ public class ChatClientNative: NSObject {
                         log("[\(methodName)] Response received, content length: \(inner.content.jsonString.count)")
                     }
 #endif
-                    return (inner.content.jsonString, inner.transcriptEntries)
+                    return (inner.content.jsonString, inner.transcriptEntries, self.toUsageDetailsNative(inner))
                 } else {
                     let inner = try await session.respond(to: prompt, options: genOptions)
 #if APPLE_INTELLIGENCE_LOGGING_ENABLED
@@ -210,7 +210,7 @@ public class ChatClientNative: NSObject {
                         log("[\(methodName)] Response received, content length: \(inner.content.count)")
                     }
 #endif
-                    return (inner.content, inner.transcriptEntries)
+                    return (inner.content, inner.transcriptEntries, self.toUsageDetailsNative(inner))
                 }
             }()
 
@@ -298,6 +298,25 @@ public class ChatClientNative: NSObject {
         return (session, prompt, schema, genOptions)
     }
 
+    private func toUsageDetailsNative<Content>(
+        _ response: LanguageModelSession.Response<Content>
+    ) -> UsageDetailsNative? where Content: Generable {
+#if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+            let usage = response.usage
+            return UsageDetailsNative(
+                inputTokenCount: usage.input.totalTokenCount,
+                outputTokenCount: usage.output.totalTokenCount,
+                totalTokenCount: usage.totalTokenCount,
+                cachedInputTokenCount: usage.input.cachedTokenCount,
+                reasoningTokenCount: usage.output.reasoningTokenCount
+            )
+        }
+#endif
+
+        return nil
+    }
+
     private func executeTask(
         _ methodName: String,
         _ messages: [ChatMessageNative],
@@ -306,7 +325,7 @@ public class ChatClientNative: NSObject {
         _ onComplete: @escaping (ChatResponseNative?, NSError?) -> Void,
         operation:
             @escaping (LanguageModelSession, Prompt, GenerationSchema?, GenerationOptions) async throws
-            -> (String, ArraySlice<Transcript.Entry>)
+            -> (String, ArraySlice<Transcript.Entry>, UsageDetailsNative?)
     ) -> CancellationTokenNative? {
 
         let cq = OperationQueue.current?.underlyingQueue
@@ -337,7 +356,7 @@ public class ChatClientNative: NSObject {
                 let transcriptMessages = try result.1.compactMap(self.fromTranscriptEntry)
 
                 // Create response with all transcript messages
-                let response = ChatResponseNative(messages: transcriptMessages)
+                let response = ChatResponseNative(messages: transcriptMessages, usage: result.2)
 
 #if APPLE_INTELLIGENCE_LOGGING_ENABLED
                 if let log = AppleIntelligenceLogger.log {

--- a/src/AI/AppleNative/EssentialsAI/ChatResponseNative.swift
+++ b/src/AI/AppleNative/EssentialsAI/ChatResponseNative.swift
@@ -4,9 +4,41 @@ import FoundationModels
 @objc(ChatResponseNative)
 public class ChatResponseNative: NSObject, @unchecked Sendable {
     @objc public var messages: [ChatMessageNative]
+    @objc public let usage: UsageDetailsNative?
     
     @objc public init(messages: [ChatMessageNative]) {
         self.messages = messages
+        self.usage = nil
+        super.init()
+    }
+
+    @objc public init(messages: [ChatMessageNative], usage: UsageDetailsNative?) {
+        self.messages = messages
+        self.usage = usage
+        super.init()
+    }
+}
+
+@objc(UsageDetailsNative)
+public final class UsageDetailsNative: NSObject, Sendable {
+    @objc public let inputTokenCount: Int
+    @objc public let outputTokenCount: Int
+    @objc public let totalTokenCount: Int
+    @objc public let cachedInputTokenCount: Int
+    @objc public let reasoningTokenCount: Int
+
+    @objc public init(
+        inputTokenCount: Int,
+        outputTokenCount: Int,
+        totalTokenCount: Int,
+        cachedInputTokenCount: Int,
+        reasoningTokenCount: Int
+    ) {
+        self.inputTokenCount = inputTokenCount
+        self.outputTokenCount = outputTokenCount
+        self.totalTokenCount = totalTokenCount
+        self.cachedInputTokenCount = cachedInputTokenCount
+        self.reasoningTokenCount = reasoningTokenCount
         super.init()
     }
 }

--- a/src/AI/Microsoft.Maui.Essentials.AI/Platform/MaciOS/AppleIntelligenceChatClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/Platform/MaciOS/AppleIntelligenceChatClient.cs
@@ -190,7 +190,7 @@ public sealed partial class AppleIntelligenceChatClient : IChatClient
 				{
 					try
 					{
-						handler.Complete();
+						handler.Complete(FromNativeUsage(finalResult?.Usage));
 					}
 					catch (Exception ex)
 					{
@@ -298,9 +298,24 @@ public sealed partial class AppleIntelligenceChatClient : IChatClient
 			.Select(FromNative)
 			.ToList();
 
-		// Create ChatResponse with all messages
-		return new ChatResponse(messages);
+		// Create ChatResponse with all messages and native usage when available.
+		return new ChatResponse(messages)
+		{
+			Usage = FromNativeUsage(response.Usage)
+		};
 	}
+
+	private static UsageDetails? FromNativeUsage(UsageDetailsNative? usage) =>
+		usage is null
+			? null
+			: new UsageDetails
+			{
+				InputTokenCount = usage.InputTokenCount,
+				OutputTokenCount = usage.OutputTokenCount,
+				TotalTokenCount = usage.TotalTokenCount,
+				CachedInputTokenCount = usage.CachedInputTokenCount,
+				ReasoningTokenCount = usage.ReasoningTokenCount
+			};
 
 	private static ChatMessage FromNative(ChatMessageNative nativeMessage)
 	{

--- a/src/AI/Microsoft.Maui.Essentials.AI/Platform/StreamingResponseHandler.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/Platform/StreamingResponseHandler.cs
@@ -104,9 +104,9 @@ internal sealed class StreamingResponseHandler
 	}
 
 	/// <summary>
-	/// Flushes remaining chunker content and completes the channel successfully.
+	/// Flushes remaining chunker content, emits usage, and completes the channel successfully.
 	/// </summary>
-	public void Complete()
+	public void Complete(UsageDetails? usage = null)
 	{
 		if (_chunker is not null)
 		{
@@ -119,6 +119,14 @@ internal sealed class StreamingResponseHandler
 					Contents = { new TextContent(finalChunk) }
 				});
 			}
+		}
+
+		if (usage is not null)
+		{
+			_channel.Writer.TryWrite(new ChatResponseUpdate
+			{
+				Contents = { new UsageContent(usage) }
+			});
 		}
 
 		_channel.Writer.TryComplete();

--- a/src/AI/Microsoft.Maui.Essentials.AI/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI/README.md
@@ -59,6 +59,40 @@ await foreach (var update in _chat.GetStreamingResponseAsync("Plan a day trip to
 }
 ```
 
+### Token usage
+
+On Apple OS 27 and later, token usage is returned through the standard
+`Microsoft.Extensions.AI` response APIs:
+
+```csharp
+var response = await _chat.GetResponseAsync("Summarize this text.");
+
+if (response.Usage is { } usage)
+{
+    Console.WriteLine($"Input: {usage.InputTokenCount}");
+    Console.WriteLine($"Output: {usage.OutputTokenCount}");
+    Console.WriteLine($"Cached input: {usage.CachedInputTokenCount}");
+    Console.WriteLine($"Reasoning: {usage.ReasoningTokenCount}");
+    Console.WriteLine($"Total: {usage.TotalTokenCount}");
+}
+```
+
+Streaming responses emit a final `UsageContent` update. Aggregate the stream
+into a `ChatResponse` to read it from `ChatResponse.Usage`:
+
+```csharp
+var response = await _chat
+    .GetStreamingResponseAsync("Plan a day trip to Tokyo")
+    .ToChatResponseAsync();
+
+Console.WriteLine($"Total tokens: {response.Usage?.TotalTokenCount}");
+```
+
+Each response reports usage for that request. To track a conversation or
+application total, accumulate responses with `UsageDetails.Add`. Usage is
+`null` on Apple OS 26 because the native Foundation Models usage API was
+introduced in OS 27.
+
 ### Embeddings for semantic search
 
 ```csharp

--- a/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Microsoft.Maui.Essentials.AI.DeviceTests.csproj
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Microsoft.Maui.Essentials.AI.DeviceTests.csproj
@@ -20,6 +20,11 @@
     <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
   </PropertyGroup>
 
+  <!-- Opt in with -p:EnableOpenAITests=true when OpenAI credentials are configured. -->
+  <PropertyGroup Condition="'$(EnableOpenAITests)' == 'true'">
+    <DefineConstants>$(DefineConstants);ENABLE_OPENAI_CLIENT</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ApplicationTitle>AI Tests</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.ai.devicetests</ApplicationId>
@@ -40,6 +45,11 @@
     <PackageReference Include="DeviceRunners.VisualRunners.Xunit" />
     <PackageReference Include="DeviceRunners.VisualRunners.Maui" />
     <PackageReference Include="DeviceRunners.Testing.Targets" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(EnableOpenAITests)' == 'true'">
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="OpenAI" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/ChatClientUsageTestsBase.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/ChatClientUsageTestsBase.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.AI.DeviceTests;
+
+/// <summary>
+/// Base class for chat client usage tests.
+/// Provides common consistency checks for any <see cref="IChatClient"/> implementation.
+/// </summary>
+/// <typeparam name="T">The concrete chat client type to test.</typeparam>
+public abstract class ChatClientUsageTestsBase<T>
+	where T : class, IChatClient, new()
+{
+	/// <summary>
+	/// Gets whether the provider is expected to report usage in the current environment.
+	/// </summary>
+	protected virtual bool IsUsageAvailable => true;
+
+	[Fact]
+	[Trait(TestTraits.RequiresModel, TestTraits.True)]
+	public async Task GetResponseAsync_ReturnsExpectedUsage()
+	{
+		var client = new T();
+
+		var response = await client.GetResponseAsync("Reply with exactly one word: hello.");
+
+		AssertExpectedUsage(response.Usage);
+	}
+
+	[Fact]
+	[Trait(TestTraits.RequiresModel, TestTraits.True)]
+	public async Task GetStreamingResponseAsync_ReturnsExpectedUsage()
+	{
+		var client = new T();
+
+		var response = await client
+			.GetStreamingResponseAsync("Reply with exactly one word: hello.")
+			.ToChatResponseAsync();
+
+		AssertExpectedUsage(response.Usage);
+	}
+
+	/// <summary>
+	/// Validates usage according to the provider's support in the current environment.
+	/// </summary>
+	protected void AssertExpectedUsage(UsageDetails? usage)
+	{
+		if (!IsUsageAvailable)
+		{
+			Assert.Null(usage);
+			return;
+		}
+
+		Assert.NotNull(usage);
+		Assert.NotNull(usage.InputTokenCount);
+		Assert.NotNull(usage.OutputTokenCount);
+		Assert.NotNull(usage.TotalTokenCount);
+		Assert.True(usage.InputTokenCount.Value >= 1);
+		Assert.True(usage.OutputTokenCount.Value >= 1);
+		Assert.Equal(usage.InputTokenCount + usage.OutputTokenCount, usage.TotalTokenCount);
+
+		if (usage.CachedInputTokenCount is { } cachedInputTokenCount)
+			Assert.True(cachedInputTokenCount >= 0);
+
+		if (usage.ReasoningTokenCount is { } reasoningTokenCount)
+			Assert.True(reasoningTokenCount >= 0);
+
+		AssertProviderUsage(usage);
+	}
+
+	/// <summary>
+	/// Validates provider-specific usage details when usage is available.
+	/// </summary>
+	protected virtual void AssertProviderUsage(UsageDetails usage)
+	{
+	}
+}

--- a/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/ChatClientUsageTestsBase.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/ChatClientUsageTestsBase.cs
@@ -57,7 +57,8 @@ public abstract class ChatClientUsageTestsBase<T>
 		Assert.NotNull(usage.TotalTokenCount);
 		Assert.True(usage.InputTokenCount.Value >= 1);
 		Assert.True(usage.OutputTokenCount.Value >= 1);
-		Assert.Equal(usage.InputTokenCount + usage.OutputTokenCount, usage.TotalTokenCount);
+		Assert.True(usage.TotalTokenCount.Value >= usage.InputTokenCount.Value);
+		Assert.True(usage.TotalTokenCount.Value >= usage.OutputTokenCount.Value);
 
 		if (usage.CachedInputTokenCount is { } cachedInputTokenCount)
 			Assert.True(cachedInputTokenCount >= 0);

--- a/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/MaciOS/AppleIntelligenceChatClientTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/MaciOS/AppleIntelligenceChatClientTests.cs
@@ -88,6 +88,29 @@ public class AppleIntelligenceChatClientStreamingTests : ChatClientStreamingTest
 {
 }
 
+public class AppleIntelligenceChatClientUsageTests : ChatClientUsageTestsBase<AppleIntelligenceChatClient>
+{
+	protected override bool IsUsageAvailable
+	{
+		get
+		{
+#if IOS
+			return OperatingSystem.IsIOSVersionAtLeast(27);
+#elif MACCATALYST
+			return OperatingSystem.IsMacCatalystVersionAtLeast(27);
+#else
+			return false;
+#endif
+		}
+	}
+
+	protected override void AssertProviderUsage(UsageDetails usage)
+	{
+		Assert.NotNull(usage.CachedInputTokenCount);
+		Assert.NotNull(usage.ReasoningTokenCount);
+	}
+}
+
 public class AppleIntelligenceChatClientJsonSchemaTests : ChatClientJsonSchemaTestsBase<AppleIntelligenceChatClient>
 {
 	[Fact(Skip = "Apple Intelligence requires a JSON schema for structured responses, so this test is not applicable.")]

--- a/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/OpenAI/OpenAIChatClientTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/OpenAI/OpenAIChatClientTests.cs
@@ -43,6 +43,9 @@ public class OpenAIChatClientResponseTests : ChatClientResponseTestsBase<OpenAIC
 public class OpenAIChatClientStreamingTests : ChatClientStreamingTestsBase<OpenAIChatClient>
 {
 }
+public class OpenAIChatClientUsageTests : ChatClientUsageTestsBase<OpenAIChatClient>
+{
+}
 public class OpenAIChatClientJsonSchemaTests : ChatClientJsonSchemaTestsBase<OpenAIChatClient>
 {
 }

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/StreamingResponseHandlerTests/Completion.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/StreamingResponseHandlerTests/Completion.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.AI;
 using Xunit;
 
 namespace Microsoft.Maui.Essentials.AI.UnitTests;
@@ -66,6 +67,56 @@ public partial class StreamingResponseHandlerTests
 				.SelectMany(u => u.Contents.OfType<Microsoft.Extensions.AI.TextContent>())
 				.Select(tc => tc.Text));
 			Assert.Contains("Hello", allText, StringComparison.Ordinal);
+		}
+
+		[Fact]
+		public async Task Complete_WithUsage_EmitsUsageContent()
+		{
+			var handler = new StreamingResponseHandler(new PlainTextStreamChunker());
+			var usage = new UsageDetails
+			{
+				InputTokenCount = 12,
+				OutputTokenCount = 5,
+				TotalTokenCount = 17,
+				CachedInputTokenCount = 3,
+				ReasoningTokenCount = 2
+			};
+
+			handler.ProcessContent("Hello");
+			handler.Complete(usage);
+
+			var updates = await ReadAll(handler);
+
+			Assert.Equal(2, updates.Count);
+			Assert.Equal("Hello", updates[0].Text);
+			Assert.Same(usage, Assert.IsType<UsageContent>(Assert.Single(updates[1].Contents)).Details);
+		}
+
+		[Fact]
+		public async Task Complete_WithUsage_AggregatesIntoChatResponse()
+		{
+			var handler = new StreamingResponseHandler();
+			handler.ProcessContent("Hello");
+			handler.Complete(new UsageDetails
+			{
+				InputTokenCount = 12,
+				OutputTokenCount = 5,
+				TotalTokenCount = 17,
+				CachedInputTokenCount = 3,
+				ReasoningTokenCount = 2
+			});
+
+			var response = await handler
+				.ReadAllAsync(CancellationToken.None)
+				.ToChatResponseAsync();
+
+			Assert.Equal("Hello", response.Text);
+			Assert.NotNull(response.Usage);
+			Assert.Equal(12, response.Usage.InputTokenCount);
+			Assert.Equal(5, response.Usage.OutputTokenCount);
+			Assert.Equal(17, response.Usage.TotalTokenCount);
+			Assert.Equal(3, response.Usage.CachedInputTokenCount);
+			Assert.Equal(2, response.Usage.ReasoningTokenCount);
 		}
 	}
 }


### PR DESCRIPTION
Apple Foundation Models in Xcode 27 reports detailed token usage, but `AppleIntelligenceChatClient` currently drops it. This makes usage telemetry inconsistent with OpenAI and other Microsoft.Extensions.AI providers.

## Changes

- Bridge Xcode 27 response usage into `ChatResponse.Usage`, including input, output, total, cached-input, and reasoning token counts.
- Emit a final `UsageContent` update for streaming responses so `ToChatResponseAsync` aggregates usage normally.
- Keep Xcode 26 and OS 26 behavior compatible: the bridge still compiles and usage remains `null` where the native API is unavailable.
- Add reusable `ChatClientUsageTestsBase<T>` coverage for non-streaming and streaming providers, with Apple OS-version expectations and opt-in OpenAI validation.
- Document response usage and caller-side accumulation with `UsageDetails.Add`.

No new provider-specific public API is introduced; usage stays on the standard Microsoft.Extensions.AI response surface.

## Validation

- 335 Essentials.AI unit tests passed.
- Apple Mac Catalyst usage contract tests passed on OS 26.
- OpenAI response and streaming usage tests passed with the opt-in backend.
- Native and managed Apple builds succeeded with Xcode 26.6 and Xcode 27 beta 4.