### PR TITLE
fix(cli): scope device list to the requested platform's providers

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -654,4 +654,148 @@ public class DeviceManagerTests
 		Assert.Contains(devices, d => d.Id == "emulator-5554" && d.State == DeviceState.Booted && string.IsNullOrEmpty(d.EmulatorId));
 		Assert.Contains(devices, d => d.EmulatorId == "Pixel_6_API_35" && d.State == DeviceState.Booting);
 	}
+
+	// --- Provider scoping (issue #416) ---
+	//
+	// `--platform` must decide *which providers get queried*, not just filter the combined
+	// result. On macOS the Apple provider shells out to `xcrun simctl list devices`, which
+	// takes 8-16s and can hang indefinitely when CoreSimulator is wedged. Asking for Android
+	// devices must never pay that cost, so these tests assert on provider invocation counts
+	// rather than only on the returned devices.
+
+	static FakeAndroidProvider CreateAndroidProvider() => new()
+	{
+		Devices = new List<Device>
+		{
+			new Device { Id = "emulator-5554", Name = "Pixel 6", Platforms = new[] { "android" }, Type = DeviceType.Emulator, State = DeviceState.Booted, IsEmulator = true, IsRunning = true }
+		}
+	};
+
+	static FakeAppleProvider CreateAppleProvider() => new()
+	{
+		Devices = new List<Device>
+		{
+			new Device { Id = "sim-udid-1234", Name = "iPhone 15 Pro", Platforms = new[] { "ios" }, Type = DeviceType.Simulator, State = DeviceState.Booted, IsEmulator = true, IsRunning = true }
+		}
+	};
+
+	[Theory]
+	[InlineData("android")]
+	[InlineData("ANDROID")]
+	public async Task GetDevicesByPlatformAsync_Android_DoesNotQueryAppleProvider(string platform)
+	{
+		var fakeAndroid = CreateAndroidProvider();
+		var fakeApple = CreateAppleProvider();
+		var manager = new DeviceManager(fakeAndroid, fakeApple);
+
+		var devices = await manager.GetDevicesByPlatformAsync(platform);
+
+		Assert.Equal(0, fakeApple.GetDevicesCallCount);
+		Assert.Equal(1, fakeAndroid.GetDevicesCallCount);
+		Assert.Single(devices);
+		Assert.Equal("emulator-5554", devices[0].Id);
+	}
+
+	[Theory]
+	[InlineData("ios")]
+	[InlineData("apple")]
+	[InlineData("iphone")]
+	[InlineData("ipad")]
+	public async Task GetDevicesByPlatformAsync_Ios_DoesNotQueryAndroidProvider(string platform)
+	{
+		var fakeAndroid = CreateAndroidProvider();
+		var fakeApple = CreateAppleProvider();
+		var manager = new DeviceManager(fakeAndroid, fakeApple);
+
+		var devices = await manager.GetDevicesByPlatformAsync(platform);
+
+		Assert.Equal(0, fakeAndroid.GetDevicesCallCount);
+		Assert.Equal(0, fakeAndroid.GetAvdsCallCount);
+		Assert.Equal(1, fakeApple.GetDevicesCallCount);
+		Assert.Single(devices);
+		Assert.Equal("sim-udid-1234", devices[0].Id);
+	}
+
+	[Theory]
+	[InlineData("maccatalyst")]
+	[InlineData("windows")]
+	public async Task GetDevicesByPlatformAsync_UnbackedPlatform_QueriesNoProvider(string platform)
+	{
+		var fakeAndroid = CreateAndroidProvider();
+		var fakeApple = CreateAppleProvider();
+		var manager = new DeviceManager(fakeAndroid, fakeApple);
+
+		var devices = await manager.GetDevicesByPlatformAsync(platform);
+
+		Assert.Equal(0, fakeAndroid.GetDevicesCallCount);
+		Assert.Equal(0, fakeAndroid.GetAvdsCallCount);
+		Assert.Equal(0, fakeApple.GetDevicesCallCount);
+		Assert.Empty(devices);
+	}
+
+	[Fact]
+	public async Task GetDevicesByPlatformAsync_All_QueriesEveryProvider()
+	{
+		var fakeAndroid = CreateAndroidProvider();
+		var fakeApple = CreateAppleProvider();
+		var manager = new DeviceManager(fakeAndroid, fakeApple);
+
+		var devices = await manager.GetDevicesByPlatformAsync(Platforms.All);
+
+		Assert.Equal(1, fakeAndroid.GetDevicesCallCount);
+		Assert.Equal(1, fakeApple.GetDevicesCallCount);
+		Assert.Equal(2, devices.Count);
+	}
+
+	[Fact]
+	public async Task GetAllDevicesAsync_QueriesEveryProvider()
+	{
+		var fakeAndroid = CreateAndroidProvider();
+		var fakeApple = CreateAppleProvider();
+		var manager = new DeviceManager(fakeAndroid, fakeApple);
+
+		var devices = await manager.GetAllDevicesAsync();
+
+		Assert.Equal(1, fakeAndroid.GetDevicesCallCount);
+		Assert.Equal(1, fakeApple.GetDevicesCallCount);
+		Assert.Equal(2, devices.Count);
+	}
+
+	[Fact]
+	public async Task GetDevicesByPlatformAsync_Android_SkipsAvdEnumerationForOtherPlatforms()
+	{
+		// The AVD query is a second adb/emulator round-trip; iOS must not trigger it either.
+		var fakeAndroid = CreateAndroidProvider();
+		var manager = new DeviceManager(fakeAndroid, CreateAppleProvider());
+
+		await manager.GetDevicesByPlatformAsync(Platforms.iOS);
+
+		Assert.Equal(0, fakeAndroid.GetAvdsCallCount);
+
+		await manager.GetDevicesByPlatformAsync(Platforms.Android);
+
+		Assert.Equal(1, fakeAndroid.GetAvdsCallCount);
+	}
+
+	[Theory]
+	[InlineData(Platforms.All, true)]
+	[InlineData(Platforms.Android, true)]
+	[InlineData(Platforms.iOS, false)]
+	[InlineData(Platforms.MacCatalyst, false)]
+	[InlineData(Platforms.Windows, false)]
+	[InlineData("apple", false)]
+	[InlineData(null, true)]
+	public void QueriesAndroid_ReturnsExpected(string? platform, bool expected)
+		=> Assert.Equal(expected, DeviceManager.QueriesAndroid(platform));
+
+	[Theory]
+	[InlineData(Platforms.All, true)]
+	[InlineData(Platforms.iOS, true)]
+	[InlineData("apple", true)]
+	[InlineData(Platforms.Android, false)]
+	[InlineData(Platforms.MacCatalyst, false)]
+	[InlineData(Platforms.Windows, false)]
+	[InlineData(null, true)]
+	public void QueriesApple_ReturnsExpected(string? platform, bool expected)
+		=> Assert.Equal(expected, DeviceManager.QueriesApple(platform));
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -777,25 +777,46 @@ public class DeviceManagerTests
 		Assert.Equal(1, fakeAndroid.GetAvdsCallCount);
 	}
 
+	// Queries* take an already-normalized platform; alias handling ("apple", "iphone", ...) is
+	// covered end-to-end by GetDevicesByPlatformAsync above.
 	[Theory]
 	[InlineData(Platforms.All, true)]
 	[InlineData(Platforms.Android, true)]
 	[InlineData(Platforms.iOS, false)]
 	[InlineData(Platforms.MacCatalyst, false)]
 	[InlineData(Platforms.Windows, false)]
-	[InlineData("apple", false)]
-	[InlineData(null, true)]
-	public void QueriesAndroid_ReturnsExpected(string? platform, bool expected)
+	public void QueriesAndroid_ReturnsExpected(string platform, bool expected)
 		=> Assert.Equal(expected, DeviceManager.QueriesAndroid(platform));
 
 	[Theory]
 	[InlineData(Platforms.All, true)]
 	[InlineData(Platforms.iOS, true)]
-	[InlineData("apple", true)]
 	[InlineData(Platforms.Android, false)]
 	[InlineData(Platforms.MacCatalyst, false)]
 	[InlineData(Platforms.Windows, false)]
-	[InlineData(null, true)]
-	public void QueriesApple_ReturnsExpected(string? platform, bool expected)
+	public void QueriesApple_ReturnsExpected(string platform, bool expected)
 		=> Assert.Equal(expected, DeviceManager.QueriesApple(platform));
+
+	[Theory]
+	[InlineData(Platforms.All, true)]
+	[InlineData(Platforms.Android, true)]
+	[InlineData(Platforms.iOS, true)]
+	[InlineData("apple", true)]
+	[InlineData(null, true)]
+	[InlineData(Platforms.MacCatalyst, false)]
+	[InlineData(Platforms.Windows, false)]
+	public void HasProviderFor_ReturnsExpected(string? platform, bool expected)
+		=> Assert.Equal(expected, DeviceManager.HasProviderFor(platform));
+
+	[Fact]
+	public void HasProviderFor_CoversEveryPlatformThatQueriesAProvider()
+	{
+		// Guards the mapping from drifting: a platform that reaches a provider must report as
+		// supported, and one that reaches none must not.
+		foreach (var platform in Platforms.Supported)
+		{
+			var reachesProvider = DeviceManager.QueriesAndroid(platform) || DeviceManager.QueriesApple(platform);
+			Assert.Equal(reachesProvider, DeviceManager.HasProviderFor(platform));
+		}
+	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DeviceManagerTests.cs
@@ -777,26 +777,10 @@ public class DeviceManagerTests
 		Assert.Equal(1, fakeAndroid.GetAvdsCallCount);
 	}
 
