### PR TITLE
Add AI chat conversation threads, restore, and retry

### DIFF
--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Blocks/ContentBlock.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Blocks/ContentBlock.cs
@@ -27,6 +27,12 @@ public abstract class ContentBlock
 
     public string? AuthorName { get; internal set; }
 
+    internal string? RestoredTurnId { get; set; }
+
+    internal bool StartsRestoredTurn { get; set; }
+
+    internal bool IsRestoredRequest { get; set; }
+
     private readonly List<Action> _callbacks = new();
 
     public ContentBlockChangedSubscription OnChanged(Action callback)

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Blocks/ToolApproval/ToolApprovalBlock.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Blocks/ToolApproval/ToolApprovalBlock.cs
@@ -45,6 +45,17 @@ public class ToolApprovalBlock : InteractiveFunctionBlock, IInteractiveBlock
     public Task<AIContent> GetResultAsync(CancellationToken cancellationToken = default)
         => _tcs.Task.WaitAsync(cancellationToken);
 
+    internal void RestoreResponse(ToolApprovalResponseContent response)
+    {
+        if (response.RequestId != ApprovalRequest.RequestId)
+            return;
+
+        Status = response.Approved
+            ? ApprovalStatus.Approved
+            : ApprovalStatus.Rejected;
+        _tcs.TrySetResult(response);
+    }
+
     private void Resolve(ApprovalStatus status, bool approved, string? reason)
     {
         if (Status != ApprovalStatus.Pending)

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/AgentContext.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/AgentContext.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Maui.AI.Chat;
 /// Drives the tool/approval loop: after streaming from the <see cref="UIAgent"/> it invokes any pending
 /// backend tools and awaits <see cref="IInteractiveBlock"/>s (e.g. approvals), then feeds the results
 /// back for another round.
+/// <para>
+/// This type is single-thread-affine and is not thread-safe. Callers must serialize access and
+/// enter the owning application thread before calling it. Status checks are misuse guards, not
+/// synchronization.
+/// </para>
 /// </remarks>
 public class AgentContext(UIAgent agent) : IDisposable
 {
@@ -23,6 +28,9 @@ public class AgentContext(UIAgent agent) : IDisposable
     private readonly List<Action<ConversationStatus>> _statusChangedCallbacks = new();
     private readonly List<Action<ConversationTurn, ContentBlock>> _blockAddedCallbacks = new();
     private CancellationTokenSource? _streamingCts;
+    private ChatMessage? _retryMessage;
+    private UIAgent.HistoryCheckpoint _retryHistoryCheckpoint;
+    private bool _restoreCompleted;
     private bool _disposed;
 
     public IReadOnlyList<ConversationTurn> Turns => _turns;
@@ -32,7 +40,7 @@ public class AgentContext(UIAgent agent) : IDisposable
     public Exception? Error { get; private set; }
 
     /// <summary>
-    /// Clears all conversation turns and resets the session to idle state.
+    /// Clears all conversation turns, local and persistent history, and error state.
     /// The underlying agent and tools remain configured.
     /// </summary>
     public void Clear()
@@ -41,6 +49,9 @@ public class AgentContext(UIAgent agent) : IDisposable
         CancelAndDisposeStreaming();
         _turns.Clear();
         agent.ClearHistory();
+        _retryMessage = null;
+        _retryHistoryCheckpoint = default;
+        _restoreCompleted = false;
         Error = null;
         Status = ConversationStatus.Idle;
         NotifyStatusChanged();
@@ -60,40 +71,125 @@ public class AgentContext(UIAgent agent) : IDisposable
         if (Status == ConversationStatus.Streaming)
             throw new InvalidOperationException("A message is already being processed.");
 
-        var turn = new ConversationTurn();
+        var requestMessage = EnsureMessageId(message);
+        var turn = new ConversationTurn { Id = requestMessage.MessageId! };
         _turns.Add(turn);
         NotifyTurnAdded(turn);
 
         var historyCheckpoint = agent.CaptureHistoryCheckpoint();
+        await RunAttemptAsync(
+            requestMessage,
+            turn,
+            historyCheckpoint,
+            includeInitialRequestBlocks: true,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Restores committed conversation turns from the configured <see cref="IConversationThread"/>.
+    /// </summary>
+    /// <remarks>
+    /// Restore requires an idle, empty context and may be called only once before <see cref="Clear"/>.
+    /// It reconstructs display/history blocks only: restored approvals, tools, and other interactive
+    /// blocks are not resumed or invoked.
+    /// </remarks>
+    public async Task RestoreAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (Status != ConversationStatus.Idle)
+            throw new InvalidOperationException("RestoreAsync requires an idle context.");
+
+        if (_restoreCompleted || _turns.Count != 0)
+        {
+            throw new InvalidOperationException(
+                "RestoreAsync requires an empty context and may not be called twice. Call Clear first.");
+        }
+
+        var blocks = await agent.RestoreAsync(cancellationToken);
+        ConversationTurn? currentTurn = null;
+
+        foreach (var block in blocks)
+        {
+            if (block.StartsRestoredTurn || currentTurn is null)
+            {
+                currentTurn = new ConversationTurn
+                {
+                    Id = block.RestoredTurnId
+                        ?? block.Id
+                        ?? Guid.NewGuid().ToString("N"),
+                };
+                _turns.Add(currentTurn);
+            }
+
+            if (block.IsRestoredRequest)
+                currentTurn.AddRequestBlock(block);
+            else
+                currentTurn.AddResponseBlock(block);
+        }
+
+        _restoreCompleted = true;
+    }
+
+    /// <summary>
+    /// Retries the last failed message in its existing turn.
+    /// </summary>
+    public async Task RetryAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (Status != ConversationStatus.Error || _retryMessage is null)
+        {
+            throw new InvalidOperationException(
+                $"RetryAsync requires Status == Error, but Status is {Status}.");
+        }
+
+        var turn = _turns[^1];
+        turn.ClearResponseBlocks();
+        agent.RestoreHistory(_retryHistoryCheckpoint);
+
+        await RunAttemptAsync(
+            _retryMessage,
+            turn,
+            _retryHistoryCheckpoint,
+            includeInitialRequestBlocks: false,
+            cancellationToken);
+    }
+
+    private async Task RunAttemptAsync(
+        ChatMessage message,
+        ConversationTurn turn,
+        UIAgent.HistoryCheckpoint historyCheckpoint,
+        bool includeInitialRequestBlocks,
+        CancellationToken callerToken)
+    {
         var (streamingCts, streamingToken) = ReplaceStreamingCancellationSource();
         CancellationTokenSource? linkedCts = null;
 
         try
         {
-            if (cancellationToken.CanBeCanceled)
+            if (callerToken.CanBeCanceled)
             {
                 linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
                     streamingToken,
-                    cancellationToken);
+                    callerToken);
                 streamingToken = linkedCts.Token;
             }
 
-            await StreamIntoTurnAsync(
+            var outcome = await StreamIntoTurnAsync(
                 message,
                 turn,
                 historyCheckpoint,
+                includeInitialRequestBlocks,
                 streamingToken);
 
-            if (cancellationToken.IsCancellationRequested)
+            if (outcome != AttemptOutcome.Succeeded && callerToken.IsCancellationRequested)
+            {
                 CleanupCanceledTurn(turn, historyCheckpoint, message);
-
-            cancellationToken.ThrowIfCancellationRequested();
-        }
-        catch (Exception) when (cancellationToken.IsCancellationRequested)
-        {
-            CleanupCanceledTurn(turn, historyCheckpoint, message);
-            cancellationToken.ThrowIfCancellationRequested();
-            throw;
+                callerToken.ThrowIfCancellationRequested();
+            }
         }
         finally
         {
@@ -104,10 +200,11 @@ public class AgentContext(UIAgent agent) : IDisposable
         }
     }
 
