### PR TITLE
Add dependabot config for AzDO

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,5 @@
+version: 2
+
+# Disabling dependabot on Azure DevOps as this is a mirrored repo. Updates should go through github.
+enable-campaigned-updates: false
+enable-security-updates: false


### PR DESCRIPTION
Disable dependabot internally since it breaks mirroring when internal PRs are merged, see https://github.com/dotnet/maui-labs/issues/428

Copied from dotnet/maui repo