### PR TITLE
feat(devflow): real gesture injection — pinch, rotate, pan, swipe, double-tap, long-press

### DIFF
--- a/.github/instructions/devflow-architecture.instructions.md
+++ b/.github/instructions/devflow-architecture.instructions.md
@@ -149,6 +149,35 @@ Override virtual methods from `Agent.Abstractions/DevFlowAgentService.cs`:
 - `ElementInfo` captures: Id, Type, AutomationId, Text, IsVisible, IsEnabled, Bounds, WindowBounds
 - CSS selectors (Fizzler) work in Blazor WebViews via CDP
 
+## Gesture Injection
+
+`POST /api/v1/ui/actions/gesture` supports `tap`, `doubletap`, `longpress`, `swipe`, `pan`,
+`pinch` and `rotate`. Resolution is two-tier, and the response reports which tier ran via
+`handledBy` (`recognizer` | `native` | `scroll` | `none`) plus a `detail` string:
+
+1. **Managed recognizer** (`Agent.Core`, all platforms) — walks the target element and its
+   ancestors for a matching MAUI gesture recognizer and drives it through MAUI's public
+   controller interfaces: `IPinchGestureController`, `IPanGestureController`,
+   `ISwipeGestureController`. Only `TapGestureRecognizer.SendTapped` needs reflection
+   (`TryInvokeTapped`), because it is `internal`. Continuous gestures are emitted as N
+   interpolated steps — `SendPinch` in particular takes a *delta* scale per event.
+2. **Native injection** (`Agent/PlatformAgentService.Gestures.cs`) — the fallback when no
+   recognizer exists, which is the case for Map, WebView and other controls that handle
+   gestures internally. Override the `TryNative{Pinch,Rotate,Pan,Swipe,LongPress,DoubleTap}`
+   virtuals; return a description string when handled, `null` when not.
+   - **Android** — real multi-pointer `MotionEvent`s dispatched via `Activity.DispatchTouchEvent`,
+     so the full hit-test and `GestureDetector` pipeline runs. Fully faithful.
+   - **iOS / Mac Catalyst** — MKMapView camera distance → UIScrollView zoom/offset → driving
+     the attached `UIGestureRecognizer` via `setState:`. In-process synthetic `UITouch` needs
+     private API and is not attempted, so the recognizer path is best-effort.
+   - **Windows** — `ScrollViewer.ChangeView`. Input injection needs the restricted
+     `inputInjectionBrokered` capability and is unusable from a normal app package.
+   - **macOS AppKit** — `NSScrollView` magnification and content offset.
+   - **GTK** — tier 1 only.
+
+Gestures against `samples/DevFlow.Sample` → `GestureTestPage` (`//gestures`) write what they
+received to `AutomationId`'d status labels, so tests assert the gesture actually reached the app.
+
 ## Screenshot Capture Flow
 
 1. **Default** (no params): captures `window.Page` via `VisualDiagnostics.CaptureAsPngAsync` — page content only

--- a/.github/instructions/devflow-architecture.instructions.md
+++ b/.github/instructions/devflow-architecture.instructions.md
@@ -177,7 +177,8 @@ Override virtual methods from `Agent.Abstractions/DevFlowAgentService.cs`:
 
 Gesture directions describe finger travel, not content travel. An `up` swipe moves the pointer
 upward; a scroll fallback inverts that vector so scrollable content moves downward consistently
-with native touch injection. Named gestures target MAUI `VisualElement` IDs (or the current page);
+with native touch injection. Named gestures target MAUI `VisualElement` IDs (or the current page
+for non-tap gestures; tap requires an element ID);
 registered native-only element IDs remain supported by the dedicated tap action, but are not
 targets for multi-pointer gesture synthesis.
 

--- a/.github/instructions/devflow-architecture.instructions.md
+++ b/.github/instructions/devflow-architecture.instructions.md
@@ -153,7 +153,7 @@ Override virtual methods from `Agent.Abstractions/DevFlowAgentService.cs`:
 
 `POST /api/v1/ui/actions/gesture` supports `tap`, `doubletap`, `longpress`, `swipe`, `pan`,
 `pinch` and `rotate`. Resolution is two-tier, and the response reports which tier ran via
-`handledBy` (`recognizer` | `native` | `scroll` | `none`) plus a `detail` string:
+`handledBy` (`recognizer` | `native` | `action` | `scroll` | `none`) plus a `detail` string:
 
 1. **Managed recognizer** (`Agent.Core`, all platforms) — walks the target element and its
    ancestors for a matching MAUI gesture recognizer and drives it through MAUI's public
@@ -174,6 +174,12 @@ Override virtual methods from `Agent.Abstractions/DevFlowAgentService.cs`:
      `inputInjectionBrokered` capability and is unusable from a normal app package.
    - **macOS AppKit** — `NSScrollView` magnification and content offset.
    - **GTK** — tier 1 only.
+
+Gesture directions describe finger travel, not content travel. An `up` swipe moves the pointer
+upward; a scroll fallback inverts that vector so scrollable content moves downward consistently
+with native touch injection. Named gestures target MAUI `VisualElement` IDs (or the current page);
+registered native-only element IDs remain supported by the dedicated tap action, but are not
+targets for multi-pointer gesture synthesis.
 
 Gestures against `samples/DevFlow.Sample` → `GestureTestPage` (`//gestures`) write what they
 received to `AutomationId`'d status labels, so tests assert the gesture actually reached the app.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ DevFlow exposes 67 MCP tools for AI agent integration (in `src/Cli/Microsoft.Mau
 | `maui_fill` | Fill text into Entry/Editor |
 | `maui_focus` | Set focus to an element |
 | `maui_geolocation` | GPS coordinates |
-| `maui_gesture` | Perform a touch gesture on the app |
+| `maui_gesture` | Pinch/zoom, rotate, pan, swipe, double-tap, long-press |
 | `maui_get_property` | Read any element property |
 | `maui_get_theme` | Get the current app-scoped light/dark theme |
 | `maui_hittest` | Find elements at screen coordinates |

--- a/docs/DevFlow/inspector.md
+++ b/docs/DevFlow/inspector.md
@@ -137,7 +137,7 @@ The DevFlow agent exposes these UI endpoints. The inspector uses them as follows
 |----------|--------|---------|---------------|
 | `/api/v1/ui/actions/tap` | POST | Tap element by ID or coordinates | Click handler |
 | `/api/v1/ui/actions/scroll` | POST | Scroll by delta or to index | Wheel event handler |
-| `/api/v1/ui/actions/gesture` | POST | Touch gesture (swipe, drag, pinch) | Pointer drag handler |
+| `/api/v1/ui/actions/gesture` | POST | Named gesture (pinch, rotate, pan, swipe, double-tap, long-press, tap) | Gesture inspector control |
 | `/api/v1/ui/actions/back` | POST | Navigate back | Toolbar back button |
 | `/api/v1/ui/actions/fill` | POST | Fill text into Entry/Editor | Text input (V1.1) |
 | `/api/v1/ui/actions/clear` | POST | Clear text from element | Text input (V1.1) |

--- a/docs/DevFlow/spec/examples/capabilities-maui-response.json
+++ b/docs/DevFlow/spec/examples/capabilities-maui-response.json
@@ -11,7 +11,7 @@
       "features": ["css-selector", "type", "text", "accessibility-id"]
     },
     "ui.actions": {
-      "version": 1,
+      "version": 2,
       "features": ["tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "properties"],
       "gestures": [
         "tap",

--- a/docs/DevFlow/spec/examples/capabilities-maui-response.json
+++ b/docs/DevFlow/spec/examples/capabilities-maui-response.json
@@ -12,7 +12,16 @@
     },
     "ui.actions": {
       "version": 1,
-      "features": ["tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "properties"]
+      "features": ["tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "properties"],
+      "gestures": [
+        "tap",
+        "doubletap",
+        "longpress",
+        "swipe",
+        "pan",
+        "pinch",
+        "rotate"
+      ]
     },
     "ui.screenshot": {
       "version": 1,

--- a/docs/DevFlow/spec/examples/gesture-request.json
+++ b/docs/DevFlow/spec/examples/gesture-request.json
@@ -1,8 +1,8 @@
 {
-  "actions": [
-    { "type": "pointerMove", "x": 200, "y": 600, "duration": 0 },
-    { "type": "pointerDown" },
-    { "type": "pointerMove", "x": 200, "y": 200, "duration": 300 },
-    { "type": "pointerUp" }
-  ]
+  "type": "swipe",
+  "elementId": "todo-list",
+  "direction": "up",
+  "distance": 300,
+  "durationMs": 150,
+  "steps": 8
 }

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -628,10 +628,14 @@ paths:
     post:
       operationId: performGesture
       tags: [ui-actions]
-      summary: Perform complex gesture
+      summary: Perform a gesture
       description: >
-        Executes a sequence of pointer actions (move, down, up, pause) to
-        perform complex gestures like swipe, pinch, or drag.
+        Performs a named gesture — pinch, rotate, pan, swipe, doubletap, longpress or tap.
+        The gesture is first offered to a matching MAUI gesture recognizer on the target
+        element or its ancestors. If there is none, it is injected natively at the platform
+        view, which is how pinch-to-zoom reaches controls that handle gestures internally
+        such as Map, WebView and native scroll views. The response reports which tier
+        serviced the gesture so callers can tell a real recognizer hit from a native fallback.
       requestBody:
         required: true
         content:
@@ -640,7 +644,11 @@ paths:
               $ref: "./schemas/actions.json#/$defs/GestureRequest"
       responses:
         "200":
-          $ref: "#/components/responses/ActionSuccess"
+          description: Gesture performed.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/actions.json#/$defs/GestureResponse"
         "408":
           $ref: "#/components/responses/Timeout"
         "409":

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -649,6 +649,12 @@ paths:
             application/json:
               schema:
                 $ref: "./schemas/actions.json#/$defs/GestureResponse"
+        "400":
+          description: The gesture request was invalid or no recognizer/native surface handled it.
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/actions.json#/$defs/GestureErrorResponse"
         "408":
           $ref: "#/components/responses/Timeout"
         "409":

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -636,6 +636,7 @@ paths:
         view, which is how pinch-to-zoom reaches controls that handle gestures internally
         such as Map, WebView and native scroll views. The response reports which tier
         serviced the gesture so callers can tell a real recognizer hit from a native fallback.
+        Tap requires elementId; other gesture types target the current page when it is omitted.
       requestBody:
         required: true
         content:

--- a/docs/DevFlow/spec/schemas/actions.json
+++ b/docs/DevFlow/spec/schemas/actions.json
@@ -332,7 +332,7 @@
             "right",
             null
           ],
-          "description": "Travel direction for swipe and pan. Required for swipe."
+          "description": "Finger travel direction for swipe and pan. Required for swipe. For example, 'up' moves the pointer upward and scrollable content downward."
         },
         "distance": {
           "type": "number",
@@ -341,7 +341,7 @@
         },
         "durationMs": {
           "type": "integer",
-          "description": "Total gesture duration in milliseconds. Longer durations read as drags, shorter ones as flicks.",
+          "description": "Total gesture duration in milliseconds. Longer durations read as drags, shorter ones as flicks. Long press defaults to 600 ms and clamps values below 500 ms.",
           "default": 200,
           "minimum": 0
         },
@@ -442,10 +442,11 @@
           "enum": [
             "recognizer",
             "native",
+            "action",
             "scroll",
             "none"
           ],
-          "description": "'recognizer' — a MAUI gesture recognizer on the element or an ancestor handled it. 'native' — injected at the platform view. 'scroll' — the legacy swipe-to-scroll fallback ran. 'none' — nothing handled the gesture."
+          "description": "'recognizer' — a MAUI gesture recognizer on the element or an ancestor handled it. 'native' — injected at the platform view. 'action' — the dedicated DevFlow tap action handled it. 'scroll' — the legacy swipe-to-scroll fallback ran. 'none' — nothing handled the gesture."
         },
         "platform": {
           "type": [
@@ -467,6 +468,61 @@
             "null"
           ],
           "description": "Why the gesture could not be performed, when success is false."
+        }
+      }
+    },
+    "GestureErrorResponse": {
+      "type": "object",
+      "description": "A rejected or unhandled gesture request. Validation failures may not have a normalized gesture type; attempted gestures also report the tier outcome.",
+      "required": [
+        "success",
+        "error"
+      ],
+      "properties": {
+        "success": {
+          "const": false
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Normalized gesture type when one could be determined, otherwise the rejected caller value or null."
+        },
+        "elementId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "handledBy": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "recognizer",
+            "native",
+            "action",
+            "scroll",
+            "none",
+            null
+          ]
+        },
+        "platform": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "detail": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "error": {
+          "type": "string"
         }
       }
     },
@@ -526,14 +582,14 @@
             "number",
             "null"
           ],
-          "description": "Horizontal scroll delta (for scroll action)."
+          "description": "Horizontal delta for scroll, or explicit horizontal pointer travel for gesture pan."
         },
         "deltaY": {
           "type": [
             "number",
             "null"
           ],
-          "description": "Vertical scroll delta (for scroll action)."
+          "description": "Vertical delta for scroll, or explicit vertical pointer travel for gesture pan."
         },
         "animated": {
           "type": [
@@ -618,7 +674,7 @@
             "right",
             null
           ],
-          "description": "Travel direction (for gesture swipe/pan)."
+          "description": "Finger travel direction (for gesture swipe/pan)."
         },
         "distance": {
           "type": "number",

--- a/docs/DevFlow/spec/schemas/actions.json
+++ b/docs/DevFlow/spec/schemas/actions.json
@@ -290,69 +290,119 @@
         }
       }
     },
-    "GestureAction": {
+    "GestureType": {
+      "type": "string",
+      "enum": [
+        "tap",
+        "doubletap",
+        "longpress",
+        "swipe",
+        "pan",
+        "pinch",
+        "rotate"
+      ],
+      "description": "The kind of gesture to perform."
+    },
+    "GestureRequest": {
       "type": "object",
-      "description": "A single action within a gesture sequence.",
+      "description": "Request to perform a named gesture. The gesture is first offered to a matching MAUI gesture recognizer on the target element or its ancestors; if none exists it is injected natively at the platform view, which is how pinch-to-zoom reaches controls that own their gestures internally (Map, WebView, native scroll views).",
       "required": [
         "type"
       ],
       "properties": {
         "type": {
-          "type": "string",
-          "enum": [
-            "pointerMove",
-            "pointerDown",
-            "pointerUp",
-            "pause"
-          ],
-          "description": "The type of gesture action to perform."
+          "$ref": "#/$defs/GestureType"
         },
-        "x": {
-          "type": [
-            "number",
-            "null"
-          ],
-          "description": "X coordinate for the action."
-        },
-        "y": {
-          "type": [
-            "number",
-            "null"
-          ],
-          "description": "Y coordinate for the action."
-        },
-        "duration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "description": "Duration of this action in milliseconds.",
-          "minimum": 0
-        },
-        "button": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "description": "Pointer button index (0 = primary, 1 = middle, 2 = secondary).",
-          "default": 0,
-          "minimum": 0
-        }
-      }
-    },
-    "GestureRequest": {
-      "type": "object",
-      "description": "Request to perform a complex gesture as a sequence of pointer actions.",
-      "required": [
-        "actions"
-      ],
-      "properties": {
         "elementId": {
           "type": [
             "string",
             "null"
           ],
-          "description": "Optional target element identifier."
+          "description": "Target element identifier. When omitted the gesture targets the window's current page."
+        },
+        "direction": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "up",
+            "down",
+            "left",
+            "right",
+            null
+          ],
+          "description": "Travel direction for swipe and pan. Required for swipe."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Travel distance in device-independent pixels for swipe and pan when using 'direction'.",
+          "default": 120
+        },
+        "durationMs": {
+          "type": "integer",
+          "description": "Total gesture duration in milliseconds. Longer durations read as drags, shorter ones as flicks.",
+          "default": 200,
+          "minimum": 0
+        },
+        "scale": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Pinch factor: 2.0 zooms in 2x, 0.5 zooms out by half. Used by 'pinch'; defaults to 1.5.",
+          "exclusiveMinimum": 0
+        },
+        "rotation": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Rotation in degrees, positive is clockwise. Used by 'rotate'; defaults to 90."
+        },
+        "deltaX": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Explicit horizontal pan distance in device-independent pixels. Overrides direction/distance."
+        },
+        "deltaY": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Explicit vertical pan distance in device-independent pixels. Overrides direction/distance."
+        },
+        "originX": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Gesture focal point X, element-relative from 0 (left) to 1 (right).",
+          "default": 0.5,
+          "minimum": 0,
+          "maximum": 1
+        },
+        "originY": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Gesture focal point Y, element-relative from 0 (top) to 1 (bottom).",
+          "default": 0.5,
+          "minimum": 0,
+          "maximum": 1
+        },
+        "steps": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of interpolation steps emitted between the gesture's start and end.",
+          "default": 10,
+          "minimum": 1,
+          "maximum": 120
         },
         "captureEpoch": {
           "$ref": "#/$defs/CaptureEpoch"
@@ -360,16 +410,63 @@
         "registryGeneration": {
           "$ref": "#/$defs/RegistryGeneration"
         },
-        "actions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/GestureAction"
-          },
-          "description": "Ordered sequence of gesture actions to perform."
-        },
         "include": {
           "$ref": "#/$defs/IncludeOption",
           "description": "Optional data to include in the response."
+        }
+      }
+    },
+    "GestureResponse": {
+      "type": "object",
+      "description": "Result of a gesture, naming the tier that serviced it.",
+      "required": [
+        "success",
+        "type",
+        "handledBy"
+      ],
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "type": {
+          "$ref": "#/$defs/GestureType"
+        },
+        "elementId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "handledBy": {
+          "type": "string",
+          "enum": [
+            "recognizer",
+            "native",
+            "scroll",
+            "none"
+          ],
+          "description": "'recognizer' — a MAUI gesture recognizer on the element or an ancestor handled it. 'native' — injected at the platform view. 'scroll' — the legacy swipe-to-scroll fallback ran. 'none' — nothing handled the gesture."
+        },
+        "platform": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Device platform that ran the gesture."
+        },
+        "detail": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "What actually serviced the gesture, e.g. 'PinchGestureRecognizer on Grid' or 'MKMapView.Camera.CenterCoordinateDistance /2'."
+        },
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Why the gesture could not be performed, when success is false."
         }
       }
     },
@@ -505,15 +602,76 @@
           ],
           "description": "Key to press (for key action)."
         },
-        "actions": {
+        "type": {
+          "$ref": "#/$defs/GestureType",
+          "description": "Gesture kind (for gesture action)."
+        },
+        "direction": {
           "type": [
-            "array",
+            "string",
             "null"
           ],
-          "items": {
-            "$ref": "#/$defs/GestureAction"
-          },
-          "description": "Gesture action sequence (for gesture action)."
+          "enum": [
+            "up",
+            "down",
+            "left",
+            "right",
+            null
+          ],
+          "description": "Travel direction (for gesture swipe/pan)."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Travel distance in device-independent pixels (for gesture swipe/pan).",
+          "default": 120
+        },
+        "durationMs": {
+          "type": "integer",
+          "description": "Gesture duration in milliseconds (for gesture action).",
+          "default": 200,
+          "minimum": 0
+        },
+        "scale": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Pinch factor (for gesture pinch): 2.0 zooms in, 0.5 zooms out.",
+          "exclusiveMinimum": 0
+        },
+        "rotation": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Rotation in degrees (for gesture rotate)."
+        },
+        "originX": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Gesture focal point X, element-relative 0..1.",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "originY": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Gesture focal point Y, element-relative 0..1.",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "steps": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Interpolation steps between gesture start and end.",
+          "minimum": 1,
+          "maximum": 120
         }
       }
     },

--- a/docs/DevFlow/spec/schemas/actions.json
+++ b/docs/DevFlow/spec/schemas/actions.json
@@ -318,7 +318,7 @@
             "string",
             "null"
           ],
-          "description": "Target element identifier. When omitted the gesture targets the window's current page."
+          "description": "Target element identifier. Required for tap. Other gestures target the window's current page when omitted."
         },
         "direction": {
           "type": [

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -58,6 +58,22 @@
               "type": "string"
             },
             "description": "List of supported features within this capability namespace."
+          },
+          "gestures": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "tap",
+                "doubletap",
+                "longpress",
+                "swipe",
+                "pan",
+                "pinch",
+                "rotate"
+              ]
+            },
+            "description": "Named gestures accepted by ui.actions/gesture when the backend exposes gesture automation."
           }
         },
         "additionalProperties": true,
@@ -103,6 +119,15 @@
               "capture-bound-batch",
               "properties",
               "stale-capture-rejection"