-    private async Task StreamIntoTurnAsync(
+    private async Task<AttemptOutcome> StreamIntoTurnAsync(
         ChatMessage message,
         ConversationTurn turn,
-        int historyCheckpoint,
+        UIAgent.HistoryCheckpoint historyCheckpoint,
+        bool includeInitialRequestBlocks,
         CancellationToken cancellationToken)
     {
         Status = ConversationStatus.Streaming;
@@ -117,13 +214,19 @@ public class AgentContext(UIAgent agent) : IDisposable
         try
         {
             ChatMessage? currentMessage = message;
+            var startsThreadTurn = true;
+            var isInitialRequest = true;
 
             while (currentMessage is not null)
             {
                 var interactiveBlocks = new List<IInteractiveBlock>();
                 var uninvokedToolBlocks = new List<FunctionInvocationContentBlock>();
 
-                await foreach (var block in agent.SendMessageAsync(currentMessage, cancellationToken).WithCancellation(cancellationToken))
+                await foreach (var block in agent.SendMessageAsync(
+                    currentMessage,
+                    startsThreadTurn,
+                    completesThreadTurn: false,
+                    cancellationToken).WithCancellation(cancellationToken))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
@@ -139,36 +242,36 @@ public class AgentContext(UIAgent agent) : IDisposable
                     }
 
                     if (block.Role == currentMessage.Role)
-                        turn.AddRequestBlock(block);
+                    {
+                        if (!isInitialRequest || includeInitialRequestBlocks)
+                        {
+                            turn.AddRequestBlock(block);
+                            NotifyBlockAdded(turn, block);
+                        }
+                    }
                     else
+                    {
                         turn.AddResponseBlock(block);
-
-                    NotifyBlockAdded(turn, block);
+                        NotifyBlockAdded(turn, block);
+                    }
                 }
 
+                startsThreadTurn = false;
+                isInitialRequest = false;
                 currentMessage = null;
 
-                // Remove tool blocks that were already resolved during streaming
-                // (e.g., FunctionInvokingChatClient handled the invocation internally)
                 uninvokedToolBlocks.RemoveAll(b => b.Result is not null);
 
                 if (interactiveBlocks.Count == 0 && uninvokedToolBlocks.Count == 0)
-                {
                     break;
-                }
 
-                // Build tasks for all pending work
                 var resultTasks = new List<Task<AIContent>>();
 
                 foreach (var interactive in interactiveBlocks)
-                {
                     resultTasks.Add(interactive.GetResultAsync(cancellationToken));
-                }
 
                 foreach (var toolBlock in uninvokedToolBlocks)
-                {
                     resultTasks.Add(InvokeBackendToolAsync(toolBlock, cancellationToken));
-                }
 
                 if (interactiveBlocks.Count > 0)
                 {
@@ -184,7 +287,10 @@ public class AgentContext(UIAgent agent) : IDisposable
                     var role = results.Any(r => r is not FunctionResultContent)
                         ? ChatRole.User
                         : ChatRole.Tool;
-                    currentMessage = new ChatMessage(role, [.. results]);
+                    currentMessage = new ChatMessage(role, [.. results])
+                    {
+                        MessageId = Guid.NewGuid().ToString("N"),
+                    };
                 }
 
                 Status = ConversationStatus.Streaming;
@@ -192,21 +298,28 @@ public class AgentContext(UIAgent agent) : IDisposable
             }
 
             cancellationToken.ThrowIfCancellationRequested();
+            agent.CompleteThreadTurn();
+
+            _retryMessage = null;
+            _retryHistoryCheckpoint = default;
             Status = ConversationStatus.Idle;
             NotifyStatusChanged();
+            return AttemptOutcome.Succeeded;
         }
         catch (Exception) when (cancellationToken.IsCancellationRequested)
         {
             CleanupCanceledTurn(turn, historyCheckpoint, message);
+            return AttemptOutcome.Canceled;
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
-            // Failures surface via Status/Error only — the UI renders them. No block is
-            // added to the turn, so the persistable message thread stays clean.
             agent.RollbackHistory(historyCheckpoint, message);
+            _retryMessage = message;
+            _retryHistoryCheckpoint = historyCheckpoint;
             Error = ex;
             Status = ConversationStatus.Error;
             NotifyStatusChanged();
+            return AttemptOutcome.Failed;
         }
     }
 
@@ -223,6 +336,8 @@ public class AgentContext(UIAgent agent) : IDisposable
 
     public Task CancelAsync()
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
         if (Status is ConversationStatus.Idle or ConversationStatus.Error)
             return Task.CompletedTask;
 
@@ -265,11 +380,13 @@ public class AgentContext(UIAgent agent) : IDisposable
 
     private void CleanupCanceledTurn(
         ConversationTurn turn,
-        int historyCheckpoint,
+        UIAgent.HistoryCheckpoint historyCheckpoint,
         ChatMessage requestMessage)
     {
         turn.ClearResponseBlocks();
         agent.RollbackHistory(historyCheckpoint, requestMessage);
+        _retryMessage = null;
+        _retryHistoryCheckpoint = default;
         Error = null;
 
         if (Status != ConversationStatus.Idle)
@@ -277,6 +394,16 @@ public class AgentContext(UIAgent agent) : IDisposable
             Status = ConversationStatus.Idle;
             NotifyStatusChanged();
         }
+    }
+
+    private static ChatMessage EnsureMessageId(ChatMessage message)
+    {
+        if (!string.IsNullOrEmpty(message.MessageId))
+            return message;
+
+        var clone = message.Clone();
+        clone.MessageId = Guid.NewGuid().ToString("N");
+        return clone;
     }
 
     public IDisposable RegisterOnTurnAdded(Action<ConversationTurn> callback)
@@ -316,6 +443,13 @@ public class AgentContext(UIAgent agent) : IDisposable
         var snapshot = _blockAddedCallbacks.ToArray();
         foreach (var cb in snapshot)
             cb(turn, block);
+    }
+
+    private enum AttemptOutcome
+    {
+        Succeeded,
+        Failed,
+        Canceled,
     }
 
     private sealed class CallbackRegistration<T> : IDisposable

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/ConversationTurn.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/ConversationTurn.cs
@@ -13,7 +13,7 @@ public class ConversationTurn
     private readonly List<ContentBlock> _requestBlocks = new();
     private readonly List<ContentBlock> _responseBlocks = new();
 
-    public string Id { get; internal set; } = string.Empty;
+    public string Id { get; internal set; } = Guid.NewGuid().ToString("N");
 
     public IReadOnlyList<ContentBlock> RequestBlocks => _requestBlocks;
 

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/IConversationThread.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/IConversationThread.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Maui.AI.Chat;
+
+/// <summary>
+/// Represents persistent storage for the raw updates in one conversation thread.
+/// Implementations own persistence, serialization, and reconstruction of message history.
+/// </summary>
+/// <remarks>
+/// Conversation threads are single-thread-affine and are not thread-safe. Callers must serialize
+/// access and enter the owning application thread before using the agent or thread.
+/// </remarks>
+public interface IConversationThread
+{
+    /// <summary>Gets the unique identifier for this conversation thread.</summary>
+    string ThreadId { get; }
+
+    /// <summary>
+    /// Gets whether the provider maintains conversation history remotely.
+    /// </summary>
+    bool IsStateful { get; }
+
+    /// <summary>
+    /// Gets the current provider conversation identifier for a stateful conversation.
+    /// </summary>
+    string? ConversationId { get; }
+
+    /// <summary>
+    /// Starts a pending turn with the user-initiated message.
+    /// A new call replaces any previous turn that was not completed.
+    /// </summary>
+    void AppendUserMessage(ChatMessage message);
+
+    /// <summary>
+    /// Appends a raw update to the pending turn. Updates can be provider output or an
+    /// engine-generated continuation input for a tool or approval round.
+    /// </summary>
+    /// <remarks>
+    /// Implementations must preserve the update's role, message identifier, contents, and
+    /// additional properties so logical turn boundaries can be replayed.
+    /// </remarks>
+    void AppendUpdate(ChatResponseUpdate update);
+
+    /// <summary>
+    /// Commits the pending turn. Only completed turns may be returned by
+    /// <see cref="GetUpdates"/> or <see cref="GetMessageHistory"/>.
+    /// </summary>
+    void CompleteTurn();
+
+    /// <summary>Returns the raw updates for all committed turns.</summary>
+    IReadOnlyList<ChatResponseUpdate> GetUpdates();
+
+    /// <summary>
+    /// Reconstructs the committed message history suitable for a stateless provider.
+    /// </summary>
+    IReadOnlyList<ChatMessage> GetMessageHistory();
+
+    /// <summary>
+    /// Removes all committed and pending updates and resets provider conversation state.
+    /// </summary>
+    void Clear();
+}

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/UIAgent.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/UIAgent.cs
@@ -15,11 +15,19 @@ namespace Microsoft.Maui.AI.Chat;
 /// <see cref="ContentBlock"/>s.
 /// </summary>
 /// <remarks>
-/// Configured with <see cref="UIAgentOptions"/> (instructions, tools, custom handlers). The stateful,
-/// UI-facing wrapper on top of it is <see cref="AgentContext"/>.
+/// Configured with <see cref="UIAgentOptions"/> (instructions, tools, persistence, custom handlers).
+/// The stateful, UI-facing wrapper on top of it is <see cref="AgentContext"/>.
+/// <para>
+/// This type is single-thread-affine and is not thread-safe. Callers must serialize access and
+/// enter the owning application thread before calling it.
+/// </para>
 /// </remarks>
 public class UIAgent : IDisposable
 {
+    private const string ContinuationPropertyName =
+        "Microsoft.Maui.AI.Chat.Persistence.IsContinuation.v1";
+    private const string ContinuationPropertyValue = "true";
+
     private readonly IChatClient _chatClient;
     private readonly UIAgentOptions _options;
     private readonly ILogger _logger;
@@ -57,47 +65,93 @@ public class UIAgent : IDisposable
         _logger = (ILogger?)loggerFactory?.CreateLogger<BlockMappingPipeline>() ?? NullLogger.Instance;
     }
 
-    /// <summary>Clears the accumulated chat history so the next message starts a fresh conversation.</summary>
+    /// <summary>
+    /// Clears local message history and the configured persistent conversation thread.
+    /// </summary>
+    /// <remarks>
+    /// The agent is single-thread-affine. Cancel and await an active send before starting another.
+    /// </remarks>
     public void ClearHistory()
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         _history.Clear();
+        _options.Thread?.Clear();
     }
 
-    internal int CaptureHistoryCheckpoint() => _history.Count;
+    internal readonly record struct HistoryCheckpoint(int Count);
 