-	// Queries* take an already-normalized platform; alias handling ("apple", "iphone", ...) is
-	// covered end-to-end by GetDevicesByPlatformAsync above.
-	[Theory]
-	[InlineData(Platforms.All, true)]
-	[InlineData(Platforms.Android, true)]
-	[InlineData(Platforms.iOS, false)]
-	[InlineData(Platforms.MacCatalyst, false)]
-	[InlineData(Platforms.Windows, false)]
-	public void QueriesAndroid_ReturnsExpected(string platform, bool expected)
-		=> Assert.Equal(expected, DeviceManager.QueriesAndroid(platform));
-
-	[Theory]
-	[InlineData(Platforms.All, true)]
-	[InlineData(Platforms.iOS, true)]
-	[InlineData(Platforms.Android, false)]
-	[InlineData(Platforms.MacCatalyst, false)]
-	[InlineData(Platforms.Windows, false)]
-	public void QueriesApple_ReturnsExpected(string platform, bool expected)
-		=> Assert.Equal(expected, DeviceManager.QueriesApple(platform));
-
+	// Provider gating is observable through HasProviderFor, which reads the providers' own
+	// SupportedPlatforms. The fakes default to the same platforms the real providers declare
+	// (android / ios), so this pins the shipped behaviour. Alias handling ("apple", "iphone",
+	// ...) is covered end-to-end by GetDevicesByPlatformAsync above.
 	[Theory]
 	[InlineData(Platforms.All, true)]
 	[InlineData(Platforms.Android, true)]
@@ -806,17 +790,88 @@ public class DeviceManagerTests
 	[InlineData(Platforms.MacCatalyst, false)]
 	[InlineData(Platforms.Windows, false)]
 	public void HasProviderFor_ReturnsExpected(string? platform, bool expected)
-		=> Assert.Equal(expected, DeviceManager.HasProviderFor(platform));
+	{
+		var manager = new DeviceManager(CreateAndroidProvider(), CreateAppleProvider());
+
+		Assert.Equal(expected, manager.HasProviderFor(platform));
+	}
+
+	// A provider that starts serving a new platform must be followed by the device manager
+	// without any change to DeviceManager itself. Before providers declared their own
+	// platforms, this required editing a second list by hand and silently returned nothing
+	// when that was forgotten. Mac Catalyst stands in for any not-yet-served platform.
+	[Fact]
+	public async Task GetDevicesByPlatformAsync_FollowsAppleProviderIntoANewPlatform()
+	{
+		var fakeApple = CreateAppleProvider();
+		fakeApple.SupportedPlatforms = [Platforms.iOS, Platforms.MacCatalyst];
+		fakeApple.Devices = new List<Device>
+		{
+			new Device { Id = "mac-1", Name = "My Mac", Platforms = new[] { Platforms.MacCatalyst }, Type = DeviceType.Physical }
+		};
+		var manager = new DeviceManager(CreateAndroidProvider(), fakeApple);
+
+		var devices = await manager.GetDevicesByPlatformAsync(Platforms.MacCatalyst);
+
+		Assert.Equal(1, fakeApple.GetDevicesCallCount);
+		Assert.Equal("mac-1", Assert.Single(devices).Id);
+	}
 
 	[Fact]
-	public void HasProviderFor_CoversEveryPlatformThatQueriesAProvider()
+	public async Task GetDevicesByPlatformAsync_FollowsAndroidProviderIntoANewPlatform()
 	{
-		// Guards the mapping from drifting: a platform that reaches a provider must report as
-		// supported, and one that reaches none must not.
+		var fakeAndroid = CreateAndroidProvider();
+		fakeAndroid.SupportedPlatforms = [Platforms.Android, Platforms.Windows];
+		fakeAndroid.Devices = new List<Device>
+		{
+			new Device { Id = "win-1", Name = "Windows Device", Platforms = new[] { Platforms.Windows }, Type = DeviceType.Physical }
+		};
+		fakeAndroid.Avds = new List<AvdInfo>();
+		var manager = new DeviceManager(fakeAndroid, CreateAppleProvider());
+
+		var devices = await manager.GetDevicesByPlatformAsync(Platforms.Windows);
+
+		Assert.Equal(1, fakeAndroid.GetDevicesCallCount);
+		Assert.Equal("win-1", Assert.Single(devices).Id);
+	}
+
+	[Fact]
+	public void HasProviderFor_FollowsProviderDeclaredPlatforms()
+	{
+		var fakeApple = CreateAppleProvider();
+		fakeApple.SupportedPlatforms = [Platforms.iOS, Platforms.MacCatalyst];
+		var manager = new DeviceManager(CreateAndroidProvider(), fakeApple);
+
+		Assert.True(manager.HasProviderFor(Platforms.MacCatalyst));
+		// Still unbacked: neither provider declares it.
+		Assert.False(manager.HasProviderFor(Platforms.Windows));
+	}
+
+	[Fact]
+	public void HasProviderFor_WithoutProviders_IsFalseForEveryPlatform()
+	{
+		var manager = new DeviceManager();
+
+		foreach (var platform in Platforms.Supported)
+			Assert.False(manager.HasProviderFor(platform), $"'{platform}' reported as backed with no providers registered.");
+	}
+
+	// The real invariant: HasProviderFor must predict whether GetDevicesByPlatformAsync
+	// actually reaches a provider. Asserting against observed invocations rather than against
+	// the gating logic keeps this from restating the implementation.
+	[Fact]
+	public async Task HasProviderFor_AgreesWithWhichProvidersAreActuallyQueried()
+	{
 		foreach (var platform in Platforms.Supported)
 		{
-			var reachesProvider = DeviceManager.QueriesAndroid(platform) || DeviceManager.QueriesApple(platform);
-			Assert.Equal(reachesProvider, DeviceManager.HasProviderFor(platform));
+			var fakeAndroid = CreateAndroidProvider();
+			var fakeApple = CreateAppleProvider();
+			var manager = new DeviceManager(fakeAndroid, fakeApple);
+
+			await manager.GetDevicesByPlatformAsync(platform);
+
+			var queriedAProvider = fakeAndroid.GetDevicesCallCount > 0 || fakeApple.GetDevicesCallCount > 0;
+			Assert.Equal(queriedAProvider, manager.HasProviderFor(platform));
 		}
 	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
@@ -23,6 +23,12 @@ public class FakeAndroidProvider : IAndroidProvider
 
 	public List<HealthCheck> HealthChecks { get; set; } = new();
 	public List<Device> Devices { get; set; } = new();
+
+	/// <summary>
+	/// Platforms this fake claims to serve. Settable so tests can simulate a provider that has
+	/// been extended to a new platform and assert the device manager follows it.
+	/// </summary>
+	public IReadOnlyList<string> SupportedPlatforms { get; set; } = [Platforms.Android];
 	public List<AvdInfo> Avds { get; set; } = new();
 	public List<string> DeviceProfiles { get; set; } = new();
 	public List<SdkPackage> InstalledPackages { get; set; } = new();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAndroidProvider.cs
@@ -64,16 +64,28 @@ public class FakeAndroidProvider : IAndroidProvider
 	public List<int?> InstallJdkCalls { get; } = new();
 	public bool Disposed { get; private set; }
 
+	/// <summary>Number of times <see cref="GetDevicesAsync"/> was invoked.</summary>
+	public int GetDevicesCallCount { get; private set; }
+
+	/// <summary>Number of times <see cref="GetAvdsAsync"/> was invoked.</summary>
+	public int GetAvdsCallCount { get; private set; }
+
 	// --- IAndroidProvider implementation ---
 
 	public Task<List<HealthCheck>> CheckHealthAsync(CancellationToken cancellationToken = default)
 		=> Task.FromResult(HealthChecks);
 
 	public Task<List<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
-		=> Task.FromResult(Devices);
+	{
+		GetDevicesCallCount++;
+		return Task.FromResult(Devices);
+	}
 
 	public Task<List<AvdInfo>> GetAvdsAsync(CancellationToken cancellationToken = default)
-		=> Task.FromResult(Avds);
+	{
+		GetAvdsCallCount++;
+		return Task.FromResult(Avds);
+	}
 
 	public Task<List<string>> GetDeviceProfilesAsync(CancellationToken cancellationToken = default)
 		=> Task.FromResult(DeviceProfiles);

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
@@ -23,6 +23,12 @@ public class FakeAppleProvider : IAppleProvider
 	public List<SimulatorInfo> Simulators { get; set; } = new();
 	public List<HealthCheck> HealthChecks { get; set; } = new();
 	public List<Device> Devices { get; set; } = new();
+
+	/// <summary>
+	/// Platforms this fake claims to serve. Settable so tests can simulate a provider that has
+	/// been extended to a new platform and assert the device manager follows it.
+	/// </summary>
+	public IReadOnlyList<string> SupportedPlatforms { get; set; } = [Platforms.iOS];
 	public AppleInstallResult InstallResult { get; set; } = new() { Status = "ok" };
 
 	public bool SelectXcodeResult { get; set; } = true;

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fakes/FakeAppleProvider.cs
@@ -79,6 +79,9 @@ public class FakeAppleProvider : IAppleProvider
 	public List<(string Udid, string OutputPath, ScreenshotFormat Format)> ScreenshotCalls { get; } = new();
 	public List<(string Udid, string OutputPath, RecordingOptions? Options)> StartRecordingCalls { get; } = new();
 
+	/// <summary>Number of times <see cref="GetDevices"/> was invoked.</summary>
+	public int GetDevicesCallCount { get; private set; }
+
 	// --- IAppleProvider implementation ---
 
 	public List<XcodeInstallation> GetXcodeInstallations() => XcodeInstallations;
@@ -256,7 +259,11 @@ public class FakeAppleProvider : IAppleProvider
 		return Task.FromResult(InstallResult);
 	}
 