+            ],
+            "gestures": [
+              "tap",
+              "doubletap",
+              "longpress",
+              "swipe",
+              "pan",
+              "pinch",
+              "rotate"
             ]
           },
           "ui.screenshot": {

--- a/samples/DevFlow.Sample/AppShell.xaml
+++ b/samples/DevFlow.Sample/AppShell.xaml
@@ -13,6 +13,8 @@
                   ContentTemplate="{DataTemplate local:MultiBlazorPage}" />
     <ShellContent Title="Interactions" Route="interactions"
                   ContentTemplate="{DataTemplate local:InteractionTestPage}" />
+    <ShellContent Title="Gestures" Route="gestures"
+                  ContentTemplate="{DataTemplate local:GestureTestPage}" />
     <ShellContent Title="Dialogs" Route="dialogs"
                   ContentTemplate="{DataTemplate local:DialogTestPage}" />
     <ShellContent Title="Network" Route="network"

--- a/samples/DevFlow.Sample/GestureTestPage.xaml
+++ b/samples/DevFlow.Sample/GestureTestPage.xaml
@@ -113,6 +113,23 @@
                 </VerticalStackLayout>
             </Border>
 
+            <Border StrokeShape="RoundRectangle 8" Padding="16">
+                <Border.BackgroundColor>
+                    <AppThemeBinding Light="#E6E0E9" Dark="#49454F" />
+                </Border.BackgroundColor>
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Long-press target" FontAttributes="Bold" FontSize="16" />
+                    <Button AutomationId="LongPressTarget"
+                            Text="Press and hold"
+                            Pressed="OnLongPressStarted"
+                            Released="OnLongPressEnded" />
+                    <Label x:Name="LongPressStatusLabel"
+                           Text="longpress: none"
+                           FontSize="14"
+                           AutomationId="LongPressStatusLabel" />
+                </VerticalStackLayout>
+            </Border>
+
             <!-- No managed recognizer at all: proves the native injection tier fires -->
             <Border StrokeShape="RoundRectangle 8" Padding="16">
                 <Border.BackgroundColor>

--- a/samples/DevFlow.Sample/GestureTestPage.xaml
+++ b/samples/DevFlow.Sample/GestureTestPage.xaml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="DevFlow.Sample.GestureTestPage"
+             Title="Gesture Tests">
+    <ContentPage.BackgroundColor>
+        <AppThemeBinding Light="#F5F5F5" Dark="#1C1B1F" />
+    </ContentPage.BackgroundColor>
+
+    <ScrollView Padding="16">
+        <VerticalStackLayout Spacing="16">
+
+            <Label Text="Each target reports the gesture it received, so an automated pinch/pan/swipe can be verified by reading the status label back."
+                   FontSize="13"
+                   AutomationId="GestureIntroLabel">
+                <Label.TextColor>
+                    <AppThemeBinding Light="#49454F" Dark="#CAC4D0" />
+                </Label.TextColor>
+            </Label>
+
+            <!-- Pinch: PinchGestureRecognizer, accumulates e.Scale like a real pinch -->
+            <Border StrokeShape="RoundRectangle 8" Padding="16">
+                <Border.BackgroundColor>
+                    <AppThemeBinding Light="#E8DEF8" Dark="#4A4458" />
+                </Border.BackgroundColor>
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Pinch target" FontAttributes="Bold" FontSize="16" />
+                    <Grid AutomationId="PinchTarget" HeightRequest="120">
+                        <Grid.GestureRecognizers>
+                            <PinchGestureRecognizer PinchUpdated="OnPinchUpdated" />
+                        </Grid.GestureRecognizers>
+                        <BoxView x:Name="PinchBox"
+                                 Color="#6750A4"
+                                 CornerRadius="8"
+                                 WidthRequest="80" HeightRequest="80"
+                                 HorizontalOptions="Center" VerticalOptions="Center" />
+                    </Grid>
+                    <Label x:Name="PinchStatusLabel"
+                           Text="pinch: none"
+                           FontSize="14"
+                           AutomationId="PinchStatusLabel" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Pan: PanGestureRecognizer, reports cumulative totals -->
+            <Border StrokeShape="RoundRectangle 8" Padding="16">
+                <Border.BackgroundColor>
+                    <AppThemeBinding Light="#D0E4FF" Dark="#33455C" />
+                </Border.BackgroundColor>
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Pan target" FontAttributes="Bold" FontSize="16" />
+                    <Grid AutomationId="PanTarget" HeightRequest="120">
+                        <Grid.GestureRecognizers>
+                            <PanGestureRecognizer PanUpdated="OnPanUpdated" />
+                        </Grid.GestureRecognizers>
+                        <BoxView Color="#0061A4"
+                                 CornerRadius="8"
+                                 WidthRequest="80" HeightRequest="80"
+                                 HorizontalOptions="Center" VerticalOptions="Center" />
+                    </Grid>
+                    <Label x:Name="PanStatusLabel"
+                           Text="pan: none"
+                           FontSize="14"
+                           AutomationId="PanStatusLabel" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Swipe: all four directions on one target -->
+            <Border StrokeShape="RoundRectangle 8" Padding="16">
+                <Border.BackgroundColor>
+                    <AppThemeBinding Light="#D8F2D8" Dark="#33503A" />
+                </Border.BackgroundColor>
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Swipe target" FontAttributes="Bold" FontSize="16" />
+                    <Grid AutomationId="SwipeTarget" HeightRequest="100">
+                        <Grid.GestureRecognizers>
+                            <SwipeGestureRecognizer Direction="Up" Swiped="OnSwiped" />
+                            <SwipeGestureRecognizer Direction="Down" Swiped="OnSwiped" />
+                            <SwipeGestureRecognizer Direction="Left" Swiped="OnSwiped" />
+                            <SwipeGestureRecognizer Direction="Right" Swiped="OnSwiped" />
+                        </Grid.GestureRecognizers>
+                        <BoxView Color="#3C6E47"
+                                 CornerRadius="8"
+                                 HorizontalOptions="Fill" VerticalOptions="Fill" />
+                    </Grid>
+                    <Label x:Name="SwipeStatusLabel"
+                           Text="swipe: none"
+                           FontSize="14"
+                           AutomationId="SwipeStatusLabel" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Double tap: distinguishes itself from a single tap -->
+            <Border StrokeShape="RoundRectangle 8" Padding="16">
+                <Border.BackgroundColor>
+                    <AppThemeBinding Light="#FFE0C2" Dark="#5C4433" />
+                </Border.BackgroundColor>
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Double-tap target" FontAttributes="Bold" FontSize="16" />
+                    <Grid AutomationId="DoubleTapTarget" HeightRequest="100">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer NumberOfTapsRequired="1" Tapped="OnSingleTapped" />
+                            <TapGestureRecognizer NumberOfTapsRequired="2" Tapped="OnDoubleTapped" />
+                        </Grid.GestureRecognizers>
+                        <BoxView Color="#8C5000"
+                                 CornerRadius="8"
+                                 HorizontalOptions="Fill" VerticalOptions="Fill" />
+                    </Grid>
+                    <Label x:Name="TapStatusLabel"
+                           Text="tap: none"
+                           FontSize="14"
+                           AutomationId="TapStatusLabel" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- No managed recognizer at all: proves the native injection tier fires -->
+            <Border StrokeShape="RoundRectangle 8" Padding="16">
+                <Border.BackgroundColor>
+                    <AppThemeBinding Light="#FFD8E4" Dark="#5C3341" />
+                </Border.BackgroundColor>
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Native target (no MAUI gesture recognizer)" FontAttributes="Bold" FontSize="16" />
+                    <Label Text="Gestures here have no recognizer to hit, so they fall through to native injection."
+                           FontSize="12" />
+                    <ScrollView AutomationId="NativeScrollTarget"
+                                HeightRequest="140"
+                                Orientation="Vertical">
+                        <VerticalStackLayout x:Name="NativeScrollContent" Spacing="4" />
+                    </ScrollView>
+                </VerticalStackLayout>
+            </Border>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/samples/DevFlow.Sample/GestureTestPage.xaml.cs
+++ b/samples/DevFlow.Sample/GestureTestPage.xaml.cs
@@ -16,6 +16,7 @@ public partial class GestureTestPage : ContentPage
     // Last Running pan totals; see OnPanUpdated for why Completed cannot be used.
     private double _panX;
     private double _panY;
+    private DateTime _longPressStartedAtUtc;
 
     public GestureTestPage()
     {
@@ -72,4 +73,15 @@ public partial class GestureTestPage : ContentPage
 
     private void OnDoubleTapped(object? sender, TappedEventArgs e)
         => TapStatusLabel.Text = "tap: double";
+
+    private void OnLongPressStarted(object? sender, EventArgs e)
+        => _longPressStartedAtUtc = DateTime.UtcNow;
+
+    private void OnLongPressEnded(object? sender, EventArgs e)
+    {
+        var elapsedMs = (DateTime.UtcNow - _longPressStartedAtUtc).TotalMilliseconds;
+        LongPressStatusLabel.Text = string.Create(
+            CultureInfo.InvariantCulture,
+            $"longpress: {elapsedMs:0}ms");
+    }
 }

--- a/samples/DevFlow.Sample/GestureTestPage.xaml.cs
+++ b/samples/DevFlow.Sample/GestureTestPage.xaml.cs
@@ -13,6 +13,10 @@ public partial class GestureTestPage : ContentPage
     // scale 2.0 ends up reported as 2.00 regardless of how many steps it arrived in.
     private double _pinchScale = 1;
 
+    // Last Running pan totals; see OnPanUpdated for why Completed cannot be used.
+    private double _panX;
+    private double _panY;
+
     public GestureTestPage()
     {
         InitializeComponent();
@@ -43,8 +47,21 @@ public partial class GestureTestPage : ContentPage
 
     private void OnPanUpdated(object? sender, PanUpdatedEventArgs e)
     {
+        // MAUI raises Completed with TotalX/TotalY reset to 0, so keep the last Running
+        // totals — those are the values an app would actually have applied.
+        switch (e.StatusType)
+        {
+            case GestureStatus.Started:
+                _panX = _panY = 0;
+                break;
+            case GestureStatus.Running:
+                _panX = e.TotalX;
+                _panY = e.TotalY;
+                break;
+        }
+
         PanStatusLabel.Text = string.Create(CultureInfo.InvariantCulture,
-            $"pan: {e.StatusType.ToString().ToLowerInvariant()} dx={e.TotalX:0} dy={e.TotalY:0}");
+            $"pan: {e.StatusType.ToString().ToLowerInvariant()} dx={_panX:0} dy={_panY:0}");
     }
 
     private void OnSwiped(object? sender, SwipedEventArgs e)

--- a/samples/DevFlow.Sample/GestureTestPage.xaml.cs
+++ b/samples/DevFlow.Sample/GestureTestPage.xaml.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+
+namespace DevFlow.Sample;
+
+/// <summary>
+/// Targets for DevFlow's gesture automation. Each handler writes what it received to an
+/// AutomationId'd label so a test can assert the gesture genuinely reached the app,
+/// rather than only that the HTTP call returned 200.
+/// </summary>
+public partial class GestureTestPage : ContentPage
+{
+    // Accumulated across a pinch the way an app would apply it, so a request for
+    // scale 2.0 ends up reported as 2.00 regardless of how many steps it arrived in.
+    private double _pinchScale = 1;
+
+    public GestureTestPage()
+    {
+        InitializeComponent();
+
+        for (var i = 1; i <= 30; i++)
+            NativeScrollContent.Add(new Label { Text = $"Native row {i}", AutomationId = $"NativeRow{i}" });
+    }
+
+    private void OnPinchUpdated(object? sender, PinchGestureUpdatedEventArgs e)
+    {
+        switch (e.Status)
+        {
+            case GestureStatus.Started:
+                _pinchScale = 1;
+                break;
+            case GestureStatus.Running:
+                _pinchScale *= e.Scale;
+                PinchBox.Scale = Math.Clamp(_pinchScale, 0.2, 4);
+                break;
+            case GestureStatus.Completed:
+            case GestureStatus.Canceled:
+                break;
+        }
+
+        PinchStatusLabel.Text = string.Create(CultureInfo.InvariantCulture,
+            $"pinch: {e.Status.ToString().ToLowerInvariant()} scale={_pinchScale:0.00}");
+    }
+
+    private void OnPanUpdated(object? sender, PanUpdatedEventArgs e)
+    {
+        PanStatusLabel.Text = string.Create(CultureInfo.InvariantCulture,
+            $"pan: {e.StatusType.ToString().ToLowerInvariant()} dx={e.TotalX:0} dy={e.TotalY:0}");
+    }
+
+    private void OnSwiped(object? sender, SwipedEventArgs e)
+        => SwipeStatusLabel.Text = $"swipe: {e.Direction.ToString().ToLowerInvariant()}";
+
+    private void OnSingleTapped(object? sender, TappedEventArgs e)
+        => TapStatusLabel.Text = "tap: single";
+
+    private void OnDoubleTapped(object? sender, TappedEventArgs e)
+        => TapStatusLabel.Text = "tap: double";
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
@@ -321,6 +321,18 @@ public class DevFlowCliCommandTests
     }
 
     [Fact]
+    public async Task UiGesture_TapWithoutTarget_FailsWithoutCallingAgent()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "gesture", "tap", "--json");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.DoesNotContain(server.RecordedRequests, r => r.Path == "/api/v1/ui/actions/gesture");
+    }
+
+    [Fact]
     public async Task UiResize_SendsResizeAction()
     {
         var (server, cli) = await CreateFixturesAsync();

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
@@ -235,6 +235,91 @@ public class DevFlowCliCommandTests
         Assert.Contains("-100", req.Body);
     }
 
+    // ========== ui gesture ==========
+
+    [Fact]
+    public async Task UiGesture_Pinch_SendsScaleToGestureRoute()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "gesture", "pinch", "--element", "el-1", "--scale", "2.0", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var req = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/ui/actions/gesture");
+        Assert.Equal("POST", req.Method);
+        Assert.Contains("\"type\":\"pinch\"", req.Body);
+        Assert.Contains("\"scale\":2", req.Body);
+        Assert.Contains("\"elementId\":\"el-1\"", req.Body);
+    }
+
+    [Fact]
+    public async Task UiGesture_Pan_SendsExplicitVector()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "gesture", "pan", "--element", "el-1", "--dx", "0", "--dy", "-150", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var req = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/ui/actions/gesture");
+        Assert.Contains("\"type\":\"pan\"", req.Body);
+        Assert.Contains("-150", req.Body);
+    }
+
+    [Fact]
+    public async Task UiGesture_Rotate_SendsDegrees()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "gesture", "rotate", "--rotation", "45", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var req = Assert.Single(server.RecordedRequests, r => r.Path == "/api/v1/ui/actions/gesture");
+        Assert.Contains("\"type\":\"rotate\"", req.Body);
+        Assert.Contains("\"rotation\":45", req.Body);
+    }
+
+    [Fact]
+    public async Task UiGesture_ReportsWhichTierHandledIt()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "gesture", "pinch", "--element", "el-1", "--scale", "2.0", "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var payload = result.ParseJsonOutput();
+        Assert.True(payload.GetProperty("success").GetBoolean());
+        Assert.Equal("recognizer", payload.GetProperty("handledBy").GetString());
+        Assert.Equal("PinchGestureRecognizer on Grid", payload.GetProperty("detail").GetString());
+    }
+
+    [Fact]
+    public async Task UiGesture_UnknownType_FailsWithoutCallingAgent()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "gesture", "wiggle", "--json");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.DoesNotContain(server.RecordedRequests, r => r.Path == "/api/v1/ui/actions/gesture");
+    }
+
+    [Fact]
+    public async Task UiGesture_SwipeWithoutDirection_FailsWithoutCallingAgent()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+
+        var result = await cli.InvokeAsync("devflow", "ui", "gesture", "swipe", "--json");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.DoesNotContain(server.RecordedRequests, r => r.Path == "/api/v1/ui/actions/gesture");
+    }
+
     [Fact]
     public async Task UiResize_SendsResizeAction()
     {

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentResponses.cs
@@ -57,7 +57,11 @@ internal static class MockAgentResponses
           },
           "capabilities": {
             "ui.tree": { "version": 1, "features": ["tree", "query"] },
-            "ui.actions": { "version": 2, "features": ["tap", "fill", "batch", "stale-capture-rejection"] },
+            "ui.actions": {
+              "version": 2,
+              "features": ["tap", "fill", "gesture", "batch", "stale-capture-rejection"],
+              "gestures": ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate"]
+            },
             "webview": { "version": 1, "features": ["contexts", "evaluate", "source"] },
             "network": { "version": 1, "features": ["list", "detail", "clear"] },
             "logs": { "version": 1, "features": ["list", "stream"] },
@@ -322,6 +326,9 @@ internal static class MockAgentResponses
         """;
 
     public const string ActionSuccess = """{"success":true,"message":"ok"}""";
+
+    public const string GestureSuccess =
+        """{"success":true,"type":"pinch","elementId":"el-1","handledBy":"recognizer","platform":"iOS","detail":"PinchGestureRecognizer on Grid","error":null}""";
 
     public const string DeviceInfo = """
         {

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/MockAgentServer.cs
@@ -403,8 +403,13 @@ public sealed class MockAgentServer : IAsyncDisposable
             return Results.Content(MockAgentResponses.ActionSuccess, "application/json");
         });
 
-        foreach (var action in new[] { "clear", "focus", "navigate", "scroll", "resize", "back", "gesture", "batch" })
+        foreach (var action in new[] { "clear", "focus", "navigate", "scroll", "resize", "back", "batch" })
             app.MapPost($"/api/v1/ui/actions/{action}", () => Results.Content(MockAgentResponses.ActionSuccess, "application/json"));
+
+        // Gestures return a richer body than the shared ActionSuccess: callers need to know
+        // which tier serviced them.
+        app.MapPost("/api/v1/ui/actions/gesture", () =>
+            Results.Content(MockAgentResponses.GestureSuccess, "application/json"));
     }
 
     private static void RegisterDeviceEndpoints(WebApplication app)

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -702,7 +702,7 @@ public class DevFlowCommands
         {
             Description = "Gesture: pinch, rotate, pan, swipe, doubletap, longpress, or tap"
         };
-        var gestureElementOption = new Option<string?>("--element") { Description = "Target element ID (defaults to the current page)" };
+        var gestureElementOption = new Option<string?>("--element") { Description = "Target element ID (required for tap; other gestures default to the current page)" };
         var gestureDirectionOption = new Option<string?>("--direction") { Description = "Direction for swipe/pan: up, down, left, right" };
         var gestureDistanceOption = new Option<double?>("--distance") { Description = "Swipe/pan distance in device-independent pixels (default: 120)" };
         var gestureScaleOption = new Option<double?>("--scale") { Description = "Pinch factor: 2.0 zooms in 2x, 0.5 zooms out (default: 1.5)" };
@@ -732,7 +732,7 @@ public class DevFlowCommands
             var index = ctx.GetValue(resolveIndexOption);
             ElementInfo? target = null;
 
-            // A gesture with no target is legitimate and aims at the current page.
+            // Non-tap gestures may omit a target and aim at the current page.
             if (elementId != null || autoId != null || text != null)
             {
                 target = await ResolveElementTargetAsync(
@@ -3558,6 +3558,16 @@ public class DevFlowCommands
         if (normalizedType == "swipe" && string.IsNullOrWhiteSpace(direction))
         {
             Output.WriteError("Swipe requires --direction (up, down, left, right).", json, "ValidationError");
+            _errorOccurred = true;
+            return;
+        }
+
+        if (normalizedType == "tap" && element is null)
+        {
+            Output.WriteError(
+                "Tap requires --element, --automationId, or --text to resolve a target.",
+                json,
+                "ValidationError");
             _errorOccurred = true;
             return;
         }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -696,6 +696,65 @@ public class DevFlowCommands
         });
         mauiCommand.Add(mauiScrollCmd);
 