-    internal void RollbackHistory(int checkpoint, ChatMessage requestMessage)
+    internal HistoryCheckpoint CaptureHistoryCheckpoint() => new(_history.Count);
+
+    internal void RestoreHistory(HistoryCheckpoint checkpoint)
     {
-        if (checkpoint < 0)
+        if (checkpoint.Count < 0)
             throw new ArgumentOutOfRangeException(nameof(checkpoint));
 
-        if (checkpoint > _history.Count)
+        if (checkpoint.Count > _history.Count)
             return;
 
-        var requestWasAdded = _history.Count > checkpoint;
-        _history.RemoveRange(checkpoint, _history.Count - checkpoint);
+        _history.RemoveRange(checkpoint.Count, _history.Count - checkpoint.Count);
+    }
+
+    internal void RollbackHistory(HistoryCheckpoint checkpoint, ChatMessage requestMessage)
+    {
+        if (checkpoint.Count < 0)
+            throw new ArgumentOutOfRangeException(nameof(checkpoint));
+
+        if (checkpoint.Count > _history.Count)
+            return;
+
+        var requestWasAdded = _history.Count > checkpoint.Count;
+        _history.RemoveRange(checkpoint.Count, _history.Count - checkpoint.Count);
         if (requestWasAdded)
             _history.Add(requestMessage);
     }
 
-    public async IAsyncEnumerable<ContentBlock> SendMessageAsync(
+    /// <summary>
+    /// Sends one message and streams renderable blocks. When used directly, one successful call
+    /// commits one persistent conversation turn.
+    /// </summary>
+    public IAsyncEnumerable<ContentBlock> SendMessageAsync(
         ChatMessage message,
+        CancellationToken cancellationToken = default)
+        => SendMessageAsync(
+            message,
+            startsThreadTurn: true,
+            completesThreadTurn: true,
+            cancellationToken);
+
+    internal async IAsyncEnumerable<ContentBlock> SendMessageAsync(
+        ChatMessage message,
+        bool startsThreadTurn,
+        bool completesThreadTurn,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(message);
 
         cancellationToken.ThrowIfCancellationRequested();
-        _history.Add(message);
-        ChatMessage[] historySnapshot = [.. _history];
-        var pipeline = new BlockMappingPipeline(_options, _logger);
 
-        // Process user message through pipeline
-        var userUpdate = new ChatResponseUpdate
+        var requestMessage = EnsureMessageId(message);
+        var thread = _options.Thread;
+
+        if (startsThreadTurn)
         {
-            Role = message.Role,
-            Contents = [.. message.Contents]
-        };
-        await foreach (var block in pipeline.Process(userUpdate, cancellationToken).ConfigureAwait(false))
+            thread?.AppendUserMessage(requestMessage);
+            RefreshHistoryFromThread(thread);
+        }
+        else
+        {
+            thread?.AppendUpdate(CreateMessageUpdate(requestMessage, isContinuation: true));
+        }
+
+        _history.Add(requestMessage);
+        ChatMessage[] historySnapshot = thread is { IsStateful: true }
+            ? [requestMessage]
+            : [.. _history];
+
+        var pipeline = new BlockMappingPipeline(_options, _logger);
+        var userUpdate = CreateMessageUpdate(requestMessage, isContinuation: false);
+        await foreach (var block in pipeline.Process(userUpdate, cancellationToken))
         {
             yield return block;
         }
@@ -106,22 +160,25 @@ public class UIAgent : IDisposable
             yield return block;
         }
 
-        // Stream assistant response
         UIAgentLog.StreamingAssistantResponse(_logger);
         var assistantUpdates = new List<ChatResponseUpdate>();
-        string? turnId = null;
-        var chatOptions = _options.ChatOptions;
+        var chatOptions = BuildChatOptions(thread);
 
         var updateIndex = 0;
-        await foreach (var update in _chatClient.GetStreamingResponseAsync(historySnapshot, chatOptions, cancellationToken).ConfigureAwait(false))
+        await foreach (var update in _chatClient.GetStreamingResponseAsync(
+            historySnapshot,
+            chatOptions,
+            cancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
             UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);
 
             assistantUpdates.Add(update);
-            turnId ??= update.ResponseId;
+            thread?.AppendUpdate(update);
 
-            await foreach (var block in pipeline.Process(update, cancellationToken).ConfigureAwait(false))
+            await foreach (var block in pipeline.Process(update, cancellationToken))
             {
                 yield return block;
             }
@@ -136,13 +193,112 @@ public class UIAgent : IDisposable
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Add assistant response to history
         var response = assistantUpdates.ToChatResponse();
-        cancellationToken.ThrowIfCancellationRequested();
-        foreach (var msg in response.Messages)
-            _history.Add(msg);
+        if (completesThreadTurn)
+            thread?.CompleteTurn();
+
+        foreach (var responseMessage in response.Messages)
+            _history.Add(responseMessage);
 
         UIAgentLog.AddedToHistory(_logger, response.Messages.Count);
+    }
+
+    /// <summary>
+    /// Replays the configured thread's committed raw updates through newly-created block pipelines.
+    /// </summary>
+    /// <remarks>
+    /// Restore only reconstructs renderable history; it does not invoke backend tools or resume
+    /// interactive blocks. Custom projections require the same handlers to be registered, and their
+    /// discriminator data must survive the thread implementation's serialization. In particular,
+    /// <see cref="AIContent.RawRepresentation"/> and <see cref="ChatResponseUpdate.RawRepresentation"/>
+    /// are not durable discriminators unless the implementation explicitly persists them. Thread
+    /// implementations must also round-trip <see cref="ChatResponseUpdate.AdditionalProperties"/>,
+    /// which carries engine metadata for continuation rounds.
+    /// </remarks>
+    public async Task<IReadOnlyList<ContentBlock>> RestoreAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var thread = _options.Thread;
+        if (thread is null)
+            return Array.Empty<ContentBlock>();
+
+        var updates = thread.GetUpdates();
+        if (updates.Count == 0)
+        {
+            _history.Clear();
+            return Array.Empty<ContentBlock>();
+        }
+
+        _history.Clear();
+        if (!thread.IsStateful)
+            _history.AddRange(thread.GetMessageHistory());
+
+        var blocks = new List<ContentBlock>();
+        BlockMappingPipeline? responsePipeline = null;
+        string? currentTurnId = null;
+        var nextBlockStartsTurn = false;
+
+        foreach (var update in updates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var startsTurn = update.Role == ChatRole.User && !IsContinuation(update);
+            if (startsTurn)
+            {
+                responsePipeline?.Finalize();
+                currentTurnId = update.MessageId
+                    ?? update.ResponseId
+                    ?? Guid.NewGuid().ToString("N");
+                nextBlockStartsTurn = true;
+
+                var requestPipeline = new BlockMappingPipeline(_options, _logger);
+                await foreach (var block in requestPipeline.Process(update, cancellationToken))
+                {
+                    AddRestoredBlock(
+                        blocks,
+                        block,
+                        currentTurnId,
+                        isRequest: true,
+                        ref nextBlockStartsTurn);
+                }
+                requestPipeline.Finalize();
+                responsePipeline = new BlockMappingPipeline(_options, _logger);
+                continue;
+            }
+
+            if (responsePipeline is null)
+            {
+                currentTurnId = update.MessageId
+                    ?? update.ResponseId
+                    ?? Guid.NewGuid().ToString("N");
+                nextBlockStartsTurn = true;
+                responsePipeline = new BlockMappingPipeline(_options, _logger);
+            }
+
+            await foreach (var block in responsePipeline.Process(update, cancellationToken))
+            {
+                AddRestoredBlock(
+                    blocks,
+                    block,
+                    currentTurnId!,
+                    isRequest: false,
+                    ref nextBlockStartsTurn);
+            }
+
+            RestoreApprovalResponses(update, blocks, currentTurnId!);
+        }
+
+        responsePipeline?.Finalize();
+        return blocks;
+    }
+
+    internal void CompleteThreadTurn()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _options.Thread?.CompleteTurn();
     }
 
     internal async Task<FunctionResultContent> InvokeToolAsync(
@@ -161,22 +317,128 @@ public class UIAgent : IDisposable
         return new FunctionResultContent(call.CallId, result);
     }
 
