### PR TITLE
Harden AI chat default rendering and cancellation

### DIFF
--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/ContentContext.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/ContentContext.cs
@@ -14,14 +14,22 @@ namespace Microsoft.Maui.AI.Chat.Controls;
 public sealed class ContentContext
 {
     public ContentContext(AgentContext agentContext, ContentBlock block)
+        : this(agentContext, block, owner: null)
+    {
+    }
+
+    internal ContentContext(AgentContext agentContext, ContentBlock block, MessageListView? owner)
     {
         AgentContext = agentContext ?? throw new ArgumentNullException(nameof(agentContext));
         Block = block ?? throw new ArgumentNullException(nameof(block));
+        Owner = owner;
     }
 
     public AgentContext AgentContext { get; }
 
     public ContentBlock Block { get; }
+
+    internal MessageListView? Owner { get; }
 
     /// <summary>The role of this block (User, Assistant, Tool).</summary>
     public ChatRole? Role => Block.Role;

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/ContentTemplateSelector.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/ContentTemplateSelector.cs
@@ -6,10 +6,9 @@ namespace Microsoft.Maui.AI.Chat.Controls;
 /// registered template's <c>When(...)</c> and choosing the highest-priority match.
 /// </summary>
 /// <remarks>
-/// The registered templates act as an allow-list: a block is only rendered if some template matches it.
-/// When nothing matches, the block renders as an empty (zero-size) view — omitting a template is how you
-/// suppress a block kind (e.g. leave out <see cref="FunctionInvocationTemplate"/> to hide tool calls). To
-/// render unexpected blocks with a catch-all instead, register a low-priority <see cref="DefaultContentTemplate"/>.
+/// Consumer templates are evaluated before the built-in fallback tier, so any explicit match wins regardless
+/// of its numeric priority. Within each tier, the highest priority wins and declaration order breaks ties.
+/// When nothing matches, the block renders as an empty (zero-size) view.
 /// </remarks>
 public class ContentTemplateSelector : DataTemplateSelector
 {
@@ -20,15 +19,26 @@ public class ContentTemplateSelector : DataTemplateSelector
 
     public IList<ContentTemplate> Templates { get; } = new List<ContentTemplate>();
 
+    internal IList<ContentTemplate> FallbackTemplates { get; } = new List<ContentTemplate>();
+
     protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
     {
         if (item is not ContentContext context)
             return EmptyTemplate;
 
+        return SelectBestTemplate(Templates, context)?.GetTemplate()
+            ?? SelectBestTemplate(FallbackTemplates, context)?.GetTemplate()
+            ?? EmptyTemplate;
+    }
+
+    private static ContentTemplate? SelectBestTemplate(
+        IEnumerable<ContentTemplate> templates,
+        ContentContext context)
+    {
         ContentTemplate? selectedTemplate = null;
         var highestPriority = int.MinValue;
 
-        foreach (var template in Templates)
+        foreach (var template in templates)
         {
             if (!template.When(context))
                 continue;
@@ -41,6 +51,6 @@ public class ContentTemplateSelector : DataTemplateSelector
             }
         }
 
-        return selectedTemplate?.GetTemplate() ?? EmptyTemplate;
+        return selectedTemplate;
     }
 }

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Error/ErrorContentBlock.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Error/ErrorContentBlock.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Maui.AI.Chat.Controls;
 /// </remarks>
 public sealed class ErrorContentBlock : ContentBlock
 {
+    internal const string DefaultUserMessage = "Something went wrong. Please try again.";
+
     public ErrorContentBlock(string message)
     {
         Message = message;

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Error/ErrorContentTemplate.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Error/ErrorContentTemplate.cs
@@ -4,8 +4,8 @@ namespace Microsoft.Maui.AI.Chat.Controls;
 
 /// <summary>Matches an <see cref="ErrorContentBlock"/> and renders it as an error bubble.</summary>
 /// <remarks>
-/// <see cref="AgentContext"/> adds an <see cref="ErrorContentBlock"/> when a turn fails, so failures
-/// render inline as messages (in addition to <see cref="ConversationStatus.Error"/>).
+/// <see cref="MessageListView"/> projects an <see cref="ErrorContentBlock"/> when a turn fails, so failures
+/// render inline as messages without adding diagnostic details to the persisted conversation.
 /// </remarks>
 public class ErrorContentTemplate : ContentTemplate
 {

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Error/ErrorMessageView.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Error/ErrorMessageView.cs
@@ -10,6 +10,9 @@ public sealed class ErrorMessageView : ContentContextView
 
     public ErrorMessageView()
     {
+        SemanticProperties.SetDescription(this, "Chat error");
+        AutomationId = "ChatError";
+
         _label = new Label { TextColor = Color.FromArgb("#C75050") };
 
         Content = new Border

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Media/MediaContentView.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Media/MediaContentView.cs
@@ -34,6 +34,7 @@ public class MediaContentView : ContentContextView
                     Margin = new Thickness(0, 4),
                     HorizontalOptions = LayoutOptions.Start,
                 };
+                SemanticProperties.SetDescription(image, "Image attachment");
 
                 // Render from the raw bytes (efficient for large generated images).
                 var bytes = item.Data.ToArray();
@@ -44,12 +45,14 @@ public class MediaContentView : ContentContextView
             else
             {
                 // Non-image media — show as a label
-                _layout.Children.Add(new Label
+                var attachmentLabel = new Label
                 {
                     Text = $"📎 {item.MediaType ?? "file"} ({item.Data.Length} bytes)",
                     TextColor = Colors.Gray,
                     FontSize = 11,
-                });
+                };
+                SemanticProperties.SetDescription(attachmentLabel, attachmentLabel.Text);
+                _layout.Children.Add(attachmentLabel);
             }
         }
     }

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/TextContent/ChatMessageView.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/TextContent/ChatMessageView.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.AI.Chat;
 using Microsoft.Extensions.AI;
+using Microsoft.Maui.Controls.Shapes;
 
 namespace Microsoft.Maui.AI.Chat.Controls;
 
@@ -12,7 +13,11 @@ namespace Microsoft.Maui.AI.Chat.Controls;
 public class ChatMessageView : ContentContextView
 {
     public static readonly BindableProperty TextProperty =
-        BindableProperty.Create(nameof(Text), typeof(string), typeof(ChatMessageView));
+        BindableProperty.Create(
+            nameof(Text),
+            typeof(string),
+            typeof(ChatMessageView),
+            propertyChanged: OnAppearancePropertyChanged);
 
     public string? Text
     {
@@ -21,7 +26,11 @@ public class ChatMessageView : ContentContextView
     }
 
     public static readonly BindableProperty MessageRoleProperty =
-        BindableProperty.Create(nameof(MessageRole), typeof(string), typeof(ChatMessageView));
+        BindableProperty.Create(
+            nameof(MessageRole),
+            typeof(string),
+            typeof(ChatMessageView),
+            propertyChanged: OnAppearancePropertyChanged);
 
     public string? MessageRole
     {
@@ -47,7 +56,140 @@ public class ChatMessageView : ContentContextView
         set => SetValue(ShowTimestampProperty, value);
     }
 
+    public static readonly BindableProperty ShowAvatarsProperty =
+        BindableProperty.Create(nameof(ShowAvatars), typeof(bool), typeof(ChatMessageView), false);
+
+    public bool ShowAvatars
+    {
+        get => (bool)GetValue(ShowAvatarsProperty);
+        set => SetValue(ShowAvatarsProperty, value);
+    }
+
+    public static readonly BindableProperty AvatarSizeProperty =
+        BindableProperty.Create(nameof(AvatarSize), typeof(double), typeof(ChatMessageView), 28.0);
+
+    public double AvatarSize
+    {
+        get => (double)GetValue(AvatarSizeProperty);
+        set => SetValue(AvatarSizeProperty, value);
+    }
+
+    public static readonly BindableProperty UserDisplayNameProperty =
+        BindableProperty.Create(
+            nameof(UserDisplayName),
+            typeof(string),
+            typeof(ChatMessageView),
+            "You",
+            propertyChanged: OnAppearancePropertyChanged);
+
+    public string UserDisplayName
+    {
+        get => (string)GetValue(UserDisplayNameProperty);
+        set => SetValue(UserDisplayNameProperty, value);
+    }
+
+    public static readonly BindableProperty AssistantDisplayNameProperty =
+        BindableProperty.Create(
+            nameof(AssistantDisplayName),
+            typeof(string),
+            typeof(ChatMessageView),
+            "Assistant",
+            propertyChanged: OnAppearancePropertyChanged);
+
+    public string AssistantDisplayName
+    {
+        get => (string)GetValue(AssistantDisplayNameProperty);
+        set => SetValue(AssistantDisplayNameProperty, value);
+    }
+
+    public static readonly BindableProperty DisplayNameProperty =
+        BindableProperty.Create(nameof(DisplayName), typeof(string), typeof(ChatMessageView));
+
+    public string? DisplayName
+    {
+        get => (string?)GetValue(DisplayNameProperty);
+        private set => SetValue(DisplayNameProperty, value);
+    }
+
+    public static readonly BindableProperty AvatarTextProperty =
+        BindableProperty.Create(nameof(AvatarText), typeof(string), typeof(ChatMessageView));
+
+    public string? AvatarText
+    {
+        get => (string?)GetValue(AvatarTextProperty);
+        private set => SetValue(AvatarTextProperty, value);
+    }
+
+    public static readonly BindableProperty BubbleCornerRadiusProperty =
+        BindableProperty.Create(
+            nameof(BubbleCornerRadius),
+            typeof(double),
+            typeof(ChatMessageView),
+            16.0,
+            propertyChanged: OnAppearancePropertyChanged);
+
+    public double BubbleCornerRadius
+    {
+        get => (double)GetValue(BubbleCornerRadiusProperty);
+        set => SetValue(BubbleCornerRadiusProperty, value);
+    }
+
+    public static readonly BindableProperty BubbleCornerRadiiProperty =
+        BindableProperty.Create(
+            nameof(BubbleCornerRadii),
+            typeof(CornerRadius),
+            typeof(ChatMessageView),
+            new CornerRadius(16));
+
+    public CornerRadius BubbleCornerRadii
+    {
+        get => (CornerRadius)GetValue(BubbleCornerRadiiProperty);
+        private set => SetValue(BubbleCornerRadiiProperty, value);
+    }
+
+    public static readonly BindableProperty BubbleStrokeThicknessProperty =
+        BindableProperty.Create(nameof(BubbleStrokeThickness), typeof(double), typeof(ChatMessageView), 0.0);
+
+    public double BubbleStrokeThickness
+    {
+        get => (double)GetValue(BubbleStrokeThicknessProperty);
+        set => SetValue(BubbleStrokeThicknessProperty, value);
+    }
+
+    public static readonly BindableProperty BubbleStrokeColorProperty =
+        BindableProperty.Create(nameof(BubbleStrokeColor), typeof(Color), typeof(ChatMessageView));
+
+    public Color? BubbleStrokeColor
+    {
+        get => (Color?)GetValue(BubbleStrokeColorProperty);
+        set => SetValue(BubbleStrokeColorProperty, value);
+    }
+
+    public static readonly BindableProperty MaxBubbleWidthProperty =
+        BindableProperty.Create(nameof(MaxBubbleWidth), typeof(double), typeof(ChatMessageView), 340.0);
+
+    public double MaxBubbleWidth
+    {
+        get => (double)GetValue(MaxBubbleWidthProperty);
+        set => SetValue(MaxBubbleWidthProperty, value);
+    }
+
+    public static readonly BindableProperty SemanticDescriptionProperty =
+        BindableProperty.Create(nameof(SemanticDescription), typeof(string), typeof(ChatMessageView));
+
+    public string? SemanticDescription
+    {
+        get => (string?)GetValue(SemanticDescriptionProperty);
+        private set => SetValue(SemanticDescriptionProperty, value);
+    }
+
     private VisualElement? _stateRoot;
+    private MessageListView? _appearanceOwner;
+
+    public ChatMessageView()
+    {
+        AutomationId = "ChatMessage";
+    }
 
     protected override void RefreshFromContentContext()
     {
@@ -58,9 +200,8 @@ public class ChatMessageView : ContentContextView
         MessageRole = ContentContext.Role?.ToString();
         TimestampText = DateTimeOffset.Now.ToLocalTime().ToString("h:mm tt");
 
-        // Look up ancestor CopilotChatView for ShowTimestamps setting
-        var panel = FindAncestor<CopilotChatView>();
-        ShowTimestamp = panel?.ShowTimestamps ?? false;
+        BindAppearance(ContentContext.Owner);
+        RefreshComputedAppearance();
 
         ApplyRoleState();
     }
@@ -84,15 +225,75 @@ public class ChatMessageView : ContentContextView
         VisualStateManager.GoToState(_stateRoot ?? this, roleName);
     }
 