+        // MAUI gesture — the gesture kind is a positional argument because --type is
+        // already taken by element resolution.
+        var gestureTypeArg = new Argument<string>("gestureType")
+        {
+            Description = "Gesture: pinch, rotate, pan, swipe, doubletap, longpress, or tap"
+        };
+        var gestureElementOption = new Option<string?>("--element") { Description = "Target element ID (defaults to the current page)" };
+        var gestureDirectionOption = new Option<string?>("--direction") { Description = "Direction for swipe/pan: up, down, left, right" };
+        var gestureDistanceOption = new Option<double?>("--distance") { Description = "Swipe/pan distance in device-independent pixels (default: 120)" };
+        var gestureScaleOption = new Option<double?>("--scale") { Description = "Pinch factor: 2.0 zooms in 2x, 0.5 zooms out (default: 1.5)" };
+        var gestureRotationOption = new Option<double?>("--rotation") { Description = "Rotation in degrees, positive = clockwise (default: 90)" };
+        var gestureDxOption = new Option<double?>("--dx") { Description = "Explicit horizontal pan distance; overrides --direction" };
+        var gestureDyOption = new Option<double?>("--dy") { Description = "Explicit vertical pan distance; overrides --direction" };
+        var gestureOriginXOption = new Option<double?>("--origin-x") { Description = "Focal point X, element-relative 0..1 (default: 0.5)" };
+        var gestureOriginYOption = new Option<double?>("--origin-y") { Description = "Focal point Y, element-relative 0..1 (default: 0.5)" };
+        var gestureDurationOption = new Option<int?>("--duration") { Description = "Gesture duration in milliseconds (default: 200)" };
+        var gestureStepsOption = new Option<int?>("--steps") { Description = "Interpolation steps between start and end (default: 10)" };
+        var mauiGestureCmd = new Command("gesture", "Perform a gesture: pinch, rotate, pan, swipe, doubletap, longpress, tap")
+        {
+            gestureTypeArg, gestureElementOption, resolveAutoIdOption, resolveTextOption, resolveIndexOption,
+            gestureDirectionOption, gestureDistanceOption, gestureScaleOption, gestureRotationOption,
+            gestureDxOption, gestureDyOption, gestureOriginXOption, gestureOriginYOption,
+            gestureDurationOption, gestureStepsOption
+        };
+        mauiGestureCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+
+            var elementId = ctx.GetValue(gestureElementOption);
+            var autoId = ctx.GetValue(resolveAutoIdOption);
+            var text = ctx.GetValue(resolveTextOption);
+            var index = ctx.GetValue(resolveIndexOption);
+
+            // Only resolve when a selector was actually supplied — a gesture with no target
+            // is legitimate and aims at the current page.
+            if (elementId == null && (autoId != null || text != null))
+            {
+                elementId = await ResolveElementIdAsync(host, port, isJson, null, autoId, null, text, index);
+                if (elementId == null) return;
+            }
+
+            await MauiGestureAsync(host, port, isJson,
+                ctx.GetValue(gestureTypeArg)!,
+                elementId,
+                ctx.GetValue(gestureDirectionOption),
+                ctx.GetValue(gestureDistanceOption),
+                ctx.GetValue(gestureDurationOption),
+                ctx.GetValue(gestureScaleOption),
+                ctx.GetValue(gestureRotationOption),
+                ctx.GetValue(gestureDxOption),
+                ctx.GetValue(gestureDyOption),
+                ctx.GetValue(gestureOriginXOption),
+                ctx.GetValue(gestureOriginYOption),
+                ctx.GetValue(gestureStepsOption));
+        });
+        mauiCommand.Add(mauiGestureCmd);
+
         // MAUI focus
         var focusIdArg = new Argument<string?>("elementId") { Description = "Element ID to focus (optional if --automationId, --type, or --text is used)", DefaultValueFactory = _ => null };
         var mauiFocusCmd = new Command("focus", "Set focus to element") { focusIdArg, resolveAutoIdOption, resolveTypeOption, resolveTextOption, resolveIndexOption };
@@ -3454,6 +3513,88 @@ public class DevFlowCommands
                     Console.WriteLine(success ? $"Scrolled by dx={dx}, dy={dy}" : "Failed to scroll");
             }
             if (!success) _errorOccurred = true;