+    private void RefreshHistoryFromThread(IConversationThread? thread)
+    {
+        if (thread is null)
+            return;
+
+        _history.Clear();
+        if (!thread.IsStateful)
+            _history.AddRange(thread.GetMessageHistory());
+    }
+
+    private ChatOptions? BuildChatOptions(IConversationThread? thread)
+    {
+        if (thread is not { IsStateful: true, ConversationId: not null })
+            return _options.ChatOptions;
+
+        var chatOptions = _options.ChatOptions?.Clone() ?? new ChatOptions();
+        chatOptions.ConversationId = thread.ConversationId;
+        return chatOptions;
+    }
+
     private AIFunction? FindBackendFunction(string name)
     {
         if (_options.ChatOptions?.Tools is null)
-        {
             return null;
-        }
 
         foreach (var tool in _options.ChatOptions.Tools)
         {
             if (tool is AIFunction function && function.Name == name)
-            {
                 return function;
-            }
         }
 
         return null;
+    }
+
+    private static ChatMessage EnsureMessageId(ChatMessage message)
+    {
+        if (!string.IsNullOrEmpty(message.MessageId))
+            return message;
+
+        var clone = message.Clone();
+        clone.MessageId = Guid.NewGuid().ToString("N");
+        return clone;
+    }
+
+    private static ChatResponseUpdate CreateMessageUpdate(
+        ChatMessage message,
+        bool isContinuation)
+    {
+        AdditionalPropertiesDictionary? additionalProperties = null;
+        if (message.AdditionalProperties is not null || isContinuation)
+        {
+            additionalProperties = message.AdditionalProperties is null
+                ? new AdditionalPropertiesDictionary()
+                : new AdditionalPropertiesDictionary(message.AdditionalProperties);
+
+            if (isContinuation)
+                additionalProperties[ContinuationPropertyName] = ContinuationPropertyValue;
+        }
+
+        return new ChatResponseUpdate
+        {
+            Role = message.Role,
+            AuthorName = message.AuthorName,
+            CreatedAt = message.CreatedAt,
+            MessageId = message.MessageId,
+            Contents = [.. message.Contents],
+            RawRepresentation = message.RawRepresentation,
+            AdditionalProperties = additionalProperties,
+        };
+    }
+
+    private static bool IsContinuation(ChatResponseUpdate update)
+        => (update.AdditionalProperties is not null
+                && update.AdditionalProperties.TryGetValue(
+                    ContinuationPropertyName,
+                    out var value)
+                && value is string text
+                && string.Equals(
+                    text,
+                    ContinuationPropertyValue,
+                    StringComparison.Ordinal))
+            || (update.Contents.Count > 0
+                && update.Contents.All(
+                    content => content is ToolApprovalResponseContent));
+
+    private static void AddRestoredBlock(
+        List<ContentBlock> blocks,
+        ContentBlock block,
+        string turnId,
+        bool isRequest,
+        ref bool nextBlockStartsTurn)
+    {
+        block.RestoredTurnId = turnId;
+        block.StartsRestoredTurn = nextBlockStartsTurn;
+        block.IsRestoredRequest = isRequest;
+        nextBlockStartsTurn = false;
+        blocks.Add(block);
+    }
+
+    private static void RestoreApprovalResponses(
+        ChatResponseUpdate update,
+        List<ContentBlock> blocks,
+        string turnId)
+    {
+        foreach (var content in update.Contents)
+        {
+            if (content is not ToolApprovalResponseContent response)
+                continue;
+
+            for (var i = blocks.Count - 1; i >= 0; i--)
+            {
+                if (blocks[i].RestoredTurnId != turnId)
+                    break;
+
+                if (blocks[i] is ToolApprovalBlock approval
+                    && approval.ApprovalRequest.RequestId == response.RequestId)
+                {
+                    approval.RestoreResponse(response);
+                    break;
+                }
+            }
+        }
     }
 
     public void Dispose()

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/UIAgentOptions.cs
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/Engine/UIAgentOptions.cs
@@ -6,14 +6,23 @@ using Microsoft.Extensions.AI;
 namespace Microsoft.Maui.AI.Chat;
 
 /// <summary>