-	public List<Device> GetDevices() => Devices;
+	public List<Device> GetDevices()
+	{
+		GetDevicesCallCount++;
+		return Devices;
+	}
 
 	sealed class NoopDisposable : IDisposable
 	{

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/CliCollection.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/CliCollection.cs
@@ -8,3 +8,18 @@ namespace Microsoft.Maui.Cli.UnitTests.Fixtures;
 public sealed class CliCollection
 {
 }
+
+/// <summary>
+/// Serializes test classes that mutate
+/// <c>StandardErrorToolsLogger.DefaultVerbose</c>.
+/// </summary>
+/// <remarks>
+/// The assembly currently disables parallelization outright, so this is belt-and-braces. It
+/// exists so the isolation survives that setting being relaxed: any test class that touches the
+/// static must carry <c>[Collection("StandardErrorToolsLogger static state")]</c>, otherwise it
+/// can race a class that mutates it and produce order-dependent flakes.
+/// </remarks>
+[CollectionDefinition("StandardErrorToolsLogger static state", DisableParallelization = true)]
+public sealed class StandardErrorToolsLoggerStateCollection
+{
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/PlatformsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/PlatformsTests.cs
@@ -45,4 +45,19 @@ public class PlatformsTests
 	{
 		Assert.Equal(expected, Platforms.Normalize(input));
 	}
+
+	[Fact]
+	public void Supported_ContainsEveryValueAcceptedByIsValid()
+	{
+		Assert.All(Platforms.Supported, p => Assert.True(Platforms.IsValid(p), $"'{p}' is listed as supported but rejected by IsValid"));
+		Assert.Equal(new[] { "android", "ios", "maccatalyst", "windows", "all" }, Platforms.Supported);
+	}
+
+	[Fact]
+	public void Supported_IsJoinableAsAUserFacingList()
+	{
+		// Regression: `string.Join(", ", Platforms.All)` bound to the IEnumerable<char>
+		// overload and rendered "a, l, l" in the unknown-platform warning.
+		Assert.Equal("android, ios, maccatalyst, windows, all", string.Join(", ", Platforms.Supported));
+	}
 }

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/StandardErrorToolsLoggerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/StandardErrorToolsLoggerTests.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Maui.Cli.Providers.Apple;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+/// <summary>
+/// The Apple tools library ships <c>ConsoleLogger</c>, which writes Info/Debug/Warning to
+/// stdout. That corrupts <c>--json</c> output, so the CLI substitutes this logger. These
+/// tests pin the behaviour that keeps stdout clean.
+/// </summary>
+public class StandardErrorToolsLoggerTests
+{
+	[Fact]
+	public void LogInfo_WritesToTheConfiguredWriter()
+	{
+		var writer = new StringWriter();
+		var logger = new StandardErrorToolsLogger(writer);
+
+		logger.LogInfo("Executing: {0}", "/usr/bin/xcrun");
+
+		Assert.Equal($"Info: Executing: /usr/bin/xcrun{Environment.NewLine}", writer.ToString());
+	}
+
+	[Fact]
+	public void LogWarning_WritesWarningPrefix()
+	{
+		var writer = new StringWriter();
+		var logger = new StandardErrorToolsLogger(writer);
+
+		logger.LogWarning("Xcode {0} is unsupported", "12.0");
+
+		Assert.Equal($"Warning: Xcode 12.0 is unsupported{Environment.NewLine}", writer.ToString());
+	}
+
+	[Fact]
+	public void LogError_WithoutException_WritesErrorPrefix()
+	{
+		var writer = new StringWriter();
+		var logger = new StandardErrorToolsLogger(writer);
+
+		logger.LogError("simctl failed", null);
+
+		Assert.Equal($"Error: simctl failed{Environment.NewLine}", writer.ToString());
+	}
+
+	[Fact]
+	public void LogError_WithException_IncludesTheException()
+	{
+		var writer = new StringWriter();
+		var logger = new StandardErrorToolsLogger(writer);
+
+		logger.LogError("simctl failed", new InvalidOperationException("boom"));
+
+		var output = writer.ToString();
+		Assert.StartsWith("Error: simctl failed", output);
+		Assert.Contains("boom", output);
+	}
+
+	[Fact]
+	public void LogDebug_IsSuppressedByDefault()
+	{
+		var writer = new StringWriter();
+		var logger = new StandardErrorToolsLogger(writer);
+
+		logger.LogDebug("noisy detail");
+
+		Assert.Equal(string.Empty, writer.ToString());
+	}
+
+	[Fact]
+	public void LogDebug_IsWrittenWhenVerbose()
+	{
+		var writer = new StringWriter();
+		var logger = new StandardErrorToolsLogger(writer, verbose: true);
+
+		logger.LogDebug("noisy detail");
+
+		Assert.Equal($"Debug: noisy detail{Environment.NewLine}", writer.ToString());
+	}
+
+	[Fact]
+	public void LogDebug_FollowsDefaultVerboseWhenNotSpecified()
+	{
+		// `maui --verbose ...` has to reach providers built by DI, which never see the
+		// parse result, so verbosity is published through a static default.
+		var original = StandardErrorToolsLogger.DefaultVerbose;
+
+		try
+		{
+			StandardErrorToolsLogger.DefaultVerbose = true;
+
+			var writer = new StringWriter();
+			new StandardErrorToolsLogger(writer).LogDebug("noisy detail");
+
+			Assert.Equal($"Debug: noisy detail{Environment.NewLine}", writer.ToString());
+		}
+		finally
+		{
+			StandardErrorToolsLogger.DefaultVerbose = original;
+		}
+	}
+
+	[Fact]
+	public void ExplicitVerbose_OverridesDefaultVerbose()
+	{
+		var original = StandardErrorToolsLogger.DefaultVerbose;
+
+		try
+		{
+			StandardErrorToolsLogger.DefaultVerbose = true;
+
+			var writer = new StringWriter();
+			new StandardErrorToolsLogger(writer, verbose: false).LogDebug("noisy detail");
+
+			Assert.Equal(string.Empty, writer.ToString());
+		}
+		finally
+		{
+			StandardErrorToolsLogger.DefaultVerbose = original;
+		}
+	}
+
+	[Fact]
+	public void Log_MalformedFormatString_FallsBackToRawMessage()
+	{
+		// Upstream messages sometimes contain literal braces (paths, JSON); a bad template
+		// must not take the command down.
+		var writer = new StringWriter();
+		var logger = new StandardErrorToolsLogger(writer);
+
+		logger.LogInfo("unbalanced {brace", "arg");
+
+		Assert.Equal($"Info: unbalanced {{brace{Environment.NewLine}", writer.ToString());
+	}
+
+	[Fact]
+	public void Log_MessageWithBracesAndNoArgs_IsNotFormatted()
+	{
+		var writer = new StringWriter();
+		var logger = new StandardErrorToolsLogger(writer);
+
+		logger.LogInfo("{\"key\": \"value\"}");
+
+		Assert.Equal($"Info: {{\"key\": \"value\"}}{Environment.NewLine}", writer.ToString());
+	}
+
+	[Fact]
+	public void DefaultWriter_IsStandardError()
+	{
+		var stdout = new StringWriter();
+		var stderr = new StringWriter();
+		var originalOut = Console.Out;
+		var originalError = Console.Error;
+
+		try
+		{
+			Console.SetOut(stdout);
+			Console.SetError(stderr);
+
+			// Constructed after the redirect so the default Console.Error is the fake.
+			new StandardErrorToolsLogger().LogInfo("hello");
+		}
+		finally
+		{
+			Console.SetOut(originalOut);
+			Console.SetError(originalError);
+		}
+
+		Assert.Equal(string.Empty, stdout.ToString());
+		Assert.Equal($"Info: hello{Environment.NewLine}", stderr.ToString());
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/StandardErrorToolsLoggerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/StandardErrorToolsLoggerTests.cs
@@ -60,10 +60,10 @@ public class StandardErrorToolsLoggerTests
 	}
 
 	[Fact]
-	public void LogDebug_IsSuppressedByDefault()
+	public void LogDebug_IsSuppressedWhenNotVerbose()
 	{
 		var writer = new StringWriter();
-		var logger = new StandardErrorToolsLogger(writer);
+		var logger = new StandardErrorToolsLogger(writer, verbose: false);
 
 		logger.LogDebug("noisy detail");
 
@@ -116,6 +116,31 @@ public class StandardErrorToolsLoggerTests
 			new StandardErrorToolsLogger(writer, verbose: false).LogDebug("noisy detail");
 
 			Assert.Equal(string.Empty, writer.ToString());
+		}
+		finally
+		{
+			StandardErrorToolsLogger.DefaultVerbose = original;
+		}
+	}
+
+	[Fact]
+	public void LogDebug_FollowsDefaultVerboseSetAfterConstruction()
+	{
+		// AppleProvider is a DI singleton, so its logger can be built before Program publishes
+		// the --verbose flag. Verbosity is read per call so that ordering does not matter.
+		var original = StandardErrorToolsLogger.DefaultVerbose;
+
+		try
+		{
+			StandardErrorToolsLogger.DefaultVerbose = false;
+
+			var writer = new StringWriter();
+			var logger = new StandardErrorToolsLogger(writer);
+
+			StandardErrorToolsLogger.DefaultVerbose = true;
+			logger.LogDebug("noisy detail");
+
+			Assert.Equal($"Debug: noisy detail{Environment.NewLine}", writer.ToString());
 		}
 		finally
 		{

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/StandardErrorToolsLoggerTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/StandardErrorToolsLoggerTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Cli.UnitTests;
 /// stdout. That corrupts <c>--json</c> output, so the CLI substitutes this logger. These
 /// tests pin the behaviour that keeps stdout clean.
 /// </summary>
+[Collection("StandardErrorToolsLogger static state")]
 public class StandardErrorToolsLoggerTests
 {
 	[Fact]

--- a/src/Cli/Microsoft.Maui.Cli/Commands/DeviceCommand.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/DeviceCommand.cs
@@ -25,7 +25,11 @@ public static class DeviceCommand
 
 	static Command CreateListCommand()
 	{
-		var platformOption = new Option<string>("--platform") { Description = "Filter by platform (android, apple, windows, all)", DefaultValueFactory = _ => "all" };
+		var platformOption = new Option<string>("--platform")
+		{
+			Description = $"Only query the providers for this platform ({string.Join(", ", Platforms.Supported)})",
+			DefaultValueFactory = _ => Platforms.All
+		};
 		var command = new Command("list", "List available devices")
 		{
 			platformOption
@@ -36,19 +40,19 @@ public static class DeviceCommand
 			var deviceManager = Program.DeviceManager;
 			var formatter = Program.GetFormatter(parseResult);
 			var useJson = parseResult.GetValue(GlobalOptions.JsonOption);
-			var platform = Platforms.Normalize(parseResult.GetValue(platformOption) ?? "all");
+			var platform = Platforms.Normalize(parseResult.GetValue(platformOption) ?? Platforms.All);
 
-			if (platform != "all" && !Platforms.IsValid(platform))
+			if (!Platforms.IsValid(platform))
 			{
-				formatter.WriteWarning($"Unknown platform '{platform}'. Valid values: {string.Join(", ", Platforms.All)}");
+				formatter.WriteWarning($"Unknown platform '{platform}'. Valid values: {string.Join(", ", Platforms.Supported)}");
 				return 1;
 			}
 
 			try
 			{
-				var devices = platform == "all"
+				var devices = platform == Platforms.All
 					? await deviceManager.GetAllDevicesAsync(cancellationToken)
-					: await deviceManager.GetDevicesByPlatformAsync(platform!, cancellationToken);
+					: await deviceManager.GetDevicesByPlatformAsync(platform, cancellationToken);
 
 				if (useJson)
 				{

--- a/src/Cli/Microsoft.Maui.Cli/Commands/DeviceCommand.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/DeviceCommand.cs
@@ -62,7 +62,7 @@ public static class DeviceCommand
 				{
 					if (!devices.Any())
 					{
-						formatter.WriteWarning(DeviceManager.HasProviderFor(platform)
+						formatter.WriteWarning(deviceManager.HasProviderFor(platform)
 							? "No devices found."
 							: $"No devices found: listing '{platform}' devices is not supported yet.");
 						return 0;

--- a/src/Cli/Microsoft.Maui.Cli/Commands/DeviceCommand.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/DeviceCommand.cs
@@ -62,7 +62,9 @@ public static class DeviceCommand
 				{
 					if (!devices.Any())
 					{
-						formatter.WriteWarning("No devices found.");
+						formatter.WriteWarning(DeviceManager.HasProviderFor(platform)
+							? "No devices found."
+							: $"No devices found: listing '{platform}' devices is not supported yet.");
 						return 0;
 					}
 

--- a/src/Cli/Microsoft.Maui.Cli/Models/Platforms.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Models/Platforms.cs
@@ -14,6 +14,12 @@ public static class Platforms
 	public const string Windows = "windows";
 	public const string All = "all";
 
+	/// <summary>
+	/// Every value accepted by a <c>--platform</c> option, in the order they should be
+	/// listed to users. <see cref="All"/> is a wildcard rather than a real platform.
+	/// </summary>
+	public static readonly string[] Supported = [Android, iOS, MacCatalyst, Windows, All];
+
 	public static bool IsValid(string? platform) => platform?.ToLowerInvariant() switch
 	{
 		Android or iOS or MacCatalyst or Windows or All => true,

--- a/src/Cli/Microsoft.Maui.Cli/Program.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Program.cs
@@ -53,6 +53,10 @@ public class Program
 
 		var parseResult = rootCommand.Parse(args);
 
+		// Providers are resolved from DI and cannot see the parse result, so publish the
+		// verbosity they need before any command runs.
+		Providers.Apple.StandardErrorToolsLogger.DefaultVerbose = IsVerbose(parseResult);
+
 		try
 		{
 			var exitCode = await parseResult.InvokeAsync();

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/AndroidProvider.cs
@@ -229,6 +229,9 @@ public class AndroidProvider : IAndroidProvider
 		return checks;
 	}
 
+	/// <inheritdoc />
+	public IReadOnlyList<string> SupportedPlatforms { get; } = [Platforms.Android];
+
 	public async Task<List<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
 	{
 		if (!_adb.IsAvailable)

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Android/IAndroidProvider.cs
@@ -41,8 +41,23 @@ public interface IAndroidProvider : IDisposable
 	Task<List<HealthCheck>> CheckHealthAsync(CancellationToken cancellationToken = default);
 
 	/// <summary>
+	/// The platforms <see cref="GetDevicesAsync"/> can currently produce devices for.
+	/// </summary>
+	/// <remarks>
+	/// Declared by the provider rather than by its callers so the two cannot drift: a device
+	/// manager uses this to decide whether to query this provider at all, and then filters the
+	/// results on the same platform. If an implementation starts tagging devices with a new
+	/// platform it must list it here, otherwise those devices are never asked for.
+	/// </remarks>
+	IReadOnlyList<string> SupportedPlatforms { get; }
+
+	/// <summary>
 	/// Lists connected Android devices and running emulators.
 	/// </summary>
+	/// <remarks>
+	/// Every returned device must be tagged with a platform listed in
+	/// <see cref="SupportedPlatforms"/>, or it will be filtered out downstream.
+	/// </remarks>
 	Task<List<Device>> GetDevicesAsync(CancellationToken cancellationToken = default);
 
 	/// <summary>

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
@@ -505,6 +505,15 @@ public class AppleProvider : IAppleProvider
 		}, cancellationToken);
 	}
 
+	/// <inheritdoc />
+	/// <remarks>
+	/// Scoped to iOS because <see cref="GetDevices"/> tags every simulator with
+	/// <see cref="Platforms.iOS"/>. tvOS/watchOS/visionOS simulators are returned by
+	/// <c>simctl</c> but are not yet recognized in the shared Platforms model; when they are,
+	/// add them both here and to the tagging below.
+	/// </remarks>
+	public IReadOnlyList<string> SupportedPlatforms { get; } = [Platforms.iOS];
+
 	public List<Device> GetDevices()
 	{
 		if (_simulatorService is null)

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/AppleProvider.cs
@@ -30,7 +30,9 @@ public class AppleProvider : IAppleProvider
 		if (!PlatformDetector.IsMacOS)
 			return;
 
-		var logger = ConsoleLogger.Instance;
+		// Deliberately not ConsoleLogger.Instance: it writes Info/Debug/Warning to stdout,
+		// which corrupts --json output. See StandardErrorToolsLogger.
+		var logger = new StandardErrorToolsLogger();
 		_xcodeManager = new XcodeManager(logger);
 		_simulatorService = new SimulatorService(logger);
 		_runtimeService = new RuntimeService(logger);

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/IAppleProvider.cs
@@ -191,8 +191,23 @@ public interface IAppleProvider
 	Task<AppleInstallResult> InstallEnvironmentAsync(IEnumerable<string>? platforms = null, bool dryRun = false, CancellationToken cancellationToken = default);
 
 	/// <summary>
+	/// The platforms <see cref="GetDevices"/> can currently produce devices for.
+	/// </summary>
+	/// <remarks>
+	/// Declared by the provider rather than by its callers so the two cannot drift: a device
+	/// manager uses this to decide whether to query this provider at all, and then filters the
+	/// results on the same platform. If an implementation starts tagging devices with a new
+	/// platform it must list it here, otherwise those devices are never asked for.
+	/// </remarks>
+	IReadOnlyList<string> SupportedPlatforms { get; }
+
+	/// <summary>
 	/// Lists simulator devices as <see cref="Device"/> models for device manager integration.
 	/// </summary>
+	/// <remarks>
+	/// Every returned device must be tagged with a platform listed in
+	/// <see cref="SupportedPlatforms"/>, or it will be filtered out downstream.
+	/// </remarks>
 	List<Device> GetDevices();
 }
 

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/StandardErrorToolsLogger.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/StandardErrorToolsLogger.cs
@@ -24,11 +24,23 @@ public sealed class StandardErrorToolsLogger : ICustomLogger
 	readonly TextWriter _writer;
 	readonly bool? _verbose;
 
+	static volatile bool s_defaultVerbose;
+
 	/// <summary>
 	/// Verbosity applied to loggers created without an explicit value. Set once from the global
 	/// <c>--verbose</c> flag, because providers are resolved from DI and cannot see the parse result.
 	/// </summary>
-	public static bool DefaultVerbose { get; set; }
+	/// <remarks>
+	/// Process-global mutable state, so the backing field is <c>volatile</c>: it is written on the
+	/// main thread in <c>Program.Main</c> and read from whatever thread a command's async
+	/// continuation lands on. Tests that mutate it must join the
+	/// <c>StandardErrorToolsLogger static state</c> collection so they stay serialized.
+	/// </remarks>
+	public static bool DefaultVerbose
+	{
+		get => s_defaultVerbose;
+		set => s_defaultVerbose = value;
+	}
 
 	public StandardErrorToolsLogger(TextWriter? writer = null, bool? verbose = null)
 	{

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/StandardErrorToolsLogger.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/StandardErrorToolsLogger.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.Cli.Providers.Apple;
 public sealed class StandardErrorToolsLogger : ICustomLogger
 {
 	readonly TextWriter _writer;
+	readonly bool? _verbose;
 
 	/// <summary>
 	/// Verbosity applied to loggers created without an explicit value. Set once from the global
@@ -32,13 +33,18 @@ public sealed class StandardErrorToolsLogger : ICustomLogger
 	public StandardErrorToolsLogger(TextWriter? writer = null, bool? verbose = null)
 	{
 		_writer = writer ?? Console.Error;
-		Verbose = verbose ?? DefaultVerbose;
+		_verbose = verbose;
 	}
 
 	/// <summary>
 	/// When false, <see cref="LogDebug"/> messages are suppressed.
 	/// </summary>
-	public bool Verbose { get; }
+	/// <remarks>
+	/// Read through to <see cref="DefaultVerbose"/> on every access rather than captured in the
+	/// constructor, so a logger built before the global <c>--verbose</c> flag is published still
+	/// honours it.
+	/// </remarks>
+	public bool Verbose => _verbose ?? DefaultVerbose;
 
 	public void LogError(string message, Exception? exception)
 	{

--- a/src/Cli/Microsoft.Maui.Cli/Providers/Apple/StandardErrorToolsLogger.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Providers/Apple/StandardErrorToolsLogger.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Xamarin.MacDev;
+
+namespace Microsoft.Maui.Cli.Providers.Apple;
+
+/// <summary>
+/// Routes <c>Xamarin.Apple.Tools.MaciOS</c> diagnostics to stderr.
+/// </summary>
+/// <remarks>
+/// The shipped <see cref="ConsoleLogger"/> writes Info, Debug and Warning to <b>stdout</b>
+/// (only Error goes to stderr). That pollutes machine-readable output: with <c>--json</c> the
+/// CLI would emit lines such as <c>Info: Executing: /usr/bin/xcrun simctl list devices ...</c>
+/// ahead of the JSON document, so a plain <c>JSON.parse(stdout)</c> fails and consumers have to
+/// scrape the payload back out.
+///
+/// Diagnostics are never part of a command's result, so they always belong on stderr regardless
+/// of the output format. Debug messages are dropped unless <see cref="Verbose"/> is set.
+/// </remarks>
+public sealed class StandardErrorToolsLogger : ICustomLogger
+{
+	readonly TextWriter _writer;
+
+	/// <summary>
+	/// Verbosity applied to loggers created without an explicit value. Set once from the global
+	/// <c>--verbose</c> flag, because providers are resolved from DI and cannot see the parse result.
+	/// </summary>
+	public static bool DefaultVerbose { get; set; }
+
+	public StandardErrorToolsLogger(TextWriter? writer = null, bool? verbose = null)
+	{
+		_writer = writer ?? Console.Error;
+		Verbose = verbose ?? DefaultVerbose;
+	}
+
+	/// <summary>
+	/// When false, <see cref="LogDebug"/> messages are suppressed.
+	/// </summary>
+	public bool Verbose { get; }
+
+	public void LogError(string message, Exception? exception)
+	{
+		Write("Error", message);
+
+		if (exception is not null)
+			_writer.WriteLine(exception);
+	}
+
+	public void LogWarning(string message, params object?[] args) => Write("Warning", message, args);
+
+	public void LogInfo(string message, params object?[] args) => Write("Info", message, args);
+
+	public void LogDebug(string message, params object?[] args)
+	{
+		if (Verbose)
+			Write("Debug", message, args);
+	}
+
+	void Write(string level, string message, params object?[] args)
+	{
+		// The upstream logger uses composite formatting; a malformed template must not take
+		// the whole command down, so fall back to the raw message when formatting fails.
+		string text;
+		try
+		{
+			text = args is { Length: > 0 } ? string.Format(CultureInfo.InvariantCulture, message, args) : message;
+		}
+		catch (FormatException)
+		{
+			text = message;
+		}
+
+		_writer.WriteLine($"{level}: {text}");
+	}
+}

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -28,18 +28,6 @@ public class DeviceManager : IDeviceManager
 		=> await GetDevicesForPlatformAsync(Platforms.All, cancellationToken);
 
 	/// <summary>
-	/// The platforms each provider can currently produce devices for, keyed by provider.
-	/// </summary>
-	/// <remarks>
-	/// These lists are what make <c>--platform &lt;p&gt;</c> query a provider at all, so they must
-	/// stay in lockstep with the platforms each provider actually tags its devices with. Adding
-	/// Mac host support to <c>AppleProvider.GetDevices</c>, for example, means adding
-	/// <see cref="Platforms.MacCatalyst"/> here, otherwise those devices are silently dropped.
-	/// </remarks>
-	static readonly string[] s_androidProviderPlatforms = [Platforms.Android];
-	static readonly string[] s_appleProviderPlatforms = [Platforms.iOS];
-
-	/// <summary>
 	/// Collects devices, querying only the providers that can produce devices for
 	/// <paramref name="normalizedPlatform"/>.
 	/// </summary>
@@ -57,10 +45,10 @@ public class DeviceManager : IDeviceManager
 	{
 		var devices = new List<Device>();
 
-		if (QueriesAndroid(normalizedPlatform))
+		if (Queries(_androidProvider?.SupportedPlatforms, normalizedPlatform))
 			await AddAndroidDevicesAsync(devices, cancellationToken);
 
-		if (QueriesApple(normalizedPlatform))
+		if (Queries(_appleProvider?.SupportedPlatforms, normalizedPlatform))
 			AddAppleDevices(devices);
 
 		// TODO: Get Windows devices when WindowsProvider is implemented
@@ -69,33 +57,45 @@ public class DeviceManager : IDeviceManager
 	}
 
 	/// <summary>
-	/// Whether any provider can currently produce devices for <paramref name="platform"/>.
+	/// Whether any registered provider can currently produce devices for
+	/// <paramref name="platform"/>.
 	/// </summary>
 	/// <remarks>
+	/// Answered from the providers' own <c>SupportedPlatforms</c>, so it cannot disagree with
+	/// which providers <see cref="GetDevicesByPlatformAsync"/> actually queries.
+	/// <para>
 	/// Mac Catalyst and Windows are valid platforms with no backing provider, so they always
 	/// yield zero devices. Callers can use this to tell "not supported yet" apart from
 	/// "the provider ran and found nothing".
+	/// </para>
 	/// </remarks>
-	public static bool HasProviderFor(string? platform)
+	public bool HasProviderFor(string? platform)
 	{
 		var normalized = Platforms.Normalize(platform);
-		return QueriesAndroid(normalized) || QueriesApple(normalized);
+		return Queries(_androidProvider?.SupportedPlatforms, normalized)
+			|| Queries(_appleProvider?.SupportedPlatforms, normalized);
 	}
 
 	/// <summary>
-	/// Whether the Android provider can produce devices for the given normalized platform.
+	/// Whether a provider declaring <paramref name="providerPlatforms"/> should be queried for
+	/// the given normalized platform. An absent provider is never queried.
 	/// </summary>
-	internal static bool QueriesAndroid(string normalizedPlatform)
-		=> Queries(s_androidProviderPlatforms, normalizedPlatform);
+	static bool Queries(IReadOnlyList<string>? providerPlatforms, string normalizedPlatform)
+	{
+		if (providerPlatforms is null)
+			return false;
 
-	/// <summary>
-	/// Whether the Apple provider can produce devices for the given normalized platform.
-	/// </summary>
-	internal static bool QueriesApple(string normalizedPlatform)
-		=> Queries(s_appleProviderPlatforms, normalizedPlatform);
+		if (normalizedPlatform == Platforms.All)
+			return true;
 
-	static bool Queries(string[] providerPlatforms, string normalizedPlatform)
-		=> normalizedPlatform == Platforms.All || Array.IndexOf(providerPlatforms, normalizedPlatform) >= 0;
+		for (var i = 0; i < providerPlatforms.Count; i++)
+		{
+			if (providerPlatforms[i] == normalizedPlatform)
+				return true;
+		}
+
+		return false;
+	}
 
 	async Task AddAndroidDevicesAsync(List<Device> devices, CancellationToken cancellationToken)
 	{

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -25,12 +25,27 @@ public class DeviceManager : IDeviceManager
 	}
 
 	public async Task<IReadOnlyList<Device>> GetAllDevicesAsync(CancellationToken cancellationToken = default)
-		=> await GetDevicesAsync(Platforms.All, cancellationToken);
+		=> await GetDevicesForPlatformAsync(Platforms.All, cancellationToken);
+
+	/// <summary>
+	/// The platforms each provider can currently produce devices for, keyed by provider.
+	/// </summary>
+	/// <remarks>
+	/// These lists are what make <c>--platform &lt;p&gt;</c> query a provider at all, so they must
+	/// stay in lockstep with the platforms each provider actually tags its devices with. Adding
+	/// Mac host support to <c>AppleProvider.GetDevices</c>, for example, means adding
+	/// <see cref="Platforms.MacCatalyst"/> here, otherwise those devices are silently dropped.
+	/// </remarks>
+	static readonly string[] s_androidProviderPlatforms = [Platforms.Android];
+	static readonly string[] s_appleProviderPlatforms = [Platforms.iOS];
 
 	/// <summary>
 	/// Collects devices, querying only the providers that can produce devices for
-	/// <paramref name="platform"/>.
+	/// <paramref name="normalizedPlatform"/>.
 	/// </summary>
+	/// <param name="normalizedPlatform">
+	/// A platform that has already been through <see cref="Platforms.Normalize"/>.
+	/// </param>
 	/// <remarks>
 	/// Provider selection is deliberately done *before* enumeration rather than by filtering
 	/// the combined result. Querying a provider is expensive and can hang: on macOS the Apple
@@ -38,15 +53,14 @@ public class DeviceManager : IDeviceManager
 	/// number of installed runtimes and blocks indefinitely when CoreSimulator is wedged.
 	/// Asking for Android devices must never pay that cost.
 	/// </remarks>
-	async Task<IReadOnlyList<Device>> GetDevicesAsync(string? platform, CancellationToken cancellationToken)
+	async Task<IReadOnlyList<Device>> GetDevicesForPlatformAsync(string normalizedPlatform, CancellationToken cancellationToken)
 	{
-		var normalized = Platforms.Normalize(platform);
 		var devices = new List<Device>();
 
-		if (QueriesAndroid(normalized))
+		if (QueriesAndroid(normalizedPlatform))
 			await AddAndroidDevicesAsync(devices, cancellationToken);
 
-		if (QueriesApple(normalized))
+		if (QueriesApple(normalizedPlatform))
 			AddAppleDevices(devices);
 
 		// TODO: Get Windows devices when WindowsProvider is implemented
@@ -55,28 +69,33 @@ public class DeviceManager : IDeviceManager
 	}
 
 	/// <summary>
-	/// Whether the Android provider can produce devices for <paramref name="platform"/>.
+	/// Whether any provider can currently produce devices for <paramref name="platform"/>.
 	/// </summary>
-	internal static bool QueriesAndroid(string? platform)
+	/// <remarks>
+	/// Mac Catalyst and Windows are valid platforms with no backing provider, so they always
+	/// yield zero devices. Callers can use this to tell "not supported yet" apart from
+	/// "the provider ran and found nothing".
+	/// </remarks>
+	public static bool HasProviderFor(string? platform)
 	{
 		var normalized = Platforms.Normalize(platform);
-		return normalized is Platforms.All or Platforms.Android;
+		return QueriesAndroid(normalized) || QueriesApple(normalized);
 	}
 
 	/// <summary>
-	/// Whether the Apple provider can produce devices for <paramref name="platform"/>.
+	/// Whether the Android provider can produce devices for the given normalized platform.
 	/// </summary>
-	/// <remarks>
-	/// The Apple provider currently only surfaces iOS simulators (see
-	/// <c>AppleProvider.GetDevices</c>), so Mac Catalyst and Windows are intentionally excluded:
-	/// running <c>simctl</c> for them costs seconds and can only ever return zero matches.
-	/// Revisit this when the provider starts reporting Mac hosts or physical devices.
-	/// </remarks>
-	internal static bool QueriesApple(string? platform)
-	{
-		var normalized = Platforms.Normalize(platform);
-		return normalized is Platforms.All or Platforms.iOS;
-	}
+	internal static bool QueriesAndroid(string normalizedPlatform)
+		=> Queries(s_androidProviderPlatforms, normalizedPlatform);
+
+	/// <summary>
+	/// Whether the Apple provider can produce devices for the given normalized platform.
+	/// </summary>
+	internal static bool QueriesApple(string normalizedPlatform)
+		=> Queries(s_appleProviderPlatforms, normalizedPlatform);
+
+	static bool Queries(string[] providerPlatforms, string normalizedPlatform)
+		=> normalizedPlatform == Platforms.All || Array.IndexOf(providerPlatforms, normalizedPlatform) >= 0;
 
 	async Task AddAndroidDevicesAsync(List<Device> devices, CancellationToken cancellationToken)
 	{
@@ -270,7 +289,7 @@ public class DeviceManager : IDeviceManager
 	public async Task<IReadOnlyList<Device>> GetDevicesByPlatformAsync(string platform, CancellationToken cancellationToken = default)
 	{
 		var normalized = Platforms.Normalize(platform);
-		var devices = await GetDevicesAsync(normalized, cancellationToken);
+		var devices = await GetDevicesForPlatformAsync(normalized, cancellationToken);
 
 		if (normalized == Platforms.All)
 			return devices;

--- a/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/DeviceManager.cs
@@ -25,203 +25,257 @@ public class DeviceManager : IDeviceManager
 	}
 
 	public async Task<IReadOnlyList<Device>> GetAllDevicesAsync(CancellationToken cancellationToken = default)
+		=> await GetDevicesAsync(Platforms.All, cancellationToken);
+
+	/// <summary>
+	/// Collects devices, querying only the providers that can produce devices for
+	/// <paramref name="platform"/>.
+	/// </summary>
+	/// <remarks>
+	/// Provider selection is deliberately done *before* enumeration rather than by filtering
+	/// the combined result. Querying a provider is expensive and can hang: on macOS the Apple
+	/// provider shells out to <c>xcrun simctl list devices</c>, which takes 8-16s with a normal
+	/// number of installed runtimes and blocks indefinitely when CoreSimulator is wedged.
+	/// Asking for Android devices must never pay that cost.
+	/// </remarks>
+	async Task<IReadOnlyList<Device>> GetDevicesAsync(string? platform, CancellationToken cancellationToken)
 	{
+		var normalized = Platforms.Normalize(platform);
 		var devices = new List<Device>();
 
-		// Get Android devices
-		if (_androidProvider != null)
-		{
-			var androidDevices = await _androidProvider.GetDevicesAsync(cancellationToken);
-			devices.AddRange(androidDevices);
+		if (QueriesAndroid(normalized))
+			await AddAndroidDevicesAsync(devices, cancellationToken);
 
-			// Also get AVDs (virtual devices that may not be running)
-			var avds = await _androidProvider.GetAvdsAsync(cancellationToken);
-
-			// Track which running emulator entries we've already merged with an
-			// AVD, so we can pair "offline" emulator-NNNN serials (whose AVD name
-			// has not yet been resolved by adb) with locked AVDs as a fallback.
-			var mergedIndices = new HashSet<int>();
-
-			foreach (var avd in avds)
-			{
-				// First pass: match by AVD name (requires adb to have resolved it,
-				// which only happens once the device is fully online).
-				var runningIndex = devices.FindIndex(d =>
-					d.Platforms.Contains("android") &&
-					d.IsEmulator &&
-					(
-						(d.Details != null &&
-						 d.Details.TryGetPropertyValue("avd", out var avdName) &&
-						 string.Equals(avdName?.ToString(), avd.Name, StringComparison.OrdinalIgnoreCase))
-						||
-						string.Equals(d.EmulatorId, avd.Name, StringComparison.OrdinalIgnoreCase)
-					));
-
-				// Second pass: if this AVD has an active lock file it is currently
-				// starting / booting. Pair it with the first unmerged offline
-				// emulator-* serial that has no resolved AVD name — that is the
-				// device produced by this AVD's qemu instance.
-				//
-				// Known limitation: when multiple AVDs are booted at exactly the
-				// same moment, pairing happens by iteration order and names can
-				// be swapped across the resulting entries. We accept this rather
-				// than leaving duplicates, and a future improvement could read
-				// the emulator console port from the lock files to disambiguate.
-				if (runningIndex < 0 && avd.IsLocked)
-				{
-					for (var i = 0; i < devices.Count; i++)
-					{
-						if (mergedIndices.Contains(i))
-							continue;
-
-						var d = devices[i];
-						if (!d.Platforms.Contains("android") || !d.IsEmulator)
-							continue;
-
-						// Only pair with serials adb currently reports as Offline —
-						// an online/Booted/Connected emulator with a transient empty
-						// AVD name must not be hijacked by a locked AVD.
-						if (d.State != DeviceState.Offline)
-							continue;
-
-						var hasAvdName =
-							(d.Details != null &&
-							 d.Details.TryGetPropertyValue("avd", out var existingAvd) &&
-							 !string.IsNullOrEmpty(existingAvd?.ToString())) ||
-							!string.IsNullOrEmpty(d.EmulatorId);
-						if (hasAvdName)
-							continue;
-
-						runningIndex = i;
-						break;
-					}
-				}
-
-				// Extract metadata from system image path (e.g., "system-images;android-35;google_apis_playstore;arm64-v8a")
-				var (apiLevel, tagId, abi) = ParseSystemImage(avd.SystemImage);
-				var playStoreEnabled = tagId?.Contains("playstore", StringComparison.OrdinalIgnoreCase) ?? false;
-
-				if (runningIndex >= 0)
-				{
-					// Merge AVD metadata into the running emulator device
-					var running = devices[runningIndex];
-					var subModel = AndroidEnvironment.MapTagIdToSubModel(tagId, playStoreEnabled);
-					var details = running.Details?.DeepClone() as JsonObject ?? new JsonObject();
-					details["avd"] = avd.Name;
-					details["tag_id"] = tagId ?? "default";
-					details["target"] = avd.Target ?? "unknown";
-
-					// If the running device didn't have an AVD-resolved name yet
-					// (e.g. still offline/booting), prefer the AVD name as the
-					// display name while keeping the adb serial as the Id so
-					// subsequent adb commands still work.
-					var displayName = string.IsNullOrEmpty(running.EmulatorId) ? avd.Name : running.Name;
-					var state = running.State == DeviceState.Offline && avd.IsLocked
-						? DeviceState.Booting
-						: running.State;
-
-					// A locked AVD paired with an adb-visible serial means qemu
-					// is alive. Keep IsRunning in sync with the promoted State
-					// so we never surface "Booting + IsRunning=false", which is
-					// internally inconsistent and confuses consumers.
-					var isRunning = running.IsRunning
-						|| state == DeviceState.Booting
-						|| state == DeviceState.Booted
-						|| state == DeviceState.Connected;
-
-					devices[runningIndex] = running with
-					{
-						Name = displayName,
-						EmulatorId = avd.Name,
-						Model = string.IsNullOrWhiteSpace(avd.DeviceProfile) ? running.Model : avd.DeviceProfile,
-						Manufacturer = !string.IsNullOrWhiteSpace(avd.Manufacturer)
-							? avd.Manufacturer
-							: (running.Manufacturer ?? "Google"),
-						SubModel = subModel,
-						State = state,
-						IsRunning = isRunning,
-						Details = details
-					};
-					mergedIndices.Add(runningIndex);
-				}
-				else
-				{
-					var architecture = AndroidEnvironment.MapAbiToArchitecture(abi) ?? (PlatformDetector.IsArm64 ? "arm64" : "x64");
-					var resolvedAbi = abi ?? (PlatformDetector.IsArm64 ? "arm64-v8a" : "x86_64");
-					var versionName = AndroidEnvironment.MapApiLevelToVersion(apiLevel);
-					var subModel = AndroidEnvironment.MapTagIdToSubModel(tagId, playStoreEnabled);
-
-					// Lock files signal that the emulator qemu process is alive.
-					// They cannot distinguish "still booting" from "fully
-					// booted"; only adb can, via the Offline -> Online
-					// transition surfaced by the merge path above. When we
-					// reach this else branch adb listed no serial for this
-					// AVD - almost always because the emulator is in the
-					// early boot window before adb has registered it.
-					// Report Booting so users know it's not yet ready; on
-					// the next refresh the merge path will take over and
-					// surface Booted once adb is online.
-					//
-					// The less common cause is a healthy emulator with a
-					// broken adb server (blind to a fully booted device).
-					// That is a user-environment issue (restart adb) rather
-					// than something we can reliably detect from lock files.
-					// IsRunning stays false in this branch even when the AVD
-					// is locked: we have no adb serial, so the entry is NOT
-					// addressable via `adb -s <id>`. Consumers like the
-					// profile command filter on IsRunning and then pass
-					// device.Id to adb — marking this IsRunning=true would
-					// let `maui profile --device <avd_name>` auto-select an
-					// un-addressable target and fail downstream.
-					devices.Add(new Device
-					{
-						Id = avd.Name,
-						Name = avd.Name,
-						Platforms = new[] { "android" },
-						Type = DeviceType.Emulator,
-						State = avd.IsLocked ? DeviceState.Booting : DeviceState.Shutdown,
-						IsEmulator = true,
-						IsRunning = false,
-						ConnectionType = Models.ConnectionType.Local,
-						EmulatorId = avd.Name,
-						Model = avd.DeviceProfile,
-						SubModel = subModel,
-						Manufacturer = avd.Manufacturer ?? "Google",
-						Version = apiLevel,
-						VersionName = versionName,
-						Architecture = architecture,
-						PlatformArchitecture = resolvedAbi,
-						RuntimeIdentifiers = AndroidEnvironment.GetRuntimeIdentifiers(architecture),
-						Idiom = DeviceIdiom.Phone,
-						Details = new JsonObject
-						{
-							["avd"] = avd.Name,
-							["target"] = avd.Target ?? "unknown",
-							["api_level"] = apiLevel ?? "unknown",
-							["abi"] = resolvedAbi,
-							["tag_id"] = tagId ?? "default"
-						}
-					});
-				}
-			}
-		}
-
-		// Get Apple devices (simulators) when on macOS
-		if (_appleProvider != null)
-		{
-			var appleDevices = _appleProvider.GetDevices();
-			devices.AddRange(appleDevices);
-		}
+		if (QueriesApple(normalized))
+			AddAppleDevices(devices);
 
 		// TODO: Get Windows devices when WindowsProvider is implemented
 
 		return devices;
 	}
 
+	/// <summary>
+	/// Whether the Android provider can produce devices for <paramref name="platform"/>.
+	/// </summary>
+	internal static bool QueriesAndroid(string? platform)
+	{
+		var normalized = Platforms.Normalize(platform);
+		return normalized is Platforms.All or Platforms.Android;
+	}
+
+	/// <summary>
+	/// Whether the Apple provider can produce devices for <paramref name="platform"/>.
+	/// </summary>
+	/// <remarks>
+	/// The Apple provider currently only surfaces iOS simulators (see
+	/// <c>AppleProvider.GetDevices</c>), so Mac Catalyst and Windows are intentionally excluded:
+	/// running <c>simctl</c> for them costs seconds and can only ever return zero matches.
+	/// Revisit this when the provider starts reporting Mac hosts or physical devices.
+	/// </remarks>
+	internal static bool QueriesApple(string? platform)
+	{
+		var normalized = Platforms.Normalize(platform);
+		return normalized is Platforms.All or Platforms.iOS;
+	}
+
+	async Task AddAndroidDevicesAsync(List<Device> devices, CancellationToken cancellationToken)
+	{
+		if (_androidProvider is null)
+			return;
+
+		var androidDevices = await _androidProvider.GetDevicesAsync(cancellationToken);
+		devices.AddRange(androidDevices);
+
+		// Also get AVDs (virtual devices that may not be running)
+		var avds = await _androidProvider.GetAvdsAsync(cancellationToken);
+
+		// Track which running emulator entries we've already merged with an
+		// AVD, so we can pair "offline" emulator-NNNN serials (whose AVD name
+		// has not yet been resolved by adb) with locked AVDs as a fallback.
+		var mergedIndices = new HashSet<int>();
+
+		foreach (var avd in avds)
+		{
+			// First pass: match by AVD name (requires adb to have resolved it,
+			// which only happens once the device is fully online).
+			var runningIndex = devices.FindIndex(d =>
+				d.Platforms.Contains("android") &&
+				d.IsEmulator &&
+				(
+					(d.Details != null &&
+					 d.Details.TryGetPropertyValue("avd", out var avdName) &&
+					 string.Equals(avdName?.ToString(), avd.Name, StringComparison.OrdinalIgnoreCase))
+					||
+					string.Equals(d.EmulatorId, avd.Name, StringComparison.OrdinalIgnoreCase)
+				));
+
+			// Second pass: if this AVD has an active lock file it is currently
+			// starting / booting. Pair it with the first unmerged offline
+			// emulator-* serial that has no resolved AVD name — that is the
+			// device produced by this AVD's qemu instance.
+			//
+			// Known limitation: when multiple AVDs are booted at exactly the
+			// same moment, pairing happens by iteration order and names can
+			// be swapped across the resulting entries. We accept this rather
+			// than leaving duplicates, and a future improvement could read
+			// the emulator console port from the lock files to disambiguate.
+			if (runningIndex < 0 && avd.IsLocked)
+			{
+				for (var i = 0; i < devices.Count; i++)
+				{
+					if (mergedIndices.Contains(i))
+						continue;
+
+					var d = devices[i];
+					if (!d.Platforms.Contains("android") || !d.IsEmulator)
+						continue;
+
+					// Only pair with serials adb currently reports as Offline —
+					// an online/Booted/Connected emulator with a transient empty
+					// AVD name must not be hijacked by a locked AVD.
+					if (d.State != DeviceState.Offline)
+						continue;
+
+					var hasAvdName =
+						(d.Details != null &&
+						 d.Details.TryGetPropertyValue("avd", out var existingAvd) &&
+						 !string.IsNullOrEmpty(existingAvd?.ToString())) ||
+						!string.IsNullOrEmpty(d.EmulatorId);
+					if (hasAvdName)
+						continue;
+
+					runningIndex = i;
+					break;
+				}
+			}
+
+			// Extract metadata from system image path (e.g., "system-images;android-35;google_apis_playstore;arm64-v8a")
+			var (apiLevel, tagId, abi) = ParseSystemImage(avd.SystemImage);
+			var playStoreEnabled = tagId?.Contains("playstore", StringComparison.OrdinalIgnoreCase) ?? false;
+
+			if (runningIndex >= 0)
+			{
+				// Merge AVD metadata into the running emulator device
+				var running = devices[runningIndex];
+				var subModel = AndroidEnvironment.MapTagIdToSubModel(tagId, playStoreEnabled);
+				var details = running.Details?.DeepClone() as JsonObject ?? new JsonObject();
+				details["avd"] = avd.Name;
+				details["tag_id"] = tagId ?? "default";
+				details["target"] = avd.Target ?? "unknown";
+
+				// If the running device didn't have an AVD-resolved name yet
+				// (e.g. still offline/booting), prefer the AVD name as the
+				// display name while keeping the adb serial as the Id so
+				// subsequent adb commands still work.
+				var displayName = string.IsNullOrEmpty(running.EmulatorId) ? avd.Name : running.Name;
+				var state = running.State == DeviceState.Offline && avd.IsLocked
+					? DeviceState.Booting
+					: running.State;
+
+				// A locked AVD paired with an adb-visible serial means qemu
+				// is alive. Keep IsRunning in sync with the promoted State
+				// so we never surface "Booting + IsRunning=false", which is
+				// internally inconsistent and confuses consumers.
+				var isRunning = running.IsRunning
+					|| state == DeviceState.Booting
+					|| state == DeviceState.Booted
+					|| state == DeviceState.Connected;
+
+				devices[runningIndex] = running with
+				{
+					Name = displayName,
+					EmulatorId = avd.Name,
+					Model = string.IsNullOrWhiteSpace(avd.DeviceProfile) ? running.Model : avd.DeviceProfile,
+					Manufacturer = !string.IsNullOrWhiteSpace(avd.Manufacturer)
+						? avd.Manufacturer
+						: (running.Manufacturer ?? "Google"),
+					SubModel = subModel,
+					State = state,
+					IsRunning = isRunning,
+					Details = details
+				};
+				mergedIndices.Add(runningIndex);
+			}
+			else
+			{
+				var architecture = AndroidEnvironment.MapAbiToArchitecture(abi) ?? (PlatformDetector.IsArm64 ? "arm64" : "x64");
+				var resolvedAbi = abi ?? (PlatformDetector.IsArm64 ? "arm64-v8a" : "x86_64");
+				var versionName = AndroidEnvironment.MapApiLevelToVersion(apiLevel);
+				var subModel = AndroidEnvironment.MapTagIdToSubModel(tagId, playStoreEnabled);
+
+				// Lock files signal that the emulator qemu process is alive.
+				// They cannot distinguish "still booting" from "fully
+				// booted"; only adb can, via the Offline -> Online
+				// transition surfaced by the merge path above. When we
+				// reach this else branch adb listed no serial for this
+				// AVD - almost always because the emulator is in the
+				// early boot window before adb has registered it.
+				// Report Booting so users know it's not yet ready; on
+				// the next refresh the merge path will take over and
+				// surface Booted once adb is online.
+				//
+				// The less common cause is a healthy emulator with a
+				// broken adb server (blind to a fully booted device).
+				// That is a user-environment issue (restart adb) rather
+				// than something we can reliably detect from lock files.
+				// IsRunning stays false in this branch even when the AVD
+				// is locked: we have no adb serial, so the entry is NOT
+				// addressable via `adb -s <id>`. Consumers like the
+				// profile command filter on IsRunning and then pass
+				// device.Id to adb — marking this IsRunning=true would
+				// let `maui profile --device <avd_name>` auto-select an
+				// un-addressable target and fail downstream.
+				devices.Add(new Device
+				{
+					Id = avd.Name,
+					Name = avd.Name,
+					Platforms = new[] { "android" },
+					Type = DeviceType.Emulator,
+					State = avd.IsLocked ? DeviceState.Booting : DeviceState.Shutdown,
+					IsEmulator = true,
+					IsRunning = false,
+					ConnectionType = Models.ConnectionType.Local,
+					EmulatorId = avd.Name,
+					Model = avd.DeviceProfile,
+					SubModel = subModel,
+					Manufacturer = avd.Manufacturer ?? "Google",
+					Version = apiLevel,
+					VersionName = versionName,
+					Architecture = architecture,
+					PlatformArchitecture = resolvedAbi,
+					RuntimeIdentifiers = AndroidEnvironment.GetRuntimeIdentifiers(architecture),
+					Idiom = DeviceIdiom.Phone,
+					Details = new JsonObject
+					{
+						["avd"] = avd.Name,
+						["target"] = avd.Target ?? "unknown",
+						["api_level"] = apiLevel ?? "unknown",
+						["abi"] = resolvedAbi,
+						["tag_id"] = tagId ?? "default"
+					}
+				});
+			}
+		}
+	}
+
+	void AddAppleDevices(List<Device> devices)
+	{
+		if (_appleProvider is null)
+			return;
+
+		// Apple devices (simulators); the provider returns an empty list off macOS.
+		devices.AddRange(_appleProvider.GetDevices());
+	}
+
 	public async Task<IReadOnlyList<Device>> GetDevicesByPlatformAsync(string platform, CancellationToken cancellationToken = default)
 	{
-		var allDevices = await GetAllDevicesAsync(cancellationToken);
-		return allDevices.Where(d => d.Platforms.Any(p => p.Equals(platform, StringComparison.OrdinalIgnoreCase))).ToList();
+		var normalized = Platforms.Normalize(platform);
+		var devices = await GetDevicesAsync(normalized, cancellationToken);
+
+		if (normalized == Platforms.All)
+			return devices;
+
+		return devices.Where(d => d.Platforms.Any(p => p.Equals(normalized, StringComparison.OrdinalIgnoreCase))).ToList();
 	}
 
 	public async Task<Device?> GetDeviceByIdAsync(string deviceId, CancellationToken cancellationToken = default)

--- a/src/Cli/Microsoft.Maui.Cli/Services/IDeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/IDeviceManager.cs
@@ -25,10 +25,23 @@ public interface IDeviceManager
 	/// Valid platforms may have no backing provider (Mac Catalyst and Windows do not today), in
 	/// which case this returns an empty list rather than failing. Callers that want to report
 	/// "not supported yet" separately from "none found" can check
-	/// <see cref="DeviceManager.HasProviderFor"/>.
+	/// <see cref="HasProviderFor"/>.
 	/// </para>
 	/// </remarks>
 	Task<IReadOnlyList<Device>> GetDevicesByPlatformAsync(string platform, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Whether any registered provider can currently produce devices for
+	/// <paramref name="platform"/>. Accepts any value handled by
+	/// <see cref="Platforms.Normalize"/>.
+	/// </summary>
+	/// <remarks>
+	/// Lets callers distinguish "this platform has no backing provider yet" from "the provider
+	/// ran and found nothing", which are both an empty result from
+	/// <see cref="GetDevicesByPlatformAsync"/>.
+	/// </remarks>
+	bool HasProviderFor(string? platform);
+
 	Task<Device?> GetDeviceByIdAsync(string deviceId, CancellationToken cancellationToken = default);
 	Task<Device> GetRunningDeviceOrThrowAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Cli/Microsoft.Maui.Cli/Services/IDeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/IDeviceManager.cs
@@ -11,6 +11,17 @@ namespace Microsoft.Maui.Cli.Services;
 public interface IDeviceManager
 {
 	Task<IReadOnlyList<Device>> GetAllDevicesAsync(CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Returns the devices for <paramref name="platform"/>, querying only the providers that
+	/// can produce them. Accepts any value handled by <see cref="Platforms.Normalize"/>,
+	/// including <see cref="Platforms.All"/>.
+	/// </summary>
+	/// <remarks>
+	/// Implementations must not enumerate every provider and then filter: provider queries are
+	/// expensive (the Apple provider shells out to <c>simctl</c>) and asking for one platform
+	/// must never pay another platform's cost.
+	/// </remarks>
 	Task<IReadOnlyList<Device>> GetDevicesByPlatformAsync(string platform, CancellationToken cancellationToken = default);
 	Task<Device?> GetDeviceByIdAsync(string deviceId, CancellationToken cancellationToken = default);
 	Task<Device> GetRunningDeviceOrThrowAsync(CancellationToken cancellationToken = default);

--- a/src/Cli/Microsoft.Maui.Cli/Services/IDeviceManager.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Services/IDeviceManager.cs
@@ -21,6 +21,12 @@ public interface IDeviceManager
 	/// Implementations must not enumerate every provider and then filter: provider queries are
 	/// expensive (the Apple provider shells out to <c>simctl</c>) and asking for one platform
 	/// must never pay another platform's cost.
+	/// <para>
+	/// Valid platforms may have no backing provider (Mac Catalyst and Windows do not today), in
+	/// which case this returns an empty list rather than failing. Callers that want to report
+	/// "not supported yet" separately from "none found" can check
+	/// <see cref="DeviceManager.HasProviderFor"/>.
+	/// </para>
 	/// </remarks>
 	Task<IReadOnlyList<Device>> GetDevicesByPlatformAsync(string platform, CancellationToken cancellationToken = default);
 	Task<Device?> GetDeviceByIdAsync(string deviceId, CancellationToken cancellationToken = default);


### PR DESCRIPTION
Fixes #416

## The bug

`maui device list --platform android` still ran the Apple provider on macOS. `GetDevicesByPlatformAsync` called `GetAllDevicesAsync()` — which queried *every* provider — and then filtered the combined result:

```csharp
var allDevices = await GetAllDevicesAsync(cancellationToken);
return allDevices.Where(d => d.Platforms.Any(p => p.Equals(platform, ...))).ToList();
```

So asking for Android devices paid the full `xcrun simctl list devices` cost: 8–16s on a host with a normal number of runtimes, and an indefinite hang when CoreSimulator is wedged (the issue reports a SIGKILL at 90s, exit 137). The `dotnet-maui` VS Code extension calls this on every device-picker refresh, which broke Android F5 on macOS.

## The fix

Provider selection now happens *before* enumeration, and each provider declares which platforms it serves:

```csharp
async Task<IReadOnlyList<Device>> GetDevicesForPlatformAsync(string normalizedPlatform, CancellationToken ct)
{
    var devices = new List<Device>();

    if (Queries(_androidProvider?.SupportedPlatforms, normalizedPlatform))
        await AddAndroidDevicesAsync(devices, ct);

    if (Queries(_appleProvider?.SupportedPlatforms, normalizedPlatform))
        AddAppleDevices(devices);

    return devices;
}
```

The Android/AVD merge logic moves into `AddAndroidDevicesAsync` unchanged — most of the line count in `DeviceManager.cs` is re-indentation.

`GetDevicesByPlatformAsync` normalizes once up front, so aliases such as `apple` now select the right provider *and* match the right devices, and `all` returns everything instead of an empty list.

### Providers own their platform list

The obvious implementation is a lookup table in `DeviceManager` saying "the Apple provider serves iOS". That works, but it puts the list in a different file from the code it has to agree with — `AppleProvider.GetDevices()`, which tags every simulator `Platforms.iOS`. Extend the provider to surface tvOS or physical devices and those devices get **silently dropped**: the gate says don't query, and the post-filter removes anything that slips through.

So the declaration lives next to the tagging instead:

```csharp
// AppleProvider.cs, directly above GetDevices()
/// <remarks>
/// Scoped to iOS because GetDevices() tags every simulator with Platforms.iOS.
/// tvOS/watchOS/visionOS simulators are returned by simctl but are not yet recognized in the
/// shared Platforms model; when they are, add them both here and to the tagging below.
/// </remarks>
public IReadOnlyList<string> SupportedPlatforms { get; } = [Platforms.iOS];
```

`SupportedPlatforms` is an **abstract** member on `IAppleProvider` / `IAndroidProvider`, so a new provider that forgets it is a compile error rather than a silent empty list. `DeviceManager` holds no platform lists at all now, and `HasProviderFor` answers from the same source the gate reads, so the two cannot disagree.

> **Not a breaking change.** `Microsoft.Maui.Cli` ships as a `DotnetTool` package (`PackAsTool=true`, no `lib/` folder). NuGet rejects a `PackageReference` to it (NU1212), so no external assembly can implement these interfaces. All five implementers are in this repo.

## Secondary fix: `Info:` diagnostics no longer pollute stdout

The Apple tools library ships `Xamarin.MacDev.ConsoleLogger`, which writes Info, Debug and Warning to **stdout** and only Error to stderr (verified by reflection against `Xamarin.Apple.Tools.MaciOS` 1.0.0-preview.1.26301.3). With `--json` that put

```
Info: Executing: /usr/bin/xcrun simctl list devices --json --json-output=...
Info: Found 57 simulator device(s).
```

ahead of the JSON array, so a plain `JSON.parse(stdout)` failed and the VS Code extension only survived via a fragile `extractJson()` scrape.

New `StandardErrorToolsLogger : ICustomLogger` routes everything to stderr and replaces `ConsoleLogger.Instance` in `AppleProvider`.

## Bonus

`string.Join(", ", Platforms.All)` bound to the `IEnumerable<char>` overload, so the unknown-platform warning rendered as `a, l, l`. Added `Platforms.Supported` and used it for both the warning and the `--platform` option description.

## Verification (macOS)

| command | time | stderr | stdout |
|---|---|---|---|
| `device list --platform android --json` | 1.63s | **empty — simctl never ran** | clean JSON |
| `device list --platform ios --json` | — | `Info: Executing: xcrun simctl …` | `json.load` parses directly |
| `device list --platform maccatalyst --json` | 0.18s | empty | `[]` |
| `device list --json` (all) | 1.06s | — | android + ios |

## Tests

**847 CLI unit tests pass.** `dotnet build src/Cli/Cli.slnf` is clean, 0 warnings.

- `DeviceManagerTests` — tests assert on **provider invocation counts**, not just returned devices, so a regression that reintroduces filter-after-fan-out fails the suite. `FakeAndroidProvider` / `FakeAppleProvider` gained `GetDevicesCallCount` / `GetAvdsCallCount` and a settable `SupportedPlatforms`.
- `StandardErrorToolsLoggerTests` — stream routing, level prefixes, `Debug` gating, and malformed-format-template fallback.
- `PlatformsTests` — `Supported` stays in sync with `IsValid`, plus a regression test for the `a, l, l` join.

The drift tests are deliberately **falsifiable**: mutating `DeviceManager` to gate off a hardcoded `[Android, iOS]` list — exactly the bug the design prevents — turns 10 tests red, including all 3 new ones. An earlier version of these tests derived their input from the same list the gate read and could not fail for any value of it; those were replaced.

> ⚠️ Two unrelated tests fail on this branch **and on clean `main`**: `DevFlowCliCommandTests.UiGesture_Pinch_SendsScaleToGestureRoute` and `UiGesture_ReportsWhichTierHandledIt`. They came in with #431 and are locale-dependent — `Option<double?>` parses `--scale 2.0` with the current culture, so on a machine whose locale uses `,` as the decimal separator (`en_PT` here) the argument is rejected outright. CI is en-US, so it stays green there. Filed as #440; not touched by this PR.

## Judgement calls worth a look

1. **`maccatalyst` and `windows` query no provider.** `AppleProvider` declares `[Platforms.iOS]` because that is what it tags, so running simctl for Mac Catalyst would cost seconds for guaranteed-zero results. The non-JSON path now says `No devices found: listing 'maccatalyst' devices is not supported yet.` rather than an unexplained empty list; `--json` still emits a bare `[]` to keep stdout machine-parseable.
2. **Diagnostics go to stderr always**, not only under `--json`. The issue asked for "whenever `--json` is passed"; always-stderr is a superset, and diagnostics are never part of a command result.
3. **`--verbose` is published via a static.** `AppleProvider` is a DI singleton with no access to `ParseResult`, so `Program.Main` sets `StandardErrorToolsLogger.DefaultVerbose` right after parsing. `Verbose` is computed per call, so a logger built before the flag is published still honours it. `Debug:` lines previously always appeared on stdout; they are now gated behind `-v` / `--verbose`.