+        }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
+    }
+
+    private static readonly string[] GestureTypes = ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate"];
+
+    private static async Task MauiGestureAsync(
+        string host, int port, bool json, string gestureType, string? elementId,
+        string? direction, double? distance, int? durationMs, double? scale, double? rotation,
+        double? deltaX, double? deltaY, double? originX, double? originY, int? steps)
+    {
+        var normalizedType = gestureType.Trim().ToLowerInvariant().Replace("-", "").Replace("_", "");
+        if (normalizedType == "zoom") normalizedType = "pinch";
+        if (normalizedType == "drag") normalizedType = "pan";
+
+        if (Array.IndexOf(GestureTypes, normalizedType) < 0)
+        {
+            Output.WriteError(
+                $"Unsupported gesture type '{gestureType}'. Supported: {string.Join(", ", GestureTypes)}.",
+                json, "ValidationError");
+            _errorOccurred = true;
+            return;
+        }
+
+        if (normalizedType == "swipe" && string.IsNullOrWhiteSpace(direction))
+        {
+            Output.WriteError("Swipe requires --direction (up, down, left, right).", json, "ValidationError");
+            _errorOccurred = true;
+            return;
+        }
+
+        if (normalizedType == "pan" && string.IsNullOrWhiteSpace(direction) && deltaX is null && deltaY is null)
+        {
+            Output.WriteError("Pan requires --direction, or an explicit --dx/--dy vector.", json, "ValidationError");
+            _errorOccurred = true;
+            return;
+        }
+
+        try
+        {
+            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            var result = await client.GestureDetailedAsync(
+                normalizedType, elementId, direction, distance, durationMs,
+                scale, rotation, deltaX, deltaY, originX, originY, steps);
+
+            if (json)
+            {
+                Output.WriteRawJson(CliJson.SerializeUntyped(new JsonObject
+                {
+                    ["success"] = result.Success,
+                    ["action"] = "gesture",
+                    ["type"] = result.Type ?? normalizedType,
+                    ["elementId"] = elementId,
+                    ["handledBy"] = result.HandledBy,
+                    ["platform"] = result.Platform,
+                    ["detail"] = result.Detail,
+                    ["error"] = result.Error
+                }, indented: false));
+            }
+            else
+            {
+                var target = elementId != null ? $" on {elementId}" : "";
+                if (result.Success)
+                {
+                    // Say which tier ran: a recognizer hit proves the app's own handler fired,
+                    // native means the platform control absorbed the gesture instead.
+                    var how = result.HandledBy switch
+                    {
+                        "recognizer" => $"MAUI recognizer — {result.Detail}",
+                        "native" => $"native {result.Platform} — {result.Detail}",
+                        "scroll" => $"scroll fallback — {result.Detail}",
+                        _ => result.Detail ?? "ok"
+                    };
+                    Console.WriteLine($"Performed {normalizedType}{target} ({how})");
+                }
+                else
+                {
+                    Console.WriteLine($"Failed to perform {normalizedType}{target}: {result.Error}");
+                }
+            }
+
+            if (!result.Success) _errorOccurred = true;
         }
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -730,18 +730,28 @@ public class DevFlowCommands
             var autoId = ctx.GetValue(resolveAutoIdOption);
             var text = ctx.GetValue(resolveTextOption);
             var index = ctx.GetValue(resolveIndexOption);
+            ElementInfo? target = null;
 
-            // Only resolve when a selector was actually supplied — a gesture with no target
-            // is legitimate and aims at the current page.
-            if (elementId == null && (autoId != null || text != null))
+            // A gesture with no target is legitimate and aims at the current page.
+            if (elementId != null || autoId != null || text != null)
             {
-                elementId = await ResolveElementIdAsync(host, port, isJson, null, autoId, null, text, index);
-                if (elementId == null) return;
+                target = await ResolveElementTargetAsync(
+                    host,
+                    port,
+                    isJson,
+                    elementId,
+                    autoId,
+                    type: null,
+                    text,
+                    index,
+                    ElementActionKind.Gesture,
+                    preferActionable: ctx.GetResult(resolveIndexOption)?.Tokens.Count == 0);
+                if (target == null) return;
             }
 
             await MauiGestureAsync(host, port, isJson,
                 ctx.GetValue(gestureTypeArg)!,
-                elementId,
+                target,
                 ctx.GetValue(gestureDirectionOption),
                 ctx.GetValue(gestureDistanceOption),
                 ctx.GetValue(gestureDurationOption),
@@ -2526,7 +2536,8 @@ public class DevFlowCommands
     {
         Tap,
         TextInput,
-        Focus
+        Focus,
+        Gesture
     }
 
     /// <summary>
@@ -2677,6 +2688,13 @@ public class DevFlowCommands
                 {
                     score += 50;
                 }
+                break;
+
+            case ElementActionKind.Gesture:
+                if (gestures.Count > 0)
+                    score += 100;
+                if (traits.Any(trait => trait.Equals("scrollable", StringComparison.OrdinalIgnoreCase)))
+                    score += 40;
                 break;
         }
 
@@ -3520,7 +3538,7 @@ public class DevFlowCommands
     private static readonly string[] GestureTypes = ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate"];
 
     private static async Task MauiGestureAsync(
-        string host, int port, bool json, string gestureType, string? elementId,
+        string host, int port, bool json, string gestureType, ElementInfo? element,
         string? direction, double? distance, int? durationMs, double? scale, double? rotation,
         double? deltaX, double? deltaY, double? originX, double? originY, int? steps)
     {
@@ -3553,10 +3571,14 @@ public class DevFlowCommands
 
         try
         {
-            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            using var client = await CreateAgentClientAsync(host, port);
+            var (captureEpoch, registryGeneration) = element is null
+                ? (null, null)
+                : GetCaptureMetadata(element);
             var result = await client.GestureDetailedAsync(
-                normalizedType, elementId, direction, distance, durationMs,
-                scale, rotation, deltaX, deltaY, originX, originY, steps);
+                normalizedType, element?.Id, direction, distance, durationMs,
+                scale, rotation, deltaX, deltaY, originX, originY, steps,
+                captureEpoch, registryGeneration);
 
             if (json)
             {
@@ -3565,7 +3587,7 @@ public class DevFlowCommands
                     ["success"] = result.Success,
                     ["action"] = "gesture",
                     ["type"] = result.Type ?? normalizedType,
-                    ["elementId"] = elementId,
+                    ["elementId"] = element?.Id,
                     ["handledBy"] = result.HandledBy,
                     ["platform"] = result.Platform,
                     ["detail"] = result.Detail,
@@ -3574,7 +3596,7 @@ public class DevFlowCommands
             }
             else
             {
-                var target = elementId != null ? $" on {elementId}" : "";
+                var target = element != null ? $" on {element.Id}" : "";
                 if (result.Success)
                 {
                     // Say which tier ran: a recognizer hit proves the app's own handler fired,

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
@@ -23,11 +23,14 @@ public sealed class BatchTools
 		- {"action":"focus", "elementId":"<id>"}
 		- {"action":"scroll", "elementId":"<id>", "deltaX":0, "deltaY":200}
 		- {"action":"gesture", "type":"swipe", "elementId":"<id>", "direction":"up"}
+		- {"action":"gesture", "type":"pinch", "elementId":"<id>", "scale":2.0}
+		- {"action":"gesture", "type":"pan", "elementId":"<id>", "deltaX":0, "deltaY":-150}
 		- {"action":"navigate", "route":"//page"}
 		- {"action":"back"}
 
 		Note: The backend accepts both "action" and "type" fields. For gesture actions,
-		use "action":"gesture" with a separate "type" field for the gesture kind.
+		use "action":"gesture" with a separate "type" field for the gesture kind
+		(tap, doubletap, longpress, swipe, pan, pinch, rotate).
 
 		Example: [{"action":"fill","elementId":"entry1","text":"hello"},{"action":"tap","elementId":"btn1"}]
 		""")]

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
@@ -97,11 +97,11 @@ public sealed class InteractionTools
 		"Each gesture is first sent to a matching MAUI gesture recognizer on the element or its ancestors, and if there is " +
 		"none it is injected natively at the platform view — which is how pinch-to-zoom works on Maps, WebViews and other " +
 		"controls that handle gestures internally. Use maui_tree first to find the element ID; the 'gestures' field on each " +
-		"element lists the recognizers it has. Omitting elementId aims the gesture at the current page.")]
+		"element lists the recognizers it has. Omitting elementId aims non-tap gestures at the current page; tap requires an element ID.")]
 	public static async Task<string> Gesture(
 		McpAgentSession session,
 		[Description("Gesture type: 'pinch', 'rotate', 'pan', 'swipe', 'doubletap', 'longpress', or 'tap'")] string type,
-		[Description("Target element ID from maui_tree. If omitted, the gesture targets the current page.")] string? elementId = null,
+		[Description("Target element ID from maui_tree. Required for tap; other gestures target the current page when omitted.")] string? elementId = null,
 		[Description("Direction for swipe/pan: 'up', 'down', 'left', or 'right'. Required for swipe.")] string? direction = null,
 		[Description("Travel distance in device-independent pixels for swipe/pan when using 'direction'. Defaults to 120.")] double? distance = null,
 		[Description("Gesture duration in milliseconds. Longer durations read as drags, shorter ones as flicks. Defaults to 200.")] int? durationMs = null,
@@ -129,6 +129,9 @@ public sealed class InteractionTools
 
 		if (normalizedType == "swipe" && string.IsNullOrEmpty(normalizedDirection))
 			return "Swipe gesture requires a 'direction' parameter ('up', 'down', 'left', 'right').";
+
+		if (normalizedType == "tap" && string.IsNullOrWhiteSpace(elementId))
+			return "Tap gesture requires an 'elementId'. Use maui_tree or maui_query to resolve the target first.";
 
 		if (normalizedType == "pan" && string.IsNullOrEmpty(normalizedDirection) && deltaX is null && deltaY is null)
 			return "Pan gesture requires either a 'direction' or an explicit 'deltaX'/'deltaY' vector.";

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
@@ -151,12 +151,12 @@ public sealed class InteractionTools
 		// "native" means the platform control absorbed it — different things to assert against.
 		var how = result.HandledBy switch
 		{
+			"action" => result.Detail ?? "handled by the DevFlow action pipeline",
 			"recognizer" => $"handled by the app's MAUI gesture recognizer ({result.Detail})",
 			"native" => $"injected natively on {result.Platform} ({result.Detail})",
 			"scroll" => $"fell back to a scroll ({result.Detail})",
-			_ => result.Detail
+			_ => result.Detail ?? result.HandledBy ?? "handled"
 		};
-		return $"Performed {normalizedType} gesture{target} — {how}.";
 		return $"Performed {normalizedType} gesture{target} — {how}.";
 	}
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
@@ -86,55 +86,78 @@ public sealed class InteractionTools
 			$"Failed to send key '{key}'. The target element may not support keyboard input, or no target element was provided.");
 	}
 
-	[McpServerTool(Name = "maui_gesture"), Description("Perform a touch gesture on the app. Supported gesture types: 'swipe' (requires direction), 'tap', 'longpress', and 'long-press'. Use maui_tap for simple taps — this tool is for advanced gestures like swiping.")]
+	private static readonly string[] ValidGestureTypes = ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate"];
+	private static readonly string[] ValidGestureDirections = ["up", "down", "left", "right"];
+
+	[McpServerTool(Name = "maui_gesture"), Description(
+		"Perform a touch gesture on the app. Types: 'pinch' (zoom — use 'scale', e.g. 2.0 to zoom in, 0.5 to zoom out), " +
+		"'rotate' (use 'rotation' in degrees), 'pan' (drag — use deltaX/deltaY, or direction + distance), " +
+		"'swipe' (flick — requires direction), 'doubletap', 'longpress', and 'tap'. " +
+		"Use maui_tap for simple taps and maui_scroll for scrolling a list; this tool is for real gestures. " +
+		"Each gesture is first sent to a matching MAUI gesture recognizer on the element or its ancestors, and if there is " +
+		"none it is injected natively at the platform view — which is how pinch-to-zoom works on Maps, WebViews and other " +
+		"controls that handle gestures internally. Use maui_tree first to find the element ID; the 'gestures' field on each " +
+		"element lists the recognizers it has. Omitting elementId aims the gesture at the current page.")]
 	public static async Task<string> Gesture(
 		McpAgentSession session,
-		[Description("Gesture type: 'swipe', 'tap', 'longpress', or 'long-press'")] string type,
-		[Description("Target element ID (optional)")] string? elementId = null,
-		[Description("Swipe direction: 'up', 'down', 'left', or 'right' (required for swipe)")] string? direction = null,
-		[Description("Swipe distance in pixels (optional, uses default if omitted)")] double? distance = null,
-		[Description("Gesture duration in milliseconds (optional)")] int? durationMs = null,
+		[Description("Gesture type: 'pinch', 'rotate', 'pan', 'swipe', 'doubletap', 'longpress', or 'tap'")] string type,
+		[Description("Target element ID from maui_tree. If omitted, the gesture targets the current page.")] string? elementId = null,
+		[Description("Direction for swipe/pan: 'up', 'down', 'left', or 'right'. Required for swipe.")] string? direction = null,
+		[Description("Travel distance in device-independent pixels for swipe/pan when using 'direction'. Defaults to 120.")] double? distance = null,
+		[Description("Gesture duration in milliseconds. Longer durations read as drags, shorter ones as flicks. Defaults to 200.")] int? durationMs = null,
+		[Description("Pinch factor: 2.0 zooms in 2x, 0.5 zooms out by half. Required for pinch; defaults to 1.5.")] double? scale = null,
+		[Description("Rotation in degrees, positive is clockwise. Used by 'rotate'; defaults to 90.")] double? rotation = null,
+		[Description("Explicit horizontal pan distance in device-independent pixels. Overrides direction/distance.")] double? deltaX = null,
+		[Description("Explicit vertical pan distance in device-independent pixels. Overrides direction/distance.")] double? deltaY = null,
+		[Description("Gesture focal point X, element-relative from 0 (left) to 1 (right). Defaults to 0.5 (centre).")] double? originX = null,
+		[Description("Gesture focal point Y, element-relative from 0 (top) to 1 (bottom). Defaults to 0.5 (centre).")] double? originY = null,
+		[Description("Number of interpolation steps between gesture start and end. More steps are smoother. Defaults to 10.")] int? steps = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
 		[Description("Capture epoch from maui_tree or maui_hittest; stale epochs are rejected")] long? captureEpoch = null,
 		[Description("Native registry generation from maui_tree or maui_hittest")] long? registryGeneration = null)
 	{
-		var normalizedType = (type ?? string.Empty).Trim().ToLowerInvariant();
-		if (normalizedType == "long-press")
-			normalizedType = "longpress";
+		var normalizedType = (type ?? string.Empty).Trim().ToLowerInvariant().Replace("-", "").Replace("_", "");
+		if (normalizedType == "zoom") normalizedType = "pinch";
+		if (normalizedType == "drag") normalizedType = "pan";
 
-		var validTypes = new[] { "swipe", "tap", "longpress" };
-		if (Array.IndexOf(validTypes, normalizedType) < 0)
-			return $"Unsupported gesture type '{type}'. Supported types: swipe, tap, longpress, long-press.";
+		if (Array.IndexOf(ValidGestureTypes, normalizedType) < 0)
+			return $"Unsupported gesture type '{type}'. Supported types: {string.Join(", ", ValidGestureTypes)}.";
 
-		string? normalizedDirection = null;
-		if (normalizedType == "swipe")
-		{
-			normalizedDirection = direction?.Trim().ToLowerInvariant();
-			var validDirections = new[] { "up", "down", "left", "right" };
+		var normalizedDirection = direction?.Trim().ToLowerInvariant();
+		if (normalizedDirection is not null && Array.IndexOf(ValidGestureDirections, normalizedDirection) < 0)
+			return $"Unsupported direction '{direction}'. Supported directions: {string.Join(", ", ValidGestureDirections)}.";
 
-			if (string.IsNullOrEmpty(normalizedDirection))
-				return "Swipe gesture requires a 'direction' parameter ('up', 'down', 'left', 'right').";
+		if (normalizedType == "swipe" && string.IsNullOrEmpty(normalizedDirection))
+			return "Swipe gesture requires a 'direction' parameter ('up', 'down', 'left', 'right').";
 
-			if (Array.IndexOf(validDirections, normalizedDirection) < 0)
-				return $"Unsupported swipe direction '{direction}'. Supported directions: up, down, left, right.";
-		}
+		if (normalizedType == "pan" && string.IsNullOrEmpty(normalizedDirection) && deltaX is null && deltaY is null)
+			return "Pan gesture requires either a 'direction' or an explicit 'deltaX'/'deltaY' vector.";
+
+		if (normalizedType == "pinch" && scale is <= 0)
+			return "Pinch 'scale' must be greater than 0 — use 2.0 to zoom in or 0.5 to zoom out.";
 
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var result = await agent.GestureResultAsync(
-			normalizedType,
-			elementId,
-			normalizedDirection,
-			distance,
-			durationMs,
-			captureEpoch,
-			registryGeneration);
-		var successMessage = elementId is not null
-			? $"Performed {normalizedType} gesture on element '{elementId}'."
-			: $"Performed {normalizedType} gesture.";
-		return McpActionResult.RequireSuccess(
-			result,
-			successMessage,
-			$"Failed to perform {normalizedType} gesture.");
+		var result = await agent.GestureDetailedAsync(
+			normalizedType, elementId, normalizedDirection, distance, durationMs,
+			scale, rotation, deltaX, deltaY, originX, originY, steps,
+			captureEpoch, registryGeneration);
+
+		var target = elementId is not null ? $" on element '{elementId}'" : " on the current page";
+
+		if (!result.Success)
+			return $"Failed to perform {normalizedType} gesture{target}. {result.Error}".TrimEnd();
+
+		// Naming the tier matters: a "recognizer" hit proves the app's own handler ran, while
+		// "native" means the platform control absorbed it — different things to assert against.
+		var how = result.HandledBy switch
+		{
+			"recognizer" => $"handled by the app's MAUI gesture recognizer ({result.Detail})",
+			"native" => $"injected natively on {result.Platform} ({result.Detail})",
+			"scroll" => $"fell back to a scroll ({result.Detail})",
+			_ => result.Detail
+		};
+		return $"Performed {normalizedType} gesture{target} — {how}.";
+		return $"Performed {normalizedType} gesture{target} — {how}.";
 	}
 
 	[McpServerTool(Name = "maui_scroll"), Description("Scroll a ScrollView, CollectionView, or ListView. Supports delta-based scrolling, scrolling to an item index, or scrolling an element into view.")]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Handlers.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Handlers.cs
@@ -584,7 +584,7 @@ public partial class DevFlowAgentService
         public string? Type { get; set; }
         public string? Direction { get; set; }
         public double Distance { get; set; } = 120;
-        public int DurationMs { get; set; } = 200;
+        public int? DurationMs { get; set; }
         public double? Scale { get; set; }
         public double? Rotation { get; set; }
         public double? DeltaX { get; set; }
@@ -611,8 +611,8 @@ public partial class DevFlowAgentService
         public string? Value { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
-        public double DeltaX { get; set; }
-        public double DeltaY { get; set; }
+        public double? DeltaX { get; set; }
+        public double? DeltaY { get; set; }
         public int? ItemIndex { get; set; }
         public int? GroupIndex { get; set; }
         public string? ScrollToPosition { get; set; }
@@ -620,7 +620,7 @@ public partial class DevFlowAgentService
         public string? Key { get; set; }
         public string? Direction { get; set; }
         public double Distance { get; set; } = 120;
-        public int DurationMs { get; set; } = 200;
+        public int? DurationMs { get; set; }
         public double? Scale { get; set; }
         public double? Rotation { get; set; }
         public double? OriginX { get; set; }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Handlers.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Handlers.cs
@@ -585,6 +585,13 @@ public partial class DevFlowAgentService
         public string? Direction { get; set; }
         public double Distance { get; set; } = 120;
         public int DurationMs { get; set; } = 200;
+        public double? Scale { get; set; }
+        public double? Rotation { get; set; }
+        public double? DeltaX { get; set; }
+        public double? DeltaY { get; set; }
+        public double? OriginX { get; set; }
+        public double? OriginY { get; set; }
+        public int? Steps { get; set; }
     }
 
     protected sealed class BatchRequest : CaptureBoundRequest
@@ -614,6 +621,11 @@ public partial class DevFlowAgentService
         public string? Direction { get; set; }
         public double Distance { get; set; } = 120;
         public int DurationMs { get; set; } = 200;
+        public double? Scale { get; set; }
+        public double? Rotation { get; set; }
+        public double? OriginX { get; set; }
+        public double? OriginY { get; set; }
+        public int? Steps { get; set; }
         public JsonElement[]? Args { get; set; }
         public string? Name { get; set; }
     }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.cs
@@ -486,8 +486,8 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                         Body = JsonSerializer.Serialize(new ScrollRequest
                         {
                             ElementId = action.ElementId,
-                            DeltaX = action.DeltaX,
-                            DeltaY = action.DeltaY,
+                            DeltaX = action.DeltaX ?? 0,
+                            DeltaY = action.DeltaY ?? 0,
                             ItemIndex = action.ItemIndex,
                             GroupIndex = action.GroupIndex,
                             ScrollToPosition = action.ScrollToPosition,
@@ -515,7 +515,14 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                             Type = action.Type ?? action.Action,
                             Direction = action.Direction,
                             Distance = action.Distance,
-                            DurationMs = action.DurationMs
+                            DurationMs = action.DurationMs,
+                            Scale = action.Scale,
+                            Rotation = action.Rotation,
+                            DeltaX = action.DeltaX,
+                            DeltaY = action.DeltaY,
+                            OriginX = action.OriginX,
+                            OriginY = action.OriginY,
+                            Steps = action.Steps
                         })
                     });
                     break;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
@@ -25,34 +25,44 @@ public partial class MauiDevFlowAgentService
         if (await PrepareUiMutationAsync(request, body, body.ElementId) is { } staleCapture)
             return staleCapture;
 
+        var startedAtUtc = DateTime.UtcNow;
         var gestureType = NormalizeGestureType(body.Type);
+        var reservedCapture = GetReservedCapture(request);
+        var failureStatusCode = 400;
+        GestureOutcome outcome;
 
         if (gestureType == "tap")
         {
-            return await HandleTap(new HttpRequest
+            var tapResponse = await HandleTap(new HttpRequest
             {
                 Method = "POST",
                 MutationState = request.MutationState,
                 Body = JsonSerializer.Serialize(new ActionRequest { ElementId = body.ElementId })
             });
+            failureStatusCode = tapResponse.StatusCode;
+            outcome = tapResponse.StatusCode < 400
+                ? GestureOutcome.Handled("action", "DevFlow tap action")
+                : GestureOutcome.NotHandled(ExtractResponseError(tapResponse) ?? "Tap failed");
         }
-
-        var windowIndex = ParseWindowIndex(request);
-        var startedAtUtc = DateTime.UtcNow;
-        var outcome = gestureType switch
+        else
         {
-            "pinch" => await PerformPinchAsync(body, windowIndex),
-            "rotate" => await PerformRotateAsync(body, windowIndex),
-            "pan" => await PerformPanAsync(body, windowIndex),
-            "swipe" => await PerformSwipeAsync(body, windowIndex),
-            "doubletap" => await PerformDoubleTapAsync(body, windowIndex),
-            "longpress" => await PerformLongPressAsync(body, windowIndex),
-            _ => GestureOutcome.NotHandled(
-                $"Gesture '{body.Type}' is not supported. Supported types: {string.Join(", ", SupportedGestures)}")
-        };
+            var windowIndex = ParseWindowIndex(request);
+            outcome = gestureType switch
+            {
+                "pinch" => await PerformPinchAsync(body, windowIndex, reservedCapture),
+                "rotate" => await PerformRotateAsync(body, windowIndex, reservedCapture),
+                "pan" => await PerformPanAsync(body, windowIndex, reservedCapture),
+                "swipe" => await PerformSwipeAsync(body, windowIndex, reservedCapture),
+                "doubletap" => await PerformDoubleTapAsync(body, windowIndex, reservedCapture),
+                "longpress" => await PerformLongPressAsync(body, windowIndex, reservedCapture),
+                _ => GestureOutcome.NotHandled(
+                    $"Gesture '{body.Type}' is not supported. Supported types: {string.Join(", ", SupportedGestures)}")
+            };
+        }
 
         if (!outcome.Success && gestureType == "swipe")
         {
+            var durationMs = GestureDurationMs(body);
             var scrolled = await HandleScroll(new HttpRequest
             {
                 Method = "POST",
@@ -60,9 +70,9 @@ public partial class MauiDevFlowAgentService
                 Body = JsonSerializer.Serialize(new ScrollRequest
                 {
                     ElementId = body.ElementId,
-                    DeltaX = SwipeDeltaX(body.Direction, body.Distance),
-                    DeltaY = SwipeDeltaY(body.Direction, body.Distance),
-                    Animated = body.DurationMs <= 0 || body.DurationMs < 400
+                    DeltaX = -SwipeDeltaX(body.Direction, body.Distance),
+                    DeltaY = -SwipeDeltaY(body.Direction, body.Distance),
+                    Animated = durationMs <= 0 || durationMs < 400
                 })
             });
 
@@ -91,8 +101,8 @@ public partial class MauiDevFlowAgentService
 
         if (!outcome.Success)
         {
-            response.StatusCode = 400;
-            response.StatusText = "Bad Request";
+            response.StatusCode = failureStatusCode;
+            response.StatusText = HttpResponse.StatusTextFor(failureStatusCode);
         }
 
         return response;
@@ -128,13 +138,19 @@ public partial class MauiDevFlowAgentService
 
     private static int NormalizeSteps(int? steps) => Math.Clamp(steps ?? DefaultGestureSteps, 1, 120);
 
+    private static int GestureDurationMs(GestureActionRequest body) => body.DurationMs ?? 200;
+
     private static int StepDelayMs(int durationMs, int steps) =>
         durationMs <= 0 ? 0 : Math.Clamp(durationMs / Math.Max(1, steps), 0, 1000);
 
     private static Point GestureOrigin(GestureActionRequest body) =>
         new(Math.Clamp(body.OriginX ?? 0.5, 0, 1), Math.Clamp(body.OriginY ?? 0.5, 0, 1));
 
-    private VisualElement? ResolveGestureTarget(string? elementId, int? windowIndex, out string? error)
+    private VisualElement? ResolveGestureTarget(
+        string? elementId,
+        int? windowIndex,
+        UiCaptureContext capture,
+        out string? error)
     {
         error = null;
 
@@ -146,7 +162,10 @@ public partial class MauiDevFlowAgentService
             return page;
         }
 
-        var resolved = _treeWalker.GetElementById(elementId, _app);
+        var resolved = ResolveCapturedElement(
+            capture,
+            elementId,
+            id => _treeWalker.GetElementById(id, _app));
         if (resolved == null)
         {
             error = "Element not found";
@@ -183,7 +202,10 @@ public partial class MauiDevFlowAgentService
         return null;
     }
 
-    private async Task<GestureOutcome> PerformPinchAsync(GestureActionRequest body, int? windowIndex)
+    private async Task<GestureOutcome> PerformPinchAsync(
+        GestureActionRequest body,
+        int? windowIndex,
+        UiCaptureContext capture)
     {
         var scale = body.Scale ?? 1.5;
         if (scale <= 0)
@@ -191,10 +213,11 @@ public partial class MauiDevFlowAgentService
 
         var steps = NormalizeSteps(body.Steps);
         var origin = GestureOrigin(body);
-        var delay = StepDelayMs(body.DurationMs, steps);
+        var durationMs = GestureDurationMs(body);
+        var delay = StepDelayMs(durationMs, steps);
         var outcome = await DispatchAsync(async () =>
         {
-            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, capture, out var error);
             if (target == null)
                 return GestureOutcome.NotHandled(error!);
 
@@ -214,7 +237,7 @@ public partial class MauiDevFlowAgentService
                 return GestureOutcome.Recognizer($"PinchGestureRecognizer on {hit.Owner.GetType().Name}");
             }
 
-            var native = await TryNativePinch(target, scale, origin, body.DurationMs, steps);
+            var native = await TryNativePinch(target, scale, origin, durationMs, steps);
             return native != null
                 ? GestureOutcome.Native(native)
                 : GestureOutcome.NotHandled(NoHandlerMessage("pinch", target, "PinchGestureRecognizer"));
@@ -223,18 +246,22 @@ public partial class MauiDevFlowAgentService
         return outcome ?? GestureOutcome.NotHandled("Pinch dispatch failed");
     }
 
-    private async Task<GestureOutcome> PerformRotateAsync(GestureActionRequest body, int? windowIndex)
+    private async Task<GestureOutcome> PerformRotateAsync(
+        GestureActionRequest body,
+        int? windowIndex,
+        UiCaptureContext capture)
     {
         var degrees = body.Rotation ?? 90;
         var steps = NormalizeSteps(body.Steps);
         var origin = GestureOrigin(body);
+        var durationMs = GestureDurationMs(body);
         var outcome = await DispatchAsync(async () =>
         {
-            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, capture, out var error);
             if (target == null)
                 return GestureOutcome.NotHandled(error!);
 
-            var native = await TryNativeRotate(target, degrees, origin, body.DurationMs, steps);
+            var native = await TryNativeRotate(target, degrees, origin, durationMs, steps);
             return native != null
                 ? GestureOutcome.Native(native)
                 : GestureOutcome.NotHandled(
@@ -245,7 +272,10 @@ public partial class MauiDevFlowAgentService
         return outcome ?? GestureOutcome.NotHandled("Rotate dispatch failed");
     }
 
-    private async Task<GestureOutcome> PerformPanAsync(GestureActionRequest body, int? windowIndex)
+    private async Task<GestureOutcome> PerformPanAsync(
+        GestureActionRequest body,
+        int? windowIndex,
+        UiCaptureContext capture)
     {
         var totalX = body.DeltaX ?? SwipeDeltaX(body.Direction, body.Distance);
         var totalY = body.DeltaY ?? SwipeDeltaY(body.Direction, body.Distance);
@@ -253,10 +283,11 @@ public partial class MauiDevFlowAgentService
             return GestureOutcome.NotHandled("pan requires a non-zero deltaX/deltaY, or a direction with a distance");
 
         var steps = NormalizeSteps(body.Steps);
-        var delay = StepDelayMs(body.DurationMs, steps);
+        var durationMs = GestureDurationMs(body);
+        var delay = StepDelayMs(durationMs, steps);
         var outcome = await DispatchAsync(async () =>
         {
-            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, capture, out var error);
             if (target == null)
                 return GestureOutcome.NotHandled(error!);
 
@@ -276,7 +307,7 @@ public partial class MauiDevFlowAgentService
                 return GestureOutcome.Recognizer($"PanGestureRecognizer on {hit.Owner.GetType().Name}");
             }
 
-            var native = await TryNativePan(target, totalX, totalY, body.DurationMs, steps);
+            var native = await TryNativePan(target, totalX, totalY, durationMs, steps);
             return native != null
                 ? GestureOutcome.Native(native)
                 : GestureOutcome.NotHandled(NoHandlerMessage("pan", target, "PanGestureRecognizer"));
@@ -285,14 +316,17 @@ public partial class MauiDevFlowAgentService
         return outcome ?? GestureOutcome.NotHandled("Pan dispatch failed");
     }
 
-    private async Task<GestureOutcome> PerformSwipeAsync(GestureActionRequest body, int? windowIndex)
+    private async Task<GestureOutcome> PerformSwipeAsync(
+        GestureActionRequest body,
+        int? windowIndex,
+        UiCaptureContext capture)
     {
         if (!TryParseSwipeDirection(body.Direction, out var direction))
             return GestureOutcome.NotHandled("swipe requires a direction of 'up', 'down', 'left' or 'right'");
 
         var outcome = await DispatchAsync(async () =>
         {
-            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, capture, out var error);
             if (target == null)
                 return GestureOutcome.NotHandled(error!);
 
@@ -300,7 +334,7 @@ public partial class MauiDevFlowAgentService
                 target,
                 recognizer => recognizer.Direction.HasFlag(direction));
             if (found is { } hit
-                && hit.Recognizer is ISwipeGestureController controller
+                && hit.Recognizer is ISwipeGestureController controller)
             {
                 controller.SendSwipe(
                     hit.Owner,
@@ -314,7 +348,7 @@ public partial class MauiDevFlowAgentService
                 target,
                 direction.ToString().ToLowerInvariant(),
                 body.Distance,
-                body.DurationMs);
+                GestureDurationMs(body));
             return native != null
                 ? GestureOutcome.Native(native)
                 : GestureOutcome.NotHandled(NoHandlerMessage("swipe", target, "SwipeGestureRecognizer"));
@@ -323,11 +357,14 @@ public partial class MauiDevFlowAgentService
         return outcome ?? GestureOutcome.NotHandled("Swipe dispatch failed");
     }
 
-    private async Task<GestureOutcome> PerformDoubleTapAsync(GestureActionRequest body, int? windowIndex)
+    private async Task<GestureOutcome> PerformDoubleTapAsync(
+        GestureActionRequest body,
+        int? windowIndex,
+        UiCaptureContext capture)
     {
         var outcome = await DispatchAsync(async () =>
         {
-            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, capture, out var error);
             if (target == null)
                 return GestureOutcome.NotHandled(error!);
 
@@ -360,12 +397,15 @@ public partial class MauiDevFlowAgentService
         return outcome ?? GestureOutcome.NotHandled("Double-tap dispatch failed");
     }
 
-    private async Task<GestureOutcome> PerformLongPressAsync(GestureActionRequest body, int? windowIndex)
+    private async Task<GestureOutcome> PerformLongPressAsync(
+        GestureActionRequest body,
+        int? windowIndex,
+        UiCaptureContext capture)
     {
-        var durationMs = body.DurationMs > 0 ? body.DurationMs : 600;
+        var durationMs = Math.Max(body.DurationMs ?? 600, 500);
         var outcome = await DispatchAsync(async () =>
         {
-            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, capture, out var error);
             if (target == null)
                 return GestureOutcome.NotHandled(error!);
 
@@ -384,6 +424,24 @@ public partial class MauiDevFlowAgentService
     private static string NoHandlerMessage(string gesture, VisualElement target, string recognizerName) =>
         $"No {gesture} handler for {target.GetType().Name}: no {recognizerName} on the element or its " +
         $"ancestors, and native {gesture} injection is not available on {DeviceInfo.Platform}.";
+
+    private static string? ExtractResponseError(HttpResponse response)
+    {
+        if (string.IsNullOrWhiteSpace(response.Body))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(response.Body);
+            return document.RootElement.TryGetProperty("error", out var error)
+                ? error.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
 
     private static bool TryParseSwipeDirection(string? direction, out SwipeDirection parsed)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
@@ -301,9 +301,13 @@ public partial class MauiDevFlowAgentService
                 recognizer => recognizer.Direction.HasFlag(direction));
             if (found is { } hit
                 && hit.Recognizer is ISwipeGestureController controller
-                && controller.DetectSwipe(hit.Owner, direction))
             {
-                return GestureOutcome.Recognizer($"SwipeGestureRecognizer on {hit.Owner.GetType().Name}");
+                controller.SendSwipe(
+                    hit.Owner,
+                    SwipeDeltaX(body.Direction, body.Distance),
+                    SwipeDeltaY(body.Direction, body.Distance));
+                if (controller.DetectSwipe(hit.Owner, direction))
+                    return GestureOutcome.Recognizer($"SwipeGestureRecognizer on {hit.Owner.GetType().Name}");
             }
 
             var native = await TryNativeSwipe(

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
@@ -1,0 +1,442 @@
+using System.Text.Json;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.DevFlow.Agent.Core;
+
+public partial class MauiDevFlowAgentService
+{
+    internal static readonly string[] SupportedGestures =
+        ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate"];
+
+    private const int DefaultGestureSteps = 10;
+    private int _panGestureId;
+
+    protected override async Task<HttpResponse> HandleGesture(HttpRequest request)
+    {
+        if (_app == null)
+            return HttpResponse.Error("Agent not bound to app");
+
+        var body = request.BodyAs<GestureActionRequest>();
+        if (body == null || string.IsNullOrWhiteSpace(body.Type))
+            return HttpResponse.Error("type is required");
+        if (await PrepareUiMutationAsync(request, body, body.ElementId) is { } staleCapture)
+            return staleCapture;
+
+        var gestureType = NormalizeGestureType(body.Type);
+
+        if (gestureType == "tap")
+        {
+            return await HandleTap(new HttpRequest
+            {
+                Method = "POST",
+                MutationState = request.MutationState,
+                Body = JsonSerializer.Serialize(new ActionRequest { ElementId = body.ElementId })
+            });
+        }
+
+        var windowIndex = ParseWindowIndex(request);
+        var startedAtUtc = DateTime.UtcNow;
+        var outcome = gestureType switch
+        {
+            "pinch" => await PerformPinchAsync(body, windowIndex),
+            "rotate" => await PerformRotateAsync(body, windowIndex),
+            "pan" => await PerformPanAsync(body, windowIndex),
+            "swipe" => await PerformSwipeAsync(body, windowIndex),
+            "doubletap" => await PerformDoubleTapAsync(body, windowIndex),
+            "longpress" => await PerformLongPressAsync(body, windowIndex),
+            _ => GestureOutcome.NotHandled(
+                $"Gesture '{body.Type}' is not supported. Supported types: {string.Join(", ", SupportedGestures)}")
+        };
+
+        if (!outcome.Success && gestureType == "swipe")
+        {
+            var scrolled = await HandleScroll(new HttpRequest
+            {
+                Method = "POST",
+                MutationState = request.MutationState,
+                Body = JsonSerializer.Serialize(new ScrollRequest
+                {
+                    ElementId = body.ElementId,
+                    DeltaX = SwipeDeltaX(body.Direction, body.Distance),
+                    DeltaY = SwipeDeltaY(body.Direction, body.Distance),
+                    Animated = body.DurationMs <= 0 || body.DurationMs < 400
+                })
+            });
+
+            if (scrolled.StatusCode < 400)
+                outcome = GestureOutcome.Handled("scroll", "ScrollView.ScrollToAsync (legacy swipe fallback)");
+        }
+
+        PublishUiOperationSpan(
+            $"action.gesture.{gestureType}",
+            startedAtUtc,
+            outcome.Success,
+            outcome.Success ? null : outcome.Error,
+            body.ElementId,
+            new { gesture = gestureType, handledBy = outcome.HandledBy, detail = outcome.Detail });
+
+        var response = HttpResponse.Json(new
+        {
+            success = outcome.Success,
+            type = gestureType,
+            elementId = body.ElementId,
+            handledBy = outcome.HandledBy,
+            platform = DeviceInfo.Platform.ToString(),
+            detail = outcome.Detail,
+            error = outcome.Error
+        });
+
+        if (!outcome.Success)
+        {
+            response.StatusCode = 400;
+            response.StatusText = "Bad Request";
+        }
+
+        return response;
+    }
+
+    private static string NormalizeGestureType(string type)
+    {
+        var normalized = type.Trim().ToLowerInvariant().Replace("-", "").Replace("_", "");
+        return normalized switch
+        {
+            "double" => "doubletap",
+            "zoom" => "pinch",
+            "drag" => "pan",
+            _ => normalized
+        };
+    }
+
+    private static double SwipeDeltaX(string? direction, double distance) =>
+        direction?.Equals("left", StringComparison.OrdinalIgnoreCase) == true ? -distance :
+        direction?.Equals("right", StringComparison.OrdinalIgnoreCase) == true ? distance : 0;
+
+    private static double SwipeDeltaY(string? direction, double distance) =>
+        direction?.Equals("up", StringComparison.OrdinalIgnoreCase) == true ? -distance :
+        direction?.Equals("down", StringComparison.OrdinalIgnoreCase) == true ? distance : 0;
+
+    private sealed record GestureOutcome(bool Success, string HandledBy, string? Detail, string? Error)
+    {
+        public static GestureOutcome Recognizer(string detail) => new(true, "recognizer", detail, null);
+        public static GestureOutcome Native(string detail) => new(true, "native", detail, null);
+        public static GestureOutcome Handled(string handledBy, string detail) => new(true, handledBy, detail, null);
+        public static GestureOutcome NotHandled(string error) => new(false, "none", null, error);
+    }
+
+    private static int NormalizeSteps(int? steps) => Math.Clamp(steps ?? DefaultGestureSteps, 1, 120);
+
+    private static int StepDelayMs(int durationMs, int steps) =>
+        durationMs <= 0 ? 0 : Math.Clamp(durationMs / Math.Max(1, steps), 0, 1000);
+
+    private static Point GestureOrigin(GestureActionRequest body) =>
+        new(Math.Clamp(body.OriginX ?? 0.5, 0, 1), Math.Clamp(body.OriginY ?? 0.5, 0, 1));
+
+    private VisualElement? ResolveGestureTarget(string? elementId, int? windowIndex, out string? error)
+    {
+        error = null;
+
+        if (string.IsNullOrEmpty(elementId))
+        {
+            var page = GetWindow(windowIndex)?.Page;
+            if (page == null)
+                error = "No element id supplied and the window has no current page";
+            return page;
+        }
+
+        var resolved = _treeWalker.GetElementById(elementId, _app);
+        if (resolved == null)
+        {
+            error = "Element not found";
+            return null;
+        }
+
+        if (resolved is VisualElement visualElement)
+            return visualElement;
+
+        error = $"Element '{elementId}' is a {resolved.GetType().Name}, which cannot receive gestures";
+        return null;
+    }
+
+    private static (T Recognizer, View Owner)? FindGestureRecognizer<T>(
+        Element? start,
+        Func<T, bool>? predicate = null)
+        where T : class, IGestureRecognizer
+    {
+        var current = start;
+        while (current != null)
+        {
+            if (current is View view)
+            {
+                foreach (var recognizer in view.GestureRecognizers)
+                {
+                    if (recognizer is T match && (predicate == null || predicate(match)))
+                        return (match, view);
+                }
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private async Task<GestureOutcome> PerformPinchAsync(GestureActionRequest body, int? windowIndex)
+    {
+        var scale = body.Scale ?? 1.5;
+        if (scale <= 0)
+            return GestureOutcome.NotHandled("scale must be greater than 0 (2.0 zooms in, 0.5 zooms out)");
+
+        var steps = NormalizeSteps(body.Steps);
+        var origin = GestureOrigin(body);
+        var delay = StepDelayMs(body.DurationMs, steps);
+        var outcome = await DispatchAsync(async () =>
+        {
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            if (target == null)
+                return GestureOutcome.NotHandled(error!);
+
+            var found = FindGestureRecognizer<PinchGestureRecognizer>(target);
+            if (found is { } hit && hit.Recognizer is IPinchGestureController controller)
+            {
+                var stepScale = Math.Pow(scale, 1.0 / steps);
+                controller.SendPinchStarted(hit.Owner, origin);
+                for (var i = 0; i < steps; i++)
+                {
+                    controller.SendPinch(hit.Owner, stepScale, origin);
+                    if (delay > 0)
+                        await Task.Delay(delay);
+                }
+
+                controller.SendPinchEnded(hit.Owner);
+                return GestureOutcome.Recognizer($"PinchGestureRecognizer on {hit.Owner.GetType().Name}");
+            }
+
+            var native = await TryNativePinch(target, scale, origin, body.DurationMs, steps);
+            return native != null
+                ? GestureOutcome.Native(native)
+                : GestureOutcome.NotHandled(NoHandlerMessage("pinch", target, "PinchGestureRecognizer"));
+        });
+
+        return outcome ?? GestureOutcome.NotHandled("Pinch dispatch failed");
+    }
+
+    private async Task<GestureOutcome> PerformRotateAsync(GestureActionRequest body, int? windowIndex)
+    {
+        var degrees = body.Rotation ?? 90;
+        var steps = NormalizeSteps(body.Steps);
+        var origin = GestureOrigin(body);
+        var outcome = await DispatchAsync(async () =>
+        {
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            if (target == null)
+                return GestureOutcome.NotHandled(error!);
+
+            var native = await TryNativeRotate(target, degrees, origin, body.DurationMs, steps);
+            return native != null
+                ? GestureOutcome.Native(native)
+                : GestureOutcome.NotHandled(
+                    $"rotate is not available for {target.GetType().Name} on {DeviceInfo.Platform}. " +
+                    "MAUI has no RotationGestureRecognizer, so rotate requires a native rotation recognizer on the platform view.");
+        });
+
+        return outcome ?? GestureOutcome.NotHandled("Rotate dispatch failed");
+    }
+
+    private async Task<GestureOutcome> PerformPanAsync(GestureActionRequest body, int? windowIndex)
+    {
+        var totalX = body.DeltaX ?? SwipeDeltaX(body.Direction, body.Distance);
+        var totalY = body.DeltaY ?? SwipeDeltaY(body.Direction, body.Distance);
+        if (totalX == 0 && totalY == 0)
+            return GestureOutcome.NotHandled("pan requires a non-zero deltaX/deltaY, or a direction with a distance");
+
+        var steps = NormalizeSteps(body.Steps);
+        var delay = StepDelayMs(body.DurationMs, steps);
+        var outcome = await DispatchAsync(async () =>
+        {
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            if (target == null)
+                return GestureOutcome.NotHandled(error!);
+
+            var found = FindGestureRecognizer<PanGestureRecognizer>(target);
+            if (found is { } hit && hit.Recognizer is IPanGestureController controller)
+            {
+                var gestureId = Interlocked.Increment(ref _panGestureId);
+                controller.SendPanStarted(hit.Owner, gestureId);
+                for (var i = 1; i <= steps; i++)
+                {
+                    controller.SendPan(hit.Owner, totalX * i / steps, totalY * i / steps, gestureId);
+                    if (delay > 0)
+                        await Task.Delay(delay);
+                }
+
+                controller.SendPanCompleted(hit.Owner, gestureId);
+                return GestureOutcome.Recognizer($"PanGestureRecognizer on {hit.Owner.GetType().Name}");
+            }
+
+            var native = await TryNativePan(target, totalX, totalY, body.DurationMs, steps);
+            return native != null
+                ? GestureOutcome.Native(native)
+                : GestureOutcome.NotHandled(NoHandlerMessage("pan", target, "PanGestureRecognizer"));
+        });
+
+        return outcome ?? GestureOutcome.NotHandled("Pan dispatch failed");
+    }
+
+    private async Task<GestureOutcome> PerformSwipeAsync(GestureActionRequest body, int? windowIndex)
+    {
+        if (!TryParseSwipeDirection(body.Direction, out var direction))
+            return GestureOutcome.NotHandled("swipe requires a direction of 'up', 'down', 'left' or 'right'");
+
+        var outcome = await DispatchAsync(async () =>
+        {
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            if (target == null)
+                return GestureOutcome.NotHandled(error!);
+
+            var found = FindGestureRecognizer<SwipeGestureRecognizer>(
+                target,
+                recognizer => recognizer.Direction.HasFlag(direction));
+            if (found is { } hit
+                && hit.Recognizer is ISwipeGestureController controller
+                && controller.DetectSwipe(hit.Owner, direction))
+            {
+                return GestureOutcome.Recognizer($"SwipeGestureRecognizer on {hit.Owner.GetType().Name}");
+            }
+
+            var native = await TryNativeSwipe(
+                target,
+                direction.ToString().ToLowerInvariant(),
+                body.Distance,
+                body.DurationMs);
+            return native != null
+                ? GestureOutcome.Native(native)
+                : GestureOutcome.NotHandled(NoHandlerMessage("swipe", target, "SwipeGestureRecognizer"));
+        });
+
+        return outcome ?? GestureOutcome.NotHandled("Swipe dispatch failed");
+    }
+
+    private async Task<GestureOutcome> PerformDoubleTapAsync(GestureActionRequest body, int? windowIndex)
+    {
+        var outcome = await DispatchAsync(async () =>
+        {
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            if (target == null)
+                return GestureOutcome.NotHandled(error!);
+
+            var found = FindGestureRecognizer<TapGestureRecognizer>(
+                target,
+                recognizer => recognizer.NumberOfTapsRequired == 2);
+            if (found is { } hit)
+            {
+                if (hit.Recognizer.Command != null)
+                {
+                    hit.Recognizer.Command.Execute(hit.Recognizer.CommandParameter);
+                    return GestureOutcome.Recognizer(
+                        $"TapGestureRecognizer(2) command on {hit.Owner.GetType().Name}");
+                }
+
+                if (TryInvokeTapped(hit.Recognizer, hit.Owner))
+                    return GestureOutcome.Recognizer($"TapGestureRecognizer(2) on {hit.Owner.GetType().Name}");
+            }
+
+            var native = await TryNativeDoubleTap(target);
+            return native != null
+                ? GestureOutcome.Native(native)
+                : GestureOutcome.NotHandled(
+                    NoHandlerMessage(
+                        "doubletap",
+                        target,
+                        "TapGestureRecognizer with NumberOfTapsRequired=2"));
+        });
+
+        return outcome ?? GestureOutcome.NotHandled("Double-tap dispatch failed");
+    }
+
+    private async Task<GestureOutcome> PerformLongPressAsync(GestureActionRequest body, int? windowIndex)
+    {
+        var durationMs = body.DurationMs > 0 ? body.DurationMs : 600;
+        var outcome = await DispatchAsync(async () =>
+        {
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, out var error);
+            if (target == null)
+                return GestureOutcome.NotHandled(error!);
+
+            var native = await TryNativeLongPress(target, durationMs);
+            return native != null
+                ? GestureOutcome.Native(native)
+                : GestureOutcome.NotHandled(
+                    $"longpress is not available for {target.GetType().Name} on {DeviceInfo.Platform}. " +
+                    "MAUI has no long-press recognizer, so it requires native touch injection. " +
+                    "Use the 'tap' gesture if a plain tap is sufficient.");
+        });
+
+        return outcome ?? GestureOutcome.NotHandled("Long-press dispatch failed");
+    }
+
+    private static string NoHandlerMessage(string gesture, VisualElement target, string recognizerName) =>
+        $"No {gesture} handler for {target.GetType().Name}: no {recognizerName} on the element or its " +
+        $"ancestors, and native {gesture} injection is not available on {DeviceInfo.Platform}.";
+
+    private static bool TryParseSwipeDirection(string? direction, out SwipeDirection parsed)
+    {
+        switch (direction?.Trim().ToLowerInvariant())
+        {
+            case "up":
+                parsed = SwipeDirection.Up;
+                return true;
+            case "down":
+                parsed = SwipeDirection.Down;
+                return true;
+            case "left":
+                parsed = SwipeDirection.Left;
+                return true;
+            case "right":
+                parsed = SwipeDirection.Right;
+                return true;
+            default:
+                parsed = SwipeDirection.Up;
+                return false;
+        }
+    }
+
+    protected virtual Task<string?> TryNativePinch(
+        VisualElement element,
+        double scale,
+        Point origin,
+        int durationMs,
+        int steps)
+        => Task.FromResult<string?>(null);
+
+    protected virtual Task<string?> TryNativeRotate(
+        VisualElement element,
+        double degrees,
+        Point origin,
+        int durationMs,
+        int steps)
+        => Task.FromResult<string?>(null);
+
+    protected virtual Task<string?> TryNativePan(
+        VisualElement element,
+        double deltaX,
+        double deltaY,
+        int durationMs,
+        int steps)
+        => Task.FromResult<string?>(null);
+
+    protected virtual Task<string?> TryNativeSwipe(
+        VisualElement element,
+        string direction,
+        double distance,
+        int durationMs)
+        => Task.FromResult<string?>(null);
+
+    protected virtual Task<string?> TryNativeLongPress(VisualElement element, int durationMs)
+        => Task.FromResult<string?>(null);
+
+    protected virtual Task<string?> TryNativeDoubleTap(VisualElement element)
+        => Task.FromResult<string?>(null);
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
@@ -31,7 +31,12 @@ public partial class MauiDevFlowAgentService
         var failureStatusCode = 400;
         GestureOutcome outcome;
 
-        if (gestureType == "tap")
+        if (gestureType == "tap" && string.IsNullOrWhiteSpace(body.ElementId))
+        {
+            outcome = GestureOutcome.NotHandled(
+                "tap requires elementId; use the dedicated tap action after resolving a target element");
+        }
+        else if (gestureType == "tap")
         {
             var tapResponse = await HandleTap(new HttpRequest
             {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.cs
@@ -3452,8 +3452,8 @@ public partial class MauiDevFlowAgentService : DevFlowAgentService
                                 Body = JsonSerializer.Serialize(new ScrollRequest
                                 {
                                     ElementId = action.ElementId,
-                                    DeltaX = action.DeltaX,
-                                    DeltaY = action.DeltaY,
+                                    DeltaX = action.DeltaX ?? 0,
+                                    DeltaY = action.DeltaY ?? 0,
                                     ItemIndex = action.ItemIndex,
                                     GroupIndex = action.GroupIndex,
                                     ScrollToPosition = action.ScrollToPosition,
@@ -3491,8 +3491,8 @@ public partial class MauiDevFlowAgentService : DevFlowAgentService
                                     DurationMs = action.DurationMs,
                                     Scale = action.Scale,
                                     Rotation = action.Rotation,
-                                    DeltaX = action.DeltaX != 0 ? action.DeltaX : null,
-                                    DeltaY = action.DeltaY != 0 ? action.DeltaY : null,
+                                    DeltaX = action.DeltaX,
+                                    DeltaY = action.DeltaY,
                                     OriginX = action.OriginX,
                                     OriginY = action.OriginY,
                                     Steps = action.Steps

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.cs
@@ -104,9 +104,14 @@ public partial class MauiDevFlowAgentService : DevFlowAgentService
         capabilities["ui.hit-test"] = Capability(2, supported: true,
             ["native-first", "capture-epoch", "window-logical-coordinates"],
             reason: null);
-        capabilities["ui.actions"] = Capability(2, supported: true,
-            ["tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "capture-bound-batch", "properties", "stale-capture-rejection"],
-            reason: null);
+        capabilities["ui.actions"] = new
+        {
+            version = 2,
+            supported = true,
+            features = new[] { "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "capture-bound-batch", "properties", "stale-capture-rejection" },
+            gestures = SupportedGestures,
+            reason = (string?)null
+        };
         capabilities["ui.screenshot"] = Capability(2, supported: true,
             SupportsNativeElementScreenshots
                 ? ["element", "native-element", "fullscreen", "selector", "capture-epoch"]
@@ -3344,56 +3349,6 @@ public partial class MauiDevFlowAgentService : DevFlowAgentService
             : HttpResponse.Error(result ?? "Key action failed");
     }
 
-    protected override async Task<HttpResponse> HandleGesture(HttpRequest request)
-    {
-        if (_app == null) return HttpResponse.Error("Agent not bound to app");
-
-        var body = request.BodyAs<GestureActionRequest>();
-        if (body == null || string.IsNullOrWhiteSpace(body.Type))
-            return HttpResponse.Error("type is required");
-        if (await PrepareUiMutationAsync(request, body, body.ElementId) is { } staleCapture)
-            return staleCapture;
-
-        var gestureType = body.Type.Trim().ToLowerInvariant();
-
-        return gestureType switch
-        {
-            "tap" => await HandleTap(new HttpRequest
-            {
-                Method = "POST",
-                MutationState = request.MutationState,
-                Body = JsonSerializer.Serialize(new ActionRequest
-                {
-                    ElementId = body.ElementId
-                })
-            }),
-            "longpress" or "long-press" => await HandleTap(new HttpRequest
-            {
-                Method = "POST",
-                MutationState = request.MutationState,
-                Body = JsonSerializer.Serialize(new ActionRequest
-                {
-                    ElementId = body.ElementId
-                })
-            }),
-            "swipe" => await HandleScroll(new HttpRequest
-            {
-                Method = "POST",
-                MutationState = request.MutationState,
-                Body = JsonSerializer.Serialize(new ScrollRequest
-                {
-                    ElementId = body.ElementId,
-                    DeltaX = body.Direction?.Equals("left", StringComparison.OrdinalIgnoreCase) == true ? -body.Distance :
-                        body.Direction?.Equals("right", StringComparison.OrdinalIgnoreCase) == true ? body.Distance : 0,
-                    DeltaY = body.Direction?.Equals("up", StringComparison.OrdinalIgnoreCase) == true ? -body.Distance :
-                        body.Direction?.Equals("down", StringComparison.OrdinalIgnoreCase) == true ? body.Distance : 0,
-                    Animated = body.DurationMs <= 0 || body.DurationMs < 400
-                })
-            }),
-            _ => HttpResponse.Error($"Gesture '{body.Type}' is not supported")
-        };
-    }
-
     protected override async Task<HttpResponse> HandleBatch(HttpRequest request)
     {
         if (_app == null) return HttpResponse.Error("Agent not bound to app");
@@ -3533,7 +3488,14 @@ public partial class MauiDevFlowAgentService : DevFlowAgentService
                                     Type = action.Type ?? action.Action,
                                     Direction = action.Direction,
                                     Distance = action.Distance,
-                                    DurationMs = action.DurationMs
+                                    DurationMs = action.DurationMs,
+                                    Scale = action.Scale,
+                                    Rotation = action.Rotation,
+                                    DeltaX = action.DeltaX != 0 ? action.DeltaX : null,
+                                    DeltaY = action.DeltaY != 0 ? action.DeltaY : null,
+                                    OriginX = action.OriginX,
+                                    OriginY = action.OriginY,
+                                    Steps = action.Steps
                                 })
                             });
                             break;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
@@ -447,6 +447,16 @@ public class UiActionTests : IntegrationTestBase
         Assert.Contains("button", status.Text!, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task Tap_Gesture_WithoutTarget_IsRejectedConsistently()
+    {
+        using var response = await PostRawAsync("/api/v1/ui/actions/gesture", new { type = "tap" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("tap requires elementId", body);
+    }
+
     [Trait(TestFramework.Trait, TestFramework.Maui)]
     [Fact]
     public async Task LongPress_OnAndroid_HoldsTheNativeTouchForAtLeastThePlatformThreshold()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
@@ -430,14 +430,28 @@ public class UiActionTests : IntegrationTestBase
         var target = await FindElementAsync("NativeScrollTarget");
 
         var result = await Client.PinchAsync(target.Id, scale: 2.0);
+        Output.WriteLine($"pinch on NativeScrollTarget: handledBy={result.HandledBy} detail={result.Detail} error={result.Error}");
 
         // A plain ScrollView has no PinchGestureRecognizer, so this must never claim
         // the app's own recognizer handled it — either native injection ran, or nothing did.
         Assert.NotEqual("recognizer", result.HandledBy);
-        if (result.Success)
+
+        // Android synthesises real multi-pointer MotionEvents, so it must always reach
+        // the native tier. Other platforms only zoom surfaces that opt in, so they may decline.
+        if (Platform == "android")
+        {
+            Assert.True(result.Success, result.Error);
             Assert.Equal("native", result.HandledBy);
+            Assert.Contains("MotionEvent", result.Detail);
+        }
+        else if (result.Success)
+        {
+            Assert.Equal("native", result.HandledBy);
+        }
         else
+        {
             Assert.False(string.IsNullOrWhiteSpace(result.Error), "A failed gesture must explain why.");
+        }
     }
 
     [Fact]
@@ -447,10 +461,20 @@ public class UiActionTests : IntegrationTestBase
         var target = await FindElementAsync("NativeScrollTarget");
 
         var result = await Client.PanAsync(target.Id, deltaX: 0, deltaY: -120);
+        Output.WriteLine($"pan on NativeScrollTarget: handledBy={result.HandledBy} detail={result.Detail} error={result.Error}");
 
         Assert.NotEqual("recognizer", result.HandledBy);
-        if (!result.Success)
+
+        if (Platform == "android")
+        {
+            Assert.True(result.Success, result.Error);
+            Assert.Equal("native", result.HandledBy);
+            Assert.Contains("MotionEvent", result.Detail);
+        }
+        else if (!result.Success)
+        {
             Assert.False(string.IsNullOrWhiteSpace(result.Error), "A failed gesture must explain why.");
+        }
     }
 
     [Fact]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
@@ -315,6 +315,145 @@ public class UiActionTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task Gesture_UnknownType_IsRejected()
+    {
+        var response = await PostRawAsync("/api/v1/ui/actions/gesture", new { type = "wiggle" });
+        Assert.False(response.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task Capabilities_AdvertisesSupportedGestures()
+    {
+        var caps = await GetJsonAsync("/api/v1/agent/capabilities");
+        var gestures = caps.GetProperty("ui").GetProperty("gestures")
+            .EnumerateArray().Select(g => g.GetString()).ToArray();
+
+        Assert.Contains("pinch", gestures);
+        Assert.Contains("pan", gestures);
+        Assert.Contains("rotate", gestures);
+    }
+
+    // ========== gestures against GestureTestPage ==========
+    // These assert the status label changed, not just that the call returned 200 — the
+    // point is that the gesture genuinely reached the app's own recognizer.
+
+    private Task NavigateToGesturePageAsync() => NavigateToPageAsync("//gestures", "PinchTarget");
+
+    [Fact]
+    public async Task Pinch_FiresPinchGestureRecognizer()
+    {
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("PinchTarget");
+
+        var result = await Client.PinchAsync(target.Id, scale: 2.0);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("recognizer", result.HandledBy);
+
+        await SettleAsync();
+        var status = await FindElementAsync("PinchStatusLabel");
+        // The page accumulates e.Scale, so a 2x request lands at 2.00 however many steps it took.
+        Assert.Contains("scale=2.00", status.Text);
+    }
+
+    [Fact]
+    public async Task Pinch_ZoomOut_ReportsScaleBelowOne()
+    {
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("PinchTarget");
+
+        var result = await Client.PinchAsync(target.Id, scale: 0.5);
+
+        Assert.True(result.Success, result.Error);
+
+        await SettleAsync();
+        var status = await FindElementAsync("PinchStatusLabel");
+        Assert.Contains("scale=0.50", status.Text);
+    }
+
+    [Fact]
+    public async Task Pan_FiresPanGestureRecognizerWithCumulativeTotals()
+    {
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("PanTarget");
+
+        var result = await Client.PanAsync(target.Id, deltaX: 0, deltaY: -150);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("recognizer", result.HandledBy);
+
+        await SettleAsync();
+        var status = await FindElementAsync("PanStatusLabel");
+        Assert.Contains("dy=-150", status.Text);
+    }
+
+    [Theory]
+    [InlineData("up")]
+    [InlineData("down")]
+    [InlineData("left")]
+    [InlineData("right")]
+    public async Task Swipe_FiresSwipeGestureRecognizer(string direction)
+    {
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("SwipeTarget");
+
+        var result = await Client.GestureDetailedAsync("swipe", target.Id, direction);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("recognizer", result.HandledBy);
+
+        await SettleAsync();
+        var status = await FindElementAsync("SwipeStatusLabel");
+        Assert.Equal($"swipe: {direction}", status.Text);
+    }
+
+    [Fact]
+    public async Task DoubleTap_FiresTwoTapRecognizerNotTheSingleTapOne()
+    {
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("DoubleTapTarget");
+
+        var result = await Client.GestureDetailedAsync("doubletap", target.Id);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("recognizer", result.HandledBy);
+
+        await SettleAsync();
+        var status = await FindElementAsync("TapStatusLabel");
+        Assert.Equal("tap: double", status.Text);
+    }
+
+    [Fact]
+    public async Task Pinch_OnElementWithoutRecognizer_ReportsWhichTierRan()
+    {
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("NativeScrollTarget");
+
+        var result = await Client.PinchAsync(target.Id, scale: 2.0);
+
+        // A plain ScrollView has no PinchGestureRecognizer, so this must never claim
+        // the app's own recognizer handled it — either native injection ran, or nothing did.
+        Assert.NotEqual("recognizer", result.HandledBy);
+        if (result.Success)
+            Assert.Equal("native", result.HandledBy);
+        else
+            Assert.False(string.IsNullOrWhiteSpace(result.Error), "A failed gesture must explain why.");
+    }
+
+    [Fact]
+    public async Task Pan_OnElementWithoutRecognizer_FallsThroughToNative()
+    {
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("NativeScrollTarget");
+
+        var result = await Client.PanAsync(target.Id, deltaX: 0, deltaY: -120);
+
+        Assert.NotEqual("recognizer", result.HandledBy);
+        if (!result.Success)
+            Assert.False(string.IsNullOrWhiteSpace(result.Error), "A failed gesture must explain why.");
+    }
+
+    [Fact]
     public async Task Fill_MultipleEntries_SetsAllText()
     {
         await NavigateToMainPageAsync();

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
 using Microsoft.Maui.DevFlow.Driver;
@@ -317,15 +318,17 @@ public class UiActionTests : IntegrationTestBase
     [Fact]
     public async Task Gesture_UnknownType_IsRejected()
     {
-        var response = await PostRawAsync("/api/v1/ui/actions/gesture", new { type = "wiggle" });
-        Assert.False(response.IsSuccessStatusCode);
+        using var response = await PostRawAsync("/api/v1/ui/actions/gesture", new { type = "wiggle" });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Supported types", body);
     }
 
     [Fact]
     public async Task Capabilities_AdvertisesSupportedGestures()
     {
         var caps = await GetJsonAsync("/api/v1/agent/capabilities");
-        var gestures = caps.GetProperty("ui").GetProperty("gestures")
+        var gestures = caps.GetProperty("capabilities").GetProperty("ui.actions").GetProperty("gestures")
             .EnumerateArray().Select(g => g.GetString()).ToArray();
 
         Assert.Contains("pinch", gestures);
@@ -424,6 +427,54 @@ public class UiActionTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task Tap_Gesture_UsesGestureEnvelopeAndReachesTheApp()
+    {
+        await NavigateToPageAsync("//interactions", "TestButton");
+        var target = await FindElementAsync("TestButton");
+
+        var result = await Client.GestureDetailedAsync(
+            "tap",
+            target.Id,
+            captureEpoch: target.CaptureEpoch,
+            registryGeneration: target.RegistryGeneration);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("tap", result.Type);
+        Assert.Equal("action", result.HandledBy);
+
+        await SettleAsync();
+        var status = await FindElementAsync("StatusLabel");
+        Assert.Contains("button", status.Text!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Trait(TestFramework.Trait, TestFramework.Maui)]
+    [Fact]
+    public async Task LongPress_OnAndroid_HoldsTheNativeTouchForAtLeastThePlatformThreshold()
+    {
+        if (!Platform.Equals("android", StringComparison.OrdinalIgnoreCase))
+        {
+            Output.WriteLine("Native long-press timing is Android-specific.");
+            return;
+        }
+
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("LongPressTarget");
+
+        var result = await Client.GestureDetailedAsync("longpress", target.Id);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("native", result.HandledBy);
+
+        await SettleAsync();
+        var status = await FindElementAsync("LongPressStatusLabel");
+        var elapsedText = status.Text?["longpress: ".Length..].TrimEnd('m', 's');
+        Assert.True(
+            double.TryParse(elapsedText, NumberStyles.Number, CultureInfo.InvariantCulture, out var elapsedMs)
+                && elapsedMs >= 500,
+            $"Expected a native long press of at least 500ms, got '{status.Text}'.");
+    }
+
+    [Fact]
     public async Task Pinch_OnElementWithoutRecognizer_ReportsWhichTierRan()
     {
         await NavigateToGesturePageAsync();
@@ -436,15 +487,7 @@ public class UiActionTests : IntegrationTestBase
         // the app's own recognizer handled it — either native injection ran, or nothing did.
         Assert.NotEqual("recognizer", result.HandledBy);
 
-        // Android synthesises real multi-pointer MotionEvents, so it must always reach
-        // the native tier. Other platforms only zoom surfaces that opt in, so they may decline.
-        if (Platform == "android")
-        {
-            Assert.True(result.Success, result.Error);
-            Assert.Equal("native", result.HandledBy);
-            Assert.Contains("MotionEvent", result.Detail);
-        }
-        else if (result.Success)
+        if (result.Success)
         {
             Assert.Equal("native", result.HandledBy);
         }
@@ -459,19 +502,36 @@ public class UiActionTests : IntegrationTestBase
     {
         await NavigateToGesturePageAsync();
         var target = await FindElementAsync("NativeScrollTarget");
+        var beforeText = await Client.GetPropertyAsync(target.Id, "ScrollY");
+        Assert.True(
+            double.TryParse(beforeText, NumberStyles.Number, CultureInfo.InvariantCulture, out var before),
+            $"Could not read the initial ScrollY value: '{beforeText}'.");
 
-        var result = await Client.PanAsync(target.Id, deltaX: 0, deltaY: -120);
+        var result = await Client.PanAsync(
+            target.Id,
+            deltaX: 0,
+            deltaY: -120,
+            captureEpoch: target.CaptureEpoch,
+            registryGeneration: target.RegistryGeneration);
         Output.WriteLine($"pan on NativeScrollTarget: handledBy={result.HandledBy} detail={result.Detail} error={result.Error}");
 
         Assert.NotEqual("recognizer", result.HandledBy);
 
-        if (Platform == "android")
+        if (result.Success)
         {
-            Assert.True(result.Success, result.Error);
             Assert.Equal("native", result.HandledBy);
-            Assert.Contains("MotionEvent", result.Detail);
+
+            await SettleAsync();
+            var afterText = await Client.GetPropertyAsync(target.Id, "ScrollY");
+            Assert.True(
+                double.TryParse(afterText, NumberStyles.Number, CultureInfo.InvariantCulture, out var after),
+                $"Could not read ScrollY after the native pan: '{afterText}'.");
+            Assert.True(after > before, $"Expected native pan to increase ScrollY; before={before}, after={after}.");
+
+            if (Platform == "android")
+                Assert.Contains("MotionEvent", result.Detail);
         }
-        else if (!result.Success)
+        else
         {
             Assert.False(string.IsNullOrWhiteSpace(result.Error), "A failed gesture must explain why.");
         }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeDevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeDevFlowAgentService.cs
@@ -358,7 +358,7 @@ public class NativeDevFlowAgentService : DevFlowAgentService
                 if (view == null) return $"Element '{body.ElementId}' not found";
             }
 
-            return NativeUi.TryGesture(view, body.Type, body.Direction, body.Distance, body.DurationMs, out var failure)
+            return NativeUi.TryGesture(view, body.Type, body.Direction, body.Distance, body.DurationMs ?? 200, out var failure)
                 ? "ok"
                 : failure ?? $"Gesture '{body.Type}' is not handled by this element";
         });

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.DevFlow.Agent;
 /// Platform-specific agent service that provides native tap and screenshot
 /// implementations for Android, iOS, Mac Catalyst, Windows, and macOS AppKit.
 /// </summary>
-public class PlatformAgentService : MauiDevFlowAgentService
+public partial class PlatformAgentService : MauiDevFlowAgentService
 {
     public PlatformAgentService(AgentOptions? options = null) : base(options) { }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/PlatformAgentService.Gestures.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/PlatformAgentService.Gestures.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.DevFlow.Agent;
 
 /// <summary>
 /// Native gesture injection — the second tier behind the managed MAUI gesture recognizers
-/// in <see cref="Core.DevFlowAgentService"/>. This is what makes pinch-to-zoom work on
+/// in <see cref="Core.MauiDevFlowAgentService"/>. This is what makes pinch-to-zoom work on
 /// controls that own their gestures internally (Map, WebView, SKCanvasView, native scroll views)
 /// and therefore expose no <c>PinchGestureRecognizer</c> to walk.
 ///
@@ -157,6 +157,7 @@ public partial class PlatformAgentService
     /// is sampled with t in 0..1 and must return one point per pointer, in window pixels.
     /// </summary>
     private static async Task<bool> InjectAndroidTouchAsync(
+        global::Android.Views.View targetView,
         int pointerCount,
         Func<double, PointF[]> positionsAt,
         int durationMs,
@@ -164,7 +165,8 @@ public partial class PlatformAgentService
         int holdMs = 0)
     {
         var activity = global::Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
-        if (activity == null) return false;
+        var targetLocation = new int[2];
+        targetView.GetLocationInWindow(targetLocation);
 
         var properties = new MotionEvent.PointerProperties[pointerCount];
         var coords = new MotionEvent.PointerCoords[pointerCount];
@@ -189,23 +191,72 @@ public partial class PlatformAgentService
 
         bool Send(MotionEventActions action, int activePointers)
         {
-            var ev = MotionEvent.Obtain(
-                downTime, eventTime, action, activePointers,
-                properties[..activePointers], coords[..activePointers],
-                0, (MotionEventButtonState)0, 1f, 1f, 0, (Edge)0,
-                InputSourceType.Touchscreen, (MotionEventFlags)0);
-            if (ev == null) return false;
-            try { return activity.DispatchTouchEvent(ev); }
-            finally { ev.Recycle(); }
+            static MotionEvent? CreateEvent(
+                long downTime,
+                long eventTime,
+                MotionEventActions action,
+                int activePointers,
+                MotionEvent.PointerProperties[] properties,
+                MotionEvent.PointerCoords[] coords)
+                => MotionEvent.Obtain(
+                    downTime, eventTime, action, activePointers,
+                    properties[..activePointers], coords[..activePointers],
+                    0, (MotionEventButtonState)0, 1f, 1f, 0, (Edge)0,
+                    InputSourceType.Touchscreen, (MotionEventFlags)0);
+
+            if (activity != null)
+            {
+                var windowEvent = CreateEvent(
+                    downTime, eventTime, action, activePointers, properties, coords);
+                if (windowEvent != null)
+                {
+                    try
+                    {
+                        if (activity.DispatchTouchEvent(windowEvent))
+                            return true;
+                    }
+                    finally
+                    {
+                        windowEvent.Recycle();
+                    }
+                }
+            }
+
+            var localCoords = new MotionEvent.PointerCoords[activePointers];
+            for (var i = 0; i < activePointers; i++)
+            {
+                localCoords[i] = new MotionEvent.PointerCoords
+                {
+                    X = coords[i].X - targetLocation[0],
+                    Y = coords[i].Y - targetLocation[1],
+                    Pressure = coords[i].Pressure,
+                    Size = coords[i].Size
+                };
+            }
+
+            var localEvent = CreateEvent(
+                downTime, eventTime, action, activePointers, properties, localCoords);
+            if (localEvent == null)
+                return false;
+            try
+            {
+                return targetView.DispatchTouchEvent(localEvent);
+            }
+            finally
+            {
+                localEvent.Recycle();
+            }
         }
 
         try
         {
             Apply(positionsAt(0));
 
-            Send(MotionEventActions.Down, 1);
+            var handled = Send(MotionEventActions.Down, 1);
             for (var i = 1; i < pointerCount; i++)
-                Send((MotionEventActions)((int)MotionEventActions.PointerDown | (i << PointerIndexShift)), i + 1);
+                handled |= Send(
+                    (MotionEventActions)((int)MotionEventActions.PointerDown | (i << PointerIndexShift)),
+                    i + 1);
 
             if (holdMs > 0)
             {
@@ -217,7 +268,7 @@ public partial class PlatformAgentService
             {
                 eventTime += Math.Max(1, stepDelay);
                 Apply(positionsAt((double)step / steps));
-                Send(MotionEventActions.Move, pointerCount);
+                handled |= Send(MotionEventActions.Move, pointerCount);
                 if (stepDelay > 0) await Task.Delay(stepDelay);
             }
 
@@ -225,7 +276,7 @@ public partial class PlatformAgentService
             for (var i = pointerCount - 1; i >= 1; i--)
                 Send((MotionEventActions)((int)MotionEventActions.PointerUp | (i << PointerIndexShift)), i + 1);
             Send(MotionEventActions.Up, 1);
-            return true;
+            return handled;
         }
         catch (Exception ex)
         {
@@ -249,6 +300,7 @@ public partial class PlatformAgentService
             : (maxRadius, (float)(maxRadius * scale));
 
         var handled = await InjectAndroidTouchAsync(
+            view,
             pointerCount: 2,
             positionsAt: t =>
             {
@@ -275,6 +327,7 @@ public partial class PlatformAgentService
         var totalRadians = degrees * Math.PI / 180.0;
 
         var handled = await InjectAndroidTouchAsync(
+            view,
             pointerCount: 2,
             positionsAt: t =>
             {
@@ -308,6 +361,7 @@ public partial class PlatformAgentService
         var start = new PointF(center.X - pixelX / 2f, center.Y - pixelY / 2f);
 
         var handled = await InjectAndroidTouchAsync(
+            view,
             pointerCount: 1,
             positionsAt: t => [new PointF(start.X + pixelX * (float)t, start.Y + pixelY * (float)t)],
             durationMs: durationMs > 0 ? durationMs : 200,
@@ -324,6 +378,7 @@ public partial class PlatformAgentService
 
         var center = geometry.Center;
         var handled = await InjectAndroidTouchAsync(
+            view,
             pointerCount: 1,
             positionsAt: _ => [center],
             durationMs: 0,
@@ -342,10 +397,10 @@ public partial class PlatformAgentService
         var center = geometry.Center;
         Func<double, PointF[]> at = _ => [center];
 
-        if (!await InjectAndroidTouchAsync(1, at, 0, 0)) return null;
+        if (!await InjectAndroidTouchAsync(view, 1, at, 0, 0)) return null;
         // Comfortably inside Android's ~300ms double-tap timeout.
         await Task.Delay(80);
-        if (!await InjectAndroidTouchAsync(1, at, 0, 0)) return null;
+        if (!await InjectAndroidTouchAsync(view, 1, at, 0, 0)) return null;
 
         return "MotionEvent double tap";
     }
@@ -498,6 +553,8 @@ public partial class PlatformAgentService
                 (double)scrollView.ZoomScale * scale,
                 (double)scrollView.MinimumZoomScale,
                 (double)scrollView.MaximumZoomScale);
+            if (Math.Abs(target - scrollView.ZoomScale) < 0.001)
+                return null;
             scrollView.SetZoomScale(target, animated: true);
             return $"UIScrollView.ZoomScale → {target:0.##}";
         }
@@ -633,7 +690,9 @@ public partial class PlatformAgentService
             scrollView.Magnification * scale,
             scrollView.MinMagnification,
             scrollView.MaxMagnification);
-        scrollView.Magnification = target;
+        if (Math.Abs(target - scrollView.Magnification) < 0.001)
+            return null;
+        scrollView.Magnification = (nfloat)target;
         return $"NSScrollView.Magnification → {target:0.##}";
     }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/PlatformAgentService.Gestures.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/PlatformAgentService.Gestures.cs
@@ -1,0 +1,681 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+#if ANDROID
+using Android.Views;
+#endif
+#if IOS || MACCATALYST
+using System.Runtime.InteropServices;
+using ObjCRuntime;
+using UIKit;
+#endif
+#if MACOS
+using AppKit;
+#endif
+
+namespace Microsoft.Maui.DevFlow.Agent;
+
+/// <summary>
+/// Native gesture injection — the second tier behind the managed MAUI gesture recognizers
+/// in <see cref="Core.DevFlowAgentService"/>. This is what makes pinch-to-zoom work on
+/// controls that own their gestures internally (Map, WebView, SKCanvasView, native scroll views)
+/// and therefore expose no <c>PinchGestureRecognizer</c> to walk.
+///
+/// Fidelity varies by platform, and each method reports how it was handled so callers can tell:
+/// <list type="bullet">
+/// <item>Android — genuine multi-pointer <c>MotionEvent</c>s dispatched through the activity,
+/// so the whole hit-test and <c>GestureDetector</c> pipeline runs. Fully faithful.</item>
+/// <item>iOS / Mac Catalyst — drives the real native zoom/pan surfaces (MKMapView camera,
+/// UIScrollView zoom/offset) and, failing those, the attached UIGestureRecognizers.
+/// In-process synthetic <c>UITouch</c> needs private API and is deliberately not attempted.</item>
+/// <item>Windows — ScrollViewer zoom/offset. Input injection needs the restricted
+/// <c>inputInjectionBrokered</c> capability and is not usable from a normal app package.</item>
+/// <item>macOS AppKit — NSScrollView magnification and content offset.</item>
+/// </list>
+/// Every method returns a short description of what serviced the gesture, or null when unhandled.
+/// </summary>
+public partial class PlatformAgentService
+{
+    protected override async Task<string?> TryNativePinch(VisualElement element, double scale, Point origin, int durationMs, int steps)
+    {
+#if ANDROID
+        return await AndroidPinchAsync(element, scale, origin, durationMs, steps);
+#elif IOS || MACCATALYST
+        return await ApplePinchAsync(element, scale, origin, durationMs, steps);
+#elif WINDOWS
+        return await Task.FromResult(WindowsPinch(element, scale));
+#elif MACOS
+        return await Task.FromResult(MacPinch(element, scale));
+#else
+        return await base.TryNativePinch(element, scale, origin, durationMs, steps);
+#endif
+    }
+
+    protected override async Task<string?> TryNativeRotate(VisualElement element, double degrees, Point origin, int durationMs, int steps)
+    {
+#if ANDROID
+        return await AndroidRotateAsync(element, degrees, origin, durationMs, steps);
+#elif IOS || MACCATALYST
+        return await AppleRotateAsync(element, degrees, durationMs, steps);
+#else
+        return await base.TryNativeRotate(element, degrees, origin, durationMs, steps);
+#endif
+    }
+
+    protected override async Task<string?> TryNativePan(VisualElement element, double deltaX, double deltaY, int durationMs, int steps)
+    {
+#if ANDROID
+        return await AndroidPanAsync(element, deltaX, deltaY, durationMs, steps, "pan");
+#elif IOS || MACCATALYST
+        return await ApplePanAsync(element, deltaX, deltaY);
+#elif WINDOWS
+        return await Task.FromResult(WindowsPan(element, deltaX, deltaY));
+#elif MACOS
+        return await Task.FromResult(MacPan(element, deltaX, deltaY));
+#else
+        return await base.TryNativePan(element, deltaX, deltaY, durationMs, steps);
+#endif
+    }
+
+    protected override async Task<string?> TryNativeSwipe(VisualElement element, string direction, double distance, int durationMs)
+    {
+#if ANDROID
+        // A swipe is a fast pan; the shorter duration is what makes Android's
+        // VelocityTracker read it as a fling rather than a drag.
+        var dx = direction switch { "left" => -distance, "right" => distance, _ => 0 };
+        var dy = direction switch { "up" => -distance, "down" => distance, _ => 0 };
+        var swipeDuration = durationMs > 0 ? Math.Min(durationMs, 150) : 100;
+        return await AndroidPanAsync(element, dx, dy, swipeDuration, 8, "swipe");
+#else
+        return await base.TryNativeSwipe(element, direction, distance, durationMs);
+#endif
+    }
+
+    protected override async Task<string?> TryNativeLongPress(VisualElement element, int durationMs)
+    {
+#if ANDROID
+        return await AndroidLongPressAsync(element, durationMs);
+#elif IOS || MACCATALYST
+        return await AppleLongPressAsync(element, durationMs);
+#else
+        return await base.TryNativeLongPress(element, durationMs);
+#endif
+    }
+
+    protected override async Task<string?> TryNativeDoubleTap(VisualElement element)
+    {
+#if ANDROID
+        return await AndroidDoubleTapAsync(element);
+#elif IOS || MACCATALYST
+        return await AppleDoubleTapAsync(element);
+#else
+        return await base.TryNativeDoubleTap(element);
+#endif
+    }
+
+#if ANDROID
+    // MotionEvent.ACTION_POINTER_INDEX_SHIFT — the pointer index is packed into the
+    // high bits of the action for ACTION_POINTER_DOWN/UP.
+    private const int PointerIndexShift = 8;
+
+    private static global::Android.Views.View? GetAndroidView(VisualElement element)
+    {
+        if (element.Handler?.PlatformView is global::Android.Views.View view)
+            return view;
+
+        // Pages and Shell content often have no directly usable platform view — fall back
+        // to the activity's content view so a page-level gesture still lands somewhere real.
+        return global::Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?
+            .Window?.DecorView?.FindViewById(global::Android.Resource.Id.Content);
+    }
+
+    /// <summary>
+    /// Element centre and half-extent in window pixels, plus the display density.
+    /// Returns null when the view has no measured size to aim at.
+    /// </summary>
+    private static (PointF Center, float Radius, float Density)? GetAndroidTouchGeometry(
+        global::Android.Views.View view, Point origin)
+    {
+        if (view.Width <= 0 || view.Height <= 0)
+            return null;
+
+        var location = new int[2];
+        view.GetLocationInWindow(location);
+
+        var center = new PointF(
+            location[0] + (float)(view.Width * origin.X),
+            location[1] + (float)(view.Height * origin.Y));
+
+        // Keep both pinch pointers comfortably inside the view.
+        var radius = Math.Min(view.Width, view.Height) * 0.4f;
+        var density = view.Resources?.DisplayMetrics?.Density ?? 1f;
+        return (center, radius, density);
+    }
+
+    /// <summary>
+    /// Dispatches a full touch sequence (down → moves → up) through the activity so the
+    /// real hit-test and gesture-detection pipeline runs. <paramref name="positionsAt"/>
+    /// is sampled with t in 0..1 and must return one point per pointer, in window pixels.
+    /// </summary>
+    private static async Task<bool> InjectAndroidTouchAsync(
+        int pointerCount,
+        Func<double, PointF[]> positionsAt,
+        int durationMs,
+        int steps,
+        int holdMs = 0)
+    {
+        var activity = global::Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+        if (activity == null) return false;
+
+        var properties = new MotionEvent.PointerProperties[pointerCount];
+        var coords = new MotionEvent.PointerCoords[pointerCount];
+        for (var i = 0; i < pointerCount; i++)
+        {
+            properties[i] = new MotionEvent.PointerProperties { Id = i, ToolType = MotionEventToolType.Finger };
+            coords[i] = new MotionEvent.PointerCoords { Pressure = 1f, Size = 1f };
+        }
+
+        var downTime = global::Android.OS.SystemClock.UptimeMillis();
+        var stepDelay = steps > 0 && durationMs > 0 ? Math.Max(1, durationMs / steps) : 0;
+        var eventTime = downTime;
+
+        void Apply(PointF[] points)
+        {
+            for (var i = 0; i < pointerCount; i++)
+            {
+                coords[i].X = points[i].X;
+                coords[i].Y = points[i].Y;
+            }
+        }
+
+        bool Send(MotionEventActions action, int activePointers)
+        {
+            var ev = MotionEvent.Obtain(
+                downTime, eventTime, action, activePointers,
+                properties[..activePointers], coords[..activePointers],
+                0, (MotionEventButtonState)0, 1f, 1f, 0, (Edge)0,
+                InputSourceType.Touchscreen, (MotionEventFlags)0);
+            if (ev == null) return false;
+            try { return activity.DispatchTouchEvent(ev); }
+            finally { ev.Recycle(); }
+        }
+
+        try
+        {
+            Apply(positionsAt(0));
+
+            Send(MotionEventActions.Down, 1);
+            for (var i = 1; i < pointerCount; i++)
+                Send((MotionEventActions)((int)MotionEventActions.PointerDown | (i << PointerIndexShift)), i + 1);
+
+            if (holdMs > 0)
+            {
+                await Task.Delay(holdMs);
+                eventTime += holdMs;
+            }
+
+            for (var step = 1; step <= steps; step++)
+            {
+                eventTime += Math.Max(1, stepDelay);
+                Apply(positionsAt((double)step / steps));
+                Send(MotionEventActions.Move, pointerCount);
+                if (stepDelay > 0) await Task.Delay(stepDelay);
+            }
+
+            eventTime += 1;
+            for (var i = pointerCount - 1; i >= 1; i--)
+                Send((MotionEventActions)((int)MotionEventActions.PointerUp | (i << PointerIndexShift)), i + 1);
+            Send(MotionEventActions.Up, 1);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[Microsoft.Maui.DevFlow] Android touch injection failed: {ex.GetBaseException().Message}");
+            return false;
+        }
+    }
+
+    private static async Task<string?> AndroidPinchAsync(VisualElement element, double scale, Point origin, int durationMs, int steps)
+    {
+        var view = GetAndroidView(element);
+        if (view == null) return null;
+        if (GetAndroidTouchGeometry(view, origin) is not { } geometry) return null;
+
+        var (center, maxRadius, _) = geometry;
+
+        // Pick start/end radii so both ends of the pinch stay inside the view:
+        // zooming in starts close together, zooming out starts far apart.
+        var (startRadius, endRadius) = scale >= 1
+            ? ((float)(maxRadius / scale), maxRadius)
+            : (maxRadius, (float)(maxRadius * scale));
+
+        var handled = await InjectAndroidTouchAsync(
+            pointerCount: 2,
+            positionsAt: t =>
+            {
+                var r = startRadius + (endRadius - startRadius) * (float)t;
+                return
+                [
+                    new PointF(center.X - r, center.Y),
+                    new PointF(center.X + r, center.Y)
+                ];
+            },
+            durationMs: durationMs > 0 ? durationMs : 200,
+            steps: steps);
+
+        return handled ? $"MotionEvent 2-pointer pinch x{scale:0.##}" : null;
+    }
+
+    private static async Task<string?> AndroidRotateAsync(VisualElement element, double degrees, Point origin, int durationMs, int steps)
+    {
+        var view = GetAndroidView(element);
+        if (view == null) return null;
+        if (GetAndroidTouchGeometry(view, origin) is not { } geometry) return null;
+
+        var (center, radius, _) = geometry;
+        var totalRadians = degrees * Math.PI / 180.0;
+
+        var handled = await InjectAndroidTouchAsync(
+            pointerCount: 2,
+            positionsAt: t =>
+            {
+                var angle = totalRadians * t;
+                var dx = (float)(Math.Cos(angle) * radius);
+                var dy = (float)(Math.Sin(angle) * radius);
+                return
+                [
+                    new PointF(center.X - dx, center.Y - dy),
+                    new PointF(center.X + dx, center.Y + dy)
+                ];
+            },
+            durationMs: durationMs > 0 ? durationMs : 300,
+            steps: steps);
+
+        return handled ? $"MotionEvent 2-pointer rotate {degrees:0.#}°" : null;
+    }
+
+    private static async Task<string?> AndroidPanAsync(VisualElement element, double deltaX, double deltaY, int durationMs, int steps, string label)
+    {
+        var view = GetAndroidView(element);
+        if (view == null) return null;
+        if (GetAndroidTouchGeometry(view, new Point(0.5, 0.5)) is not { } geometry) return null;
+
+        var (center, _, density) = geometry;
+        // Request deltas are device-independent pixels; MotionEvent works in physical pixels.
+        var pixelX = (float)(deltaX * density);
+        var pixelY = (float)(deltaY * density);
+
+        // Start offset against the travel direction so the whole gesture stays on the view.
+        var start = new PointF(center.X - pixelX / 2f, center.Y - pixelY / 2f);
+
+        var handled = await InjectAndroidTouchAsync(
+            pointerCount: 1,
+            positionsAt: t => [new PointF(start.X + pixelX * (float)t, start.Y + pixelY * (float)t)],
+            durationMs: durationMs > 0 ? durationMs : 200,
+            steps: steps);
+
+        return handled ? $"MotionEvent {label} ({deltaX:0.#}, {deltaY:0.#})" : null;
+    }
+
+    private static async Task<string?> AndroidLongPressAsync(VisualElement element, int durationMs)
+    {
+        var view = GetAndroidView(element);
+        if (view == null) return null;
+        if (GetAndroidTouchGeometry(view, new Point(0.5, 0.5)) is not { } geometry) return null;
+
+        var center = geometry.Center;
+        var handled = await InjectAndroidTouchAsync(
+            pointerCount: 1,
+            positionsAt: _ => [center],
+            durationMs: 0,
+            steps: 0,
+            holdMs: durationMs);
+
+        return handled ? $"MotionEvent long press ({durationMs}ms)" : null;
+    }
+
+    private static async Task<string?> AndroidDoubleTapAsync(VisualElement element)
+    {
+        var view = GetAndroidView(element);
+        if (view == null) return null;
+        if (GetAndroidTouchGeometry(view, new Point(0.5, 0.5)) is not { } geometry) return null;
+
+        var center = geometry.Center;
+        Func<double, PointF[]> at = _ => [center];
+
+        if (!await InjectAndroidTouchAsync(1, at, 0, 0)) return null;
+        // Comfortably inside Android's ~300ms double-tap timeout.
+        await Task.Delay(80);
+        if (!await InjectAndroidTouchAsync(1, at, 0, 0)) return null;
+
+        return "MotionEvent double tap";
+    }
+#endif
+
+#if IOS || MACCATALYST
+    // UIGestureRecognizer.state is readonly in the public API. Driving it is how
+    // synthetic gestures reach recognizers we do not own; UIKit dispatches the
+    // recognizer's target actions on each state change.
+    [DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+    private static extern void SetGestureRecognizerState(IntPtr receiver, IntPtr selector, nint state);
+
+    private static bool TrySetState(UIGestureRecognizer recognizer, UIGestureRecognizerState state)
+    {
+        try
+        {
+            SetGestureRecognizerState(recognizer.Handle, Selector.GetHandle("setState:"), (nint)(long)state);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[Microsoft.Maui.DevFlow] setState: failed: {ex.GetBaseException().Message}");
+            return false;
+        }
+    }
+
+    private static UIView? GetAppleView(VisualElement element) => element.Handler?.PlatformView as UIView;
+
+    /// <summary>
+    /// Breadth-ish search for a recognizer of the given kind on the view, its subviews and
+    /// its ancestors. Native controls such as MKMapView keep their recognizers on internal subviews.
+    /// </summary>
+    private static T? FindRecognizer<T>(UIView? view, Func<T, bool>? predicate = null) where T : UIGestureRecognizer
+    {
+        if (view == null) return null;
+
+        static T? OnView(UIView v, Func<T, bool>? p)
+        {
+            if (v.GestureRecognizers == null) return null;
+            foreach (var recognizer in v.GestureRecognizers)
+            {
+                if (recognizer is T match && recognizer.Enabled && (p == null || p(match)))
+                    return match;
+            }
+            return null;
+        }
+
+        static T? Descend(UIView v, Func<T, bool>? p)
+        {
+            var hit = OnView(v, p);
+            if (hit != null) return hit;
+            foreach (var sub in v.Subviews)
+            {
+                var found = Descend(sub, p);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        var descendant = Descend(view, predicate);
+        if (descendant != null) return descendant;
+
+        var ancestor = view.Superview;
+        while (ancestor != null)
+        {
+            var hit = OnView(ancestor, predicate);
+            if (hit != null) return hit;
+            ancestor = ancestor.Superview;
+        }
+        return null;
+    }
+
+    private static T? FindNativeSubview<T>(UIView? view) where T : UIView
+    {
+        if (view == null) return null;
+        if (view is T match) return match;
+        foreach (var sub in view.Subviews)
+        {
+            var found = FindNativeSubview<T>(sub);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Locates an MKMapView by type name so the agent does not link MapKit into every
+    /// consuming app just to support the maps scenario.
+    /// </summary>
+    private static UIView? FindMapView(UIView? view)
+    {
+        if (view == null) return null;
+        if (view.GetType().Name.Contains("MKMapView", StringComparison.Ordinal)) return view;
+        foreach (var sub in view.Subviews)
+        {
+            var found = FindMapView(sub);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Zooms an MKMapView through its camera. MKMapCamera is a reference type with a
+    /// plain double CenterCoordinateDistance, which keeps this reachable by reflection —
+    /// unlike MKCoordinateRegion, whose nested structs cannot be updated in place.
+    /// </summary>
+    private static string? TryZoomMapView(UIView mapView, double scale)
+    {
+        try
+        {
+            var mapType = mapView.GetType();
+            var cameraProperty = mapType.GetProperty("Camera");
+            var camera = cameraProperty?.GetValue(mapView);
+            if (camera == null) return null;
+
+            var distanceProperty = camera.GetType().GetProperty("CenterCoordinateDistance");
+            if (distanceProperty?.GetValue(camera) is not double distance || distance <= 0) return null;
+
+            // Halving the camera distance doubles the apparent zoom.
+            distanceProperty.SetValue(camera, distance / scale);
+
+            var setCamera = mapType.GetMethod("SetCamera", [camera.GetType(), typeof(bool)]);
+            if (setCamera != null)
+                setCamera.Invoke(mapView, [camera, true]);
+            else
+                cameraProperty!.SetValue(mapView, camera);
+
+            return $"MKMapView.Camera.CenterCoordinateDistance /{scale:0.##}";
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[Microsoft.Maui.DevFlow] MKMapView zoom failed: {ex.GetBaseException().Message}");
+            return null;
+        }
+    }
+
+    private static async Task<string?> ApplePinchAsync(VisualElement element, double scale, Point origin, int durationMs, int steps)
+    {
+        var view = GetAppleView(element);
+        if (view == null) return null;
+
+        // 1. Maps — the scenario this feature exists for.
+        if (FindMapView(view) is { } mapView && TryZoomMapView(mapView, scale) is { } mapDetail)
+            return mapDetail;
+
+        // 2. Any zoomable UIScrollView: WKWebView's inner scroll view, ScrollView, CollectionView.
+        var scrollView = view as UIScrollView ?? FindNativeSubview<UIScrollView>(view);
+        if (scrollView != null && scrollView.MaximumZoomScale > scrollView.MinimumZoomScale)
+        {
+            var target = (nfloat)Math.Clamp(
+                (double)scrollView.ZoomScale * scale,
+                (double)scrollView.MinimumZoomScale,
+                (double)scrollView.MaximumZoomScale);
+            scrollView.SetZoomScale(target, animated: true);
+            return $"UIScrollView.ZoomScale → {target:0.##}";
+        }
+
+        // 3. Fall back to driving whatever pinch recognizer the control installed.
+        var recognizer = FindRecognizer<UIPinchGestureRecognizer>(view);
+        if (recognizer == null) return null;
+
+        var stepDelay = steps > 0 && durationMs > 0 ? Math.Max(1, durationMs / steps) : 0;
+        recognizer.Scale = 1;
+        if (!TrySetState(recognizer, UIGestureRecognizerState.Began)) return null;
+        for (var i = 1; i <= steps; i++)
+        {
+            recognizer.Scale = (nfloat)(1 + (scale - 1) * i / steps);
+            TrySetState(recognizer, UIGestureRecognizerState.Changed);
+            if (stepDelay > 0) await Task.Delay(stepDelay);
+        }
+        TrySetState(recognizer, UIGestureRecognizerState.Ended);
+        return $"UIPinchGestureRecognizer x{scale:0.##}";
+    }
+
+    private static async Task<string?> AppleRotateAsync(VisualElement element, double degrees, int durationMs, int steps)
+    {
+        var recognizer = FindRecognizer<UIRotationGestureRecognizer>(GetAppleView(element));
+        if (recognizer == null) return null;
+
+        var totalRadians = degrees * Math.PI / 180.0;
+        var stepDelay = steps > 0 && durationMs > 0 ? Math.Max(1, durationMs / steps) : 0;
+
+        recognizer.Rotation = 0;
+        if (!TrySetState(recognizer, UIGestureRecognizerState.Began)) return null;
+        for (var i = 1; i <= steps; i++)
+        {
+            recognizer.Rotation = (nfloat)(totalRadians * i / steps);
+            TrySetState(recognizer, UIGestureRecognizerState.Changed);
+            if (stepDelay > 0) await Task.Delay(stepDelay);
+        }
+        TrySetState(recognizer, UIGestureRecognizerState.Ended);
+        return $"UIRotationGestureRecognizer {degrees:0.#}°";
+    }
+
+    private static Task<string?> ApplePanAsync(VisualElement element, double deltaX, double deltaY)
+    {
+        var view = GetAppleView(element);
+        if (view == null) return Task.FromResult<string?>(null);
+
+        var scrollView = view as UIScrollView ?? FindNativeSubview<UIScrollView>(view);
+        if (scrollView != null)
+        {
+            var offset = scrollView.ContentOffset;
+            // A pan that drags content right moves the viewport left, hence the negation.
+            var x = Math.Max(0, Math.Min(offset.X - deltaX, Math.Max(0, scrollView.ContentSize.Width - scrollView.Bounds.Width)));
+            var y = Math.Max(0, Math.Min(offset.Y - deltaY, Math.Max(0, scrollView.ContentSize.Height - scrollView.Bounds.Height)));
+            scrollView.SetContentOffset(new CoreGraphics.CGPoint(x, y), animated: true);
+            return Task.FromResult<string?>($"UIScrollView.ContentOffset → ({x:0.#}, {y:0.#})");
+        }
+
+        return Task.FromResult<string?>(null);
+    }
+
+    private static async Task<string?> AppleLongPressAsync(VisualElement element, int durationMs)
+    {
+        var recognizer = FindRecognizer<UILongPressGestureRecognizer>(GetAppleView(element));
+        if (recognizer == null) return null;
+
+        if (!TrySetState(recognizer, UIGestureRecognizerState.Began)) return null;
+        await Task.Delay(durationMs);
+        TrySetState(recognizer, UIGestureRecognizerState.Ended);
+        return $"UILongPressGestureRecognizer ({durationMs}ms)";
+    }
+
+    private static Task<string?> AppleDoubleTapAsync(VisualElement element)
+    {
+        var recognizer = FindRecognizer<UITapGestureRecognizer>(
+            GetAppleView(element), r => r.NumberOfTapsRequired == 2);
+        if (recognizer == null) return Task.FromResult<string?>(null);
+
+        return Task.FromResult<string?>(
+            TrySetState(recognizer, UIGestureRecognizerState.Ended) ? "UITapGestureRecognizer(2)" : null);
+    }
+#endif
+
+#if WINDOWS
+    private static string? WindowsPinch(VisualElement element, double scale)
+    {
+        var scrollViewer = FindWindowsScrollViewer(element);
+        if (scrollViewer == null) return null;
+
+        var target = (float)Math.Clamp(
+            scrollViewer.ZoomFactor * scale,
+            scrollViewer.MinZoomFactor,
+            scrollViewer.MaxZoomFactor);
+
+        if (Math.Abs(target - scrollViewer.ZoomFactor) < 0.001)
+            return null;
+
+        return scrollViewer.ChangeView(null, null, target)
+            ? $"ScrollViewer.ZoomFactor → {target:0.##}"
+            : null;
+    }
+
+    private static string? WindowsPan(VisualElement element, double deltaX, double deltaY)
+    {
+        var scrollViewer = FindWindowsScrollViewer(element);
+        if (scrollViewer == null) return null;
+
+        // A pan that drags content right moves the viewport left, hence the negation.
+        return scrollViewer.ChangeView(
+            scrollViewer.HorizontalOffset - deltaX,
+            scrollViewer.VerticalOffset - deltaY,
+            null)
+            ? $"ScrollViewer.ChangeView ({-deltaX:0.#}, {-deltaY:0.#})"
+            : null;
+    }
+
+    private static Microsoft.UI.Xaml.Controls.ScrollViewer? FindWindowsScrollViewer(VisualElement element)
+    {
+        if (element.Handler?.PlatformView is not Microsoft.UI.Xaml.DependencyObject platformView)
+            return null;
+        return platformView as Microsoft.UI.Xaml.Controls.ScrollViewer
+            ?? FindWinUIDescendant<Microsoft.UI.Xaml.Controls.ScrollViewer>(platformView)
+            ?? FindWinUIScrollViewer(platformView);
+    }
+#endif
+
+#if MACOS
+    private static string? MacPinch(VisualElement element, double scale)
+    {
+        var scrollView = FindMacScrollView(element);
+        if (scrollView is not { AllowsMagnification: true }) return null;
+
+        var target = Math.Clamp(
+            scrollView.Magnification * scale,
+            scrollView.MinMagnification,
+            scrollView.MaxMagnification);
+        scrollView.Magnification = target;
+        return $"NSScrollView.Magnification → {target:0.##}";
+    }
+
+    private static string? MacPan(VisualElement element, double deltaX, double deltaY)
+    {
+        var scrollView = FindMacScrollView(element);
+        if (scrollView?.ContentView == null) return null;
+
+        var origin = scrollView.ContentView.Bounds.Location;
+        // A pan that drags content right moves the viewport left, hence the negation.
+        var point = new CoreGraphics.CGPoint(origin.X - deltaX, origin.Y - deltaY);
+        scrollView.ContentView.ScrollToPoint(point);
+        scrollView.ReflectScrolledClipView(scrollView.ContentView);
+        return $"NSScrollView.ScrollToPoint ({point.X:0.#}, {point.Y:0.#})";
+    }
+
+    private static NSScrollView? FindMacScrollView(VisualElement element)
+    {
+        if (element.Handler?.PlatformView is not NSView view) return null;
+        if (view is NSScrollView direct) return direct;
+
+        static NSScrollView? Descend(NSView v)
+        {
+            if (v is NSScrollView match) return match;
+            foreach (var sub in v.Subviews)
+            {
+                var found = Descend(sub);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        var descendant = Descend(view);
+        if (descendant != null) return descendant;
+
+        var ancestor = view.Superview;
+        while (ancestor != null)
+        {
+            if (ancestor is NSScrollView match) return match;
+            ancestor = ancestor.Superview;
+        }
+        return null;
+    }
+#endif
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -518,29 +518,36 @@ public class AgentClient : IDisposable
         return PostActionResultAsync($"{UiApi}/actions/key", payload);
     }
 
-    public Task<bool> GestureAsync(
+    /// <summary>
+    /// Performs a gesture. Supported types: tap, doubletap, longpress, swipe, pan, pinch, rotate.
+    /// </summary>
+    public async Task<bool> GestureAsync(
         string type,
         string? elementId = null,
         string? direction = null,
         double? distance = null,
         int? durationMs = null)
-        => GestureAsync(
-            type,
-            elementId,
-            direction,
-            distance,
-            durationMs,
-            captureEpoch: null,
-            registryGeneration: null);
+        => (await GestureDetailedAsync(type, elementId, direction, distance, durationMs)).Success;
 
-    public async Task<bool> GestureAsync(
+    /// <summary>
+    /// Performs a gesture and reports which tier serviced it — a managed MAUI gesture
+    /// recognizer, native platform injection, or nothing at all.
+    /// </summary>
+    public async Task<GestureResult> GestureDetailedAsync(
         string type,
-        string? elementId,
-        string? direction,
-        double? distance,
-        int? durationMs,
-        long? captureEpoch,
-        long? registryGeneration)
+        string? elementId = null,
+        string? direction = null,
+        double? distance = null,
+        int? durationMs = null,
+        double? scale = null,
+        double? rotation = null,
+        double? deltaX = null,
+        double? deltaY = null,
+        double? originX = null,
+        double? originY = null,
+        int? steps = null,
+        long? captureEpoch = null,
+        long? registryGeneration = null)
     {
         var payload = new JsonObject
         {
@@ -551,9 +558,35 @@ public class AgentClient : IDisposable
         if (direction is not null) payload["direction"] = direction;
         if (distance.HasValue) payload["distance"] = distance.Value;
         if (durationMs.HasValue) payload["durationMs"] = durationMs.Value;
+        if (scale.HasValue) payload["scale"] = scale.Value;
+        if (rotation.HasValue) payload["rotation"] = rotation.Value;
+        if (deltaX.HasValue) payload["deltaX"] = deltaX.Value;
+        if (deltaY.HasValue) payload["deltaY"] = deltaY.Value;
+        if (originX.HasValue) payload["originX"] = originX.Value;
+        if (originY.HasValue) payload["originY"] = originY.Value;
+        if (steps.HasValue) payload["steps"] = steps.Value;
         AddCaptureMetadata(payload, captureEpoch, registryGeneration);
 
-        return await PostActionAsync($"{UiApi}/actions/gesture", payload);
+        try
+        {
+            using var content = DriverJson.CreateJsonContent(payload);
+            var response = await _http.PostAsync($"{_baseUrl}{UiApi}/actions/gesture", content);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            var result = DriverJson.Deserialize<GestureResult>(responseBody);
+
+            if (result == null)
+                return new GestureResult { Success = false, Type = type, Error = "Agent returned an unreadable response" };
+
+            // A non-2xx response is a failure even if the body says otherwise.
+            if (!response.IsSuccessStatusCode)
+                result.Success = false;
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return new GestureResult { Success = false, Type = type, Error = ex.Message };
+        }
     }
 
     public Task<ActionResult> GestureResultAsync(
@@ -578,6 +611,47 @@ public class AgentClient : IDisposable
 
         return PostActionResultAsync($"{UiApi}/actions/gesture", payload);
     }
+
+    /// <summary>Pinch to zoom. <paramref name="scale"/> of 2.0 zooms in 2x, 0.5 zooms out.</summary>
+    public Task<GestureResult> PinchAsync(
+        string? elementId,
+        double scale,
+        double? originX = null,
+        double? originY = null,
+        int? durationMs = null,
+        int? steps = null,
+        long? captureEpoch = null,
+        long? registryGeneration = null)
+        => GestureDetailedAsync(
+            "pinch", elementId, scale: scale, originX: originX, originY: originY,
+            durationMs: durationMs, steps: steps,
+            captureEpoch: captureEpoch, registryGeneration: registryGeneration);
+
+    /// <summary>Rotate by <paramref name="degrees"/>, positive = clockwise.</summary>
+    public Task<GestureResult> RotateAsync(
+        string? elementId,
+        double degrees,
+        int? durationMs = null,
+        int? steps = null,
+        long? captureEpoch = null,
+        long? registryGeneration = null)
+        => GestureDetailedAsync(
+            "rotate", elementId, rotation: degrees, durationMs: durationMs, steps: steps,
+            captureEpoch: captureEpoch, registryGeneration: registryGeneration);
+
+    /// <summary>Drag by a vector in device-independent pixels.</summary>
+    public Task<GestureResult> PanAsync(
+        string? elementId,
+        double deltaX,
+        double deltaY,
+        int? durationMs = null,
+        int? steps = null,
+        long? captureEpoch = null,
+        long? registryGeneration = null)
+        => GestureDetailedAsync(
+            "pan", elementId, deltaX: deltaX, deltaY: deltaY,
+            durationMs: durationMs, steps: steps,
+            captureEpoch: captureEpoch, registryGeneration: registryGeneration);
 
     public Task<JsonElement> BatchAsync(
         IEnumerable<JsonObject> actions,
@@ -2097,6 +2171,37 @@ public readonly record struct UiReadResult(
     string? Reason,
     bool Retryable,
     bool TransportFailure);
+
+/// <summary>
+/// Outcome of a gesture, including which tier serviced it. Gestures can be satisfied by a
+/// managed MAUI gesture recognizer or by native platform injection, and the two behave
+/// differently enough that it is worth knowing which one ran.
+/// </summary>
+public class GestureResult
+{
+    [System.Text.Json.Serialization.JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("elementId")]
+    public string? ElementId { get; set; }
+
+    /// <summary>"recognizer", "native", "scroll" (legacy swipe fallback), or "none".</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("handledBy")]
+    public string? HandledBy { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("platform")]
+    public string? Platform { get; set; }
+
+    /// <summary>What actually serviced the gesture, e.g. "MKMapView.Camera.CenterCoordinateDistance /2".</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("detail")]
+    public string? Detail { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
 
 public class AgentStatus
 {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -529,6 +529,23 @@ public class AgentClient : IDisposable
         int? durationMs = null)
         => (await GestureDetailedAsync(type, elementId, direction, distance, durationMs)).Success;
 
+    public async Task<bool> GestureAsync(
+        string type,
+        string? elementId,
+        string? direction,
+        double? distance,
+        int? durationMs,
+        long? captureEpoch,
+        long? registryGeneration)
+        => (await GestureDetailedAsync(
+            type,
+            elementId,
+            direction,
+            distance,
+            durationMs,
+            captureEpoch: captureEpoch,
+            registryGeneration: registryGeneration)).Success;
+
     /// <summary>
     /// Performs a gesture and reports which tier serviced it — a managed MAUI gesture
     /// recognizer, native platform injection, or nothing at all.
@@ -569,8 +586,11 @@ public class AgentClient : IDisposable
 
         try
         {
-            using var content = DriverJson.CreateJsonContent(payload);
-            var response = await _http.PostAsync($"{_baseUrl}{UiApi}/actions/gesture", content);
+            using var response = await SendWithTransientRetriesAsync(HttpMethod.Post, async () =>
+            {
+                using var content = DriverJson.CreateJsonContent(payload);
+                return await _http.PostAsync($"{_baseUrl}{UiApi}/actions/gesture", content);
+            });
             var responseBody = await response.Content.ReadAsStringAsync();
             var result = DriverJson.Deserialize<GestureResult>(responseBody);
 
@@ -583,7 +603,17 @@ public class AgentClient : IDisposable
 
             return result;
         }
-        catch (Exception ex)
+        catch (NotSupportedByAgentException ex)
+        {
+            return new GestureResult
+            {
+                Success = false,
+                Type = type,
+                HandledBy = "none",
+                Error = ex.Message
+            };
+        }
+        catch (Exception ex) when (IsExpectedClientException(ex))
         {
             return new GestureResult { Success = false, Type = type, Error = ex.Message };
         }
@@ -2188,7 +2218,7 @@ public class GestureResult
     [System.Text.Json.Serialization.JsonPropertyName("elementId")]
     public string? ElementId { get; set; }
 
-    /// <summary>"recognizer", "native", "scroll" (legacy swipe fallback), or "none".</summary>
+    /// <summary>"recognizer", "native", "action", "scroll" (legacy swipe fallback), or "none".</summary>
     [System.Text.Json.Serialization.JsonPropertyName("handledBy")]
     public string? HandledBy { get; set; }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/DevFlowDriverJson.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/DevFlowDriverJson.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui.DevFlow.Driver;
 [JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(AgentClient.ProfilerSessionEnvelope))]
 [JsonSerializable(typeof(AgentClient.ActionResponse))]
+[JsonSerializable(typeof(GestureResult))]
 [JsonSerializable(typeof(InvokeResult))]
 [JsonSerializable(typeof(AgentCapabilitiesResponse))]
 [JsonSerializable(typeof(ExtensionDescriptor))]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
@@ -158,6 +158,70 @@ public class AgentHttpServerTests : IDisposable
     }
 
     [Fact]
+    public async Task PinchEndpoint_SendsScaleAndReportsHandlingTier()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            var client = await listener.AcceptTcpClientAsync();
+            var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("POST /api/v1/ui/actions/gesture", request);
+            Assert.Contains("\"type\":\"pinch\"", request);
+            Assert.Contains("\"scale\":2", request);
+
+            var body = """{"success":true,"type":"pinch","elementId":"map1","handledBy":"native","platform":"iOS","detail":"MKMapView.Camera.CenterCoordinateDistance /2"}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+            client.Close();
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.PinchAsync("map1", scale: 2.0);
+
+        Assert.True(result.Success);
+        Assert.Equal("native", result.HandledBy);
+        Assert.Equal("MKMapView.Camera.CenterCoordinateDistance /2", result.Detail);
+
+        listener.Stop();
+    }
+
+    [Fact]
+    public async Task GestureEndpoint_UnhandledGesture_SurfacesTheReason()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            var client = await listener.AcceptTcpClientAsync();
+            var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var read = await stream.ReadAsync(buffer);
+            Assert.Contains("POST /api/v1/ui/actions/gesture", Encoding.UTF8.GetString(buffer, 0, read));
+
+            var body = """{"success":false,"type":"rotate","handledBy":"none","error":"rotate is not available for Grid on Android"}""";
+            var response = $"HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+            client.Close();
+        });
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.RotateAsync("grid1", 90);
+
+        Assert.False(result.Success);
+        Assert.Equal("none", result.HandledBy);
+        Assert.Contains("not available", result.Error);
+
+        listener.Stop();
+    }
+
+    [Fact]
     public async Task FillEndpoint_SendsPostWithText()
     {
         using var listener = new TcpListener(IPAddress.Loopback, _port);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
@@ -174,6 +174,8 @@ public class AgentHttpServerTests : IDisposable
             Assert.Contains("POST /api/v1/ui/actions/gesture", request);
             Assert.Contains("\"type\":\"pinch\"", request);
             Assert.Contains("\"scale\":2", request);
+            Assert.Contains("\"captureEpoch\":42", request);
+            Assert.Contains("\"registryGeneration\":7", request);
 
             var body = """{"success":true,"type":"pinch","elementId":"map1","handledBy":"native","platform":"iOS","detail":"MKMapView.Camera.CenterCoordinateDistance /2"}""";
             var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
@@ -182,7 +184,11 @@ public class AgentHttpServerTests : IDisposable
         });
 
         using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