-/// Configuration for a <see cref="UIAgent"/>: the <see cref="ChatOptions"/> (instructions and tools) plus any
-/// custom block handlers.
+/// Configuration for a <see cref="UIAgent"/>: the <see cref="ChatOptions"/> (instructions and tools),
+/// optional conversation persistence, and custom block handlers.
 /// </summary>
 /// <remarks>Use <see cref="AddBlockHandler{TState}"/> to plug a custom <see cref="ContentBlockHandler{TState}"/>
 /// into the pipeline.</remarks>
 public class UIAgentOptions
 {
     public ChatOptions? ChatOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the conversation thread that persists committed raw updates.
+    /// </summary>
+    /// <remarks>
+    /// The thread and agent are single-thread-affine and not thread-safe. Implementations own
+    /// persistence and serialization.
+    /// </remarks>
+    public IConversationThread? Thread { get; set; }
 
     internal List<IHandlerRegistration> HandlerRegistrations { get; } = new();
 

--- a/src/AIExtensions/Microsoft.Maui.AI.Chat/UPSTREAM-CHANGES.md
+++ b/src/AIExtensions/Microsoft.Maui.AI.Chat/UPSTREAM-CHANGES.md
@@ -23,30 +23,30 @@ as the MVP grows. When the upstream engine ships on NuGet, we want to be able to
 | `Blocks/`, `Engine/`, `Pipeline/` | **Kept** as the engine (`Microsoft.Maui.AI.Chat`), simplified — see below. |
 | `Components/` (Blazor UI), `wwwroot/` (CSS/JS) | **Removed entirely**, replaced by a native MAUI UI layer (`Microsoft.Maui.AI.Chat.Controls`). |
 | `Attributes/` (`[ToolBlock]` source-generator attrs) | **Removed** — the sample shows the hand-written `ContentBlockHandler` pattern instead. |
-| Reasoning, Activity, UI Actions, State, Persistence (Thread), Retry, Rich text | **Removed** from the engine (see section 2). |
+| Reasoning, Activity, UI Actions, State, Rich text | **Removed** from the engine (see section 2). |
 
 The engine has **no dependency** on the UI layer, Blazor, or ASP.NET.
 
 ---
 
-## 2. Removed features (the "add back" list)
+## 2. Feature status
 
-Each of these existed upstream and was cut for the MVP. Grouped by capability, with the exact
-upstream types so we know what to restore.
+These capabilities existed upstream and were initially cut for the MVP. They are grouped by
+capability with their current MAUI status.
 
-### 2a. Conversation persistence / threads  ⭐ highest priority to add back
+### 2a. Conversation persistence / threads
 The upstream engine treats an `IConversationThread` as the persistable source of truth, and
 `AgentContext` is a projection that can be re-hydrated from it. The Blazor `AgentBoundary`
 calls `AgentContext.RestoreAsync()` when a thread has stored updates.
 
 | Upstream type | Status |
 |---|---|
-| `Engine/IConversationThread.cs` | **Removed** |
-| `Engine/AgentContext.RestoreAsync(...)` | **Removed** |
-| `Engine/UIAgent.RestoreAsync(...)` | **Removed** |
-| `Pipeline/UIAgentOptions.Thread` (`IConversationThread?`) | **Removed** |
+| `Engine/IConversationThread.cs` | **Restored**, plus an explicit `Clear()` reset hook |
+| `Engine/AgentContext.RestoreAsync(...)` | **Restored** |
+| `Engine/UIAgent.RestoreAsync(...)` | **Restored** |
+| `Pipeline/UIAgentOptions.Thread` (`IConversationThread?`) | **Restored** |
 
-> **Note for adding back:** our recent refactors were done *specifically* to keep this clean —
+> **Persistence invariant:** our recent refactors were done *specifically* to keep this clean —
 > the engine's `Turns` and `UIAgent`'s `ChatMessage` history contain **only real content**, no
 > fabricated status blocks (see 2f). That preserves the "turns == projection of the thread"
 > invariant persistence depends on.
@@ -83,7 +83,7 @@ client-side and can call device APIs (GPS, etc.) directly via normal backend too
 ### 2f. Retry
 | Upstream type | Status |
 |---|---|
-| `Engine/AgentContext.RetryAsync(...)` | **Removed** |
+| `Engine/AgentContext.RetryAsync(...)` | **Restored**, preserving MAUI cancellation semantics |
 
 ### 2g. Rich text (markdown node hierarchy)
 Upstream had a structured rich-text/markdown block and a `RichText/` node tree. We simplified
@@ -199,9 +199,9 @@ Legend: ✅ kept · ✏️ renamed/changed · ❌ removed · ➕ added by us
 `RichText/` ❌ · `UIActionBlock.cs` ❌
 
 **`Engine/`**
-`AgentContext.cs` ✏️(no Restore/Retry; +Clear; error path) · `AgentState.cs` ❌ ·
-`ConversationStatus.cs` ✅ · `ConversationTurn.cs` ✅ · `IConversationThread.cs` ❌ ·
-`UIAgent.cs` ✏️(no RestoreAsync; double-invoke guard) · `UIAgentLog.cs` ✅ ·
+`AgentContext.cs` ✏️(Restore/Retry/Clear; MAUI cancellation and error paths) · `AgentState.cs` ❌ ·
+`ConversationStatus.cs` ✅ · `ConversationTurn.cs` ✏️(stable IDs) · `IConversationThread.cs` ✏️(+Clear) ·
+`UIAgent.cs` ✏️(thread persistence/restore; double-invoke guard) · `UIAgentLog.cs` ✅ ·
 `UIAgentOfT.cs` ❌
 
 **`Pipeline/`** (handlers moved to `Pipeline/Handlers/`)
@@ -211,7 +211,7 @@ Legend: ✅ kept · ✏️ renamed/changed · ❌ removed · ➕ added by us
 `HandleResult.cs` ✅ · `HandlerEntry.cs` ✅ · `IActiveEntry.cs` ✅ · `IHandlerEntry.cs` ✅ ·
 `MediaContentHandler.cs` ✅ · `ReasoningHandler.cs` ❌ · `StateMapperContext.cs` ❌ ·
 `TextBlockHandler.cs` ✅ · `UIActionHandler.cs` ❌ ·
-`UIAgentOptions.cs` ✏️(removed `StateMapper`, `Thread`, `RegisterUIAction`)
+`UIAgentOptions.cs` ✏️(restored `Thread`; removed `StateMapper`, `RegisterUIAction`)
 
 **`Attributes/`** — `ToolBlockAttribute.cs` ❌ · `ToolParameterAttribute.cs` ❌ · `ToolResultAttribute.cs` ❌
 
@@ -227,8 +227,8 @@ Convenience/robustness we'd like the core engine to gain:
 - `AgentContext.SystemPrompt` — sugar over `UIAgentOptions.ChatOptions.Instructions`.
 - `AgentContext.HasPendingApprovals` + `AutoRejectPendingApprovals()` — reject pending on new user message.
 - `UIAgentOptions.AllowMultipleToolCalls` convenience property.
-- Thread-safety on the callback lists (`ContentBlock._callbacks`, `AgentContext._*Callbacks`) —
-  use `ImmutableList` or a lock.
+- The MAUI engine deliberately remains single-thread-affine and not thread-safe. Callers serialize
+  access and enter the owning application thread before calling it.
 
 ## 9. Porting notes
 

--- a/src/AIExtensions/README.md
+++ b/src/AIExtensions/README.md
@@ -10,6 +10,12 @@ AI integration packages for .NET MAUI, built on [`Microsoft.Extensions.AI`](http
 | [`Microsoft.Maui.AI.Chat`](Microsoft.Maui.AI.Chat/) | Chat engine — a block-mapping pipeline that turns `Microsoft.Extensions.AI` content into strongly-typed `ContentBlock`s, plus a stateful `AgentContext` |
 | [`Microsoft.Maui.AI.Chat.Controls`](Microsoft.Maui.AI.Chat.Controls/) | MAUI chat UI — `CopilotChatView` / `MessageListView` with a XAML content-template system for rendering blocks |
 
+`Microsoft.Maui.AI.Chat` supports caller-provided `IConversationThread` persistence, history
+restore, retry, and coherent clear/reset behavior. No storage provider is built in:
+applications own persistence and serialization. The engine and thread contracts are deliberately
+single-thread-affine and not thread-safe; callers serialize access on their owning application
+thread.
+
 - [Attributes documentation](Microsoft.Maui.AI.Attributes/README.md) — API reference, samples, and equivalence rules
 - [Chat upstream notes](Microsoft.Maui.AI.Chat/UPSTREAM-CHANGES.md) — how the chat engine relates to the ASP.NET AI Components it forked from
 

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/AgentContextThreadTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/AgentContextThreadTests.cs
@@ -1,0 +1,544 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.AI.Chat.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Maui.AI.Chat.Tests.Engine;
+
+public class AgentContextThreadTests
+{
+    [Fact]
+    public async Task RetryAsync_Success_ReusesTurnAndCommitsOnlySuccessfulAttempt()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var callCount = 0;
+        var context = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            callCount++;
+            return callCount == 1
+                ? ResponseEmitters.EmitErrorAfterTokens(
+                    ["partial"],
+                    new InvalidOperationException("failed"),
+                    cancellationToken)
+                : ResponseEmitters.EmitTextResponse("success", cancellationToken);
+        });
+
+        await context.SendMessageAsync("question");
+
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        var failedTurn = Assert.Single(context.Turns);
+        var originalId = failedTurn.Id;
+        Assert.False(string.IsNullOrWhiteSpace(originalId));
+
+        await context.RetryAsync();
+
+        var completedTurn = Assert.Single(context.Turns);
+        Assert.Same(failedTurn, completedTurn);
+        Assert.Equal(originalId, completedTurn.Id);
+        Assert.Single(completedTurn.RequestBlocks);
+        var response = Assert.Single(
+            completedTurn.ResponseBlocks.OfType<TextContentBlock>());
+        Assert.Equal("success", response.RawText);
+        Assert.Equal(1, thread.CompleteTurnCallCount);
+        Assert.Equal(1, thread.CommittedTurnCount);
+        Assert.Equal(2, thread.GetMessageHistory().Count);
+        Assert.DoesNotContain(
+            thread.GetUpdates().SelectMany(update => update.Contents),
+            content => content is TextContent text && text.Text == "partial");
+    }
+
+    [Fact]
+    public async Task RetryAsync_RepeatedFailure_RemainsRetryableUntilSuccess()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var callCount = 0;
+        var context = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            callCount++;
+            return callCount < 3
+                ? ResponseEmitters.EmitErrorAfterTokens(
+                    [$"partial-{callCount}"],
+                    new InvalidOperationException($"failed-{callCount}"),
+                    cancellationToken)
+                : ResponseEmitters.EmitTextResponse("success", cancellationToken);
+        });
+
+        await context.SendMessageAsync("question");
+        await context.RetryAsync();
+
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        Assert.Equal("failed-2", context.Error?.Message);
+
+        await context.RetryAsync();
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Equal(3, callCount);
+        Assert.Single(context.Turns);
+        Assert.Equal(3, thread.AppendUserMessageCount);
+        Assert.Equal(1, thread.CompleteTurnCallCount);
+        Assert.Equal(1, thread.CommittedTurnCount);
+    }
+
+    [Fact]
+    public async Task RetryAsync_WhenNotInError_Throws()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var context = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                ResponseEmitters.EmitTextResponse("success", cancellationToken));
+
+        await context.SendMessageAsync("question");
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.RetryAsync());
+        Assert.Contains("Status == Error", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RetryAsync_CallerCancellation_DiscardsPartialAttemptAndAllowsFreshSend()
+    {
+        var retryStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new InMemoryConversationThread("thread-1");
+        var callCount = 0;
+        var context = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            callCount++;
+            return callCount switch
+            {
+                1 => ResponseEmitters.EmitErrorAfterTokens(
+                    [],
+                    new InvalidOperationException("failed"),
+                    cancellationToken),
+                2 => SlowStream(retryStarted, cancellationToken),
+                _ => ResponseEmitters.EmitTextResponse("fresh", cancellationToken),
+            };
+        });
+        await context.SendMessageAsync("question");
+        using var callerCts = new CancellationTokenSource();
+
+        var retry = context.RetryAsync(callerCts.Token);
+        await retryStarted.Task;
+        callerCts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await retry);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks);
+        Assert.Empty(thread.GetUpdates());
+        Assert.Equal(0, thread.CompleteTurnCallCount);
+
+        await context.SendMessageAsync("fresh question");
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Equal(3, callCount);
+        Assert.Equal(1, thread.CompleteTurnCallCount);
+        Assert.Equal(1, thread.CommittedTurnCount);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ReconstructsTurnsWithStableUniqueIds()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var responseCount = 0;
+        var source = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            responseCount++;
+            return ResponseEmitters.EmitTextResponse(
+                $"response-{responseCount}",
+                cancellationToken);
+        });
+        await source.SendMessageAsync("first");
+        await source.SendMessageAsync("second");
+        var originalIds = source.Turns.Select(turn => turn.Id).ToArray();
+
+        var restored = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                ResponseEmitters.EmitEmptyResponse(cancellationToken));
+
+        await restored.RestoreAsync();
+
+        Assert.Equal(2, restored.Turns.Count);
+        Assert.All(
+            restored.Turns,
+            turn => Assert.False(string.IsNullOrWhiteSpace(turn.Id)));
+        Assert.Equal(2, restored.Turns.Select(turn => turn.Id).Distinct().Count());
+        Assert.Equal(originalIds, restored.Turns.Select(turn => turn.Id));
+        Assert.All(restored.Turns, turn =>
+        {
+            Assert.NotEmpty(turn.RequestBlocks);
+            Assert.NotEmpty(turn.ResponseBlocks);
+        });
+    }
+
+    [Fact]
+    public async Task RestoreAsync_CalledTwiceWithoutClear_ThrowsWithoutDuplicatingTurns()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        CommitTextTurn(thread, "question", "answer", "turn-1");
+        var context = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                ResponseEmitters.EmitEmptyResponse(cancellationToken));
+
+        await context.RestoreAsync();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.RestoreAsync());
+        Assert.Single(context.Turns);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ApprovalIsDisplayOnly()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Delete it")
+        {
+            MessageId = "turn-1",
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-1",
+            Contents =
+            [
+                new ToolApprovalRequestContent(
+                    "approval-1",
+                    new FunctionCallContent("call-1", "Delete", null)),
+            ],
+        });
+        thread.CompleteTurn();
+
+        var clientCallCount = 0;
+        var context = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            clientCallCount++;
+            return ResponseEmitters.EmitTextResponse("unexpected", cancellationToken);
+        });
+
+        await context.RestoreAsync();
+
+        var approval = Assert.Single(
+            Assert.Single(context.Turns).ResponseBlocks.OfType<ToolApprovalBlock>());
+        approval.Approve();
+        await Task.Yield();
+
+        Assert.Equal(ApprovalStatus.Approved, approval.Status);
+        Assert.Equal(0, clientCallCount);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_CompletedApprovalRemainsOneDisplayOnlyTurn()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var sourceCallCount = 0;
+        var source = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            sourceCallCount++;
+            return sourceCallCount == 1
+                ? ResponseEmitters.EmitApprovalRequest(
+                    "call-1",
+                    "Delete",
+                    ct: cancellationToken)
+                : ResponseEmitters.EmitTextResponse("deleted", cancellationToken);
+        });
+        source.RegisterOnStatusChanged(status =>
+        {
+            if (status == ConversationStatus.AwaitingInput)
+            {
+                source.Turns[^1]
+                    .ResponseBlocks
+                    .OfType<ToolApprovalBlock>()
+                    .Single()
+                    .Approve();
+            }
+        });
+        await source.SendMessageAsync("Delete it");
+        Assert.Equal(1, thread.CompleteTurnCallCount);
+
+        var restoredClientCallCount = 0;
+        var restored = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            restoredClientCallCount++;
+            return ResponseEmitters.EmitTextResponse("unexpected", cancellationToken);
+        });
+
+        await restored.RestoreAsync();
+
+        var turn = Assert.Single(restored.Turns);
+        var approval = Assert.Single(
+            turn.ResponseBlocks.OfType<ToolApprovalBlock>());
+        Assert.Equal(ApprovalStatus.Approved, approval.Status);
+        Assert.Contains(
+            turn.ResponseBlocks.OfType<TextContentBlock>(),
+            block => block.RawText == "deleted");
+        Assert.Equal(0, restoredClientCallCount);
+        Assert.Equal(ConversationStatus.Idle, restored.Status);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ApprovalResponseWithoutAdditionalProperties_UsesStructuralBoundary()
+    {
+        var thread = new InMemoryConversationThread(
+            "thread-1",
+            preserveAdditionalProperties: false);
+        var sourceCallCount = 0;
+        var source = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            sourceCallCount++;
+            return sourceCallCount == 1
+                ? ResponseEmitters.EmitApprovalRequest(
+                    "call-1",
+                    "Delete",
+                    ct: cancellationToken)
+                : ResponseEmitters.EmitTextResponse("deleted", cancellationToken);
+        });
+        source.RegisterOnStatusChanged(status =>
+        {
+            if (status == ConversationStatus.AwaitingInput)
+            {
+                source.Turns[^1]
+                    .ResponseBlocks
+                    .OfType<ToolApprovalBlock>()
+                    .Single()
+                    .Approve();
+            }
+        });
+        await source.SendMessageAsync("Delete it");
+
+        var restored = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                ResponseEmitters.EmitEmptyResponse(cancellationToken));
+
+        await restored.RestoreAsync();
+
+        var turn = Assert.Single(restored.Turns);
+        var approval = Assert.Single(
+            turn.ResponseBlocks.OfType<ToolApprovalBlock>());
+        Assert.Equal(ApprovalStatus.Approved, approval.Status);
+        Assert.Contains(
+            turn.ResponseBlocks.OfType<TextContentBlock>(),
+            block => block.RawText == "deleted");
+    }
+
+    [Fact]
+    public async Task Clear_AfterConversation_ClearsContextAndThread()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        IReadOnlyList<ChatMessage>? freshMessages = null;
+        var callCount = 0;
+        var context = CreateContext(thread, (messages, options, cancellationToken) =>
+        {
+            callCount++;
+            if (callCount == 2)
+                freshMessages = messages.ToArray();
+
+            return ResponseEmitters.EmitTextResponse(
+                $"response-{callCount}",
+                cancellationToken);
+        });
+        await context.SendMessageAsync("first");
+
+        context.Clear();
+
+        Assert.Empty(context.Turns);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Empty(thread.GetUpdates());
+        Assert.Equal(1, thread.ClearCallCount);
+
+        await context.SendMessageAsync("fresh");
+
+        Assert.NotNull(freshMessages);
+        Assert.Single(freshMessages);
+        Assert.Equal("fresh", freshMessages[0].Text);
+        Assert.Single(context.Turns);
+    }
+
+    [Fact]
+    public async Task Clear_AfterError_DiscardsPendingAttempt()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var context = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                ResponseEmitters.EmitErrorAfterTokens(
+                    ["partial"],
+                    new InvalidOperationException("failed"),
+                    cancellationToken));
+
+        await context.SendMessageAsync("question");
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        Assert.True(thread.PendingUpdateCount > 0);
+
+        context.Clear();
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Empty(context.Turns);
+        Assert.Empty(thread.GetUpdates());
+        Assert.Equal(0, thread.PendingUpdateCount);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.RetryAsync());
+    }
+
+    [Fact]
+    public async Task Clear_AfterRestore_AllowsFreshEmptyRestore()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        CommitTextTurn(thread, "question", "answer", "turn-1");
+        var context = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                ResponseEmitters.EmitEmptyResponse(cancellationToken));
+        await context.RestoreAsync();
+        Assert.Single(context.Turns);
+
+        context.Clear();
+        await context.RestoreAsync();
+
+        Assert.Empty(context.Turns);
+        Assert.Empty(thread.GetUpdates());
+    }
+
+    [Fact]
+    public async Task Clear_DuringConversation_CancelsAndRemovesPendingPersistence()
+    {
+        var streamStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new InMemoryConversationThread("thread-1");
+        var context = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                SlowStream(streamStarted, cancellationToken));
+
+        var send = context.SendMessageAsync("question");
+        await streamStarted.Task;
+
+        context.Clear();
+        await send;
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Empty(context.Turns);
+        Assert.Empty(thread.GetUpdates());
+        Assert.Equal(0, thread.PendingUpdateCount);
+        Assert.Equal(0, thread.CompleteTurnCallCount);
+    }
+
+    [Fact]
+    public async Task CancelAsync_DiscardsPartialPersistentTurn()
+    {
+        var streamStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new InMemoryConversationThread("thread-1");
+        var context = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                SlowStream(streamStarted, cancellationToken));
+
+        var send = context.SendMessageAsync("question");
+        await streamStarted.Task;
+        await context.CancelAsync();
+        await send;
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Empty(thread.GetUpdates());
+        Assert.Empty(thread.GetMessageHistory());
+        Assert.Equal(0, thread.CompleteTurnCallCount);
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task CallerCancellation_DiscardsPartialPersistentTurnAndCancelsTask()
+    {
+        var streamStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new InMemoryConversationThread("thread-1");
+        var context = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                SlowStream(streamStarted, cancellationToken));
+        using var callerCts = new CancellationTokenSource();
+
+        var send = context.SendMessageAsync("question", callerCts.Token);
+        await streamStarted.Task;
+        callerCts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await send);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Empty(thread.GetUpdates());
+        Assert.Empty(thread.GetMessageHistory());
+        Assert.Equal(0, thread.CompleteTurnCallCount);
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task NewTurns_HaveNonEmptyUniqueIds()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var context = CreateContext(
+            thread,
+            (messages, options, cancellationToken) =>
+                ResponseEmitters.EmitTextResponse("answer", cancellationToken));
+
+        await context.SendMessageAsync("first");
+        await context.SendMessageAsync("second");
+
+        Assert.All(
+            context.Turns,
+            turn => Assert.False(string.IsNullOrWhiteSpace(turn.Id)));
+        Assert.Equal(2, context.Turns.Select(turn => turn.Id).Distinct().Count());
+    }
+
+    private static AgentContext CreateContext(
+        InMemoryConversationThread thread,
+        Func<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken,
+            IAsyncEnumerable<ChatResponseUpdate>> handler)
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler(handler);
+        return new AgentContext(new UIAgent(
+            client,
+            options => options.Thread = thread));
+    }
+
+    private static void CommitTextTurn(
+        InMemoryConversationThread thread,
+        string request,
+        string response,
+        string turnId)
+    {
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, request)
+        {
+            MessageId = turnId,
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = $"{turnId}-response",
+            Contents = [new TextContent(response)],
+        });
+        thread.CompleteTurn();
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> SlowStream(
+        TaskCompletionSource streamStarted,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent("partial")],
+        };
+        streamStarted.TrySetResult();
+        await Task.Delay(Timeout.Infinite, cancellationToken);
+    }
+}

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/ConversationThreadTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/ConversationThreadTests.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Maui.AI.Chat.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Maui.AI.Chat.Tests.Engine;
+
+public class ConversationThreadTests
+{
+    [Fact]
+    public void CompleteTurn_CommitsPendingUpdatesExactlyOnce()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Hello")
+        {
+            MessageId = "user-1",
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-1",
+            Contents = [new TextContent("Hi")],
+        });
+
+        Assert.Empty(thread.GetUpdates());
+        Assert.Empty(thread.GetMessageHistory());
+
+        thread.CompleteTurn();
+
+        Assert.Equal(2, thread.GetUpdates().Count);
+        Assert.Equal(2, thread.GetMessageHistory().Count);
+        Assert.Equal(1, thread.CompleteTurnCallCount);
+        Assert.Equal(1, thread.CommittedTurnCount);
+    }
+
+    [Fact]
+    public void NewUserMessage_DiscardsIncompleteTurn()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "failed"));
+        thread.AppendUpdate(new ChatResponseUpdate(
+            ChatRole.Assistant,
+            "partial"));
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "retry"));
+        thread.AppendUpdate(new ChatResponseUpdate(
+            ChatRole.Assistant,
+            "complete"));
+        thread.CompleteTurn();
+
+        var history = thread.GetMessageHistory();
+        Assert.Equal(2, history.Count);
+        Assert.Equal("retry", history[0].Text);
+        Assert.Equal("complete", history[1].Text);
+    }
+
+    [Fact]
+    public void GetMessageHistory_ReconstructsMixedMessageRoles()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Run it")
+        {
+            MessageId = "user-1",
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-call",
+            Contents = [new FunctionCallContent("call-1", "Run", null)],
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Tool,
+            MessageId = "tool-1",
+            Contents = [new FunctionResultContent("call-1", "done")],
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-final",
+            Contents = [new TextContent("Finished")],
+        });
+        thread.CompleteTurn();
+
+        var history = thread.GetMessageHistory();
+        Assert.Equal(
+            [ChatRole.User, ChatRole.Assistant, ChatRole.Tool, ChatRole.Assistant],
+            history.Select(message => message.Role));
+    }
+
+    [Fact]
+    public void ConversationId_TracksPendingResponseAndResetsWithAttempt()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "first"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            ConversationId = "failed-conversation",
+        });
+
+        Assert.True(thread.IsStateful);
+        Assert.Equal("failed-conversation", thread.ConversationId);
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "retry"));
+
+        Assert.False(thread.IsStateful);
+        Assert.Null(thread.ConversationId);
+
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            ConversationId = "committed-conversation",
+        });
+        thread.CompleteTurn();
+
+        Assert.True(thread.IsStateful);
+        Assert.Equal("committed-conversation", thread.ConversationId);
+    }
+
+    [Fact]
+    public void Clear_RemovesCommittedAndPendingState()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "committed"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            ConversationId = "conversation-1",
+            Contents = [new TextContent("response")],
+        });
+        thread.CompleteTurn();
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "pending"));
+
+        thread.Clear();
+
+        Assert.Empty(thread.GetUpdates());
+        Assert.Empty(thread.GetMessageHistory());
+        Assert.Equal(0, thread.PendingUpdateCount);
+        Assert.False(thread.IsStateful);
+        Assert.Null(thread.ConversationId);
+        Assert.Equal(1, thread.ClearCallCount);
+    }
+
+    [Fact]
+    public void ThreadId_IsStable()
+    {
+        var thread = new InMemoryConversationThread("thread-42");
+
+        Assert.Equal("thread-42", thread.ThreadId);
+    }
+}

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/UIAgentThreadTests.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/Engine/UIAgentThreadTests.cs
@@ -1,0 +1,413 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.AI.Chat.Tests.Pipeline;
+using Microsoft.Maui.AI.Chat.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Maui.AI.Chat.Tests.Engine;
+
+public class UIAgentThreadTests
+{
+    private sealed class CitationRaw
+    {
+        internal required string Source { get; init; }
+        internal required string Quote { get; init; }
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_Success_CommitsRawTurnOnce()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = CreateClient(ResponseEmitters.EmitTextResponse("Hi"));
+        var agent = CreateAgent(client, thread);
+
+        await EnumerateAsync(agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hello")));
+
+        var updates = thread.GetUpdates();
+        Assert.Equal(2, updates.Count);
+        Assert.Equal(ChatRole.User, updates[0].Role);
+        Assert.Equal(ChatRole.Assistant, updates[1].Role);
+        Assert.Equal(1, thread.AppendUserMessageCount);
+        Assert.Equal(1, thread.AppendUpdateCount);
+        Assert.Equal(1, thread.CompleteTurnCallCount);
+        Assert.Equal(1, thread.CommittedTurnCount);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_Failure_LeavesPartialTurnUncommitted()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = CreateClient(ResponseEmitters.EmitErrorAfterTokens(
+            ["partial"],
+            new InvalidOperationException("boom")));
+        var agent = CreateAgent(client, thread);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            EnumerateAsync(agent.SendMessageAsync(
+                new ChatMessage(ChatRole.User, "Hello"))));
+
+        Assert.Empty(thread.GetUpdates());
+        Assert.Empty(thread.GetMessageHistory());
+        Assert.Equal(2, thread.PendingUpdateCount);
+        Assert.Equal(0, thread.CompleteTurnCallCount);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_StatelessThread_UsesCommittedMessageHistory()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        CommitTextTurn(thread, "first", "first response");
+
+        IReadOnlyList<ChatMessage>? capturedMessages = null;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            capturedMessages = messages.ToArray();
+            return ResponseEmitters.EmitTextResponse(
+                "second response",
+                cancellationToken);
+        });
+        var agent = CreateAgent(client, thread);
+
+        await EnumerateAsync(agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "second")));
+
+        Assert.NotNull(capturedMessages);
+        Assert.Equal(3, capturedMessages.Count);
+        Assert.Equal(
+            ["first", "first response", "second"],
+            capturedMessages.Select(message => message.Text));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_StatefulThread_ClonesOptionsAndSendsOnlyIncrement()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "first"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-1",
+            ConversationId = "conversation-1",
+            Contents = [new TextContent("first response")],
+        });
+        thread.CompleteTurn();
+
+        var configuredOptions = new ChatOptions { Temperature = 0.25f };
+        ChatOptions? capturedOptions = null;
+        IReadOnlyList<ChatMessage>? capturedMessages = null;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            capturedMessages = messages.ToArray();
+            capturedOptions = options;
+            return ResponseEmitters.EmitTextResponse("second response", cancellationToken);
+        });
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+            options.ChatOptions = configuredOptions;
+        });
+
+        await EnumerateAsync(agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "second")));
+
+        Assert.NotNull(capturedOptions);
+        Assert.NotSame(configuredOptions, capturedOptions);
+        Assert.Equal("conversation-1", capturedOptions.ConversationId);
+        Assert.Equal(0.25f, capturedOptions.Temperature);
+        Assert.Null(configuredOptions.ConversationId);
+        Assert.NotNull(capturedMessages);
+        Assert.Single(capturedMessages);
+        Assert.Equal("second", capturedMessages[0].Text);
+    }
+
+    [Fact]
+    public async Task AgentContext_StatefulToolLoop_PropagatesLatestConversationIdAndCommitsOnce()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var configuredOptions = new ChatOptions
+        {
+            Tools =
+            [
+                AIFunctionFactory.Create(
+                    (Func<string>)(() => "tool result"),
+                    "GetValue"),
+            ],
+        };
+        ChatOptions? continuationOptions = null;
+        IReadOnlyList<ChatMessage>? continuationMessages = null;
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            callCount++;
+            if (callCount == 1)
+                return EmitToolCallWithConversationId("conversation-1", cancellationToken);
+
+            continuationOptions = options;
+            continuationMessages = messages.ToArray();
+            return EmitTextWithConversationId(
+                "done",
+                "conversation-2",
+                cancellationToken);
+        });
+        var context = new AgentContext(new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+            options.ChatOptions = configuredOptions;
+        }));
+
+        await context.SendMessageAsync("Run the tool");
+
+        Assert.Equal(2, callCount);
+        Assert.NotNull(continuationOptions);
+        Assert.NotSame(configuredOptions, continuationOptions);
+        Assert.Equal("conversation-1", continuationOptions.ConversationId);
+        Assert.Null(configuredOptions.ConversationId);
+        Assert.NotNull(continuationMessages);
+        var continuationMessage = Assert.Single(continuationMessages);
+        Assert.Equal(ChatRole.Tool, continuationMessage.Role);
+        Assert.Equal("conversation-2", thread.ConversationId);
+        Assert.Equal(1, thread.CompleteTurnCallCount);
+        Assert.Equal(1, thread.CommittedTurnCount);
+
+        var history = thread.GetMessageHistory();
+        Assert.Equal(
+            [ChatRole.User, ChatRole.Assistant, ChatRole.Tool, ChatRole.Assistant],
+            history.Select(message => message.Role));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ReplaysMultipleTurnsAndMixedBlocks()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+
+        thread.AppendUserMessage(new ChatMessage(
+            ChatRole.User,
+            [
+                new TextContent("first"),
+                new DataContent(new byte[] { 1, 2, 3 }, "image/png"),
+            ])
+        {
+            MessageId = "turn-1",
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-1",
+            Contents = [new TextContent("first response")],
+        });
+        thread.CompleteTurn();
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "second")
+        {
+            MessageId = "turn-2",
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-call",
+            Contents = [new FunctionCallContent("call-1", "GetValue", null)],
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Tool,
+            MessageId = "tool-result",
+            Contents = [new FunctionResultContent("call-1", "value")],
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-2",
+            Contents = [new TextContent("second response")],
+        });
+        thread.CompleteTurn();
+
+        var agent = CreateAgent(
+            CreateClient(ResponseEmitters.EmitEmptyResponse()),
+            thread);
+
+        var blocks = await agent.RestoreAsync();
+
+        Assert.Equal(2, blocks.Count(block => block.StartsRestoredTurn));
+        Assert.Equal(3, blocks.Count(block => block.IsRestoredRequest));
+        Assert.Contains(blocks, block => block is MediaContentBlock);
+        var functionBlock = Assert.Single(
+            blocks.OfType<FunctionInvocationContentBlock>());
+        Assert.True(functionBlock.HasResult);
+        Assert.Equal("value", functionBlock.Result?.Result);
+        Assert.Equal(
+            ["turn-1", "turn-2"],
+            blocks
+                .Where(block => block.StartsRestoredTurn)
+                .Select(block => block.RestoredTurnId));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_WithSameCustomHandler_ReprojectsRawUpdate()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var sourceAgent = CreateCitationAgent(
+            CreateClient(EmitCitation()),
+            thread);
+        await EnumerateAsync(sourceAgent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Find a source")));
+
+        var restoredAgent = CreateCitationAgent(
+            CreateClient(ResponseEmitters.EmitEmptyResponse()),
+            thread);
+
+        var blocks = await restoredAgent.RestoreAsync();
+
+        var citation = Assert.Single(blocks.OfType<CitationBlock>());
+        Assert.Equal("Journal", citation.Source);
+        Assert.Equal("Evidence", citation.Quote);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_WhenThreadDropsRawRepresentation_CustomProjectionIsUnavailable()
+    {
+        var thread = new InMemoryConversationThread(
+            "thread-1",
+            preserveRawRepresentation: false);
+        var sourceAgent = CreateCitationAgent(
+            CreateClient(EmitCitation()),
+            thread);
+        await EnumerateAsync(sourceAgent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Find a source")));
+
+        var restoredAgent = CreateCitationAgent(
+            CreateClient(ResponseEmitters.EmitEmptyResponse()),
+            thread);
+
+        var blocks = await restoredAgent.RestoreAsync();
+
+        Assert.Empty(blocks.OfType<CitationBlock>());
+    }
+
+    [Fact]
+    public async Task RestoreAsync_WithoutThread_ReturnsEmpty()
+    {
+        var agent = new UIAgent(
+            CreateClient(ResponseEmitters.EmitEmptyResponse()));
+
+        var blocks = await agent.RestoreAsync();
+
+        Assert.Empty(blocks);
+    }
+
+    private static UIAgent CreateAgent(
+        DelegatingStreamingChatClient client,
+        InMemoryConversationThread thread)
+        => new(client, options => options.Thread = thread);
+
+    private static UIAgent CreateCitationAgent(
+        DelegatingStreamingChatClient client,
+        InMemoryConversationThread thread)
+        => new(client, options =>
+        {
+            options.Thread = thread;
+            options.AddBlockHandler(
+                new DelegateBlockHandler<CitationBlock>((context, state) =>
+                {
+                    if (context.Update.RawRepresentation is not CitationRaw raw)
+                        return BlockMappingResult<CitationBlock>.Pass();
+
+                    context.MarkUpdateHandled();
+                    state.Source = raw.Source;
+                    state.Quote = raw.Quote;
+                    state.Id = context.Update.MessageId
+                        ?? Guid.NewGuid().ToString("N");
+                    return BlockMappingResult<CitationBlock>.Emit(state, state);
+                }));
+        });
+
+    private static DelegatingStreamingChatClient CreateClient(
+        IAsyncEnumerable<ChatResponseUpdate> response)
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) => response);
+        return client;
+    }
+
+    private static void CommitTextTurn(
+        InMemoryConversationThread thread,
+        string request,
+        string response)
+    {
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, request)
+        {
+            MessageId = Guid.NewGuid().ToString("N"),
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent(response)],
+        });
+        thread.CompleteTurn();
+    }
+
+    private static async Task EnumerateAsync(
+        IAsyncEnumerable<ContentBlock> blocks)
+    {
+        await foreach (var _ in blocks)
+        {
+        }
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitCitation(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "citation-1",
+            RawRepresentation = new CitationRaw
+            {
+                Source = "Journal",
+                Quote = "Evidence",
+            },
+        };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate>
+        EmitToolCallWithConversationId(
+            string conversationId,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-call",
+            ConversationId = conversationId,
+            Contents = [new FunctionCallContent("call-1", "GetValue", null)],
+            FinishReason = ChatFinishReason.ToolCalls,
+        };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate>
+        EmitTextWithConversationId(
+            string text,
+            string conversationId,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "assistant-final",
+            ConversationId = conversationId,
+            Contents = [new TextContent(text)],
+        };
+        await Task.CompletedTask;
+    }
+}