-    private T? FindAncestor<T>() where T : Element
+    private void BindAppearance(MessageListView? owner)
     {
-        Element? current = Parent;
-        while (current is not null)
+        if (owner is null)
+            return;
+
+        if (ReferenceEquals(owner, _appearanceOwner))
+            return;
+
+        if (_appearanceOwner is not null)
         {
-            if (current is T found)
-                return found;
-            current = current.Parent;
+            RemoveBinding(ShowTimestampProperty);
+            RemoveBinding(ShowAvatarsProperty);
+            RemoveBinding(AvatarSizeProperty);
+            RemoveBinding(UserDisplayNameProperty);
+            RemoveBinding(AssistantDisplayNameProperty);
+            RemoveBinding(BubbleCornerRadiusProperty);
+            RemoveBinding(BubbleStrokeThicknessProperty);
+            RemoveBinding(BubbleStrokeColorProperty);
+            RemoveBinding(MaxBubbleWidthProperty);
         }
-        return null;
+
+        SetBinding(ShowTimestampProperty, CreateOwnerBinding(owner, nameof(MessageListView.ShowTimestamps)));
+        SetBinding(ShowAvatarsProperty, CreateOwnerBinding(owner, nameof(MessageListView.ShowAvatars)));
+        SetBinding(AvatarSizeProperty, CreateOwnerBinding(owner, nameof(MessageListView.AvatarSize)));
+        SetBinding(UserDisplayNameProperty, CreateOwnerBinding(owner, nameof(MessageListView.UserDisplayName)));
+        SetBinding(AssistantDisplayNameProperty, CreateOwnerBinding(owner, nameof(MessageListView.AssistantDisplayName)));
+        SetBinding(BubbleCornerRadiusProperty, CreateOwnerBinding(owner, nameof(MessageListView.BubbleCornerRadius)));
+        SetBinding(BubbleStrokeThicknessProperty, CreateOwnerBinding(owner, nameof(MessageListView.BubbleStrokeThickness)));
+        SetBinding(BubbleStrokeColorProperty, CreateOwnerBinding(owner, nameof(MessageListView.BubbleStrokeColor)));
+        SetBinding(MaxBubbleWidthProperty, CreateOwnerBinding(owner, nameof(MessageListView.MaxBubbleWidth)));
+        _appearanceOwner = owner;
+    }
+
+    private static Binding CreateOwnerBinding(MessageListView owner, string path) =>
+        new(path, source: owner);
+
+    private static void OnAppearancePropertyChanged(BindableObject bindable, object? oldValue, object? newValue)
+    {
+        var view = (ChatMessageView)bindable;
+        view.RefreshComputedAppearance();
+        view.ApplyRoleState();
+    }
+
+    private void RefreshComputedAppearance()
+    {
+        var isUser = string.Equals(MessageRole, ChatRole.User.ToString(), StringComparison.Ordinal);
+        var displayName = isUser ? UserDisplayName : AssistantDisplayName;
+        var radius = Math.Max(0, BubbleCornerRadius);
+        var tailRadius = Math.Min(4, radius);
+
+        DisplayName = displayName;
+        AvatarText = string.IsNullOrWhiteSpace(displayName)
+            ? null
+            : displayName.Trim()[..1].ToUpperInvariant();
+        BubbleCornerRadii = isUser
+            ? new CornerRadius(
+                topLeft: radius,
+                topRight: radius,
+                bottomLeft: radius,
+                bottomRight: tailRadius)
+            : new CornerRadius(
+                topLeft: radius,
+                topRight: radius,
+                bottomLeft: tailRadius,
+                bottomRight: radius);
+
+        SemanticDescription = string.IsNullOrWhiteSpace(displayName)
+            ? Text
+            : $"{displayName}: {Text}";
+        SemanticProperties.SetDescription(this, SemanticDescription);
     }
 }

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Thinking/ThinkingView.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/Thinking/ThinkingView.cs
@@ -10,6 +10,9 @@ public sealed class ThinkingView : ContentContextView
 
     public ThinkingView()
     {
+        SemanticProperties.SetDescription(this, "Assistant is thinking");
+        AutomationId = "AssistantThinking";
+
         _label = new Label
         {
             Text = "Thinking…",

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/ToolApproval/ToolApprovalView.xaml.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Contents/ToolApproval/ToolApprovalView.xaml.cs
@@ -87,6 +87,7 @@ public class ToolApprovalView : ContentContextView
 
     public ToolApprovalView()
     {
+        AutomationId = "ToolApproval";
         ApproveCommand = new RelayCommand(Approve);
         RejectCommand = new RelayCommand(Reject);
     }
@@ -125,6 +126,12 @@ public class ToolApprovalView : ContentContextView
 
         if (Content is View innerView)
             innerView.IsEnabled = !IsResolved;
+
+        SemanticProperties.SetDescription(
+            this,
+            IsPending
+                ? $"Approval required for {ToolName ?? "tool"}"
+                : ResolutionText);
 
         ApplyVisualState();
         RefreshAutomationIds();

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/CopilotChatView.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/CopilotChatView.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using Microsoft.Maui.AI.Chat;
 using Microsoft.Extensions.AI;
-using Microsoft.Maui.Controls.Shapes;
 
 namespace Microsoft.Maui.AI.Chat.Controls;
 
@@ -86,7 +86,6 @@ public partial class CopilotChatView : TemplatedView
     private ContentView? _footerPart;
     private Entry? _inputEntryPart;
     private Button? _sendButtonPart;
-    private Border? _inputAreaPart;
 
     public static readonly BindableProperty ContentTemplatesProperty =
         BindableProperty.Create(
@@ -104,6 +103,26 @@ public partial class CopilotChatView : TemplatedView
                 self.SyncContentTemplates();
             });
 
+    public static readonly BindableProperty UseDefaultContentTemplatesProperty =
+        BindableProperty.Create(
+            nameof(UseDefaultContentTemplates),
+            typeof(bool),
+            typeof(CopilotChatView),
+            true,
+            propertyChanged: (b, _, _) => ((CopilotChatView)b).SyncContentTemplates());
+
+    internal static readonly BindableProperty EffectiveSendButtonBackgroundColorProperty =
+        BindableProperty.Create(
+            nameof(EffectiveSendButtonBackgroundColor),
+            typeof(Color),
+            typeof(CopilotChatView));
+
+    internal static readonly BindableProperty EffectiveInputAreaBackgroundColorProperty =
+        BindableProperty.Create(
+            nameof(EffectiveInputAreaBackgroundColor),
+            typeof(Color),
+            typeof(CopilotChatView));
+
     private IDisposable? _statusChangedReg;
 
     public IList<ContentTemplate> ContentTemplates
@@ -112,10 +131,37 @@ public partial class CopilotChatView : TemplatedView
         set => SetValue(ContentTemplatesProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets whether the nested message list uses the built-in text, approval, media, thinking, and
+    /// error templates when no consumer template matches. Set this to <see langword="false"/> for strict
+    /// allow-list rendering using only <see cref="ContentTemplates"/>.
+    /// </summary>
+    public bool UseDefaultContentTemplates
+    {
+        get => (bool)GetValue(UseDefaultContentTemplatesProperty);
+        set => SetValue(UseDefaultContentTemplatesProperty, value);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Color? EffectiveSendButtonBackgroundColor =>
+        (Color?)GetValue(EffectiveSendButtonBackgroundColorProperty);
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Color? EffectiveInputAreaBackgroundColor =>
+        (Color?)GetValue(EffectiveInputAreaBackgroundColorProperty);
+
     public CopilotChatView()
     {
         if (ContentTemplates is System.Collections.Specialized.INotifyCollectionChanged ctNcc)
             ctNcc.CollectionChanged += OnContentTemplatesChanged;
+
+        SetDynamicResource(MaxBubbleWidthProperty, Themes.ChatThemeKeys.BubbleMaxWidth);
+        RestoreEffectiveInputColor(
+            EffectiveSendButtonBackgroundColorProperty,
+            Themes.ChatThemeKeys.SendBackground);
+        RestoreEffectiveInputColor(
+            EffectiveInputAreaBackgroundColorProperty,
+            Themes.ChatThemeKeys.InputBackground);
 
         // Bind the default ControlTemplate via DynamicResource so it resolves
         // once the theme dictionary is available in the resource tree. The actual
@@ -167,15 +213,8 @@ public partial class CopilotChatView : TemplatedView
     {
         base.OnApplyTemplate();
 
-        // Unhook old parts
-        if (_inputEntryPart is not null)
-            _inputEntryPart.Completed -= OnInputCompleted;
-        if (_sendButtonPart is not null)
-            _sendButtonPart.Clicked -= OnSendButtonClicked;
-
         // Resolve named parts
         _headerPart = GetTemplateChild("PART_Header") as ContentView;
-        _messageListPart = GetTemplateChild("PART_MessageList") as MessageListView;
         _welcomePanelPart = GetTemplateChild("PART_WelcomePanel") as View;
         _welcomeIconPart = GetTemplateChild("PART_WelcomeIcon") as Label;
         _welcomeMessagePart = GetTemplateChild("PART_WelcomeMessage") as Label;
@@ -183,29 +222,13 @@ public partial class CopilotChatView : TemplatedView
         _busyIndicatorPart = GetTemplateChild("PART_BusyIndicator") as ActivityIndicator;
         _suggestionsPart = GetTemplateChild("PART_Suggestions") as Layout;
         _footerPart = GetTemplateChild("PART_Footer") as ContentView;
-        _inputEntryPart = GetTemplateChild("PART_InputEntry") as Entry;
-        _sendButtonPart = GetTemplateChild("PART_SendButton") as Button;
-        _inputAreaPart = GetTemplateChild("PART_InputArea") as Border;
+        AttachInputParts(
+            GetTemplateChild("PART_InputEntry") as Entry,
+            GetTemplateChild("PART_SendButton") as Button);
 
-        // Hook up new parts
-        if (_inputEntryPart is not null)
-            _inputEntryPart.Completed += OnInputCompleted;
-        if (_sendButtonPart is not null)
-            _sendButtonPart.Clicked += OnSendButtonClicked;
-
-        // Wire the nested message list — forward session and templates, and track its
-        // items (an observable collection) to refresh welcome/suggestions visibility.
-        if (_messageListPart is not null)
-        {
-            var itemsNcc = (System.Collections.Specialized.INotifyCollectionChanged)_messageListPart.Items;
-            itemsNcc.CollectionChanged -= OnMessageItemsChanged;
-            itemsNcc.CollectionChanged += OnMessageItemsChanged;
-            _messageListPart.Session = Session;
-            SyncContentTemplates();
-        }
+        AttachMessageListPart(GetTemplateChild("PART_MessageList") as MessageListView);
 
         // Apply state
-        ApplyInputStyling();
         ApplyHeaderTemplate();
         ApplyFooterTemplate();
         ApplyEmptyViewTemplate();
@@ -226,10 +249,52 @@ public partial class CopilotChatView : TemplatedView
         _messageListPart.ContentTemplates.Clear();
         foreach (var t in ContentTemplates)
             _messageListPart.ContentTemplates.Add(t);
+
+        _messageListPart.UseDefaultContentTemplates = UseDefaultContentTemplates;
+        SyncMessageAppearance();
     }
+
+    private void SyncMessageAppearance()
+    {
+        if (_messageListPart is null)
+            return;
+
+        _messageListPart.ShowAvatars = ShowAvatars;
+        _messageListPart.AvatarSize = AvatarSize;
+        _messageListPart.UserDisplayName = UserDisplayName;
+        _messageListPart.AssistantDisplayName = AssistantDisplayName;
+        _messageListPart.ShowTimestamps = ShowTimestamps;
+        _messageListPart.BubbleCornerRadius = BubbleCornerRadius;
+        _messageListPart.BubbleStrokeThickness = BubbleStrokeThickness;
+        _messageListPart.BubbleStrokeColor = BubbleStrokeColor;
+        _messageListPart.MaxBubbleWidth = MaxBubbleWidth;
+    }
+
+    private static void OnMessageAppearanceChanged(BindableObject bindable, object? oldValue, object? newValue) =>
+        ((CopilotChatView)bindable).SyncMessageAppearance();
 
     private void OnMessageItemsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) =>
         UpdateWelcomeVisibility();
+
+    internal void AttachMessageListPart(MessageListView? messageList)
+    {
+        if (_messageListPart is not null)
+        {
+            ((System.Collections.Specialized.INotifyCollectionChanged)_messageListPart.Items)
+                .CollectionChanged -= OnMessageItemsChanged;
+            _messageListPart.Session = null;
+        }
+
+        _messageListPart = messageList;
+
+        if (_messageListPart is null)
+            return;
+
+        ((System.Collections.Specialized.INotifyCollectionChanged)_messageListPart.Items)
+            .CollectionChanged += OnMessageItemsChanged;
+        _messageListPart.Session = Session;
+        SyncContentTemplates();
+    }
 
     // ── Session management ──
     // Message rendering lives in the nested MessageListView. Here we only
@@ -420,21 +485,20 @@ public partial class CopilotChatView : TemplatedView
         }
     }
 
-    // ── Input styling ──
-
-    internal void ApplyInputStyling()
+    internal void AttachInputParts(Entry? inputEntry, Button? sendButton)
     {
-        if (_sendButtonPart is not null && SendButtonBackgroundColor is not null)
-            _sendButtonPart.BackgroundColor = SendButtonBackgroundColor;
+        if (_inputEntryPart is not null)
+            _inputEntryPart.Completed -= OnInputCompleted;
+        if (_sendButtonPart is not null)
+            _sendButtonPart.Clicked -= OnSendButtonClicked;
 
-        if (_inputAreaPart is not null)
-        {
-            if (InputAreaBackgroundColor is not null)
-                _inputAreaPart.BackgroundColor = InputAreaBackgroundColor;
+        _inputEntryPart = inputEntry;
+        _sendButtonPart = sendButton;
 
-            if (_inputAreaPart.StrokeShape is RoundRectangle rr)
-                rr.CornerRadius = new CornerRadius(InputAreaCornerRadius);
-        }
+        if (_inputEntryPart is not null)
+            _inputEntryPart.Completed += OnInputCompleted;
+        if (_sendButtonPart is not null)
+            _sendButtonPart.Clicked += OnSendButtonClicked;
     }
 
     // ── Busy ──
@@ -497,7 +561,14 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty SendButtonBackgroundColorProperty =
-        BindableProperty.Create(nameof(SendButtonBackgroundColor), typeof(Color), typeof(CopilotChatView));
+        BindableProperty.Create(
+            nameof(SendButtonBackgroundColor),
+            typeof(Color),
+            typeof(CopilotChatView),
+            propertyChanged: (b, _, value) => ((CopilotChatView)b).UpdateEffectiveInputColor(
+                EffectiveSendButtonBackgroundColorProperty,
+                (Color?)value,
+                Themes.ChatThemeKeys.SendBackground));
 
     public Color? SendButtonBackgroundColor
     {
@@ -506,7 +577,14 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty InputAreaBackgroundColorProperty =
-        BindableProperty.Create(nameof(InputAreaBackgroundColor), typeof(Color), typeof(CopilotChatView));
+        BindableProperty.Create(
+            nameof(InputAreaBackgroundColor),
+            typeof(Color),
+            typeof(CopilotChatView),
+            propertyChanged: (b, _, value) => ((CopilotChatView)b).UpdateEffectiveInputColor(
+                EffectiveInputAreaBackgroundColorProperty,
+                (Color?)value,
+                Themes.ChatThemeKeys.InputBackground));
 
     public Color? InputAreaBackgroundColor
     {
@@ -515,12 +593,38 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty InputAreaCornerRadiusProperty =
-        BindableProperty.Create(nameof(InputAreaCornerRadius), typeof(double), typeof(CopilotChatView), 14.0);
+        BindableProperty.Create(
+            nameof(InputAreaCornerRadius),
+            typeof(double),
+            typeof(CopilotChatView),
+            14.0);
 
     public double InputAreaCornerRadius
     {
         get => (double)GetValue(InputAreaCornerRadiusProperty);
         set => SetValue(InputAreaCornerRadiusProperty, value);
+    }
+
+    private void UpdateEffectiveInputColor(
+        BindableProperty effectiveProperty,
+        Color? color,
+        string fallbackResourceKey)
+    {
+        if (color is not null)
+        {
+            SetValue(effectiveProperty, color);
+            return;
+        }
+
+        RestoreEffectiveInputColor(effectiveProperty, fallbackResourceKey);
+    }
+
+    private void RestoreEffectiveInputColor(
+        BindableProperty effectiveProperty,
+        string fallbackResourceKey)
+    {
+        ClearValue(effectiveProperty);
+        SetDynamicResource(effectiveProperty, fallbackResourceKey);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -552,7 +656,12 @@ public partial class CopilotChatView : TemplatedView
     // ═══════════════════════════════════════════════════════════════
 
     public static readonly BindableProperty ShowAvatarsProperty =
-        BindableProperty.Create(nameof(ShowAvatars), typeof(bool), typeof(CopilotChatView), false);
+        BindableProperty.Create(
+            nameof(ShowAvatars),
+            typeof(bool),
+            typeof(CopilotChatView),
+            false,
+            propertyChanged: OnMessageAppearanceChanged);
 
     public bool ShowAvatars
     {
@@ -561,7 +670,12 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty AvatarSizeProperty =
-        BindableProperty.Create(nameof(AvatarSize), typeof(double), typeof(CopilotChatView), 28.0);
+        BindableProperty.Create(
+            nameof(AvatarSize),
+            typeof(double),
+            typeof(CopilotChatView),
+            28.0,
+            propertyChanged: OnMessageAppearanceChanged);
 
     public double AvatarSize
     {
@@ -570,7 +684,12 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty UserDisplayNameProperty =
-        BindableProperty.Create(nameof(UserDisplayName), typeof(string), typeof(CopilotChatView), "You");
+        BindableProperty.Create(
+            nameof(UserDisplayName),
+            typeof(string),
+            typeof(CopilotChatView),
+            "You",
+            propertyChanged: OnMessageAppearanceChanged);
 
     public string UserDisplayName
     {
@@ -579,7 +698,12 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty AssistantDisplayNameProperty =
-        BindableProperty.Create(nameof(AssistantDisplayName), typeof(string), typeof(CopilotChatView), "Assistant");
+        BindableProperty.Create(
+            nameof(AssistantDisplayName),
+            typeof(string),
+            typeof(CopilotChatView),
+            "Assistant",
+            propertyChanged: OnMessageAppearanceChanged);
 
     public string AssistantDisplayName
     {
@@ -592,7 +716,12 @@ public partial class CopilotChatView : TemplatedView
     // ═══════════════════════════════════════════════════════════════
 
     public static readonly BindableProperty ShowTimestampsProperty =
-        BindableProperty.Create(nameof(ShowTimestamps), typeof(bool), typeof(CopilotChatView), false);
+        BindableProperty.Create(
+            nameof(ShowTimestamps),
+            typeof(bool),
+            typeof(CopilotChatView),
+            false,
+            propertyChanged: OnMessageAppearanceChanged);
 
     public bool ShowTimestamps
     {
@@ -605,7 +734,12 @@ public partial class CopilotChatView : TemplatedView
     // ═══════════════════════════════════════════════════════════════
 
     public static readonly BindableProperty BubbleCornerRadiusProperty =
-        BindableProperty.Create(nameof(BubbleCornerRadius), typeof(double), typeof(CopilotChatView), 16.0);
+        BindableProperty.Create(
+            nameof(BubbleCornerRadius),
+            typeof(double),
+            typeof(CopilotChatView),
+            16.0,
+            propertyChanged: OnMessageAppearanceChanged);
 
     public double BubbleCornerRadius
     {
@@ -614,7 +748,12 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty BubbleStrokeThicknessProperty =
-        BindableProperty.Create(nameof(BubbleStrokeThickness), typeof(double), typeof(CopilotChatView), 0.0);
+        BindableProperty.Create(
+            nameof(BubbleStrokeThickness),
+            typeof(double),
+            typeof(CopilotChatView),
+            0.0,
+            propertyChanged: OnMessageAppearanceChanged);
 
     public double BubbleStrokeThickness
     {
@@ -623,7 +762,11 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty BubbleStrokeColorProperty =
-        BindableProperty.Create(nameof(BubbleStrokeColor), typeof(Color), typeof(CopilotChatView));
+        BindableProperty.Create(
+            nameof(BubbleStrokeColor),
+            typeof(Color),
+            typeof(CopilotChatView),
+            propertyChanged: OnMessageAppearanceChanged);
 
     public Color? BubbleStrokeColor
     {
@@ -632,7 +775,12 @@ public partial class CopilotChatView : TemplatedView
     }
 
     public static readonly BindableProperty MaxBubbleWidthProperty =
-        BindableProperty.Create(nameof(MaxBubbleWidth), typeof(double), typeof(CopilotChatView), 340.0);
+        BindableProperty.Create(
+            nameof(MaxBubbleWidth),
+            typeof(double),
+            typeof(CopilotChatView),
+            340.0,
+            propertyChanged: OnMessageAppearanceChanged);
 
     public double MaxBubbleWidth
     {

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/MessageListView.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/MessageListView.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Maui.AI.Chat.Controls;
 /// <see cref="CopilotChatView"/>, which now hosts one internally.
 /// </summary>
 /// <remarks>
-/// Bind <see cref="Session"/> to an <see cref="AgentContext"/> and add <see cref="ContentTemplate"/>s to
-/// <see cref="ContentTemplates"/> to control how each <see cref="ContentBlock"/> renders. Because it is
-/// session-driven it updates live as blocks stream in. Use it directly for a minimal chat surface, or to
-/// compare template sets side by side (e.g. a fully templated <see cref="CopilotChatView"/> next to a
-/// bare <see cref="MessageListView"/> that uses only the default templates). The single template part is
+/// Bind <see cref="Session"/> to an <see cref="AgentContext"/> for a zero-configuration chat surface with
+/// built-in text, approval, media, thinking, and error rendering. Add consumer <see cref="ContentTemplate"/>s
+/// to <see cref="ContentTemplates"/> to replace those fallbacks for matching blocks, or set
+/// <see cref="UseDefaultContentTemplates"/> to <see langword="false"/> for strict allow-list rendering.
+/// Because it is session-driven it updates live as blocks stream in. The single template part is
 /// <c>PART_Messages</c> (a <see cref="CollectionView"/>).
 /// </remarks>
 [ContentProperty(nameof(ContentTemplates))]
@@ -44,6 +44,41 @@ public partial class MessageListView : TemplatedView
                 self.RebuildTemplateSelector();
             });
 
+    public static readonly BindableProperty UseDefaultContentTemplatesProperty =
+        BindableProperty.Create(
+            nameof(UseDefaultContentTemplates),
+            typeof(bool),
+            typeof(MessageListView),
+            true,
+            propertyChanged: (b, _, _) => ((MessageListView)b).RebuildTemplateSelector());
+
+    public static readonly BindableProperty ShowAvatarsProperty =
+        BindableProperty.Create(nameof(ShowAvatars), typeof(bool), typeof(MessageListView), false);
+
+    public static readonly BindableProperty AvatarSizeProperty =
+        BindableProperty.Create(nameof(AvatarSize), typeof(double), typeof(MessageListView), 28.0);
+
+    public static readonly BindableProperty UserDisplayNameProperty =
+        BindableProperty.Create(nameof(UserDisplayName), typeof(string), typeof(MessageListView), "You");
+
+    public static readonly BindableProperty AssistantDisplayNameProperty =
+        BindableProperty.Create(nameof(AssistantDisplayName), typeof(string), typeof(MessageListView), "Assistant");
+
+    public static readonly BindableProperty ShowTimestampsProperty =
+        BindableProperty.Create(nameof(ShowTimestamps), typeof(bool), typeof(MessageListView), false);
+
+    public static readonly BindableProperty BubbleCornerRadiusProperty =
+        BindableProperty.Create(nameof(BubbleCornerRadius), typeof(double), typeof(MessageListView), 16.0);
+
+    public static readonly BindableProperty BubbleStrokeThicknessProperty =
+        BindableProperty.Create(nameof(BubbleStrokeThickness), typeof(double), typeof(MessageListView), 0.0);
+
+    public static readonly BindableProperty BubbleStrokeColorProperty =
+        BindableProperty.Create(nameof(BubbleStrokeColor), typeof(Color), typeof(MessageListView));
+
+    public static readonly BindableProperty MaxBubbleWidthProperty =
+        BindableProperty.Create(nameof(MaxBubbleWidth), typeof(double), typeof(MessageListView), 340.0);
+
     private static readonly BindablePropertyKey ItemsPropertyKey =
         BindableProperty.CreateReadOnly(
             nameof(Items),
@@ -59,11 +94,78 @@ public partial class MessageListView : TemplatedView
         set => SetValue(SessionProperty, value);
     }
 
-    /// <summary>The content templates used to render each block; the highest matching priority wins.</summary>
+    /// <summary>
+    /// Consumer content templates used to render blocks. Any matching consumer template outranks the built-in
+    /// fallback templates; numeric priority and declaration order resolve matches within this collection.
+    /// </summary>
     public IList<ContentTemplate> ContentTemplates
     {
         get => (IList<ContentTemplate>)GetValue(ContentTemplatesProperty);
         set => SetValue(ContentTemplatesProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the built-in text, approval, media, thinking, and error templates are used when no
+    /// consumer template matches. Set this to <see langword="false"/> to restore strict allow-list rendering.
+    /// </summary>
+    public bool UseDefaultContentTemplates
+    {
+        get => (bool)GetValue(UseDefaultContentTemplatesProperty);
+        set => SetValue(UseDefaultContentTemplatesProperty, value);
+    }
+
+    public bool ShowAvatars
+    {
+        get => (bool)GetValue(ShowAvatarsProperty);
+        set => SetValue(ShowAvatarsProperty, value);
+    }
+
+    public double AvatarSize
+    {
+        get => (double)GetValue(AvatarSizeProperty);
+        set => SetValue(AvatarSizeProperty, value);
+    }
+
+    public string UserDisplayName
+    {
+        get => (string)GetValue(UserDisplayNameProperty);
+        set => SetValue(UserDisplayNameProperty, value);
+    }
+
+    public string AssistantDisplayName
+    {
+        get => (string)GetValue(AssistantDisplayNameProperty);
+        set => SetValue(AssistantDisplayNameProperty, value);
+    }
+
+    public bool ShowTimestamps
+    {
+        get => (bool)GetValue(ShowTimestampsProperty);
+        set => SetValue(ShowTimestampsProperty, value);
+    }
+
+    public double BubbleCornerRadius
+    {
+        get => (double)GetValue(BubbleCornerRadiusProperty);
+        set => SetValue(BubbleCornerRadiusProperty, value);
+    }
+
+    public double BubbleStrokeThickness
+    {
+        get => (double)GetValue(BubbleStrokeThicknessProperty);
+        set => SetValue(BubbleStrokeThicknessProperty, value);
+    }
+
+    public Color? BubbleStrokeColor
+    {
+        get => (Color?)GetValue(BubbleStrokeColorProperty);
+        set => SetValue(BubbleStrokeColorProperty, value);
+    }
+
+    public double MaxBubbleWidth
+    {
+        get => (double)GetValue(MaxBubbleWidthProperty);
+        set => SetValue(MaxBubbleWidthProperty, value);
     }
 
     /// <summary>
@@ -74,13 +176,23 @@ public partial class MessageListView : TemplatedView
         (ReadOnlyObservableCollection<ContentContext>)GetValue(ItemsProperty);
 
     private readonly ObservableCollection<ContentContext> _items = [];
+    private readonly IReadOnlyList<ContentTemplate> _defaultContentTemplates =
+    [
+        new TextContentTemplate { Role = "User", Priority = -10_000 },
+        new TextContentTemplate { Role = "Assistant", Priority = -10_000 },
+        new ToolApprovalTemplate { Priority = -10_000 },
+        new MediaContentTemplate { Priority = -10_000 },
+        new ThinkingContentTemplate { Priority = -10_000 },
+        new ErrorContentTemplate { Priority = -10_000 },
+    ];
 
     private CollectionView? _messagesPart;
 
     private IDisposable? _turnAddedReg;
     private IDisposable? _statusChangedReg;
     private IDisposable? _blockAddedReg;
-    private readonly List<IDisposable> _blockSubscriptions = [];
+    private readonly Dictionary<ContentBlock, IDisposable> _blockSubscriptions =
+        new(ReferenceEqualityComparer.Instance);
 
     // Streaming coalescing: a block can raise a change per token. Applying each one immediately
     // replaces the CollectionView item (recreating the whole cell) and rebuilds custom views from
@@ -101,6 +213,7 @@ public partial class MessageListView : TemplatedView
         if (ContentTemplates is INotifyCollectionChanged ncc)
             ncc.CollectionChanged += OnContentTemplatesChanged;
 
+        SetDynamicResource(MaxBubbleWidthProperty, Themes.ChatThemeKeys.BubbleMaxWidth);
         SetDynamicResource(ControlTemplateProperty, Themes.ChatThemeKeys.MessageListViewTemplate);
     }
 
@@ -137,10 +250,22 @@ public partial class MessageListView : TemplatedView
         if (_messagesPart is null)
             return;
 
+        _messagesPart.ItemTemplate = CreateTemplateSelector();
+    }
+
+    internal ContentTemplateSelector CreateTemplateSelector()
+    {
         var selector = new ContentTemplateSelector();
         foreach (var t in ContentTemplates)
             selector.Templates.Add(t);
-        _messagesPart.ItemTemplate = selector;
+
+        if (UseDefaultContentTemplates)
+        {
+            foreach (var t in _defaultContentTemplates)
+                selector.FallbackTemplates.Add(t);
+        }
+
+        return selector;
     }
 
     // ── Session management ──
@@ -176,7 +301,7 @@ public partial class MessageListView : TemplatedView
         _statusChangedReg = null;
         _blockAddedReg = null;
 
-        foreach (var sub in _blockSubscriptions)
+        foreach (var sub in _blockSubscriptions.Values)
             sub.Dispose();
         _blockSubscriptions.Clear();
         _dirtyBlocks.Clear();
@@ -184,24 +309,64 @@ public partial class MessageListView : TemplatedView
 
     private void OnStatusChanged(ConversationStatus status)
     {
-        // If the session was cleared (idle with no turns), rebuild to empty.
+        // Cancellation removes partial response blocks from the engine turn. Re-project only
+        // when that makes the UI projection differ, avoiding a full rebuild after normal turns.
         if (status == ConversationStatus.Idle && Session?.Turns.Count == 0)
         {
             RebuildFromSession();
             return;
         }
 
+        if (status == ConversationStatus.Idle && !ProjectionMatchesSession())
+            ReconcileItemsWithSession();
+
         // A failure surfaces via status/Error only — render a sticky error item (once).
         if (status == ConversationStatus.Error && Session?.Error is { } ex && !ReferenceEquals(ex, _shownError))
         {
             RemoveThinkingItem();
             _shownError = ex;
-            _items.Add(new ContentContext(Session, new ErrorContentBlock(ex.Message)));
+            _items.Add(CreateContentContext(new ErrorContentBlock(ErrorContentBlock.DefaultUserMessage)));
             ScrollToLatestMessage();
             return;
         }
 
         UpdateThinkingItem();
+    }
+
+    private bool ProjectionMatchesSession()
+    {
+        if (Session is null)
+            return _items.Count == 0;
+
+        var projectedBlocks = _items
+            .Where(item => item.Block is not ThinkingContentBlock and not ErrorContentBlock)
+            .Select(item => item.Block);
+        var sessionBlocks = Session.Turns.SelectMany(turn =>
+            turn.RequestBlocks.Concat(turn.ResponseBlocks));
+
+        return projectedBlocks.SequenceEqual(sessionBlocks, ReferenceEqualityComparer.Instance);
+    }
+
+    internal void ReconcileItemsWithSession()
+    {
+        if (Session is null)
+            return;
+
+        var sessionBlocks = Session.Turns
+            .SelectMany(turn => turn.RequestBlocks.Concat(turn.ResponseBlocks))
+            .ToHashSet(ReferenceEqualityComparer.Instance);
+
+        for (int i = _items.Count - 1; i >= 0; i--)
+        {
+            var block = _items[i].Block;
+            if (block is ThinkingContentBlock or ErrorContentBlock || sessionBlocks.Contains(block))
+                continue;
+
+            _items.RemoveAt(i);
+            if (_blockSubscriptions.Remove(block, out var subscription))
+                subscription.Dispose();
+            _dirtyBlocks.Remove(block);
+        }
     }
 
     private void OnBlockAdded(ConversationTurn turn, ContentBlock block)
@@ -212,8 +377,8 @@ public partial class MessageListView : TemplatedView
         // Keep any transient thinking item as the very last row.
         RemoveThinkingItem();
 
-        _items.Add(new ContentContext(Session, block));
-        _blockSubscriptions.Add(block.OnChanged(() => Dispatcher.Dispatch(() => MarkBlockDirty(block))));
+        _items.Add(CreateContentContext(block));
+        SubscribeToBlock(block);
 
         UpdateThinkingItem();
         ScrollToLatestMessage();
@@ -259,7 +424,7 @@ public partial class MessageListView : TemplatedView
         {
             if (ReferenceEquals(_items[i].Block, block))
             {
-                _items[i] = new ContentContext(Session!, block);
+                _items[i] = CreateContentContext(block);
                 return;
             }
         }
@@ -267,7 +432,7 @@ public partial class MessageListView : TemplatedView
 
     private void RebuildFromSession()
     {
-        foreach (var sub in _blockSubscriptions)
+        foreach (var sub in _blockSubscriptions.Values)
             sub.Dispose();
         _blockSubscriptions.Clear();
 
@@ -285,13 +450,13 @@ public partial class MessageListView : TemplatedView
         {
             foreach (var block in turn.RequestBlocks)
             {
-                _items.Add(new ContentContext(Session, block));
-                _blockSubscriptions.Add(block.OnChanged(() => Dispatcher.Dispatch(() => MarkBlockDirty(block))));
+                _items.Add(CreateContentContext(block));
+                SubscribeToBlock(block);
             }
             foreach (var block in turn.ResponseBlocks)
             {
-                _items.Add(new ContentContext(Session, block));
-                _blockSubscriptions.Add(block.OnChanged(() => Dispatcher.Dispatch(() => MarkBlockDirty(block))));
+                _items.Add(CreateContentContext(block));
+                SubscribeToBlock(block);
             }
         }
 
@@ -299,7 +464,7 @@ public partial class MessageListView : TemplatedView
         if (Session.Status == ConversationStatus.Error && Session.Error is { } ex)
         {
             _shownError = ex;
-            _items.Add(new ContentContext(Session, new ErrorContentBlock(ex.Message)));
+            _items.Add(CreateContentContext(new ErrorContentBlock(ErrorContentBlock.DefaultUserMessage)));
         }
 
         UpdateThinkingItem();
@@ -315,7 +480,7 @@ public partial class MessageListView : TemplatedView
 
         if (want && _thinkingItem is null)
         {
-            _thinkingItem = new ContentContext(Session!, new ThinkingContentBlock());
+            _thinkingItem = CreateContentContext(new ThinkingContentBlock());
             _items.Add(_thinkingItem);
             ScrollToLatestMessage();
         }
@@ -372,5 +537,17 @@ public partial class MessageListView : TemplatedView
 
             _messagesPart.ScrollTo(_items.Count - 1, position: ScrollToPosition.End, animate: false);
         });
+    }
+
+    private ContentContext CreateContentContext(ContentBlock block) =>
+        new(Session!, block, this);
+
+    private void SubscribeToBlock(ContentBlock block)
+    {
+        if (_blockSubscriptions.Remove(block, out var existing))
+            existing.Dispose();
+
+        _blockSubscriptions[block] =
+            block.OnChanged(() => Dispatcher.Dispatch(() => MarkBlockDirty(block)));
     }
 }

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Themes/CopilotChatTheme.xaml
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Themes/CopilotChatTheme.xaml
@@ -53,22 +53,24 @@
 
             <!-- Row 5: Input Area -->
             <Border x:Name="PART_InputArea" Grid.Row="5" Margin="12,8,12,12" Padding="6"
-                    BackgroundColor="{DynamicResource MauiAIChat.Input.Background}"
+                    BackgroundColor="{TemplateBinding EffectiveInputAreaBackgroundColor}"
                     StrokeThickness="0">
                 <Border.StrokeShape>
-                    <RoundRectangle CornerRadius="14" />
+                    <RoundRectangle CornerRadius="{TemplateBinding InputAreaCornerRadius}" />
                 </Border.StrokeShape>
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
                     <Entry x:Name="PART_InputEntry"
                            Placeholder="{TemplateBinding Placeholder}"
                            AutomationId="ChatInput"
+                           SemanticProperties.Description="Chat message input"
                            Text="{TemplateBinding Text, Mode=TwoWay}"
                            FontSize="14"
                            BackgroundColor="Transparent" />
                     <Button x:Name="PART_SendButton" Grid.Column="1"
                             Text="{TemplateBinding SendButtonText}"
                             AutomationId="SendMessageButton"
-                            BackgroundColor="{DynamicResource MauiAIChat.Send.Background}"
+                            SemanticProperties.Description="Send message"
+                            BackgroundColor="{TemplateBinding EffectiveSendButtonBackgroundColor}"
                             TextColor="{DynamicResource MauiAIChat.Send.TextColor}"
                             FontSize="16"
                             WidthRequest="42" HeightRequest="42"

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Themes/MessageListTheme.xaml
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat.Controls/Themes/MessageListTheme.xaml
@@ -14,33 +14,43 @@
     <!-- ControlTemplate: ChatMessageView (User + Assistant)           -->
     <!-- ═══════════════════════════════════════════════════════════════ -->
     <ControlTemplate x:Key="MauiAIChat.ChatMessageTemplate">
-        <Grid x:Name="PART_Root" Padding="0,4">
+        <Grid x:Name="PART_Root"
+              Padding="0,4"
+              ColumnDefinitions="Auto,*,Auto"
+              ColumnSpacing="8"
+              SemanticProperties.Description="{TemplateBinding SemanticDescription}">
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="RoleStates">
                     <VisualState x:Name="User">
                         <VisualState.Setters>
+                            <Setter TargetName="AssistantAvatar" Property="IsVisible" Value="False" />
+                            <Setter TargetName="MessageContent" Property="VerticalStackLayout.HorizontalOptions"
+                                    Value="End" />
+                            <Setter TargetName="DisplayNameLabel" Property="Label.HorizontalTextAlignment"
+                                    Value="End" />
                             <Setter TargetName="MessageBorder" Property="Border.BackgroundColor"
                                     Value="{DynamicResource MauiAIChat.User.Background}" />
                             <Setter TargetName="MessageBorder" Property="Border.HorizontalOptions"
                                     Value="End" />
                             <Setter TargetName="MessageLabel" Property="Label.TextColor"
                                     Value="{DynamicResource MauiAIChat.User.TextColor}" />
-                            <Setter TargetName="MessageShape" Property="RoundRectangle.CornerRadius"
-                                    Value="16,16,4,16" />
                             <Setter TargetName="TimestampLabel" Property="Label.HorizontalTextAlignment"
                                     Value="End" />
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Assistant">
                         <VisualState.Setters>
+                            <Setter TargetName="UserAvatar" Property="IsVisible" Value="False" />
+                            <Setter TargetName="MessageContent" Property="VerticalStackLayout.HorizontalOptions"
+                                    Value="Start" />
+                            <Setter TargetName="DisplayNameLabel" Property="Label.HorizontalTextAlignment"
+                                    Value="Start" />
                             <Setter TargetName="MessageBorder" Property="Border.BackgroundColor"
                                     Value="{DynamicResource MauiAIChat.Assistant.Background}" />
                             <Setter TargetName="MessageBorder" Property="Border.HorizontalOptions"
                                     Value="Start" />
                             <Setter TargetName="MessageLabel" Property="Label.TextColor"
                                     Value="{DynamicResource MauiAIChat.Assistant.TextColor}" />
-                            <Setter TargetName="MessageShape" Property="RoundRectangle.CornerRadius"
-                                    Value="16,16,16,4" />
                             <Setter TargetName="TimestampLabel" Property="Label.HorizontalTextAlignment"
                                     Value="Start" />
                         </VisualState.Setters>
@@ -48,14 +58,43 @@
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
 
-            <VerticalStackLayout Spacing="2">
+            <Border x:Name="AssistantAvatar"
+                    Grid.Column="0"
+                    IsVisible="{TemplateBinding ShowAvatars}"
+                    WidthRequest="{TemplateBinding AvatarSize}"
+                    HeightRequest="{TemplateBinding AvatarSize}"
+                    Padding="0"
+                    VerticalOptions="End"
+                    BackgroundColor="{DynamicResource MauiAIChat.Assistant.Background}"
+                    StrokeThickness="0"
+                    SemanticProperties.Description="{TemplateBinding DisplayName}">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="100" />
+                </Border.StrokeShape>
+                <Label Text="{TemplateBinding AvatarText}"
+                       HorizontalTextAlignment="Center"
+                       VerticalTextAlignment="Center"
+                       TextColor="{DynamicResource MauiAIChat.Assistant.TextColor}"
+                       FontAttributes="Bold" />
+            </Border>
+
+            <VerticalStackLayout x:Name="MessageContent" Grid.Column="1" Spacing="2">
+                <Label x:Name="DisplayNameLabel"
+                       Text="{TemplateBinding DisplayName}"
+                       IsVisible="{TemplateBinding ShowAvatars}"
+                       FontSize="11"
+                       FontAttributes="Bold"
+                       TextColor="{DynamicResource MauiAIChat.Default.TextColor}"
+                       Margin="4,0" />
                 <Border x:Name="MessageBorder" Padding="12,10"
-                        MaximumWidthRequest="{DynamicResource MauiAIChat.Bubble.MaxWidth}"
+                        MaximumWidthRequest="{TemplateBinding MaxBubbleWidth}"
                         HorizontalOptions="Start"
                         BackgroundColor="{DynamicResource MauiAIChat.Assistant.Background}"
-                        StrokeThickness="0">
+                        Stroke="{TemplateBinding BubbleStrokeColor}"
+                        StrokeThickness="{TemplateBinding BubbleStrokeThickness}">
                     <Border.StrokeShape>
-                        <RoundRectangle x:Name="MessageShape" CornerRadius="16,16,16,4" />
+                        <RoundRectangle x:Name="MessageShape"
+                                        CornerRadius="{TemplateBinding BubbleCornerRadii}" />
                     </Border.StrokeShape>
                     <Label x:Name="MessageLabel"
                            Text="{TemplateBinding Text}" FontSize="14"
@@ -68,6 +107,26 @@
                        TextColor="{DynamicResource MauiAIChat.Timestamp.TextColor}"
                        Margin="4,0" />
             </VerticalStackLayout>
+
+            <Border x:Name="UserAvatar"
+                    Grid.Column="2"
+                    IsVisible="{TemplateBinding ShowAvatars}"
+                    WidthRequest="{TemplateBinding AvatarSize}"
+                    HeightRequest="{TemplateBinding AvatarSize}"
+                    Padding="0"
+                    VerticalOptions="End"
+                    BackgroundColor="{DynamicResource MauiAIChat.User.Background}"
+                    StrokeThickness="0"
+                    SemanticProperties.Description="{TemplateBinding DisplayName}">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="100" />
+                </Border.StrokeShape>
+                <Label Text="{TemplateBinding AvatarText}"
+                       HorizontalTextAlignment="Center"
+                       VerticalTextAlignment="Center"
+                       TextColor="{DynamicResource MauiAIChat.User.TextColor}"
+                       FontAttributes="Bold" />
+            </Border>
         </Grid>
     </ControlTemplate>
 
@@ -171,6 +230,7 @@
                     <Button x:Name="PART_ApproveButton"
                             Text="Approve"
                             AutomationId="ApproveToolButton"
+                            SemanticProperties.Description="Approve tool invocation"
                             Command="{TemplateBinding ApproveCommand}"
                             BackgroundColor="{DynamicResource MauiAIChat.Button.Approve}"
                             TextColor="White"
@@ -182,6 +242,7 @@
                             Grid.Column="1"
                             Text="Reject"
                             AutomationId="RejectToolButton"
+                            SemanticProperties.Description="Reject tool invocation"
                             Command="{TemplateBinding RejectCommand}"
                             BackgroundColor="{DynamicResource MauiAIChat.Button.Reject}"
                             TextColor="White"

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Blocks/ToolApproval/ToolApprovalBlock.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Blocks/ToolApproval/ToolApprovalBlock.cs
@@ -34,20 +34,26 @@ public class ToolApprovalBlock : InteractiveFunctionBlock, IInteractiveBlock
 
     public void Approve()
     {
-        Status = ApprovalStatus.Approved;
-        var response = ApprovalRequest.CreateResponse(approved: true);
-        NotifyChanged();
-        _tcs.TrySetResult(response);
+        Resolve(ApprovalStatus.Approved, approved: true, reason: null);
     }
 
     public void Reject(string? reason = null)
     {
-        Status = ApprovalStatus.Rejected;
-        var response = ApprovalRequest.CreateResponse(approved: false);
-        NotifyChanged();
-        _tcs.TrySetResult(response);
+        Resolve(ApprovalStatus.Rejected, approved: false, reason);
     }
 
     public Task<AIContent> GetResultAsync(CancellationToken cancellationToken = default)
         => _tcs.Task.WaitAsync(cancellationToken);
+
+    private void Resolve(ApprovalStatus status, bool approved, string? reason)
+    {
+        if (Status != ApprovalStatus.Pending)
+            return;
+
+        Status = status;
+        var response = ApprovalRequest.CreateResponse(approved, reason);
+        _tcs.TrySetResult(response);
+
+        NotifyChanged();
+    }
 }

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/AgentContext.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/AgentContext.cs
@@ -37,9 +37,8 @@ public class AgentContext(UIAgent agent) : IDisposable
     /// </summary>
     public void Clear()
     {
-        _streamingCts?.Cancel();
-        _streamingCts?.Dispose();
-        _streamingCts = null;
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        CancelAndDisposeStreaming();
         _turns.Clear();
         agent.ClearHistory();
         Error = null;
@@ -54,23 +53,61 @@ public class AgentContext(UIAgent agent) : IDisposable
 
     public async Task SendMessageAsync(ChatMessage message, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(message);
+        cancellationToken.ThrowIfCancellationRequested();
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
         if (Status == ConversationStatus.Streaming)
-        {
             throw new InvalidOperationException("A message is already being processed.");
-        }
 
         var turn = new ConversationTurn();
         _turns.Add(turn);
         NotifyTurnAdded(turn);
 
-        _streamingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var historyCheckpoint = agent.CaptureHistoryCheckpoint();
+        var (streamingCts, streamingToken) = ReplaceStreamingCancellationSource();
+        CancellationTokenSource? linkedCts = null;
 
-        await StreamIntoTurnAsync(message, turn, _streamingCts.Token);
+        try
+        {
+            if (cancellationToken.CanBeCanceled)
+            {
+                linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    streamingToken,
+                    cancellationToken);
+                streamingToken = linkedCts.Token;
+            }
+
+            await StreamIntoTurnAsync(
+                message,
+                turn,
+                historyCheckpoint,
+                streamingToken);
+
+            if (cancellationToken.IsCancellationRequested)
+                CleanupCanceledTurn(turn, historyCheckpoint, message);
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+        catch (Exception) when (cancellationToken.IsCancellationRequested)
+        {
+            CleanupCanceledTurn(turn, historyCheckpoint, message);
+            cancellationToken.ThrowIfCancellationRequested();
+            throw;
+        }
+        finally
+        {
+            linkedCts?.Dispose();
+            if (ReferenceEquals(_streamingCts, streamingCts))
+                _streamingCts = null;
+            streamingCts.Dispose();
+        }
     }
 
     private async Task StreamIntoTurnAsync(
         ChatMessage message,
         ConversationTurn turn,
+        int historyCheckpoint,
         CancellationToken cancellationToken)
     {
         Status = ConversationStatus.Streaming;
@@ -88,6 +125,8 @@ public class AgentContext(UIAgent agent) : IDisposable
 
                 await foreach (var block in agent.SendMessageAsync(currentMessage, cancellationToken).WithCancellation(cancellationToken))
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     if (block is IInteractiveBlock interactive)
                     {
                         interactiveBlocks.Add(interactive);
@@ -99,15 +138,10 @@ public class AgentContext(UIAgent agent) : IDisposable
                         uninvokedToolBlocks.Add(ficb);
                     }
 
-                    var isRequest = block.Role == currentMessage.Role;
-                    if (isRequest)
-                    {
+                    if (block.Role == currentMessage.Role)
                         turn.AddRequestBlock(block);
-                    }
                     else
-                    {
                         turn.AddResponseBlock(block);
-                    }
 
                     NotifyBlockAdded(turn, block);
                 }
@@ -143,6 +177,7 @@ public class AgentContext(UIAgent agent) : IDisposable
                 }
 
                 var results = await Task.WhenAll(resultTasks);
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (results.Length > 0)
                 {
@@ -156,23 +191,19 @@ public class AgentContext(UIAgent agent) : IDisposable
                 NotifyStatusChanged();
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             Status = ConversationStatus.Idle;
-            if (cancellationToken.IsCancellationRequested)
-            {
-                turn.ClearResponseBlocks();
-            }
             NotifyStatusChanged();
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (Exception) when (cancellationToken.IsCancellationRequested)
         {
-            turn.ClearResponseBlocks();
-            Status = ConversationStatus.Idle;
-            NotifyStatusChanged();
+            CleanupCanceledTurn(turn, historyCheckpoint, message);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
             // Failures surface via Status/Error only — the UI renders them. No block is
             // added to the turn, so the persistable message thread stays clean.
+            agent.RollbackHistory(historyCheckpoint, message);
             Error = ex;
             Status = ConversationStatus.Error;
             NotifyStatusChanged();
@@ -184,6 +215,7 @@ public class AgentContext(UIAgent agent) : IDisposable
         CancellationToken cancellationToken)
     {
         var result = await agent.InvokeToolAsync(block.Call!, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         block.Result = result;
         block.InvokeNotifyChanged();
         return result;
@@ -191,10 +223,8 @@ public class AgentContext(UIAgent agent) : IDisposable
 
     public Task CancelAsync()
     {
-        if (Status == ConversationStatus.Idle || Status == ConversationStatus.Error)
-        {
+        if (Status is ConversationStatus.Idle or ConversationStatus.Error)
             return Task.CompletedTask;
-        }
 
         _streamingCts?.Cancel();
         return Task.CompletedTask;
@@ -203,16 +233,50 @@ public class AgentContext(UIAgent agent) : IDisposable
     public void Dispose()
     {
         if (_disposed)
-        {
             return;
-        }
 
         _disposed = true;
-        _streamingCts?.Cancel();
-        _streamingCts?.Dispose();
+        CancelAndDisposeStreaming();
         _turnAddedCallbacks.Clear();
         _statusChangedCallbacks.Clear();
         _blockAddedCallbacks.Clear();
+    }
+
+    private (CancellationTokenSource Source, CancellationToken Token)
+        ReplaceStreamingCancellationSource()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        _streamingCts?.Cancel();
+        _streamingCts?.Dispose();
+
+        var next = new CancellationTokenSource();
+        var token = next.Token;
+        _streamingCts = next;
+        return (next, token);
+    }
+
+    private void CancelAndDisposeStreaming()
+    {
+        _streamingCts?.Cancel();
+        _streamingCts?.Dispose();
+        _streamingCts = null;
+    }
+
+    private void CleanupCanceledTurn(
+        ConversationTurn turn,
+        int historyCheckpoint,
+        ChatMessage requestMessage)
+    {
+        turn.ClearResponseBlocks();
+        agent.RollbackHistory(historyCheckpoint, requestMessage);
+        Error = null;
+
+        if (Status != ConversationStatus.Idle)
+        {
+            Status = ConversationStatus.Idle;
+            NotifyStatusChanged();
+        }
     }
 
     public IDisposable RegisterOnTurnAdded(Action<ConversationTurn> callback)
@@ -237,27 +301,21 @@ public class AgentContext(UIAgent agent) : IDisposable
     {
         var snapshot = _statusChangedCallbacks.ToArray();
         foreach (var cb in snapshot)
-        {
             cb(Status);
-        }
     }
 
     private void NotifyTurnAdded(ConversationTurn turn)
     {
         var snapshot = _turnAddedCallbacks.ToArray();
         foreach (var cb in snapshot)
-        {
             cb(turn);
-        }
     }
 
     private void NotifyBlockAdded(ConversationTurn turn, ContentBlock block)
     {
         var snapshot = _blockAddedCallbacks.ToArray();
         foreach (var cb in snapshot)
-        {
             cb(turn, block);
-        }
     }
 
     private sealed class CallbackRegistration<T> : IDisposable

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/UIAgent.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/UIAgent.cs
@@ -63,13 +63,32 @@ public class UIAgent : IDisposable
         _history.Clear();
     }
 
+    internal int CaptureHistoryCheckpoint() => _history.Count;
+
+    internal void RollbackHistory(int checkpoint, ChatMessage requestMessage)
+    {
+        if (checkpoint < 0)
+            throw new ArgumentOutOfRangeException(nameof(checkpoint));
+
+        if (checkpoint > _history.Count)
+            return;
+
+        var requestWasAdded = _history.Count > checkpoint;
+        _history.RemoveRange(checkpoint, _history.Count - checkpoint);
+        if (requestWasAdded)
+            _history.Add(requestMessage);
+    }
+
     public async IAsyncEnumerable<ContentBlock> SendMessageAsync(
         ChatMessage message,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(message);
 
+        cancellationToken.ThrowIfCancellationRequested();
         _history.Add(message);
+        ChatMessage[] historySnapshot = [.. _history];
         var pipeline = new BlockMappingPipeline(_options, _logger);
 
         // Process user message through pipeline
@@ -94,7 +113,7 @@ public class UIAgent : IDisposable
         var chatOptions = _options.ChatOptions;
 
         var updateIndex = 0;
-        await foreach (var update in _chatClient.GetStreamingResponseAsync(_history, chatOptions, cancellationToken).ConfigureAwait(false))
+        await foreach (var update in _chatClient.GetStreamingResponseAsync(historySnapshot, chatOptions, cancellationToken).ConfigureAwait(false))
         {
             var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
             UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);
@@ -115,12 +134,13 @@ public class UIAgent : IDisposable
             yield return block;
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         // Add assistant response to history
         var response = assistantUpdates.ToChatResponse();
+        cancellationToken.ThrowIfCancellationRequested();
         foreach (var msg in response.Messages)
-        {
             _history.Add(msg);
-        }
 
         UIAgentLog.AddedToHistory(_logger, response.Messages.Count);
     }

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/ChatAppearanceTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/ChatAppearanceTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Maui.AI.Chat;
+using Microsoft.Maui.AI.Chat.Controls.Tests.TestHelpers;
+using Microsoft.Maui.AI.Chat.Controls.Themes;
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Microsoft.Maui.AI.Chat.Controls.Tests;
+
+public class ChatAppearanceTests
+{
+    [Fact]
+    public void BuiltInMessageView_TracksStandaloneMessageListAppearance()
+    {
+        var list = new MessageListView();
+        var block = new TextContentBlock { Role = ChatRole.User };
+        block.AppendText("Hello");
+        var stroke = Color.FromArgb("#123456");
+
+        list.ShowAvatars = true;
+        list.AvatarSize = 36;
+        list.UserDisplayName = "Morgan";
+        list.AssistantDisplayName = "Sage";
+        list.ShowTimestamps = true;
+        list.BubbleCornerRadius = 20;
+        list.BubbleStrokeThickness = 2;
+        list.BubbleStrokeColor = stroke;
+        list.MaxBubbleWidth = 480;
+
+        var message = new ChatMessageView
+        {
+            ContentContext = new ContentContext(SessionFactory.Create(), block, list),
+        };
+
+        Assert.True(message.ShowAvatars);
+        Assert.Equal(36, message.AvatarSize);
+        Assert.Equal("Morgan", message.DisplayName);
+        Assert.Equal("M", message.AvatarText);
+        Assert.True(message.ShowTimestamp);
+        Assert.Equal(20, message.BubbleCornerRadius);
+        Assert.Equal(20, message.BubbleCornerRadii.BottomLeft);
+        Assert.Equal(4, message.BubbleCornerRadii.BottomRight);
+        Assert.Equal(2, message.BubbleStrokeThickness);
+        Assert.Equal(stroke, message.BubbleStrokeColor);
+        Assert.Equal(480, message.MaxBubbleWidth);
+        Assert.Equal("Morgan: Hello", SemanticProperties.GetDescription(message));
+        Assert.Equal("ChatMessage", message.AutomationId);
+
+        block = new TextContentBlock { Role = ChatRole.Assistant };
+        block.AppendText("Welcome");
+        message.ContentContext = new ContentContext(SessionFactory.Create(), block, list);
+
+        Assert.Equal("Sage", message.DisplayName);
+        Assert.Equal("S", message.AvatarText);
+        Assert.Equal(4, message.BubbleCornerRadii.BottomLeft);
+        Assert.Equal(20, message.BubbleCornerRadii.BottomRight);
+        Assert.Equal("Sage: Welcome", SemanticProperties.GetDescription(message));
+        Assert.Equal("ChatMessage", message.AutomationId);
+    }
+
+    [Fact]
+    public void CopilotChatView_ForwardsAppearanceToNestedMessageList()
+    {
+        var chat = new CopilotChatView();
+        var list = new MessageListView();
+        var stroke = Color.FromArgb("#654321");
+        chat.AttachMessageListPart(list);
+
+        chat.ShowAvatars = true;
+        chat.AvatarSize = 40;
+        chat.UserDisplayName = "Customer";
+        chat.AssistantDisplayName = "Copilot";
+        chat.ShowTimestamps = true;
+        chat.BubbleCornerRadius = 18;
+        chat.BubbleStrokeThickness = 3;
+        chat.BubbleStrokeColor = stroke;
+        chat.MaxBubbleWidth = 520;
+        chat.UseDefaultContentTemplates = false;
+
+        Assert.True(list.ShowAvatars);
+        Assert.Equal(40, list.AvatarSize);
+        Assert.Equal("Customer", list.UserDisplayName);
+        Assert.Equal("Copilot", list.AssistantDisplayName);
+        Assert.True(list.ShowTimestamps);
+        Assert.Equal(18, list.BubbleCornerRadius);
+        Assert.Equal(3, list.BubbleStrokeThickness);
+        Assert.Equal(stroke, list.BubbleStrokeColor);
+        Assert.Equal(520, list.MaxBubbleWidth);
+        Assert.False(list.UseDefaultContentTemplates);
+    }
+
+    [Fact]
+    public void InputAppearance_UpdatesAttachedTemplatePartsLive()
+    {
+        var chat = new CopilotChatView();
+        var firstSendColor = Color.FromArgb("#112233");
+        var secondSendColor = Color.FromArgb("#334455");
+        var firstInputColor = Color.FromArgb("#556677");
+        var secondInputColor = Color.FromArgb("#778899");
+        var defaultSendColor = Color.FromArgb("#224466");
+        var defaultInputColor = Color.FromArgb("#6688AA");
+        var host = new ContentView();
+        host.Resources[ChatThemeKeys.SendBackground] = defaultSendColor;
+        host.Resources[ChatThemeKeys.InputBackground] = defaultInputColor;
+        host.Content = chat;
+
+        chat.SendButtonBackgroundColor = firstSendColor;
+        chat.InputAreaBackgroundColor = firstInputColor;
+        chat.InputAreaCornerRadius = 19;
+
+        Assert.Equal(firstSendColor, chat.EffectiveSendButtonBackgroundColor);
+        Assert.Equal(firstInputColor, chat.EffectiveInputAreaBackgroundColor);
+        Assert.Equal(19, chat.InputAreaCornerRadius);
+
+        chat.SendButtonBackgroundColor = secondSendColor;
+        chat.InputAreaBackgroundColor = secondInputColor;
+        chat.InputAreaCornerRadius = 27;
+
+        Assert.Equal(secondSendColor, chat.EffectiveSendButtonBackgroundColor);
+        Assert.Equal(secondInputColor, chat.EffectiveInputAreaBackgroundColor);
+        Assert.Equal(27, chat.InputAreaCornerRadius);
+
+        chat.SendButtonBackgroundColor = null;
+        chat.InputAreaBackgroundColor = null;
+
+        Assert.Equal(defaultSendColor, chat.EffectiveSendButtonBackgroundColor);
+        Assert.Equal(defaultInputColor, chat.EffectiveInputAreaBackgroundColor);
+    }
+
+}

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/ChatPageTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/ChatPageTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Maui.AI.Chat;
 using Microsoft.Extensions.AI;
 using Microsoft.Maui.AI.Chat.Controls.Tests.TestHelpers;
-using Microsoft.Maui.Controls.Xaml;
 
 namespace Microsoft.Maui.AI.Chat.Controls.Tests;
 
@@ -15,8 +14,7 @@ public class ChatPageTests
     [Fact]
     public void Session_CanBeSetAndCleared()
     {
-        var control = CreateControl();
-        if (control == null) return;
+        var control = new CopilotChatView();
 
         var session = SessionFactory.Create("test");
 
@@ -30,8 +28,7 @@ public class ChatPageTests
     [Fact]
     public void Session_Swap_DoesNotThrow()
     {
-        var control = CreateControl();
-        if (control == null) return;
+        var control = new CopilotChatView();
 
         var session1 = SessionFactory.Create("First");
         var session2 = SessionFactory.Create("Second");
@@ -59,8 +56,7 @@ public class ChatPageTests
     [Fact]
     public async Task SendMessage_ClearsTextProperty()
     {
-        var control = CreateControl();
-        if (control == null) return;
+        var control = new CopilotChatView();
 
         var session = SessionFactory.Create("Reply");
         control.Session = session;
@@ -76,8 +72,7 @@ public class ChatPageTests
     [Fact]
     public void SendMessage_WhenNoSession_DoesNotThrow()
     {
-        var control = CreateControl();
-        if (control == null) return;
+        var control = new CopilotChatView();
 
         control.Text = "Hello";
 
@@ -88,8 +83,7 @@ public class ChatPageTests
     [Fact]
     public void SendMessage_WhenBusy_Blocked()
     {
-        var control = CreateControl();
-        if (control == null) return;
+        var control = new CopilotChatView();
 
         control.IsBusy = true;
 
@@ -100,8 +94,7 @@ public class ChatPageTests
     [Fact]
     public void SendMessage_WhenTextEmpty_Blocked()
     {
-        var control = CreateControl();
-        if (control == null) return;
+        var control = new CopilotChatView();
 
         var session = SessionFactory.Create("Reply");
         control.Session = session;
@@ -112,7 +105,7 @@ public class ChatPageTests
     }
 
     [Fact]
-    public async Task CancelMessage_StopsStreaming()
+    public async Task CallerCancellation_CompletesSendTaskAsCanceled()
     {
         var tcs = new TaskCompletionSource<ChatResponse>();
         var client = new TestChatClient((_, _, ct) =>
@@ -127,19 +120,7 @@ public class ChatPageTests
 
         cts.Cancel();
 
-        // Should complete without throwing (cancellation is handled gracefully)
-        await sendTask;
-    }
-
-    private static CopilotChatView? CreateControl()
-    {
-        try
-        {
-            return new CopilotChatView();
-        }
-        catch (Exception ex) when (ex is XamlParseException or InvalidOperationException)
-        {
-            return null;
-        }
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+        Assert.Equal(ConversationStatus.Idle, session.Status);
     }
 }

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/EmptyViewTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/EmptyViewTests.cs
@@ -1,5 +1,3 @@
-using Microsoft.Maui.Controls.Xaml;
-
 namespace Microsoft.Maui.AI.Chat.Controls.Tests;
 
 /// <summary>
@@ -11,9 +9,7 @@ public class EmptyViewTests
     [Fact]
     public void EmptyViewTemplate_NullByDefault()
     {
-        var control = CreateControl();
-        if (control == null)
-            return; // Skip if MAUI XAML runtime unavailable in test host
+        var control = new CopilotChatView();
 
         Assert.Null(control.EmptyViewTemplate);
     }
@@ -21,9 +17,7 @@ public class EmptyViewTests
     [Fact]
     public void EmptyViewTemplate_CanBeSet_AndRoundTrips()
     {
-        var control = CreateControl();
-        if (control == null)
-            return;
+        var control = new CopilotChatView();
 
         var template = new DataTemplate(() => new Label { Text = "Nothing here yet" });
         control.EmptyViewTemplate = template;
@@ -34,9 +28,7 @@ public class EmptyViewTests
     [Fact]
     public void EmptyViewTemplate_SettingDoesNotThrow_WhenTemplateNotApplied()
     {
-        var control = CreateControl();
-        if (control == null)
-            return;
+        var control = new CopilotChatView();
 
         // No control template applied in the unit-test host, so PART_EmptyView is null.
         // Setting the property must not throw even though there is no host to fill.
@@ -49,9 +41,7 @@ public class EmptyViewTests
     [Fact]
     public void EmptyViewTemplate_ClearingBackToNull_DoesNotThrow()
     {
-        var control = CreateControl();
-        if (control == null)
-            return;
+        var control = new CopilotChatView();
 
         control.EmptyViewTemplate = new DataTemplate(() => new Label());
         var ex = Record.Exception(() => control.EmptyViewTemplate = null);
@@ -63,9 +53,7 @@ public class EmptyViewTests
     [Fact]
     public void SettingBindingContext_WithEmptyViewTemplate_DoesNotThrow()
     {
-        var control = CreateControl();
-        if (control == null)
-            return;
+        var control = new CopilotChatView();
 
         // Custom empty content binds against the control's data context (not the
         // templated parent). Changing the BindingContext must re-propagate safely,
@@ -77,19 +65,4 @@ public class EmptyViewTests
         Assert.Null(ex);
     }
 
-    /// <summary>
-    /// Creates a CopilotChatView, returning null if MAUI XAML runtime is unavailable
-    /// (InitializeComponent requires the full MAUI platform host).
-    /// </summary>
-    private static CopilotChatView? CreateControl()
-    {
-        try
-        {
-            return new CopilotChatView();
-        }
-        catch (Exception ex) when (ex is XamlParseException or InvalidOperationException)
-        {
-            return null;
-        }
-    }
 }

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/MessageListViewTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/MessageListViewTests.cs
@@ -100,9 +100,31 @@ public class MessageListViewTests
         var view = new MessageListView { Session = session };
 
         var error = Assert.Single(view.Items.Select(c => c.Block).OfType<ErrorContentBlock>());
-        Assert.Contains("boom", error.Message);
+        Assert.Equal(ErrorContentBlock.DefaultUserMessage, error.Message);
+        Assert.DoesNotContain("boom", error.Message, StringComparison.Ordinal);
+        Assert.Equal("boom", session.Error!.Message);
 
         // ...but the engine's turns never contained an error block (thread stays clean).
         Assert.DoesNotContain(session.Turns.SelectMany(t => t.ResponseBlocks), b => b is ErrorContentBlock);
+    }
+
+    [Fact]
+    public async Task CancellationReconciliation_PreservesPriorStickyError()
+    {
+        var client = new TestChatClient((_, _, _) =>
+            throw new InvalidOperationException("diagnostic"));
+        var session = SessionFactory.Create(client);
+        await session.SendMessageAsync("Hi");
+        var view = new MessageListView { Session = session };
+        var error = Assert.Single(view.Items, item => item.Block is ErrorContentBlock);
+
+        session.Turns[0].ClearResponseBlocks();
+        view.ReconcileItemsWithSession();
+
+        Assert.Contains(error, view.Items);
+        Assert.DoesNotContain(
+            view.Items,
+            item => item.Block.Role == Microsoft.Extensions.AI.ChatRole.Assistant
+                && item.Block is not ErrorContentBlock);
     }
 }

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/TemplateSelectorTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Controls.Tests/TemplateSelectorTests.cs
@@ -188,6 +188,78 @@ public class TemplateSelectorTests
         Assert.NotNull(template);
     }
 
+    [Fact]
+    public void MessageListView_ZeroConfiguration_ProvidesVisibleBuiltInFallbacks()
+    {
+        var view = new MessageListView();
+        var selector = view.CreateTemplateSelector();
+        var session = SessionFactory.Create();
+
+        Assert.IsType<ChatMessageView>(
+            selector.SelectTemplate(BlockFactory.MakeText("User", "Hello"), null!).CreateContent());
+        Assert.IsType<ChatMessageView>(
+            selector.SelectTemplate(BlockFactory.MakeText("Assistant", "Hi"), null!).CreateContent());
+        Assert.IsType<ToolApprovalView>(
+            selector.SelectTemplate(BlockFactory.MakeApproval("delete_file"), null!).CreateContent());
+        Assert.IsType<MediaContentView>(
+            selector.SelectTemplate(BlockFactory.MakeMedia(), null!).CreateContent());
+        Assert.IsType<ThinkingView>(
+            selector.SelectTemplate(
+                new ContentContext(session, new ThinkingContentBlock(), view),
+                null!).CreateContent());
+        Assert.IsType<ErrorMessageView>(
+            selector.SelectTemplate(
+                new ContentContext(session, new ErrorContentBlock("error"), view),
+                null!).CreateContent());
+    }
+
+    [Fact]
+    public void MessageListView_ZeroConfiguration_HidesRawFunctionInvocationsAndUnknownBlocks()
+    {
+        var view = new MessageListView();
+        var selector = view.CreateTemplateSelector();
+        var session = SessionFactory.Create();
+
+        AssertRendersNothing(selector.SelectTemplate(BlockFactory.MakeToolCall("get_weather"), null!));
+        AssertRendersNothing(selector.SelectTemplate(
+            new ContentContext(session, new UnknownContentBlock(), view),
+            null!));
+    }
+
+    [Fact]
+    public void ConsumerTemplate_AlwaysOutranksBuiltInFallback()
+    {
+        var view = new MessageListView();
+        view.ContentTemplates.Add(new CustomTextTemplate { Priority = -20_000 });
+
+        var block = new CustomTextBlock();
+        block.AppendText("custom");
+        block.Role = ChatRole.Assistant;
+        var context = new ContentContext(SessionFactory.Create(), block, view);
+
+        var selected = view.CreateTemplateSelector().SelectTemplate(context, null!);
+
+        Assert.IsType<Editor>(selected.CreateContent());
+    }
+
+    [Fact]
+    public void UseDefaultContentTemplatesFalse_RestoresStrictAllowListRendering()
+    {
+        var view = new MessageListView { UseDefaultContentTemplates = false };
+        var context = BlockFactory.MakeText("Assistant", "Hello");
+
+        AssertRendersNothing(view.CreateTemplateSelector().SelectTemplate(context, null!));
+
+        view.ContentTemplates.Add(new TextContentTemplate
+        {
+            ViewType = typeof(Label),
+            Priority = -20_000,
+        });
+
+        var selected = view.CreateTemplateSelector().SelectTemplate(context, null!);
+        Assert.IsType<Label>(selected.CreateContent());
+    }
+
     /// <summary>
     /// Creates a selector with all standard templates registered (mirrors the default
     /// CopilotChatView template configuration).
@@ -200,5 +272,16 @@ public class TemplateSelectorTests
         selector.Templates.Add(new MediaContentTemplate { ViewType = typeof(Label) });
         selector.Templates.Add(new DefaultContentTemplate { ViewType = typeof(Label) });
         return selector;
+    }
+
+    private sealed class UnknownContentBlock : ContentBlock;
+
+    private sealed class CustomTextBlock : TextContentBlock;
+
+    private sealed class CustomTextTemplate : ContentTemplate
+    {
+        public CustomTextTemplate() => ViewType = typeof(Editor);
+
+        public override bool When(ContentContext context) => context.Block is CustomTextBlock;
     }
 }

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Blocks/ToolApprovalBlockTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Blocks/ToolApprovalBlockTests.cs
@@ -48,6 +48,18 @@ public class ToolApprovalBlockTests
     }
 
     [Fact]
+    public async Task Reject_PropagatesReasonToApprovalResponse()
+    {
+        var block = CreateBlock();
+
+        block.Reject("Not safe");
+
+        var response = Assert.IsType<ToolApprovalResponseContent>(await block.GetResultAsync());
+        Assert.False(response.Approved);
+        Assert.Equal("Not safe", response.Reason);
+    }
+
+    [Fact]
     public void Approve_FiresNotifyChanged()
     {
         var block = CreateBlock();
@@ -80,6 +92,55 @@ public class ToolApprovalBlockTests
 
         Assert.Equal(ApprovalStatus.Approved, block.Status);
         Assert.True(block.GetResultAsync().IsCompleted);
+    }
+
+    [Fact]
+    public async Task Approve_Twice_IsSingleUse()
+    {
+        var block = CreateBlock();
+        var changedCount = 0;
+        block.OnChanged(() => changedCount++);
+
+        block.Approve();
+        var firstResult = await block.GetResultAsync();
+        block.Approve();
+        var secondResult = await block.GetResultAsync();
+
+        Assert.Equal(ApprovalStatus.Approved, block.Status);
+        Assert.Equal(1, changedCount);
+        Assert.Same(firstResult, secondResult);
+    }
+
+    [Fact]
+    public async Task RejectAfterApprove_IsNoOp()
+    {
+        var block = CreateBlock();
+        var changedCount = 0;
+        block.OnChanged(() => changedCount++);
+
+        block.Approve();
+        var approvedResult = await block.GetResultAsync();
+        block.Reject("changed mind");
+
+        Assert.Equal(ApprovalStatus.Approved, block.Status);
+        Assert.Equal(1, changedCount);
+        Assert.Same(approvedResult, await block.GetResultAsync());
+    }
+
+    [Fact]
+    public async Task ApproveAfterReject_IsNoOp()
+    {
+        var block = CreateBlock();
+        var changedCount = 0;
+        block.OnChanged(() => changedCount++);
+
+        block.Reject("not safe");
+        var rejectedResult = await block.GetResultAsync();
+        block.Approve();
+
+        Assert.Equal(ApprovalStatus.Rejected, block.Status);
+        Assert.Equal(1, changedCount);
+        Assert.Same(rejectedResult, await block.GetResultAsync());
     }
 
     private static ToolApprovalBlock CreateBlock()

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/AgentContextErrorHandlingTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/AgentContextErrorHandlingTests.cs
@@ -95,6 +95,45 @@ public class AgentContextErrorHandlingTests
         Assert.NotEmpty(turn.ResponseBlocks);
     }
 
+    [Fact]
+    public async Task ToolFailure_RollsBackDanglingToolCallHistory()
+    {
+        var sentMessages = new List<IReadOnlyList<ChatMessage>>();
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            sentMessages.Add(messages.ToArray());
+            callCount++;
+            return callCount == 1
+                ? ResponseEmitters.EmitToolCallResponse(
+                    "call-1",
+                    "explode",
+                    ct: cancellationToken)
+                : ResponseEmitters.EmitTextResponse("recovered", cancellationToken);
+        });
+        var explodingTool = AIFunctionFactory.Create(
+            (Func<string>)(() => throw new InvalidOperationException("tool failed")),
+            "explode");
+        var context = new AgentContext(new UIAgent(client, new ChatOptions
+        {
+            Tools = [explodingTool],
+        }));
+
+        await context.SendMessageAsync("first");
+        Assert.Equal(ConversationStatus.Error, context.Status);
+
+        await context.SendMessageAsync("second");
+
+        Assert.Equal(2, sentMessages.Count);
+        var retryRequest = sentMessages[1];
+        Assert.Equal(2, retryRequest.Count);
+        Assert.All(retryRequest, message => Assert.Equal(ChatRole.User, message.Role));
+        Assert.DoesNotContain(
+            retryRequest.SelectMany(message => message.Contents),
+            content => content is FunctionCallContent);
+    }
+
     // ---- CancelAsync ----
 
     [Fact]
@@ -186,5 +225,235 @@ public class AgentContextErrorHandlingTests
         }
     }
 
+    [Fact]
+    public async Task CallerCancellation_CancelsTask_DiscardsResponseBlocks_AndReturnsIdle()
+    {
+        var streamStarted = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+            SlowCancelableStream(streamStarted, cancellationToken));
+        var context = new AgentContext(new UIAgent(client));
+        using var callerCts = new CancellationTokenSource();
+
+        var sendTask = context.SendMessageAsync("Hello", callerCts.Token);
+        await streamStarted.Task;
+
+        callerCts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task CallerCancellation_WhenClientThrowsDifferentException_StillCancelsTask()
+    {
+        var streamStarted = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+            ThrowNonCancellationExceptionAfterCancellation(streamStarted, cancellationToken));
+        var context = new AgentContext(new UIAgent(client));
+        using var callerCts = new CancellationTokenSource();
+
+        var sendTask = context.SendMessageAsync("Hello", callerCts.Token);
+        await streamStarted.Task;
+        callerCts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task CallerCancellation_AfterErrorTransition_ResetsIdleAndRethrowsCancellation()
+    {
+        var expectedError = new InvalidOperationException("diagnostic");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+            ResponseEmitters.EmitErrorAfterTokens([], expectedError, cancellationToken));
+        var context = new AgentContext(new UIAgent(client));
+        using var callerCts = new CancellationTokenSource();
+        context.RegisterOnStatusChanged(status =>
+        {
+            if (status == ConversationStatus.Error)
+                callerCts.Cancel();
+        });
+
+        var sendTask = context.SendMessageAsync("Hello", callerCts.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task GracefulCancellation_DisposesLifecycleAndAllowsNextSend()
+    {
+        var streamStarted = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        var callCount = 0;
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            callCount++;
+            return callCount == 1
+                ? SlowCancelableStream(streamStarted, cancellationToken)
+                : ResponseEmitters.EmitTextResponse("second response", cancellationToken);
+        });
+        var context = new AgentContext(new UIAgent(client));
+
+        var firstSend = context.SendMessageAsync("first");
+        await streamStarted.Task;
+        await context.CancelAsync();
+        await firstSend;
+
+        await context.SendMessageAsync("second");
+
+        Assert.Equal(2, context.Turns.Count);
+        Assert.Empty(context.Turns[0].ResponseBlocks);
+        Assert.NotEmpty(context.Turns[1].ResponseBlocks);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+
+    [Fact]
+    public async Task GracefulCancellation_DoesNotCommitPartialAssistantHistory()
+    {
+        var streamStarted = new TaskCompletionSource();
+        var sentMessages = new List<IReadOnlyList<ChatMessage>>();
+        var client = new DelegatingStreamingChatClient();
+        var callCount = 0;
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            sentMessages.Add(messages.ToArray());
+            callCount++;
+            return callCount == 1
+                ? SlowCancelableStream(streamStarted, cancellationToken)
+                : ResponseEmitters.EmitTextResponse("second response", cancellationToken);
+        });
+        var context = new AgentContext(new UIAgent(client));
+
+        var firstSend = context.SendMessageAsync("first");
+        await streamStarted.Task;
+        await context.CancelAsync();
+        await firstSend;
+
+        await context.SendMessageAsync("second");
+
+        Assert.Equal(2, sentMessages.Count);
+        var secondRequest = sentMessages[1];
+        Assert.Equal(2, secondRequest.Count);
+        Assert.Equal(ChatRole.User, secondRequest[0].Role);
+        Assert.Equal(ChatRole.User, secondRequest[1].Role);
+        Assert.DoesNotContain(
+            secondRequest.SelectMany(message => message.Contents).OfType<TextContent>(),
+            content => content.Text == "partial");
+    }
+
+    [Fact]
+    public async Task CancelWhileAwaitingApproval_RollsBackDanglingApprovalHistory()
+    {
+        var awaitingInput = new TaskCompletionSource();
+        var sentMessages = new List<IReadOnlyList<ChatMessage>>();
+        var client = new DelegatingStreamingChatClient();
+        var callCount = 0;
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            sentMessages.Add(messages.ToArray());
+            callCount++;
+            return callCount == 1
+                ? ResponseEmitters.EmitApprovalRequest(
+                    "call-1",
+                    "DeleteFile",
+                    ct: cancellationToken)
+                : ResponseEmitters.EmitTextResponse("fresh response", cancellationToken);
+        });
+        var context = new AgentContext(new UIAgent(client));
+        context.RegisterOnStatusChanged(status =>
+        {
+            if (status == ConversationStatus.AwaitingInput)
+                awaitingInput.TrySetResult();
+        });
+
+        var firstSend = context.SendMessageAsync("first");
+        await awaitingInput.Task;
+        await context.CancelAsync();
+        await firstSend;
+
+        await context.SendMessageAsync("second");
+
+        Assert.Equal(2, sentMessages.Count);
+        var secondRequest = sentMessages[1];
+        Assert.Equal(2, secondRequest.Count);
+        Assert.All(secondRequest, message => Assert.Equal(ChatRole.User, message.Role));
+        Assert.DoesNotContain(
+            secondRequest.SelectMany(message => message.Contents),
+            content => content is ToolApprovalRequestContent);
+    }
+
+    [Fact]
+    public async Task Clear_DuringStreaming_CancelsCurrentSendAndAllowsFreshConversation()
+    {
+        var streamStarted = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        var callCount = 0;
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            callCount++;
+            return callCount == 1
+                ? SlowCancelableStream(streamStarted, cancellationToken)
+                : ResponseEmitters.EmitTextResponse("fresh response", cancellationToken);
+        });
+        var context = new AgentContext(new UIAgent(client));
+
+        var firstSend = context.SendMessageAsync("first");
+        await streamStarted.Task;
+
+        context.Clear();
+        await firstSend;
+        await context.SendMessageAsync("fresh");
+
+        Assert.Single(context.Turns);
+        Assert.NotEmpty(context.Turns[0].ResponseBlocks);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+
     // ---- Integration: Error recovery flow ----
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> SlowCancelableStream(
+        TaskCompletionSource streamStarted,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent("partial")],
+        };
+        streamStarted.TrySetResult();
+        await Task.Delay(Timeout.Infinite, cancellationToken);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> ThrowNonCancellationExceptionAfterCancellation(
+        TaskCompletionSource streamStarted,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent("partial")],
+        };
+        streamStarted.TrySetResult();
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw new InvalidOperationException("client translated cancellation");
+        }
+    }
 }

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/AgentContextTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/AgentContextTests.cs
@@ -67,6 +67,16 @@ public class AgentContextTests
         Assert.Equal("My message", userBlock.RawText);
     }
 