-        var result = await agentClient.PinchAsync("map1", scale: 2.0);
+        var result = await agentClient.PinchAsync(
+            "map1",
+            scale: 2.0,
+            captureEpoch: 42,
+            registryGeneration: 7);
 
         Assert.True(result.Success);
         Assert.Equal("native", result.HandledBy);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
@@ -154,6 +154,7 @@ public class AgentHttpServerTests : IDisposable
         var result = await agentClient.TapAsync("btn1");
         Assert.True(result);
 
+        await acceptTask;
         listener.Stop();
     }
 
@@ -194,6 +195,7 @@ public class AgentHttpServerTests : IDisposable
         Assert.Equal("native", result.HandledBy);
         Assert.Equal("MKMapView.Camera.CenterCoordinateDistance /2", result.Detail);
 
+        await acceptTask;
         listener.Stop();
     }
 
@@ -224,6 +226,7 @@ public class AgentHttpServerTests : IDisposable
         Assert.Equal("none", result.HandledBy);
         Assert.Contains("not available", result.Error);
 
+        await acceptTask;
         listener.Stop();
     }
 


### PR DESCRIPTION
## Why

DevFlow could tap, fill, scroll and send keys, but it could not exercise **gestures**. The `/api/v1/ui/actions/gesture` endpoint was a facade:

| requested | what actually ran |
|---|---|
| `tap` | `HandleTap` |
| `longpress` | `HandleTap` — identical to a tap |
| `swipe` | `HandleScroll` — i.e. `ScrollView.ScrollToAsync` |
| anything else | `"Gesture '<x>' is not supported"` |

Nothing in the repo synthesised a touch. `VisualTreeWalker` already *reported* `pinch`/`pan`/`swipe` recognizers on elements, so an agent could see that a view was pinchable and then had no way to pinch it.

That blocked a whole class of scenarios: maps and pinch-to-zoom, map panning, drag-to-reorder, `SwipeView` reveal, image viewers, custom `SKCanvasView` gesture surfaces.

## What

`pinch`, `rotate`, `pan`, `swipe`, `doubletap` and `longpress` are now real gestures, exposed through the agent HTTP API, `AgentClient`, the `maui_gesture` MCP tool, `maui_batch`, and a new `maui devflow ui gesture <type>` CLI command.

Resolution is two-tier:

**Tier 1 — managed recognizers** (`Agent.Core`, all platforms). Drives MAUI's own recognizers with **no reflection**: MAUI publicly exposes `IPinchGestureController`, `IPanGestureController` and `ISwipeGestureController`, so it is a plain cast. Only `TapGestureRecognizer.SendTapped` still needs reflection (it is `internal`), reusing the existing `TryInvokeTapped`. Continuous gestures emit N interpolated steps — `SendPinch` takes a *delta* scale per event, so a `scale: 2.0` request accumulates to exactly 2.0 in the app. The search walks up ancestors, so a pinch aimed at an `Image` inside a pinchable `Grid` still lands.