--- a/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/TestHelpers/InMemoryConversationThread.cs
+++ b/tests/AIExtensions/Microsoft.Maui.AI.Chat.Tests/TestHelpers/InMemoryConversationThread.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Maui.AI.Chat.Tests.TestHelpers;
+
+internal sealed class InMemoryConversationThread : IConversationThread
+{
+    private readonly List<ChatResponseUpdate> _committedUpdates = new();
+    private readonly bool _preserveRawRepresentation;
+    private readonly bool _preserveAdditionalProperties;
+    private List<ChatResponseUpdate>? _pendingUpdates;
+    private string? _committedConversationId;
+    private string? _pendingConversationId;
+
+    internal InMemoryConversationThread(
+        string threadId,
+        bool preserveRawRepresentation = true,
+        bool preserveAdditionalProperties = true)
+    {
+        ThreadId = threadId;
+        _preserveRawRepresentation = preserveRawRepresentation;
+        _preserveAdditionalProperties = preserveAdditionalProperties;
+    }
+
+    public string ThreadId { get; }
+
+    public bool IsStateful => ConversationId is not null;
+
+    public string? ConversationId => _pendingUpdates is null
+        ? _committedConversationId
+        : _pendingConversationId;
+
+    internal int AppendUserMessageCount { get; private set; }
+
+    internal int AppendUpdateCount { get; private set; }
+
+    internal int CompleteTurnCallCount { get; private set; }
+
+    internal int CommittedTurnCount { get; private set; }
+
+    internal int ClearCallCount { get; private set; }
+
+    internal int PendingUpdateCount => _pendingUpdates?.Count ?? 0;
+
+    public void AppendUserMessage(ChatMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        AppendUserMessageCount++;
+        _pendingConversationId = _committedConversationId;
+        _pendingUpdates =
+        [
+            new ChatResponseUpdate
+            {
+                Role = message.Role,
+                AuthorName = message.AuthorName,
+                CreatedAt = message.CreatedAt,
+                MessageId = message.MessageId ?? Guid.NewGuid().ToString("N"),
+                Contents = [.. message.Contents],
+                RawRepresentation = _preserveRawRepresentation
+                    ? message.RawRepresentation
+                    : null,
+                AdditionalProperties = !_preserveAdditionalProperties
+                    || message.AdditionalProperties is null
+                    ? null
+                    : new AdditionalPropertiesDictionary(message.AdditionalProperties),
+            },
+        ];
+    }
+
+    public void AppendUpdate(ChatResponseUpdate update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        if (_pendingUpdates is null)
+        {
+            throw new InvalidOperationException(
+                "AppendUserMessage must start a pending turn before updates are appended.");
+        }
+
+        AppendUpdateCount++;
+        var storedUpdate = update.Clone();
+        if (!_preserveRawRepresentation)
+            storedUpdate.RawRepresentation = null;
+        if (!_preserveAdditionalProperties)
+            storedUpdate.AdditionalProperties = null;
+
+        _pendingUpdates.Add(storedUpdate);
+        if (update.ConversationId is not null)
+            _pendingConversationId = update.ConversationId;
+    }
+
+    public void CompleteTurn()
+    {
+        CompleteTurnCallCount++;
+
+        if (_pendingUpdates is null)
+            return;
+
+        _committedUpdates.AddRange(_pendingUpdates);
+        _committedConversationId = _pendingConversationId;
+        _pendingUpdates = null;
+        _pendingConversationId = null;
+        CommittedTurnCount++;
+    }
+
+    public IReadOnlyList<ChatResponseUpdate> GetUpdates()
+        => _committedUpdates.Select(update => update.Clone()).ToArray();
+
+    public IReadOnlyList<ChatMessage> GetMessageHistory()
+    {
+        var messages = new List<ChatMessage>();
+        messages.AddMessages(_committedUpdates);
+        return messages;
+    }
+
+    public void Clear()
+    {
+        ClearCallCount++;
+        _committedUpdates.Clear();
+        _pendingUpdates = null;
+        _committedConversationId = null;
+        _pendingConversationId = null;
+    }
+}


