### PR TITLE
Add multimodal image input to Essentials.AI (Apple)

### DIFF
--- a/docs/ai/multimodal-design.md
+++ b/docs/ai/multimodal-design.md
@@ -1,0 +1,609 @@
+# Multimodal Image Input for Microsoft.Maui.Essentials.AI — Design Spec
+
+Status: **Draft / not yet implemented.** This spec covers adding **image input** (multimodal
+prompting) to the Apple backend of `Microsoft.Maui.Essentials.AI`, mapped onto
+`Microsoft.Extensions.AI` (M.E.AI) abstractions.
+
+> Scope: **images in** only. Image *generation* (images out, via `ImagePlayground`) is a separate
+> effort — it builds on today's toolchain and does not depend on anything here. It is intentionally
+> out of scope for this document.
+
+## Goal
+
+Let callers attach images to a `ChatMessage` and have Apple's on-device model analyze them —
+describe, classify, OCR/extract, compare — exposed through the existing
+`AppleIntelligenceChatClient : IChatClient`. Support attaching a **real native image**
+(`CGImage` / `UIImage` / `NSImage`) with zero byte round-tripping, while staying cross-platform-safe
+(other platforms fall back to encoded bytes).
+
+## TL;DR
+
+- FoundationModels multimodal input is the `Attachment` API + a new `Transcript` attachment segment.
+- **Both are `iOS/macOS 27.0` and still beta**, and are **absent from the Xcode 26.x SDK** (verified).
+  So this feature requires building the Swift shim with the **Xcode 27 SDK**, gating usage with
+  `if #available(… 27.0, *)`, and bumping CI's `xcode-version` to 27.x.
+- Wire shape in M.E.AI is the standard `DataContent` / `UriContent` on `ChatMessage.Contents`, plus
+  the `AIContent.RawRepresentation` native-handle fast path.
+- Work: a new native `ImageContentNative`, its binding, three touch-points in `ChatClient.swift`
+  (current prompt, history entry, history read-back), and image cases in
+  `AppleIntelligenceChatClient.ToNative(AIContent)`.
+
+---
+
+## 1. Toolchain feasibility (verified)
+
+Verified by grepping the `FoundationModels` `.swiftinterface` in the installed Xcode 26.6
+(macOS 26.5) SDK and cross-checking Apple's docs. CI currently pins **Xcode 26.3**
+(`.github/workflows/ci-essentialsai.yml`).
+
+| Symbol | Availability | In 26.x SDK? |
+|---|---|---|
+| `FoundationModels.Attachment`, `ImageAttachmentContent` | `iOS/macOS 27.0`, **beta** | ❌ Not present (`grep` → not found) |
+| `Transcript.Segment.attachment`, `Transcript.AttachmentSegment`, `Transcript.Attachment.image(_:)` | `iOS/macOS 27.0`, **beta** | ❌ Not present (26.x `Segment` is only `.text` / `.structure`) |
+
+Consequence: `#available` alone is not enough — the symbols are missing from the 26.x SDK, so the
+Swift shim will not compile there. The code below is written to compile under the **27.0 SDK** and
+to throw a clear error at runtime below 27.0. **CI `xcode-version` must move to 27.x** (both the
+`build-macos` and `device-tests-maccatalyst` jobs) when this lands. All the required symbols are
+**confirmed present in the Xcode 27.0 Beta 4 SDK** (verified via the FoundationModels swiftinterface).
+
+### Building against Xcode 27 side-by-side (no `xcode-select` switch)
+Xcode 27 can be installed alongside the active 26.x. Point individual commands at it with the
+`DEVELOPER_DIR` environment variable — this overrides the `xcode-select` default for just that
+process:
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-27.0.0-Beta.4.app/Contents/Developer
+# e.g. build only the Apple TFMs of the native + managed library:
+DEVELOPER_DIR=$DEVELOPER_DIR dotnet build src/AI/EssentialsAI.slnf -f net10.0-maccatalyst
+```
+Caveats when building (not just inspecting) against a beta SDK: the installed MAUI/`net10.0-*`
+workload must accept the newer Xcode/SDK; you may need `<SupportedOSPlatformVersion>` / Info.plist
+minimums that stay at 26.0 (deployment target) while the *SDK* is 27.0. Runtime `Attachment` use is
+`#available`-gated regardless.
+
+---
+
+## 2. Apple API surface (from the 27.0 SDK docs)
+
+### Prompt-time attachments (verified in Xcode 27.0 Beta 4 SDK)
+```swift
+struct Attachment<Content>                 // Content == ImageAttachmentContent for images
+  init(_ cgImage: CGImage,           orientation: CGImagePropertyOrientation? = nil)
+  init(_ ciImage: CIImage,           orientation: CGImagePropertyOrientation? = nil)
+  init(_ pixelBuffer: CVPixelBuffer, orientation: CGImagePropertyOrientation? = nil)
+  init(imageURL: URL,                orientation: CGImagePropertyOrientation? = nil)
+  func label(_ text: String) -> Attachment<Content>
+// Conforms to PromptRepresentable, InstructionsRepresentable.
+
+let response = try await session.respond {
+    "Describe this image:"
+    Attachment(cgImage).label("image-0")
+}
+```
+Note: there is **no `UIImage` / `NSImage` init** — funnel through `CGImage` (iOS: `UIImage.cgImage`;
+macOS: `NSImage` → `CGImageSource`) or use `imageURL`. The framework auto-scales and color-converts;
+no manual preprocessing needed.
+
+### PromptBuilder mechanics (stable, from the 26.x SDK)
+```swift
+@resultBuilder struct PromptBuilder {
+  static func buildBlock<each P: PromptRepresentable>(_: repeat each P) -> Prompt
+  static func buildArray(_ prompts: [some PromptRepresentable]) -> Prompt
+  static func buildExpression<P: PromptRepresentable>(_: P) -> P
+  // + buildEither / buildOptional / buildLimitedAvailability
+}
+```
+Strategy to build a mixed text+image prompt from a dynamic list: convert each content item to a
+`Prompt` fragment (`Prompt(text)` or `Prompt { attachment }`), then combine with `buildArray` via a
+`for` loop over `[Prompt]` (both `String` and `Attachment` are `PromptRepresentable`, and `Prompt`
+itself is `PromptRepresentable`).
+
+### Transcript-history attachments (verified in Xcode 27.0 Beta 4 SDK)
+```swift
+enum Transcript.Segment {
+  case text(TextSegment)
+  case structure(StructuredSegment)
+  case attachment(AttachmentSegment)          // NEW in 27.0
+  case custom(any CustomSegment)              // NEW in 27.0
+}
+
+struct Transcript.AttachmentSegment {
+  init(id: String = UUID().uuidString, content: Transcript.Attachment, label: String? = nil)
+  var content: Transcript.Attachment
+  var label: String?
+}
+
+enum Transcript.Attachment { case image(Transcript.ImageAttachment) }
+
+struct Transcript.ImageAttachment {
+  init(_ cgImage: CGImage,           orientation: CGImagePropertyOrientation? = nil)
+  init(_ ciImage: CIImage,           orientation: CGImagePropertyOrientation? = nil)
+  init(_ pixelBuffer: CVPixelBuffer, orientation: CGImagePropertyOrientation? = nil)
+  init(imageURL: URL,                orientation: CGImagePropertyOrientation? = nil)
+  var cgImage: CGImage { get };  var ciImage: CIImage { get };  var url: URL? { get }
+  var orientation: CGImagePropertyOrientation { get }
+}
+```
+Prior-turn images are first-class and fully constructible: they replay as
+`.attachment(AttachmentSegment(content: .image(ImageAttachment(cgImage, orientation:)), label:))`,
+and read back via `imageAttachment.cgImage` / `.url` / `.orientation`.
+
+### Capability detection & image references (verified in 27.0 SDK)
+```swift
+// SystemLanguageModel now advertises capabilities (27.0). Prefer this over pure OS gating —
+// it reflects the actual on-device model version (a device/region may lack vision even on 27.0).
+extension SystemLanguageModel /* : LanguageModel */ {
+  var capabilities: LanguageModelCapabilities { get }
+}
+struct LanguageModelCapabilities { func contains(_ c: Capability) -> Bool }
+extension LanguageModelCapabilities.Capability {
+  static var vision: Self            // ← image input supported
+  static var guidedGeneration: Self
+  static var reasoning: Self
+  static var toolCalling: Self
+}
+
+// A label you attach to a prompt image can be referenced back by the model in guided generation /
+// tool calls, then resolved to the actual image:
+struct ImageReference: Generable { let attachmentLabel: String; func resolve(in: Transcript) -> Transcript.ImageAttachment? }
+```
+So the correct gate for image input is `#available(… 27.0, *)` **and**
+`model.capabilities.contains(.vision)`. And `Attachment.label(_:)` is not cosmetic — it is how the
+model refers to a specific image (via `ImageReference`) when you ask it to pick among several.
+
+Also note `Attachment` conforms to **`InstructionsRepresentable`** as well as `PromptRepresentable`,
+so images may appear in system `Instructions`, not only in the user prompt (an edge case we can
+support later).
+
+---
+
+## 3. Microsoft.Extensions.AI mapping
+
+### Wire shape
+`ChatMessage.Contents` already carries the standard multimodal shapes:
+- `DataContent` — in-memory bytes + media type (`image/png`, `image/jpeg`, …), or a data URI.
+- `UriContent` — a `Uri` + media type (we support `file://`; see Open Questions for remote URLs).
+
+`AppleIntelligenceChatClient.ToNative(AIContent)` currently throws on anything that isn't
+`TextContent`; we add image cases.
+
+### Native-handle pass-through (the "attach a real CGImage/UIImage" feature)
+Every `AIContent` (including `DataContent`) has:
+```csharp
+[JsonIgnore] public object? RawRepresentation { get; set; }
+```
+It exists to "store the original object from another object model." So the idiomatic pattern is:
+```csharp
+new DataContent(pngBytes, "image/png") { RawRepresentation = cgImage }
+```
+- Apple client fast-path: `if content.RawRepresentation is CGImage cg` → hand the native image
+  straight to `Attachment(cg)` (zero-copy).
+- Other providers ignore `RawRepresentation` (it is `[JsonIgnore]`) and use the bytes.
+- Cross-platform-safe: Android has no `CGImage`; it just carries the bytes.
+
+We also accept `UIImage` / `NSImage` in `RawRepresentation` (extract their `CGImage`). A caller who
+only has bytes still works — the Swift shim decodes them to a `CGImage`.
+
+### Where images flow in the existing pipeline
+`ChatClient.swift` splits messages in `prepareSession`: the **last** user message becomes the
+runtime `Prompt` (attachments via the `Prompt` builder); **earlier** messages replay as `Transcript`
+entries (attachments via `Transcript.Segment.attachment`). Both paths are handled below. Chat
+`options` are unchanged — images ride in messages, not options.
+
+---
+
+## 4. Design
+
+1. New native content type `ImageContentNative : AIContentNative` carrying one of a `CGImage`
+   (fast path), encoded `Data` + mime, or a file `URL`; plus optional EXIF `orientationRaw` and
+   `label`.
+2. `.NET ToNative(AIContent)` maps image `DataContent` / `UriContent` (and the native-handle fast
+   path) → `ImageContentNative`.
+3. Swift `ChatClient.swift`:
+   - `toPrompt` → maps `ImageContentNative` to an `Attachment` in the current `Prompt`.
+   - `toUserEntry` → maps `ImageContentNative` to `.attachment(AttachmentSegment(...))` for history.
+   - `fromTranscriptSegment` → reads a `.attachment` segment back to an `ImageContentNative`.
+4. All `Attachment` / transcript-attachment usage is gated with `if #available(… 27.0, *)`; below
+   that the shim throws a clear `NSError`, surfaced on the .NET side as an `NSErrorException`.
+
+### 4.1 Swift — new file `AppleNative/EssentialsAI/ImageContent.swift`
+```swift
+import Foundation
+import CoreGraphics
+import ImageIO
+import FoundationModels
+
+@objc(ImageContentNative)
+public class ImageContentNative: AIContentNative {
+    @objc public var cgImage: CGImage?      // native fast path
+    @objc public var data: Data?            // encoded bytes (png/jpeg/…)
+    @objc public var imageURL: URL?         // file URL
+    @objc public var mimeType: String?
+    @objc public var orientationRaw: Int32  // EXIF 1…8; 0 = unset
+    @objc public var label: String?
+
+    @objc public init(cgImage: CGImage, orientationRaw: Int32, label: String?) {
+        self.cgImage = cgImage; self.orientationRaw = orientationRaw; self.label = label
+        super.init()
+    }
+    @objc public init(data: Data, mimeType: String, orientationRaw: Int32, label: String?) {
+        self.data = data; self.mimeType = mimeType; self.orientationRaw = orientationRaw; self.label = label
+        super.init()
+    }
+    @objc public init(imageURL: URL, orientationRaw: Int32, label: String?) {
+        self.imageURL = imageURL; self.orientationRaw = orientationRaw; self.label = label
+        super.init()
+    }
+
+    var orientation: CGImagePropertyOrientation? {
+        orientationRaw > 0 ? CGImagePropertyOrientation(rawValue: UInt32(orientationRaw)) : nil
+    }
+
+    func resolvedCGImage() -> CGImage? {
+        if let cg = cgImage { return cg }
+        if let d = data { return Self.decodeCGImage(from: d) }
+        return nil
+    }
+
+    static func decodeCGImage(from data: Data) -> CGImage? {
+        guard let src = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(src, 0, nil)
+    }
+}
+
+@available(iOS 27.0, macCatalyst 27.0, macOS 27.0, visionOS 27.0, *)
+extension ImageContentNative {
+    /// Builds a FoundationModels prompt attachment. Throws if there is no usable payload.
+    func toAttachment() throws -> Attachment<ImageAttachmentContent> {
+        var attachment: Attachment<ImageAttachmentContent>
+        if let cg = cgImage {
+            attachment = Attachment(cg, orientation: orientation)
+        } else if let url = imageURL {
+            attachment = Attachment(imageURL: url, orientation: orientation)
+        } else if let cg = resolvedCGImage() {
+            attachment = Attachment(cg, orientation: orientation)
+        } else {
+            throw NSError.chatError(.invalidContent, description: "Image content had no usable payload.")
+        }
+        if let label = label { attachment = attachment.label(label) }
+        return attachment
+    }
+
+    /// Builds a transcript-history attachment (prior turns).
+    func toTranscriptAttachment() throws -> Transcript.Attachment {
+        if let url = imageURL {
+            return .image(Transcript.ImageAttachment(imageURL: url, orientation: orientation))
+        }
+        guard let image = resolvedCGImage() else {
+            throw NSError.chatError(.invalidContent, description: "Image content had no usable payload.")
+        }
+        return .image(Transcript.ImageAttachment(image, orientation: orientation))
+    }
+}
+```
+> `NSError.chatError(...)` is the existing helper in `ChatClient.swift`; keep it (or widen its access
+> within the module).
+
+### 4.2 Swift — modify `ChatClient.swift`
+
+Current prompt (`toPrompt`):
+```swift
+private func toPrompt(message: ChatMessageNative) throws -> Prompt {
+    guard message.role == .user else {
+        throw NSError.chatError(.invalidRole, description: "Only user messages can be prompts. Found: \(message.role)")
+    }
+
+    // One Prompt fragment per content item, then combine.
+    let fragments: [Prompt] = try message.contents.map { content in
+        switch content {
+        case let textContent as TextContentNative:
+            return Prompt(textContent.text)
+
+        case let imageContent as ImageContentNative:
+            if #available(iOS 27.0, macCatalyst 27.0, macOS 27.0, visionOS 27.0, *) {
+                let attachment = try imageContent.toAttachment()
+                return Prompt { attachment }
+            } else {
+                throw NSError.chatError(.invalidContent,
+                    description: "Image prompts require iOS/macCatalyst/macOS 27.0 or later.")
+            }
+
+        default:
+            throw NSError.chatError(.invalidContent,
+                description: "Unsupported content type in prompt. Found: \(type(of: content))")
+        }
+    }
+
+    return Prompt {
+        for fragment in fragments { fragment }   // PromptBuilder.buildArray([Prompt])
+    }
+}
+```
+
+History entry (`toUserEntry`):
+```swift
+private func toUserEntry(_ message: ChatMessageNative) throws -> Transcript.Entry {
+    let segments: [Transcript.Segment] = try message.contents.map { content in
+        switch content {
+        case let textContent as TextContentNative:
+            return .text(Transcript.TextSegment(content: textContent.text))
+
+        case let imageContent as ImageContentNative:
+            if #available(iOS 27.0, macCatalyst 27.0, macOS 27.0, visionOS 27.0, *) {
+                let attachment = try imageContent.toTranscriptAttachment()
+                return .attachment(Transcript.AttachmentSegment(content: attachment, label: imageContent.label))
+            } else {
+                throw NSError.chatError(.invalidContent, description: "Image history requires iOS/macOS 27.0+.")
+            }
+
+        default:
+            throw NSError.chatError(.invalidContent,
+                description: "Unsupported content type in user message: \(type(of: content))")
+        }
+    }
+    return .prompt(Transcript.Prompt(segments: segments))
+}
+```
+
+History read-back (`fromTranscriptSegment`): add an `.attachment` branch so the model's returned
+transcript converts back to `ImageContentNative`:
+```swift
+private func fromTranscriptSegment(_ segment: Transcript.Segment) -> AIContentNative? {
+    switch segment {
+    case .text(let textSegment):
+        return TextContentNative(text: textSegment.content)
+    case .structure(let structuredSegment):
+        return TextContentNative(text: structuredSegment.content.jsonString)
+    case .attachment(let attachmentSegment):
+        if #available(iOS 27.0, macCatalyst 27.0, macOS 27.0, visionOS 27.0, *) {
+            switch attachmentSegment.content {
+            case .image(let image):
+                return ImageContentNative(
+                    cgImage: image.cgImage,
+                    orientationRaw: Int32(image.orientation.rawValue),
+                    label: attachmentSegment.label)
+            @unknown default:
+                return nil
+            }
+        }
+        return nil
+    @unknown default:
+        return nil
+    }
+}
+```
+
+### 4.3 Binding — add to `AppleNative/ApiDefinitions.cs`
+```csharp
+using CoreGraphics; // add at top
+
+// @interface ImageContentNative : AIContentNative
+[Introduced(PlatformName.iOS, 26, 0)]
+[Introduced(PlatformName.MacCatalyst, 26, 0)]
+[Introduced(PlatformName.MacOSX, 26, 0)]
+[BaseType(typeof(AIContentNative))]
+[DisableDefaultCtor]
+[Internal]
+interface ImageContentNative
+{
+    [NullAllowed, Export("cgImage")]
+    CGImage CgImage { get; set; }
+
+    [NullAllowed, Export("data")]
+    NSData Data { get; set; }
+
+    [NullAllowed, Export("imageURL", ArgumentSemantic.Copy)]
+    NSUrl ImageUrl { get; set; }
+
+    [NullAllowed, Export("mimeType")]
+    string MimeType { get; set; }
+
+    [Export("orientationRaw")]
+    int OrientationRaw { get; set; }
+
+    [NullAllowed, Export("label")]
+    string Label { get; set; }
+
+    [Export("initWithCgImage:orientationRaw:label:")]
+    [DesignatedInitializer]
+    NativeHandle Constructor(CGImage cgImage, int orientationRaw, [NullAllowed] string label);
+
+    [Export("initWithData:mimeType:orientationRaw:label:")]
+    NativeHandle Constructor(NSData data, string mimeType, int orientationRaw, [NullAllowed] string label);
+
+    [Export("initWithImageURL:orientationRaw:label:")]
+    NativeHandle Constructor(NSUrl imageURL, int orientationRaw, [NullAllowed] string label);
+}
+```
+> The type stays `iOS 26.0` (it always compiles/instantiates). Actual `Attachment` / transcript
+> usage is gated to 27.0 inside Swift; below 27.0 the shim throws a clear `NSError`.
+
+### 4.4 .NET — modify `Platform/MaciOS/AppleIntelligenceChatClient.cs`
+
+Add image cases to `ToNative(AIContent)`:
+```csharp
+private static IEnumerable<AIContentNative> ToNative(AIContent content, Dictionary<string, string>? callIdToName = null) =>
+    content switch
+    {
+        TextContent textContent when textContent.Text is not null => [new TextContentNative(textContent.Text)],
+        TextContent => Array.Empty<AIContentNative>(),
+
+        // NEW: images (analyzed by the model on 27.0+; below that the native layer throws).
+        DataContent data when IsImage(data.MediaType) => [ToImageNative(data)],
+        UriContent uri  when IsImage(uri.MediaType)   => [ToImageNative(uri)],
+
+        FunctionCallContent functionCall => /* unchanged */ ...,
+        FunctionResultContent functionResult => /* unchanged */ ...,
+
+        _ => throw new ArgumentException(
+            $"The content type '{content.GetType().FullName}' is not supported by Apple Intelligence chat APIs.",
+            nameof(content))
+    };
+
+private static bool IsImage(string? mediaType) =>
+    mediaType is not null && mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+
+private static ImageContentNative ToImageNative(DataContent data)
+{
+    // Fast path: caller attached a native handle via RawRepresentation.
+    switch (data.RawRepresentation)
+    {
+        case CGImage cg:
+            return new ImageContentNative(cg, 0, null);
+#if IOS || MACCATALYST || TVOS
+        case UIKit.UIImage ui when ui.CGImage is { } uicg:
+            return new ImageContentNative(uicg, 0, null);
+#elif MACOS
+        case AppKit.NSImage ns when ToCGImage(ns) is { } nscg:
+            return new ImageContentNative(nscg, 0, null);
+#endif
+    }
+
+    // Byte fallback (decoded to CGImage in Swift).
+    var bytes = data.Data.ToArray();
+    return new ImageContentNative(NSData.FromArray(bytes), data.MediaType ?? "image/png", 0, null);
+}
+
+private static ImageContentNative ToImageNative(UriContent uri)
+{
+    if (uri.RawRepresentation is CGImage cg)
+        return new ImageContentNative(cg, 0, null);
+
+    if (uri.Uri.IsFile)
+        return new ImageContentNative(NSUrl.FromFilename(uri.Uri.LocalPath), 0, null);
+
+    // v1: remote http(s) images are not fetched. Callers should pass DataContent bytes instead.
+    throw new NotSupportedException(
+        "Apple Intelligence image prompts require in-memory DataContent or a file:// UriContent. " +
+        "Remote http(s) image URLs are not downloaded automatically.");
+}
+```
+Helpers to add in the platform-specific file: `ToCGImage(NSImage)` (`AsTiff()` →
+`CGImageSource…`) for macOS. (EXIF orientation mapping from `UIImage.Orientation` is an optional
+refinement; v1 passes `0` = unset.)
+
+### 4.5 Public convenience helper
+```csharp
+public static class AppleImage
+{
+    // Wraps a native image so it flows zero-copy to the model AND carries bytes for portability.
+    public static DataContent AsAIContent(CGImage image, string mediaType = "image/png");
+#if IOS || MACCATALYST || TVOS
+    public static DataContent AsAIContent(UIKit.UIImage image, string mediaType = "image/png");
+#elif MACOS
+    public static DataContent AsAIContent(AppKit.NSImage image, string mediaType = "image/png");
+#endif
+}
+```
+
+### Usage
+```csharp
+var response = await client.GetResponseAsync(
+    [new ChatMessage(ChatRole.User, [
+        new TextContent("List every food item you can see."),
+        AppleImage.AsAIContent(photo)          // native CGImage/UIImage, zero-copy on Apple
+    ])]);
+
+// Or portable (bytes only):
+var msg = new ChatMessage(ChatRole.User, [
+    new TextContent("Describe this image."),
+    new DataContent(pngBytes, "image/png"),
+]);
+```
+
+---
+
+## 5. Gating, CI, packaging
+
+- `AppleIntelligenceChatClient` stays `[SupportedOSPlatform("ios26.0")]` etc.; the chat client keeps
+  working for text on 26.x. Image content requires 27.0 at runtime, enforced natively — document
+  that a `NotSupportedException`-equivalent `NSErrorException` is thrown below 27.0.
+- **Gate on capability, not just OS.** Before sending image content, the Swift shim should check
+  `if #available(… 27.0, *), SystemLanguageModel.default.capabilities.contains(.vision)` and throw a
+  clear "this model build does not support image input" error otherwise. Consider surfacing this to
+  callers (e.g. an `AppleIntelligence.SupportsImageInput` bool) so apps can degrade gracefully.
+- **Maintenance catch (surfaced by the 27 SDK):** `GenerationOptions(sampling:)` — which the current
+  `ChatClient.swift` `prepareSession` already uses — is **deprecated in 27.0**, renamed
+  `init(samplingMode:temperature:maximumResponseTokens:)`. It still compiles (a deprecation warning),
+  but rename `sampling:` → `samplingMode:` when we move the build to Xcode 27.
+- `.github/workflows/ci-essentialsai.yml`: bump `xcode-version` to **27.x** for `build-macos` and
+  `device-tests-maccatalyst`. Without this the Swift shim will not compile (`Attachment` /
+  `Transcript.Segment.attachment` are absent from the 26.x SDK).
+- No new frameworks to link — `FoundationModels` is a system framework resolved by the Swift shim.
+- Update `PublicAPI/**/PublicAPI.Unshipped.txt` for `AppleImage.*` (and any other new public API).
+- `README.md` platform matrix: add an "Image input (27.0+)" row.
+
+## 6. Tests
+
+Managed-only (no model; run in CI):
+- `ToNative` maps `DataContent` / `UriContent` (image mime) → `ImageContentNative` selecting the
+  correct payload branch (cgImage vs data vs url).
+- `RawRepresentation is CGImage / UIImage / NSImage` fast path chosen over bytes.
+- Non-image `DataContent` still throws; remote http `UriContent` throws the documented error.
+- `AppleImage.AsAIContent(...)` produces a `DataContent` with both bytes and
+  `RawRepresentation` set.
+
+Device tests (`RequiresModel=true`, gated to 27.0):
+- Attach an image + "describe this image"; assert a non-empty response.
+- Attach two images + "compare"; assert both are referenced.
+- Multi-turn: send an image, then a follow-up question in the next turn that relies on it (exercises
+  the `Transcript.Segment.attachment` history path).
+
+## 7. Open questions
+
+1. ~~`Transcript.ImageAttachment` constructor.~~ **Resolved** against the Xcode 27.0 Beta 4 SDK:
+   `Transcript.ImageAttachment(_ cgImage: CGImage, orientation:)` (and `ciImage` / `pixelBuffer` /
+   `imageURL` variants) exist, with `.cgImage` / `.url` / `.orientation` read-back accessors. The
+   history helpers above are final.
+2. **Remote image URLs.** v1 rejects http(s) `UriContent` (only in-memory bytes or `file://`). Do we
+   want auto-download, or keep callers responsible for fetching bytes?
+3. **EXIF orientation.** v1 passes `0` (unset). Map `UIImage.Orientation` → EXIF 1…8 as a follow-up
+   if we see rotated-image issues.
+4. **Extra fast-paths.** `CIImage` / `CVPixelBuffer` `RawRepresentation` fast paths (via the
+   corresponding `Attachment` inits) can be added later; v1 funnels everything through `CGImage`.
+5. **Vision tools.** `OCRTool` / `BarcodeReaderTool` (from the Vision framework) can be attached to a
+   session for OCR/barcode workflows — a natural follow-up once image input lands.
+
+## 8. Also in the 27.0 headers (noted, out of scope for images-in)
+
+Surfaced while reading the FoundationModels swiftinterface — not needed for image input, but worth
+tracking as future Essentials.AI work:
+
+- **Availability & model config (already shipped in 26.x, still unused):** `SystemLanguageModel`
+  `availability` / `isAvailable` / `Availability`; `init(useCase: .general, guardrails: .default)`
+  with `UseCase` (`.contentTagging`) and `Guardrails`; `contextSize`, `supportedLanguages`,
+  `supportsLocale(_:)`, `tokenCount(for:)`.
+- **Token usage:** `LanguageModelSession.usage` (`Usage` with input/output token counts) → maps to
+  M.E.AI `ChatResponse.Usage` / `UsageDetails`, which we currently don't populate.
+- **Session lifecycle:** `prewarm(promptPrefix:)`, `isResponding`, `transcriptErrorHandlingPolicy`.
+- **Tool-calling mode (new 27.0):** `GenerationOptions.ToolCallingMode` (`.allowed` / `.required` /
+  `.disallowed`) → maps to M.E.AI `ChatOptions.ToolMode`.
+- **Sampling (new 27.0):** `SamplingMode.random(probabilityThreshold:seed:)` (top-p) in addition to
+  `random(top:seed:)`.
+- **Context / metadata (new 27.0):** `ContextOptions` (incl. `includeSchemaInPrompt`) and a
+  `metadata:` parameter on the newer `respond` / `streamResponse` overloads.
+- **Feedback (new 27.0):** `LanguageModelFeedback` (`Sentiment`, `Issue.Category`) +
+  `session.logFeedbackAttachment(...)`.
+- **Advanced composition (new 27.0):** dynamic profiles / dynamic instructions
+  (`init(profile:history:)`, `init(model:dynamicInstructions:history:)`), session properties
+  (`@SessionPropertyEntry`), the pluggable `LanguageModel` protocol, and
+  `PrivateCloudComputeLanguageModel` (server-side inference with quota).
+
+## References (authoritative sources)
+
+Everything in this doc is verified against Apple's declared API contract, not blog posts.
+
+**Primary — the SDK `.swiftinterface` (the canonical contract we grepped):**
+- `…/Xcode-27.0.0-Beta.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX27.0.sdk/System/Library/Frameworks/FoundationModels.framework/Versions/A/Modules/FoundationModels.swiftmodule/arm64e-apple-macos.swiftinterface`
+- Inspect side-by-side without switching the active Xcode:
+  `DEVELOPER_DIR=/Applications/Xcode-27.0.0-Beta.4.app/Contents/Developer xcrun swiftc -typecheck -sdk "$(xcrun --sdk macosx --show-sdk-path)" -target arm64-apple-ios26.0-macabi <files>`
+
+**Apple Developer documentation:**
+- [Foundation Models](https://developer.apple.com/documentation/foundationmodels)
+- [Analyzing images with multimodal prompting](https://developer.apple.com/documentation/foundationmodels/analyzing-images-with-multimodal-prompting)
+- [`Attachment`](https://developer.apple.com/documentation/foundationmodels/attachment) · [`ImageAttachmentContent`](https://developer.apple.com/documentation/foundationmodels/imageattachmentcontent) · [`ImageReference`](https://developer.apple.com/documentation/foundationmodels/imagereference)
+- [`Transcript`](https://developer.apple.com/documentation/foundationmodels/transcript) → [`Segment`](https://developer.apple.com/documentation/foundationmodels/transcript/segment) / [`AttachmentSegment`](https://developer.apple.com/documentation/foundationmodels/transcript/attachmentsegment) / [`Attachment`](https://developer.apple.com/documentation/foundationmodels/transcript/attachment) / `ImageAttachment`
+- [`SystemLanguageModel`](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel) · [`LanguageModelSession`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession)
+- [iOS & iPadOS release notes](https://developer.apple.com/documentation/ios-ipados-release-notes) (per-version model/API changes)
+
+**Microsoft.Extensions.AI (the abstractions we map onto):** [`dotnet/extensions` — `Microsoft.Extensions.AI.Abstractions`](https://github.com/dotnet/extensions/tree/main/src/Libraries/Microsoft.Extensions.AI.Abstractions) (`DataContent`, `UriContent`, `AIContent.RawRepresentation`).

--- a/src/AI/AppleNative/ApiDefinitions.cs
+++ b/src/AI/AppleNative/ApiDefinitions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
 
@@ -253,6 +254,50 @@ interface TextContentNative
 	// @property (nonatomic, copy) NSString * _Nonnull text;
 	[Export("text")]
 	string Text { get; set; }
+}
+
+// @interface ImageContentNative : AIContentNative
+[BaseType(typeof(AIContentNative))]
+[DisableDefaultCtor]
+[Internal]
+interface ImageContentNative
+{
+	// @property (nonatomic, strong) CGImageRef _Nullable cgImage;
+	[NullAllowed, Export("cgImage")]
+	CGImage CgImage { get; set; }
+
+	// @property (nonatomic, copy) NSData * _Nullable data;
+	[NullAllowed, Export("data", ArgumentSemantic.Copy)]
+	NSData Data { get; set; }
+
+	// @property (nonatomic, copy) NSURL * _Nullable imageURL;
+	[NullAllowed, Export("imageURL", ArgumentSemantic.Copy)]
+	NSUrl ImageUrl { get; set; }
+
+	// @property (nonatomic, copy) NSString * _Nullable mimeType;
+	[NullAllowed, Export("mimeType")]
+	string MimeType { get; set; }
+
+	// @property (nonatomic) int orientationRaw;
+	[Export("orientationRaw")]
+	int OrientationRaw { get; set; }
+
+	// @property (nonatomic, copy) NSString * _Nullable label;
+	[NullAllowed, Export("label")]
+	string Label { get; set; }
+
+	// - (nonnull instancetype)initWithCgImage:(CGImageRef _Nonnull)cgImage orientationRaw:(int)orientationRaw label:(NSString * _Nullable)label OBJC_DESIGNATED_INITIALIZER;
+	[Export("initWithCgImage:orientationRaw:label:")]
+	[DesignatedInitializer]
+	NativeHandle Constructor(CGImage cgImage, int orientationRaw, [NullAllowed] string label);
+
+	// - (nonnull instancetype)initWithData:(NSData * _Nonnull)data mimeType:(NSString * _Nonnull)mimeType orientationRaw:(int)orientationRaw label:(NSString * _Nullable)label;
+	[Export("initWithData:mimeType:orientationRaw:label:")]
+	NativeHandle Constructor(NSData data, string mimeType, int orientationRaw, [NullAllowed] string label);
+
+	// - (nonnull instancetype)initWithImageURL:(NSURL * _Nonnull)imageURL orientationRaw:(int)orientationRaw label:(NSString * _Nullable)label;
+	[Export("initWithImageURL:orientationRaw:label:")]
+	NativeHandle Constructor(NSUrl imageURL, int orientationRaw, [NullAllowed] string label);
 }
 
 // @interface ResponseUpdateNative : NSObject

--- a/src/AI/AppleNative/EssentialsAI/ChatClient.swift
+++ b/src/AI/AppleNative/EssentialsAI/ChatClient.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CoreGraphics
+import ImageIO
 import FoundationModels
 
 #if APPLE_INTELLIGENCE_LOGGING_ENABLED
@@ -245,7 +247,16 @@ public class ChatClientNative: NSObject {
         let otherMessages = Array(messages.dropLast())
 
         let model = SystemLanguageModel.default
-        let tools = options?.tools?.map { ToolNative($0, toolWatcher?.notifyToolCall, toolWatcher?.notifyToolResult) } ?? []
+
+        // Wrap the (Sendable) watcher's methods in explicit @Sendable closures so the partially
+        // applied references carry Sendable-correctness through to ToolNative.
+        let onToolCall: (@Sendable (String, String, String) -> Void)? = toolWatcher.map { watcher in
+            { @Sendable id, name, arguments in watcher.notifyToolCall(id: id, name: name, arguments: arguments) }
+        }
+        let onToolResult: (@Sendable (String, String, String) -> Void)? = toolWatcher.map { watcher in
+            { @Sendable id, name, result in watcher.notifyToolResult(id: id, name: name, result: result) }
+        }
+        let tools = options?.tools?.map { ToolNative($0, onToolCall, onToolResult) } ?? []
 
 #if APPLE_INTELLIGENCE_LOGGING_ENABLED
         if let log = AppleIntelligenceLogger.log, let toolList = options?.tools {
@@ -277,7 +288,7 @@ public class ChatClientNative: NSObject {
 
         // Map options into GenerationOptions
         let genOptions = GenerationOptions(
-            sampling: {
+            samplingMode: {
                 if let topK = options?.topK?.intValue {
                     return .random(top: topK, seed: options?.seed?.uint64Value)
                 }
@@ -368,15 +379,28 @@ public class ChatClientNative: NSObject {
             throw NSError.chatError(.invalidRole, description: "Only user messages can be prompts. Found: \(message.role)")
         }
 
-        return try Prompt {
-            try message.contents.map {
-                switch $0 {
-                case let textContent as TextContentNative:
-                    return textContent.text
-                default:
-                    throw NSError.chatError(.invalidContent, description: "Unsupported content type in prompt. Found: \(type(of: $0))")
+        // Build one Prompt fragment per content item, then combine so that text and image
+        // attachments interleave in order.
+        let fragments: [Prompt] = try message.contents.map { content in
+            switch content {
+            case let textContent as TextContentNative:
+                return Prompt { textContent.text }
+
+            case let imageContent as ImageContentNative:
+                if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+                    let attachment = try imageContent.toAttachment()
+                    return Prompt { attachment }
+                } else {
+                    throw NSError.chatError(.invalidContent, description: "Image prompts require iOS/macCatalyst/macOS 27.0 or later.")
                 }
+
+            default:
+                throw NSError.chatError(.invalidContent, description: "Unsupported content type in prompt. Found: \(type(of: content))")
             }
+        }
+
+        return Prompt {
+            for fragment in fragments { fragment }
         }
     }
 
@@ -395,13 +419,28 @@ public class ChatClientNative: NSObject {
         }
     }
 
-    private func toUserEntry(_ message: ChatMessageNative) throws -> Transcript.Entry {
-        let segments: [Transcript.Segment] = try message.contents.map { content in
-            guard let textContent = content as? TextContentNative else {
-                throw NSError.chatError(.invalidContent, description: "Unsupported content type in user message: \(type(of: content))")
-            }
+    /// Maps a single content item to a transcript segment (text or image attachment).
+    /// Shared by user prompts and system instructions so both can carry images.
+    private func toSegment(_ content: AIContentNative) throws -> Transcript.Segment {
+        switch content {
+        case let textContent as TextContentNative:
             return .text(Transcript.TextSegment(content: textContent.text))
+
+        case let imageContent as ImageContentNative:
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+                let attachment = try imageContent.toTranscriptAttachment()
+                return .attachment(Transcript.AttachmentSegment(content: attachment, label: imageContent.label))
+            } else {
+                throw NSError.chatError(.invalidContent, description: "Image content requires iOS/macCatalyst/macOS 27.0 or later.")
+            }
+
+        default:
+            throw NSError.chatError(.invalidContent, description: "Unsupported content type in message: \(type(of: content))")
         }
+    }
+
+    private func toUserEntry(_ message: ChatMessageNative) throws -> Transcript.Entry {
+        let segments = try message.contents.map(self.toSegment)
         return .prompt(Transcript.Prompt(segments: segments))
     }
 
@@ -439,12 +478,7 @@ public class ChatClientNative: NSObject {
     }
 
     private func toSystemEntry(_ message: ChatMessageNative) throws -> Transcript.Entry {
-        let segments: [Transcript.Segment] = try message.contents.map { content in
-            guard let textContent = content as? TextContentNative else {
-                throw NSError.chatError(.invalidContent, description: "Unsupported content type in system message: \(type(of: content))")
-            }
-            return .text(Transcript.TextSegment(content: textContent.text))
-        }
+        let segments = try message.contents.map(self.toSegment)
         return .instructions(Transcript.Instructions(segments: segments, toolDefinitions: []))
     }
 
@@ -492,7 +526,8 @@ public class ChatClientNative: NSObject {
             message.contents = fromToolOutput(toolOutput)
             return message
 
-        @unknown default:
+        default:
+            // Reasoning and any future entry kinds are not surfaced as messages.
             return nil
         }
     }
@@ -510,7 +545,8 @@ public class ChatClientNative: NSObject {
                 resultText = textSegment.content
             case .structure(let structuredSegment):
                 resultText = structuredSegment.content.jsonString
-            @unknown default:
+            default:
+                // Attachment/custom/future tool-output segments are not represented as text.
                 return nil
             }
 
@@ -525,10 +561,20 @@ public class ChatClientNative: NSObject {
 
         case .structure(let structuredSegment):
             // For now, convert structured content to text
-            let jsonString = structuredSegment.content.jsonString
-            return TextContentNative(text: jsonString)
+            return TextContentNative(text: structuredSegment.content.jsonString)
 
-        @unknown default:
+        default:
+            // Image attachment segments are available on 27.0+. Match inside the availability
+            // guard so the case references compile against the 26.x deployment target. Other
+            // segment kinds (custom, future) are not represented as content.
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *),
+               case .attachment(let attachmentSegment) = segment,
+               case .image(let image) = attachmentSegment.content {
+                return ImageContentNative(
+                    cgImage: image.cgImage,
+                    orientationRaw: Int32(image.orientation.rawValue),
+                    label: attachmentSegment.label)
+            }
             return nil
         }
     }
@@ -594,7 +640,7 @@ public class ChatClientNative: NSObject {
 
 extension NSError {
 
-    fileprivate static func chatError(_ code: ChatClientError, description: String) -> NSError {
+    static func chatError(_ code: ChatClientError, description: String) -> NSError {
         NSError(
             domain: "ChatClientNative",
             code: code.rawValue,

--- a/src/AI/AppleNative/EssentialsAI/ChatMessageContent.swift
+++ b/src/AI/AppleNative/EssentialsAI/ChatMessageContent.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CoreGraphics
+import ImageIO
 import FoundationModels
 
 @objc(AIContentNative)
@@ -37,5 +39,88 @@ public class FunctionResultContentNative: AIContentNative {
         self.name = name
         self.result = result
         super.init()
+    }
+}
+
+@objc(ImageContentNative)
+public class ImageContentNative: AIContentNative {
+    /// Native image handle (fast path, zero-copy).
+    @objc public var cgImage: CGImage?
+    /// Encoded image bytes (png/jpeg/…), decoded to a CGImage on demand.
+    @objc public var data: Data?
+    /// File URL pointing at an image on disk.
+    @objc public var imageURL: URL?
+    @objc public var mimeType: String?
+    /// EXIF orientation (1…8); 0 means unset.
+    @objc public var orientationRaw: Int32 = 0
+    @objc public var label: String?
+
+    @objc public init(cgImage: CGImage, orientationRaw: Int32, label: String?) {
+        self.cgImage = cgImage
+        self.orientationRaw = orientationRaw
+        self.label = label
+        super.init()
+    }
+
+    @objc public init(data: Data, mimeType: String, orientationRaw: Int32, label: String?) {
+        self.data = data
+        self.mimeType = mimeType
+        self.orientationRaw = orientationRaw
+        self.label = label
+        super.init()
+    }
+
+    @objc public init(imageURL: URL, orientationRaw: Int32, label: String?) {
+        self.imageURL = imageURL
+        self.orientationRaw = orientationRaw
+        self.label = label
+        super.init()
+    }
+
+    var orientation: CGImagePropertyOrientation? {
+        orientationRaw > 0 ? CGImagePropertyOrientation(rawValue: UInt32(orientationRaw)) : nil
+    }
+
+    func resolvedCGImage() -> CGImage? {
+        if let cgImage { return cgImage }
+        if let data { return ImageContentNative.decodeCGImage(from: data) }
+        return nil
+    }
+
+    static func decodeCGImage(from data: Data) -> CGImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+extension ImageContentNative {
+    /// Builds a FoundationModels prompt attachment. Throws if there is no usable payload.
+    func toAttachment() throws -> Attachment<ImageAttachmentContent> {
+        var attachment: Attachment<ImageAttachmentContent>
+        if let cgImage {
+            attachment = Attachment(cgImage, orientation: orientation)
+        } else if let imageURL {
+            attachment = Attachment(imageURL: imageURL, orientation: orientation)
+        } else if let cg = resolvedCGImage() {
+            attachment = Attachment(cg, orientation: orientation)
+        } else {
+            throw NSError.chatError(.invalidContent, description: "Image content had no usable payload.")
+        }
+        if let label {
+            attachment = attachment.label(label)
+        }
+        return attachment
+    }
+
+    /// Builds a transcript-history image attachment (for prior turns).
+    func toTranscriptAttachment() throws -> Transcript.Attachment {
+        if let imageURL {
+            return .image(Transcript.ImageAttachment(imageURL: imageURL, orientation: orientation))
+        }
+        guard let cg = resolvedCGImage() else {
+            throw NSError.chatError(.invalidContent, description: "Image content had no usable payload.")
+        }
+        return .image(Transcript.ImageAttachment(cg, orientation: orientation))
     }
 }

--- a/src/AI/Microsoft.Maui.Essentials.AI/Platform/MaciOS/AppleIntelligenceChatClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/Platform/MaciOS/AppleIntelligenceChatClient.cs
@@ -2,6 +2,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using CoreGraphics;
+using ImageIO;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -352,6 +354,9 @@ public sealed partial class AppleIntelligenceChatClient : IChatClient
 					functionResult.CallId,
 					functionResult.Result),
 
+			ImageContentNative image =>
+				FromNative(image),
+
 			_ => throw new ArgumentException($"Unsupported content type: {content.GetType().Name}", nameof(content))
 		};
 
@@ -442,6 +447,10 @@ public sealed partial class AppleIntelligenceChatClient : IChatClient
 			TextContent textContent when textContent.Text is not null => [new TextContentNative(textContent.Text)],
 			TextContent => Array.Empty<AIContentNative>(),
 
+			// Image content (analyzed by the model on 27.0+; the native layer throws below that).
+			DataContent data when IsImage(data.MediaType) => [ToNative(data)],
+			UriContent uri when IsImage(uri.MediaType) => [ToNative(uri)],
+
 			// Function call/result content from prior tool-calling turns is converted to native types.
 			// The native Swift layer gracefully skips these when building the Transcript, since Apple's
 			// LanguageModelSession manages tool call state internally.
@@ -478,6 +487,79 @@ public sealed partial class AppleIntelligenceChatClient : IChatClient
 
 	private static NSNumber? ToNative(long? value) =>
 		value.HasValue ? NSNumber.FromInt64(value.Value) : null;
+
+	// internal for unit testing (InternalsVisibleTo).
+	internal static bool IsImage(string? mediaType) =>
+		mediaType is not null && mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+
+	internal static ImageContentNative ToNative(DataContent data)
+	{
+		// Fast path: the caller attached a native image handle via RawRepresentation (zero-copy).
+		switch (data.RawRepresentation)
+		{
+			case CGImage cg:
+				return new ImageContentNative(cg, 0, null);
+#if IOS || MACCATALYST
+			case UIKit.UIImage ui when ui.CGImage is { } uiCg:
+				return new ImageContentNative(uiCg, 0, null);
+#elif MACOS
+			case AppKit.NSImage ns when ToCGImage(ns) is { } nsCg:
+				return new ImageContentNative(nsCg, 0, null);
+#endif
+		}
+
+		// Byte fallback: the Swift shim decodes the bytes to a CGImage.
+		var bytes = data.Data.ToArray();
+		return new ImageContentNative(NSData.FromArray(bytes), data.MediaType ?? "image/png", 0, null);
+	}
+
+	internal static ImageContentNative ToNative(UriContent uri)
+	{
+		if (uri.RawRepresentation is CGImage cg)
+			return new ImageContentNative(cg, 0, null);
+
+		if (uri.Uri.IsFile)
+			return new ImageContentNative(NSUrl.FromFilename(uri.Uri.LocalPath), 0, null);
+
+		throw new NotSupportedException(
+			"Apple Intelligence image prompts require in-memory DataContent or a file:// UriContent. " +
+			"Remote http(s) image URLs are not downloaded automatically.");
+	}
+
+	internal static AIContent FromNative(ImageContentNative image)
+	{
+		var mediaType = image.MimeType ?? "image/png";
+
+		if (image.ImageUrl?.AbsoluteString is { } uri)
+			return new UriContent(uri, mediaType) { RawRepresentation = image.CgImage };
+
+		if (image.Data is { } data)
+			return new DataContent(data.ToArray(), mediaType) { RawRepresentation = image.CgImage };
+
+		if (image.CgImage is { } cg)
+			return new DataContent(EncodePng(cg), "image/png") { RawRepresentation = cg };
+
+		return new DataContent(ReadOnlyMemory<byte>.Empty, mediaType);
+	}
+
+	private static byte[] EncodePng(CGImage image)
+	{
+		using var data = new NSMutableData();
+		using var destination = CGImageDestination.Create(data, "public.png", 1)
+			?? throw new InvalidOperationException("Failed to create a PNG image destination.");
+		destination.AddImage(image);
+		if (!destination.Close())
+			throw new InvalidOperationException("Failed to encode the image to PNG.");
+		return data.ToArray();
+	}
+
+#if MACOS
+	private static CGImage? ToCGImage(AppKit.NSImage image)
+	{
+		var rect = new CGRect(0, 0, image.Size.Width, image.Size.Height);
+		return image.AsCGImage(ref rect, null, null);
+	}
+#endif
 
 	private sealed partial class AIFunctionToolAdapter(AIFunction function, ILogger logger, CancellationToken cancellationToken, IServiceProvider? services) : AIToolNative
 	{

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -63,6 +63,7 @@ The CI pipeline handles the macOS → Windows artifact flow automatically. See `
 ## Documentation
 
 - [JSON Stream Chunker Design](../../docs/ai/json-stream-chunker-design.md)
+- [Multimodal Image Input Design](../../docs/ai/multimodal-design.md)
 
 ## Requirements
 

--- a/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/MaciOS/AppleIntelligenceChatClientImageTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Tests/MaciOS/AppleIntelligenceChatClientImageTests.cs
@@ -1,0 +1,163 @@
+#if IOS || MACCATALYST
+using CoreGraphics;
+using Foundation;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.AI.DeviceTests;
+
+/// <summary>
+/// Tests for multimodal image input on the Apple Intelligence chat client.
+/// The conversion tests are model-free (they exercise only the managed ↔ native marshalling)
+/// and run in CI; the end-to-end description test requires an on-device model.
+/// </summary>
+public class AppleIntelligenceChatClientImageTests
+{
+	static CGImage CreateTestImage(int width = 2, int height = 2)
+	{
+		var bytesPerRow = width * 4;
+		var buffer = new byte[bytesPerRow * height];
+		using var colorSpace = CGColorSpace.CreateDeviceRGB();
+		using var context = new CGBitmapContext(buffer, width, height, 8, bytesPerRow, colorSpace, CGImageAlphaInfo.PremultipliedLast);
+		context.SetFillColor(new CGColor(1f, 0f, 0f, 1f));
+		context.FillRect(new CGRect(0, 0, width, height));
+		return context.ToImage()!;
+	}
+
+	[Fact]
+	public void IsImage_DetectsImageMediaTypes()
+	{
+		Assert.True(AppleIntelligenceChatClient.IsImage("image/png"));
+		Assert.True(AppleIntelligenceChatClient.IsImage("IMAGE/JPEG"));
+		Assert.False(AppleIntelligenceChatClient.IsImage("application/pdf"));
+		Assert.False(AppleIntelligenceChatClient.IsImage(null));
+	}
+
+	[Fact]
+	public void ToNative_DataContentImage_CarriesBytesAndMediaType()
+	{
+		var bytes = new byte[] { 1, 2, 3, 4 };
+		var content = new DataContent(bytes, "image/png");
+
+		var native = AppleIntelligenceChatClient.ToNative(content);
+
+		Assert.NotNull(native.Data);
+		Assert.Equal(bytes, native.Data!.ToArray());
+		Assert.Equal("image/png", native.MimeType);
+		Assert.Null(native.CgImage);
+	}
+
+	[Fact]
+	public void ToNative_DataContentWithNativeHandle_UsesZeroCopyFastPath()
+	{
+		using var image = CreateTestImage();
+		var content = new DataContent(new byte[] { 0 }, "image/png") { RawRepresentation = image };
+
+		var native = AppleIntelligenceChatClient.ToNative(content);
+
+		// Fast path: the native CGImage flows through and the byte payload is skipped.
+		Assert.NotNull(native.CgImage);
+		Assert.Null(native.Data);
+	}
+
+	[Fact]
+	public void ToNative_FileUri_ProducesImageUrl()
+	{
+		var content = new UriContent("file:///tmp/example.png", "image/png");
+
+		var native = AppleIntelligenceChatClient.ToNative(content);
+
+		Assert.NotNull(native.ImageUrl);
+		Assert.EndsWith("example.png", native.ImageUrl!.Path!);
+	}
+
+	[Fact]
+	public void ToNative_HttpUri_ThrowsNotSupported()
+	{
+		var content = new UriContent("https://example.com/image.png", "image/png");
+
+		Assert.Throws<NotSupportedException>(() => AppleIntelligenceChatClient.ToNative(content));
+	}
+
+	[Fact]
+	public void FromNative_CGImage_ProducesDecodablePng()
+	{
+		using var image = CreateTestImage();
+		var native = new ImageContentNative(image, 0, null);
+
+		var content = AppleIntelligenceChatClient.FromNative(native);
+
+		var data = Assert.IsType<DataContent>(content);
+		Assert.Equal("image/png", data.MediaType);
+
+		var bytes = data.Data.ToArray();
+		Assert.True(bytes.Length > 8);
+		Assert.Equal(new byte[] { 0x89, 0x50, 0x4E, 0x47 }, bytes[..4]); // PNG signature
+		Assert.NotNull(data.RawRepresentation);
+	}
+
+	[Fact]
+	public void RoundTrip_CGImage_SurvivesConversion()
+	{
+		using var image = CreateTestImage(3, 3);
+
+		var native = AppleIntelligenceChatClient.ToNative(
+			new DataContent(new byte[] { 0 }, "image/png") { RawRepresentation = image });
+		Assert.NotNull(native.CgImage);
+
+		var back = AppleIntelligenceChatClient.FromNative(native);
+		var data = Assert.IsType<DataContent>(back);
+
+		var decoded = data.RawRepresentation as CGImage;
+		Assert.NotNull(decoded);
+		Assert.Equal((nint)3, decoded!.Width);
+		Assert.Equal((nint)3, decoded.Height);
+	}
+
+	[Fact]
+	public async Task GetResponseAsync_WithHttpImageUri_ThrowsBeforeModel()
+	{
+		var client = new AppleIntelligenceChatClient();
+		var messages = new List<ChatMessage>
+		{
+			new(ChatRole.User,
+			[
+				new TextContent("Describe this image."),
+				new UriContent("https://example.com/x.png", "image/png"),
+			]),
+		};
+
+		// Conversion runs before any native model call, so this fails fast without a model.
+		await Assert.ThrowsAsync<NotSupportedException>(() => client.GetResponseAsync(messages));
+	}
+
+	[Fact]
+	[Trait(TestTraits.RequiresModel, TestTraits.True)]
+	public async Task GetResponseAsync_WithImageAttachment_ReturnsDescription()
+	{
+		// Multimodal image input needs the runtime OS to be 27.0+ (the 27.0 SDK only enables
+		// compilation). Skip on older runtimes so this doesn't false-fail off-device.
+		if (!OperatingSystem.IsMacCatalystVersionAtLeast(27) &&
+			!OperatingSystem.IsIOSVersionAtLeast(27) &&
+			!OperatingSystem.IsMacOSVersionAtLeast(27))
+		{
+			return;
+		}
+
+		using var image = CreateTestImage(64, 64);
+		var client = new AppleIntelligenceChatClient();
+		var messages = new List<ChatMessage>
+		{
+			new(ChatRole.User,
+			[
+				new TextContent("What is the dominant color of this image? Answer in one word."),
+				new DataContent(new byte[] { 0 }, "image/png") { RawRepresentation = image },
+			]),
+		};
+
+		var response = await client.GetResponseAsync(messages);
+
+		Assert.False(string.IsNullOrWhiteSpace(response.Text));
+	}
+}
+#endif


### PR DESCRIPTION
## Why

`AppleIntelligenceChatClient` was text-only, but FoundationModels now supports multimodal prompting (image input) on the on-device model. This lets callers attach images to a `ChatMessage` and have Apple Intelligence analyze them (describe, classify, OCR/extract, compare), exposed through the existing `IChatClient`.

## Approach

Images flow through the standard `Microsoft.Extensions.AI` shapes on `ChatMessage.Contents`, so no bespoke API is needed:

- **New `ImageContentNative`** (Swift + ObjC binding) carries one of a native `CGImage`, encoded bytes + mime type, or a file URL, plus EXIF orientation and a label.
- **`ChatClient.swift`**: the current user prompt maps images to `Attachment`; a shared segment helper feeds **both user prompts and system instructions** via the new `Transcript.Segment.attachment`, so multi-turn image history works too; returned attachment segments are read back to content. All `Attachment`/transcript usage is `#available`-gated to iOS/macCatalyst/macOS 27.0.
- **`AppleIntelligenceChatClient.ToNative`** maps image `DataContent`/`UriContent` to native. It uses a **zero-copy fast path** when `AIContent.RawRepresentation` holds a `CGImage`/`UIImage`/`NSImage` (the native handle passes straight through), falling back to encoded bytes otherwise, which keeps it cross-platform-safe. `FromNative` round-trips images back (PNG-encoding a `CGImage` on read-back).

## Notes for reviewers

- **Toolchain**: the Apple native shim must be built with the **Xcode 27 SDK** (`Attachment` and `Transcript.Segment.attachment` are 27.0-only and absent from the 26.x SDK). CI `xcode-version` will need bumping to 27.x - not done in this PR.
- **Runtime gating**: image input requires the OS itself to be **27.0+**, not just the SDK. Below that the native layer throws a clear error; verified on this macOS 26.5 machine (the guard refuses cleanly rather than crashing).
- Also handled while moving to the 27.0 SDK: renamed the now-deprecated `GenerationOptions(sampling:)` to `samplingMode:`, gave the new 27.0 transcript enum cases explicit handling, and wrapped the tool-watcher callbacks in `@Sendable` closures. Swift now compiles with **zero warnings**.
- Design doc added under `docs/ai/multimodal-design.md` (linked from the AI product README), grounded in the SDK `.swiftinterface` and Apple's docs.

## Testing

New `AppleIntelligenceChatClientImageTests`. Ran `dotnet test` on the real Mac Catalyst app (Xcode 27): **68 passed, 0 failed**, including all 8 model-free conversion tests (byte payload, native-handle fast path, file URI, http-URI rejection, PNG round-trip). The end-to-end image->description test is gated on `RequiresModel` + OS 27, so it skips on older/model-less runners.

## Follow-ups (not in this PR)

- Bump CI `xcode-version` to 27.x so this compiles in CI.
- `AppleImage.AsAIContent(...)` convenience helper + PublicAPI entries.
- Populate `ChatResponse.Usage` from `LanguageModelSession.usage`; other 27.0 additions catalogued in the design doc.