**Tier 2 — native injection** (`Agent/PlatformAgentService.Gestures.cs`, new). Six `TryNative*` virtuals, used when no recognizer exists — which is exactly the Map / WebView case.

| Platform | Mechanism | Fidelity |
|---|---|---|
| **Android** | Multi-pointer `MotionEvent`s via `Activity.DispatchTouchEvent` | Full — real hit-test + `GestureDetector` pipeline |
| **iOS / Mac Catalyst** | MKMapView camera distance → `UIScrollView` zoom/offset → attached `UIGestureRecognizer` via `setState:` | Good; the recognizer path is best-effort |
| **Windows** | `ScrollViewer.ChangeView` | Zoom/pan surfaces only |
| **macOS AppKit** | `NSScrollView` magnification / content offset | Zoom/pan surfaces only |
| **GTK** | tier 1 only | — |

MapKit is reached by type name rather than a direct reference, so the agent does not link MapKit into every consuming app. `Windows.UI.Input.Preview.Injection` is deliberately **not** used — it needs the restricted `inputInjectionBrokered` capability, which a normal app package cannot get.

**Every response names the tier that serviced it** — `handledBy: recognizer | native | scroll | none`, plus `detail` and `platform`. This is load-bearing: a `recognizer` hit proves the app's own handler ran, while `native` means the platform control absorbed it. They are different things to assert against, and the distinction caught a real bug during this work (below).