+    [Fact]
+    public async Task SendMessageAsync_NullMessage_ThrowsArgumentNullException()
+    {
+        var (agent, _) = CreateAgent();
+        var context = new AgentContext(agent);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => context.SendMessageAsync((ChatMessage)null!));
+    }
+
     // ---- Status Transitions ----
 
     [Fact]
@@ -246,5 +256,45 @@ public class AgentContextTests
 
         var userBlock = Assert.IsType<TextContentBlock>(context.Turns[0].RequestBlocks[0]);
         Assert.Equal("Hello world", userBlock.RawText);
+    }
+
+    [Fact]
+    public async Task Clear_RemovesTurnsHistoryAndError_AndReturnsToIdle()
+    {
+        var (agent, client) = CreateAgent();
+        var callCount = 0;
+        var messageCounts = new List<int>();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            callCount++;
+            messageCounts.Add(messages.Count());
+            return callCount == 1
+                ? ResponseEmitters.EmitErrorAfterTokens(
+                    ["partial"],
+                    new InvalidOperationException("diagnostic"),
+                    cancellationToken)
+                : ResponseEmitters.EmitTextResponse("fresh", cancellationToken);
+        });
+        var context = new AgentContext(agent);
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(status => statuses.Add(status));
+
+        await context.SendMessageAsync("first");
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        Assert.NotNull(context.Error);
+        Assert.Single(context.Turns);
+
+        context.Clear();
+
+        Assert.Empty(context.Turns);
+        Assert.Null(context.Error);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Equal(ConversationStatus.Idle, statuses[^1]);
+
+        await context.SendMessageAsync("second");
+
+        Assert.Single(context.Turns);
+        Assert.Equal(new[] { 1, 1 }, messageCounts);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
     }
 }

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/UIAgentTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/UIAgentTests.cs
@@ -9,6 +9,35 @@ namespace Microsoft.Maui.AI.Chat.Tests.Engine;
 public class UIAgentTests
 {
     [Fact]
+    public async Task SendMessageAsync_NullMessage_ThrowsWithoutPoisoningHistory()
+    {
+        IReadOnlyList<ChatMessage>? sentMessages = null;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            sentMessages = messages.ToArray();
+            return ResponseEmitters.EmitTextResponse("ok", cancellationToken);
+        });
+        var agent = new UIAgent(client);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => EnumerateAsync(agent.SendMessageAsync(null!)));
+
+        await EnumerateAsync(agent.SendMessageAsync(new ChatMessage(ChatRole.User, "valid")));
+
+        Assert.NotNull(sentMessages);
+        Assert.Single(sentMessages);
+        Assert.Equal("valid", sentMessages[0].Text);
+
+        static async Task EnumerateAsync(IAsyncEnumerable<ContentBlock> blocks)
+        {
+            await foreach (var _ in blocks)
+            {
+            }
+        }
+    }
+
+    [Fact]
     public async Task SendMessageAsync_TextResponse_YieldsUserThenAssistantBlocks()
     {
         var client = new DelegatingStreamingChatClient();


### PR DESCRIPTION
## Summary

- Makes `MessageListView` and `CopilotChatView` true zero-configuration controls with low-priority built-in rendering for user/assistant text, approvals, media, thinking, and generic errors. Raw function-invocation and unknown blocks remain hidden unless explicitly templated.
- Gives consumer templates an explicit higher selection tier so Garden's typed templates always win, and adds `UseDefaultContentTemplates="False"` for strict allow-list replacement/opt-out behavior.
- Wires avatars, display names, timestamps, bubble shape/stroke/width, semantics, and live input-area colors/radius into the built-in templates while preserving `ControlTemplate` extensibility.
- Separates graceful `CancelAsync` from caller-token cancellation: both discard partial response/history and return to `Idle`, but only the caller-token path completes the send task as canceled. Also disposes/replaces CTS instances, validates null messages, keeps errors non-leaking in the UI, and makes approval decisions single-use while forwarding rejection reasons.
- Adds focused regressions for default rendering and precedence, appearance state, cancellation/history/clear lifecycle, generic errors, approval idempotency, and previously silent control-test setup paths.

## Stack scope

This is **layer 1** stacked on PR #357 (`mattleibow/ai-chat-mvp`) and intentionally contains only current correctness/default-rendering hardening. It does not include later thread/state/rich-content/UI-action/tool-generator/attachment layers and does not register stack metadata.

The engine/control contract remains explicitly single-thread-affine; callers serialize operations and perform platform dispatch. No synchronization gates, locks, concurrent collections, or dispatcher abstractions were added.

## Validation

- `Microsoft.Maui.AI.Chat.Tests`: 137 passed (Release, warnings as errors)
- `Microsoft.Maui.AI.Chat.Controls.Tests`: 98 passed (Release, warnings as errors)
- Garden sample: `net10.0-maccatalyst` Release build passed with warnings as errors