### PR DESCRIPTION
## Stack

Layer 2 over #420 (`mattleibow-ai-chat-default-hardening` at `8250635f`), which itself targets #357. This PR is intentionally scoped to conversation persistence, restore, retry, clear, and turn identity; typed state, rich text/reasoning, UI actions, ToolBlock generation, attachments, and later UI layers remain out of scope.

## Semantics

- Adds the public raw-update `IConversationThread` contract, including an explicit `Clear()` hook. Applications own persistence and serialization; there is no built-in storage provider.
- Integrates `UIAgentOptions.Thread` with stateless history reconstruction and stateful `ConversationId` propagation through cloned per-send `ChatOptions`.
- Commits each successful logical turn exactly once, including backend-tool and approval continuations. Failed and canceled partial attempts remain uncommitted; retry replaces the pending attempt and commits only eventual success.
- Replays committed raw updates through fresh block pipelines for restore, preserving custom-handler reprojection when discriminator data survives serialization. Restored interactive/tool blocks are display/history-only.
- Adds `AgentContext.RestoreAsync`, `RetryAsync`, coherent thread-aware `Clear()`, and stable non-empty turn IDs.
- Deliberately keeps the engine and conversation-thread contract single-thread-affine and not thread-safe. Callers serialize access and enter the owning application thread; no locks, async gates, concurrent collections, dispatcher abstraction, or concurrent-caller support was added.

## Tests

- `Microsoft.Maui.AI.Chat.Tests` Release, warnings as errors: 168 passed
- `Microsoft.Maui.AI.Chat.Controls.Tests` Release, warnings as errors: 98 passed
- Garden sample Release MacCatalyst build: succeeded for x64 and arm64 with 0 warnings/errors

Coverage includes commit/discard behavior, stateless/stateful providers and immutable configured options, stateful tool-loop IDs, mixed/custom restore, serialization limitations, display-only approvals, retry/error/cancellation lifecycle, clear scenarios, stable IDs, duplicate-restore rejection, and persistence under caller/graceful cancellation.