The OpenAPI spec is corrected. `actions.json` documented a WebDriver-style `pointerDown`/`pointerMove`/`pointerUp` sequence that nothing had ever implemented; it now describes the named-gesture API that actually exists, with a `GestureResponse` schema.

## Behaviour change worth flagging

`longpress` used to be a silent alias for tap. It now genuinely holds a touch down, and on platforms without native injection it **fails with an explanatory message** rather than quietly doing a tap. A test that asks for a long press and silently gets a tap is a test that lies, so this is intentional — but it will surface in any existing script that relied on the aliasing. `swipe` keeps its scroll fallback, so that path cannot regress.

## Testing

Verified on simulators — **iOS 125/125, Android 125/125** (full `Agent.IntegrationTests` suite, iPhone Air / iOS 26.5 and a Pixel 9a AVD). Plus 228 DevFlow unit tests and 469 CLI unit tests.

New `GestureTestPage` in `DevFlow.Sample` (`//gestures`) gives each gesture an `AutomationId`'d status label, so integration tests assert the **label changed** — that the gesture genuinely reached the app — not merely that the HTTP call returned 200. A `NativeScrollTarget` with no managed recognizer proves tier 2 fires; on Android that test asserts `handledBy == "native"` with `MotionEvent` in the detail, so a no-op cannot pass it.

The simulator run caught two bugs that unit tests could not see, both fixed here:

1. **Swipe never fired the recognizer.** `ISwipeGestureController` has two members and only one was being called. `DetectSwipe` measures travel accumulated by `SendSwipe` against the recognizer's `Threshold`; without feeding the vector in first the totals are zero and detection always declines. All four directions were silently landing on the legacy scroll fallback — precisely the quiet wrong-path that `handledBy` exists to expose.
2. **Pan reported `dx=0 dy=0`.** Engine was correct; MAUI raises `Completed` with the totals reset to zero and the sample page overwrote its label on every event. The page now keeps the last `Running` totals, which is what an app actually applies.

### Not verified

- **`net10.0-macos` is uncompiled.** The `macos` workload could not be installed in my environment. The macOS code is `NSScrollView` magnification/offset only — no new API surface — but it has not been through a compiler. Worth a CI check before merge.
- **No on-device run against a real `Map`.** A `Map` was deliberately kept out of `DevFlow.Sample` (it would pull `Microsoft.Maui.Controls.Maps` plus API keys into the CI sample). The MKMapView and Android `MotionEvent` paths are exercised by the native-target tests, but not against MapKit/Google Maps itself.
- The iOS suite showed real variance on my machine — one run had widespread `NavigateToPageAsync("//native")` timeouts in pre-existing tests, later runs were fully green. No gesture tests were among those failures, but I could not get a clean baseline to confirm the flakiness is pre-existing.

## Non-goals

- **WebView-internal gestures via CDP.** A Leaflet/Blazor map inside a WebView needs `Input.dispatchTouchEvent` through the existing CDP bridge. Natural follow-up.
- **WebDriver pointer-action sequences.** Deferred; the handlers are structured so a future `actions[]` endpoint can reuse the same `InjectTouchSequenceAsync` primitive.
- **Private-API `UITouch` synthesis on iOS.** Not attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
