### PR TITLE
fix(devflow): make background-job capability reporting truthful; add real WorkManager/BGTask sample jobs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MicrosoftAspNetCoreComponentsWebViewMauiVersion)" />
   </ItemGroup>
 
+  <ItemGroup Label="AndroidX">
+    <PackageVersion Include="Xamarin.AndroidX.Work.Runtime" Version="$(XamarinAndroidXWorkRuntimeVersion)" />
+  </ItemGroup>
+
   <!-- Microsoft Extensions (versions from eng/Versions.props, flowing via maestro) -->
   <ItemGroup Label="Extensions">
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,11 @@
 
   <ItemGroup Label="AndroidX">
     <PackageVersion Include="Xamarin.AndroidX.Work.Runtime" Version="$(XamarinAndroidXWorkRuntimeVersion)" />
+    <PackageVersion Include="Xamarin.AndroidX.Concurrent.Futures.Ktx" Version="$(XamarinAndroidXKtxFacadeVersion)" />
+    <PackageVersion Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="$(XamarinAndroidXKtxFacadeVersion)" />
+    <!-- Work.Runtime pins Lifecycle.Service to the 2.8.7 line while the MAUI baseline resolves
+         Lifecycle.Runtime 2.9.x; matching the two keeps restore warning-free. -->
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Service" Version="$(XamarinAndroidXLifecycleServiceVersion)" />
   </ItemGroup>
 
   <!-- Microsoft Extensions (versions from eng/Versions.props, flowing via maestro) -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,12 +25,16 @@
   </PropertyGroup>
   <PropertyGroup Label="AndroidX">
     <!-- WorkManager: used by DevFlow.Sample to exercise background job inspection/triggering.
-         Held at 2.11.1.1 deliberately. 2.11.2.1 requires Xamarin.AndroidX.Core 1.19.0.1, which
-         absorbed the core-ktx classes; that collides with the Core.Core.Ktx 1.16.0.3 the MAUI
-         baseline pulls in and fails dexing with "androidx.core.animation.AnimatorKt is defined
-         multiple times". 2.11.1.1 requires Core 1.17.0.2, which predates the merge.
-         Revisit when the MAUI AndroidX baseline moves to Core 1.19+. -->
-    <XamarinAndroidXWorkRuntimeVersion>2.11.1.1</XamarinAndroidXWorkRuntimeVersion>
+         Held at 2.10.0.5 because it is the newest version whose *complete* dependency graph is
+         available on this repo's feeds. From 2.10.1 on, WorkManager depends on Room 2.7+, which
+         AndroidX split into KMP-style sub-packages (Room.Runtime.Android, Room.Common.JVM,
+         Sqlite.Android, Sqlite.Framework.Android). Those sub-packages are not mirrored to
+         dotnet-public, so restore fails with NU1101 in CI even though it succeeds on a machine
+         with a warm package cache. Room 2.6.x, which 2.10.0.5 uses, predates the split.
+         Revisit once the Room/Sqlite platform packages are mirrored. -->
+    <XamarinAndroidXWorkRuntimeVersion>2.10.0.5</XamarinAndroidXWorkRuntimeVersion>
+    <XamarinAndroidXKtxFacadeVersion>1.3.0.1</XamarinAndroidXKtxFacadeVersion>
+    <XamarinAndroidXLifecycleServiceVersion>2.9.2.1</XamarinAndroidXLifecycleServiceVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dotnet Runtime / Extensions">
     <MicrosoftExtensionsDependencyInjectionVersion>10.0.5</MicrosoftExtensionsDependencyInjectionVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,6 +23,15 @@
     <MicrosoftMauiControlsMapsVersion>$(MicrosoftMauiControlsVersion)</MicrosoftMauiControlsMapsVersion>
     <MicrosoftAspNetCoreComponentsWebViewMauiVersion>$(MicrosoftMauiControlsVersion)</MicrosoftAspNetCoreComponentsWebViewMauiVersion>
   </PropertyGroup>
+  <PropertyGroup Label="AndroidX">
+    <!-- WorkManager: used by DevFlow.Sample to exercise background job inspection/triggering.
+         Held at 2.11.1.1 deliberately. 2.11.2.1 requires Xamarin.AndroidX.Core 1.19.0.1, which
+         absorbed the core-ktx classes; that collides with the Core.Core.Ktx 1.16.0.3 the MAUI
+         baseline pulls in and fails dexing with "androidx.core.animation.AnimatorKt is defined
+         multiple times". 2.11.1.1 requires Core 1.17.0.2, which predates the merge.
+         Revisit when the MAUI AndroidX baseline moves to Core 1.19+. -->
+    <XamarinAndroidXWorkRuntimeVersion>2.11.1.1</XamarinAndroidXWorkRuntimeVersion>
+  </PropertyGroup>
   <PropertyGroup Label="Dotnet Runtime / Extensions">
     <MicrosoftExtensionsDependencyInjectionVersion>10.0.5</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsConfigurationVersion>10.0.5</MicrosoftExtensionsConfigurationVersion>

--- a/samples/DevFlow.Sample/DevFlow.Sample.csproj
+++ b/samples/DevFlow.Sample/DevFlow.Sample.csproj
@@ -38,6 +38,14 @@
     <!-- WorkManager gives DevFlow a real background job to list, force-run via adb, and assert on. -->
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
         <PackageReference Include="Xamarin.AndroidX.Work.Runtime" />
+        <!-- Work.Runtime asks for 1.2.x of these two -Ktx packages, whose classes AndroidX has
+             since merged into their base packages. The MAUI baseline pulls the merged 1.3.0
+             bases in, so the old -Ktx packages both conflict on version and duplicate classes
+             at dex time. Referencing the matching 1.3.0 -Ktx facades directly settles both.
+             Lifecycle.Service is matched to the baseline Lifecycle.Runtime for the same reason. -->
+        <PackageReference Include="Xamarin.AndroidX.Concurrent.Futures.Ktx" />
+        <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Service" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/DevFlow.Sample/DevFlow.Sample.csproj
+++ b/samples/DevFlow.Sample/DevFlow.Sample.csproj
@@ -35,6 +35,11 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     </ItemGroup>
 
+    <!-- WorkManager gives DevFlow a real background job to list, force-run via adb, and assert on. -->
+    <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+        <PackageReference Include="Xamarin.AndroidX.Work.Runtime" />
+    </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\..\src\DevFlow\Microsoft.Maui.DevFlow.Agent\Microsoft.Maui.DevFlow.Agent.csproj" />
         <ProjectReference Include="..\..\src\DevFlow\Microsoft.Maui.DevFlow.Blazor\Microsoft.Maui.DevFlow.Blazor.csproj" />

--- a/samples/DevFlow.Sample/Platforms/Android/MainActivity.cs
+++ b/samples/DevFlow.Sample/Platforms/Android/MainActivity.cs
@@ -7,4 +7,20 @@ namespace DevFlow.Sample;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        // Queue a real background job on every launch so the DevFlow jobs API always has
+        // something to list and force-run. Enqueued as unique/Replace, so relaunching does
+        // not pile up duplicates.
+        try
+        {
+            SampleSyncWorker.Enqueue(this);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[DevFlow.Sample] Failed to enqueue {SampleSyncWorker.WorkName}: {ex}");
+        }
+    }
 }

--- a/samples/DevFlow.Sample/Platforms/Android/SampleSyncWorker.cs
+++ b/samples/DevFlow.Sample/Platforms/Android/SampleSyncWorker.cs
@@ -1,0 +1,67 @@
+using Android.Content;
+using AndroidX.Work;
+using Java.Util.Concurrent;
+using Microsoft.Maui.Storage;
+
+namespace DevFlow.Sample;
+
+/// <summary>
+/// A real WorkManager Worker so DevFlow's background-job surface has something to inspect,
+/// force-run and assert against. Without this the jobs API can only ever return an empty list,
+/// which is indistinguishable from a broken query.
+///
+/// Every run records its outcome in Preferences, which DevFlow can read back over HTTP — that is
+/// what turns "the job was triggered" into "the job actually executed and reported success".
+/// </summary>
+public class SampleSyncWorker : Worker
+{
+    /// <summary>Unique work name; also used as the tag callers filter on.</summary>
+    public const string WorkName = "devflow-sample-sync";
+
+    /// <summary>Input key that makes the worker report failure, for testing the failure path.</summary>
+    public const string ShouldFailKey = "shouldFail";
+
+    public const string RunCountPreference = "worker-run-count";
+    public const string LastResultPreference = "worker-last-result";
+    public const string LastRunPreference = "worker-last-run-utc";
+
+    public SampleSyncWorker(Context context, WorkerParameters workerParams)
+        : base(context, workerParams)
+    {
+    }
+
+    public override Result DoWork()
+    {
+        var shouldFail = InputData?.GetBoolean(ShouldFailKey, false) ?? false;
+
+        Preferences.Set(RunCountPreference, Preferences.Get(RunCountPreference, 0) + 1);
+        Preferences.Set(LastRunPreference, DateTime.UtcNow.ToString("O"));
+        Preferences.Set(LastResultPreference, shouldFail ? "failure" : "success");
+
+        return (shouldFail ? Result.InvokeFailure() : Result.InvokeSuccess())!;
+    }
+
+    /// <summary>
+    /// Enqueues the sample job with a long initial delay so it sits in JobScheduler as pending
+    /// rather than running on its own. That is deliberate: it gives
+    /// <c>adb shell cmd jobscheduler run -f</c> something to force, and keeps the job from
+    /// firing spontaneously in the middle of an unrelated test.
+    /// </summary>
+    public static void Enqueue(Context context, bool shouldFail = false)
+    {
+        var data = new Data.Builder()
+            .PutBoolean(ShouldFailKey, shouldFail)
+            .Build()!;
+
+        // Builder.Build() is typed as the WorkRequest base in the AndroidX binding,
+        // but EnqueueUniqueWork requires the OneTimeWorkRequest it actually returns.
+        var request = (OneTimeWorkRequest)new OneTimeWorkRequest.Builder(Java.Lang.Class.FromType(typeof(SampleSyncWorker)))
+            .SetInputData(data)
+            .SetInitialDelay(1, TimeUnit.Days!)
+            .AddTag(WorkName)
+            .Build()!;
+
+        WorkManager.GetInstance(context)
+            .EnqueueUniqueWork(WorkName, ExistingWorkPolicy.Replace, request);
+    }
+}

--- a/samples/DevFlow.Sample/Platforms/Android/SampleSyncWorker.cs
+++ b/samples/DevFlow.Sample/Platforms/Android/SampleSyncWorker.cs
@@ -64,4 +64,17 @@ public class SampleSyncWorker : Worker
         WorkManager.GetInstance(context)
             .EnqueueUniqueWork(WorkName, ExistingWorkPolicy.Replace, request);
     }
+
+    /// <summary>
+    /// Re-enqueues the sample job, optionally in a mode that reports failure, so both the
+    /// success and failure outcomes of `devflow ui jobs run` can be exercised.
+    /// </summary>
+    [Microsoft.Maui.DevFlow.Agent.Core.DevFlowAction("workmanager-enqueue",
+        Description = "Re-enqueue the sample WorkManager job, optionally set to fail")]
+    public static string EnqueueAction(
+        [System.ComponentModel.Description("true to make the worker report failure")] bool shouldFail = false)
+    {
+        Enqueue(global::Android.App.Application.Context!, shouldFail);
+        return $"enqueued '{WorkName}' (shouldFail={shouldFail})";
+    }
 }

--- a/samples/DevFlow.Sample/Platforms/iOS/AppDelegate.cs
+++ b/samples/DevFlow.Sample/Platforms/iOS/AppDelegate.cs
@@ -1,4 +1,5 @@
-﻿using Foundation;
+using Foundation;
+using UIKit;
 
 namespace DevFlow.Sample;
 
@@ -6,4 +7,31 @@ namespace DevFlow.Sample;
 public class AppDelegate : MauiUIApplicationDelegate
 {
 	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+	public override bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
+	{
+		// BGTask handlers must be registered before didFinishLaunchingWithOptions returns,
+		// so this has to happen ahead of the base call.
+		try
+		{
+			SampleBackgroundTask.Register();
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"[DevFlow.Sample] BGTask registration failed: {ex.Message}");
+		}
+
+		var result = base.FinishedLaunching(application, launchOptions);
+
+		try
+		{
+			Console.WriteLine($"[DevFlow.Sample] BGTask schedule: {SampleBackgroundTask.Schedule()}");
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"[DevFlow.Sample] BGTask schedule failed: {ex.Message}");
+		}
+
+		return result;
+	}
 }

--- a/samples/DevFlow.Sample/Platforms/iOS/Info.plist
+++ b/samples/DevFlow.Sample/Platforms/iOS/Info.plist
@@ -38,5 +38,15 @@
     <string>This app needs contacts access for testing dialog handling.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>This app needs microphone access for testing dialog handling.</string>
+    <!-- BGTaskScheduler refuses to register or submit an identifier that is not listed here. -->
+    <key>BGTaskSchedulerPermittedIdentifiers</key>
+    <array>
+        <string>com.companyname.mauitodo.sync</string>
+    </array>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>fetch</string>
+        <string>processing</string>
+    </array>
 </dict>
 </plist>

--- a/samples/DevFlow.Sample/Platforms/iOS/SampleBackgroundTask.cs
+++ b/samples/DevFlow.Sample/Platforms/iOS/SampleBackgroundTask.cs
@@ -1,0 +1,88 @@
+using System.Runtime.InteropServices;
+using BackgroundTasks;
+using Foundation;
+using Microsoft.Maui.DevFlow.Agent.Core;
+using Microsoft.Maui.Storage;
+using ObjCRuntime;
+
+namespace DevFlow.Sample;
+
+/// <summary>
+/// A real BGTask so DevFlow's background-job surface has something to list, trigger and
+/// assert against on iOS — the counterpart to <see cref="SampleSyncWorker"/> on Android.
+///
+/// <para>
+/// Unlike Android, there is no host-side way to force a BGTask: simctl has no equivalent of
+/// <c>adb shell cmd jobscheduler run</c>. <c>BGTaskScheduler.Submit</c> only *schedules*; iOS
+/// decides if and when to launch, and organically that essentially never happens on a Simulator.
+/// The only trigger is the private <c>_simulateLaunchForTaskWithIdentifier:</c> selector that
+/// Apple documents for use from the debugger.
+/// </para>
+/// </summary>
+public static class SampleBackgroundTask
+{
+    public const string SyncTaskIdentifier = "com.companyname.mauitodo.sync";
+
+    public const string RunCountPreference = "bgtask-run-count";
+    public const string LastRunPreference = "bgtask-last-run-utc";
+
+    /// <summary>
+    /// Registers the launch handler. Must be called before didFinishLaunchingWithOptions returns,
+    /// or BGTaskScheduler throws when the identifier is later submitted.
+    /// </summary>
+    public static void Register()
+    {
+        BGTaskScheduler.Shared.Register(SyncTaskIdentifier, null, task =>
+        {
+            Preferences.Set(RunCountPreference, Preferences.Get(RunCountPreference, 0) + 1);
+            Preferences.Set(LastRunPreference, DateTime.UtcNow.ToString("O"));
+            Console.WriteLine($"[DevFlow.Sample] BGTask '{SyncTaskIdentifier}' executed.");
+            task.SetTaskCompleted(true);
+        });
+    }
+
+    /// <summary>Submits the task with a far-future begin date so it stays pending until forced.</summary>
+    public static string Schedule()
+    {
+        var request = new BGProcessingTaskRequest(SyncTaskIdentifier)
+        {
+            EarliestBeginDate = (NSDate)DateTime.Now.AddDays(1),
+            RequiresNetworkConnectivity = false,
+            RequiresExternalPower = false
+        };
+
+        BGTaskScheduler.Shared.Submit(request, out var error);
+        return error != null ? $"submit failed: {error.LocalizedDescription}" : "submitted";
+    }
+
+    [DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+    private static extern void SendSimulateLaunch(IntPtr receiver, IntPtr selector, IntPtr identifier);
+
+    /// <summary>
+    /// Invokes the private SPI that Apple documents for triggering a BGTask from LLDB, but from
+    /// inside the process. This is the only thing that actually runs a BGTask on demand.
+    /// Probes with RespondsToSelector first so an OS that drops the SPI degrades to a clear
+    /// message instead of crashing.
+    /// </summary>
+    [DevFlowAction("bgtask-simulate-launch", Description = "Force a registered BGTask to run now (debug only; uses a private selector)")]
+    public static string SimulateLaunch(
+        [System.ComponentModel.Description("BGTask identifier to launch")] string identifier = SyncTaskIdentifier)
+    {
+        var selector = new Selector("_simulateLaunchForTaskWithIdentifier:");
+        var scheduler = BGTaskScheduler.Shared;
+
+        if (!scheduler.RespondsToSelector(selector))
+            return "unavailable: BGTaskScheduler does not respond to _simulateLaunchForTaskWithIdentifier:";
+
+        using var nsIdentifier = new NSString(identifier);
+        SendSimulateLaunch(scheduler.Handle, selector.Handle, nsIdentifier.Handle);
+        return $"invoked _simulateLaunchForTaskWithIdentifier: for '{identifier}'";
+    }
+
+    [DevFlowAction("bgtask-schedule", Description = "Submit the sample BGTask request so it becomes pending")]
+    public static string ScheduleAction() => Schedule();
+
+    [DevFlowAction("bgtask-run-count", Description = "How many times the sample BGTask handler has executed")]
+    public static string RunCount() =>
+        $"{Preferences.Get(RunCountPreference, 0)} run(s), last at {Preferences.Get(LastRunPreference, "never")}";
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -653,17 +653,20 @@ public class DevFlowCommands
         {
             jobRunIdArg, jobRunTypeOption, jobRunSerialOption, jobRunPackageOption, jobRunTimeoutOption
         };
+        // Returns a non-zero exit code when the job fails. This command is a pass/fail
+        // assertion, so a failing job has to fail the process for CI to be able to use it.
         jobsRunCmd.SetAction(async (ctx, ct) =>
         {
             var host = ctx.GetValue(agentHostOption)!;
             var port = ctx.GetValue(agentPortOption);
             var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
-            await MauiJobsRunAsync(host, port, isJson,
+            var succeeded = await MauiJobsRunAsync(host, port, isJson,
                 ctx.GetValue(jobRunIdArg)!,
                 ctx.GetValue(jobRunTypeOption),
                 ctx.GetValue(jobRunSerialOption),
                 ctx.GetValue(jobRunPackageOption),
                 ctx.GetValue(jobRunTimeoutOption));
+            return succeeded ? 0 : 1;
         });
         jobsCommand.Add(jobsRunCmd);
         mauiCommand.Add(jobsCommand);
@@ -2947,7 +2950,7 @@ public class DevFlowCommands
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
-    private static async Task MauiJobsRunAsync(
+    private static async Task<bool> MauiJobsRunAsync(
         string host, int port, bool json, string identifier,
         string? type, string? serial, string? package, int timeoutSeconds)
     {
@@ -2958,10 +2961,7 @@ public class DevFlowCommands
             var platform = jobs.TryGetProperty("platform", out var p) ? p.GetString() ?? "" : "";
 
             if (platform.Equals("Android", StringComparison.OrdinalIgnoreCase))
-            {
-                await RunAndroidJobAsync(client, json, identifier, serial, package, timeoutSeconds);
-                return;
-            }
+                return await RunAndroidJobAsync(client, json, identifier, serial, package, timeoutSeconds);
 
             // iOS / Mac Catalyst: the agent schedules the request and forces the launch in-process.
             var result = await client.RunJobAsync(identifier, type);
@@ -2977,8 +2977,9 @@ public class DevFlowCommands
             }
 
             if (!ok) _errorOccurred = true;
+            return ok;
         }
-        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; return false; }
     }
 
     /// <summary>
@@ -2987,7 +2988,7 @@ public class DevFlowCommands
     /// host-side and then reads the outcome back from the in-app WorkManager query, which is the
     /// only place the real SUCCEEDED/FAILED result lives.
     /// </summary>
-    private static async Task RunAndroidJobAsync(
+    private static async Task<bool> RunAndroidJobAsync(
         Microsoft.Maui.DevFlow.Driver.AgentClient client, bool json,
         string identifier, string? serial, string? package, int timeoutSeconds)
     {
@@ -3001,7 +3002,7 @@ public class DevFlowCommands
         {
             Output.WriteError("Could not determine the Android package name; pass --package.", json);
             _errorOccurred = true;
-            return;
+            return false;
         }
 
         using var driver = new Microsoft.Maui.DevFlow.Driver.AndroidAppDriver { Serial = serial };
@@ -3019,7 +3020,7 @@ public class DevFlowCommands
             var known = scheduled.Count == 0 ? "none" : string.Join(", ", scheduled.Select(x => x.ToString()));
             Output.WriteError($"No scheduled JobScheduler job matched '{identifier}'. Scheduled: {known}", json);
             _errorOccurred = true;
-            return;
+            return false;
         }
 
         var (before, _) = await ReadWorkStateAsync(client, identifier, target.Worker);
@@ -3065,6 +3066,7 @@ public class DevFlowCommands
         }
 
         if (!succeeded) _errorOccurred = true;
+        return succeeded;
     }
 
     private static async Task<(string? State, int Attempts)> ReadWorkStateAsync(

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -628,6 +628,46 @@ public class DevFlowCommands
         mauiCommand.Add(mauiResizeCmd);
 
         // MAUI alert subcommands — supports iOS simulator (apple CLI) and Mac Catalyst (macOS AX API)
+        // MAUI background jobs — Android WorkManager, iOS BGTaskScheduler
+        var jobsCommand = new Command("jobs", "List and run background jobs (Android WorkManager, iOS BGTask)");
+
+        var jobsListCmd = new Command("list", "List registered background jobs");
+        jobsListCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            await MauiJobsListAsync(host, port, isJson);
+        });
+        jobsCommand.Add(jobsListCmd);
+
+        var jobRunIdArg = new Argument<string>("identifier")
+        {
+            Description = "Job identifier from 'jobs list' (Android WorkManager UUID or worker name, iOS BGTask identifier)"
+        };
+        var jobRunTypeOption = new Option<string?>("--type") { Description = "iOS BGTask type: processing or refresh" };
+        var jobRunSerialOption = new Option<string?>("--serial") { Description = "Android device/emulator serial (adb -s)" };
+        var jobRunPackageOption = new Option<string?>("--package") { Description = "Android package name (auto-detected from the agent if omitted)" };
+        var jobRunTimeoutOption = new Option<int>("--timeout") { Description = "Seconds to wait for the job to reach a terminal state", DefaultValueFactory = _ => 30 };
+        var jobsRunCmd = new Command("run", "Run a background job now and report whether it succeeded or failed")
+        {
+            jobRunIdArg, jobRunTypeOption, jobRunSerialOption, jobRunPackageOption, jobRunTimeoutOption
+        };
+        jobsRunCmd.SetAction(async (ctx, ct) =>
+        {
+            var host = ctx.GetValue(agentHostOption)!;
+            var port = ctx.GetValue(agentPortOption);
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            await MauiJobsRunAsync(host, port, isJson,
+                ctx.GetValue(jobRunIdArg)!,
+                ctx.GetValue(jobRunTypeOption),
+                ctx.GetValue(jobRunSerialOption),
+                ctx.GetValue(jobRunPackageOption),
+                ctx.GetValue(jobRunTimeoutOption));
+        });
+        jobsCommand.Add(jobsRunCmd);
+        mauiCommand.Add(jobsCommand);
+
         var alertCommand = new Command("alert", "Detect and dismiss system/app dialogs");
 
         // detect
@@ -2845,6 +2885,235 @@ public class DevFlowCommands
             if (!success) _errorOccurred = true;
         }
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
+    }
+
+    private static readonly string[] TerminalJobStates = ["SUCCEEDED", "FAILED", "CANCELLED"];
+
+    private static async Task MauiJobsListAsync(string host, int port, bool json)
+    {
+        try
+        {
+            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            var result = await client.GetJobsAsync();
+
+            if (json) { Output.WriteJsonElement(result, json); return; }
+
+            var platform = result.TryGetProperty("platform", out var p) ? p.GetString() : "unknown";
+            var kind = result.TryGetProperty("type", out var t) ? t.GetString() : "";
+            var supported = result.TryGetProperty("supported", out var s) && s.GetBoolean();
+
+            if (!supported)
+            {
+                Console.WriteLine($"Background jobs are not available on {platform}.");
+                if (result.TryGetProperty("reason", out var reason))
+                    Console.WriteLine(reason.GetString());
+                return;
+            }
+
+            // An error means the query failed — never render that as "no jobs scheduled".
+            if (result.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.String)
+            {
+                Output.WriteError($"Could not read {kind} jobs: {err.GetString()}", json);
+                _errorOccurred = true;
+                return;
+            }
+
+            var jobs = result.TryGetProperty("jobs", out var j) && j.ValueKind == JsonValueKind.Array
+                ? j.EnumerateArray().ToList()
+                : [];
+
+            if (jobs.Count == 0)
+            {
+                Console.WriteLine($"{platform} / {kind}: no jobs scheduled.");
+                return;
+            }
+
+            Console.WriteLine($"{platform} / {kind}: {jobs.Count} job(s)");
+            foreach (var job in jobs)
+            {
+                Console.WriteLine($"  {(job.TryGetProperty("identifier", out var i) ? i.GetString() : "?")}");
+                if (job.TryGetProperty("state", out var st))
+                    Console.WriteLine($"    state:    {st.GetString()}");
+                if (job.TryGetProperty("runAttemptCount", out var rc))
+                    Console.WriteLine($"    attempts: {rc}");
+                if (job.TryGetProperty("type", out var ty))
+                    Console.WriteLine($"    type:     {ty.GetString()}");
+                if (job.TryGetProperty("earliestBeginDate", out var eb) && !string.IsNullOrWhiteSpace(eb.GetString()))
+                    Console.WriteLine($"    earliest: {eb.GetString()}");
+                if (job.TryGetProperty("tags", out var tg) && tg.ValueKind == JsonValueKind.Array)
+                    Console.WriteLine($"    tags:     {string.Join(", ", tg.EnumerateArray().Select(x => x.GetString()))}");
+            }
+        }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
+    }
+
+    private static async Task MauiJobsRunAsync(
+        string host, int port, bool json, string identifier,
+        string? type, string? serial, string? package, int timeoutSeconds)
+    {
+        try
+        {
+            using var client = new Microsoft.Maui.DevFlow.Driver.AgentClient(host, port);
+            var jobs = await client.GetJobsAsync();
+            var platform = jobs.TryGetProperty("platform", out var p) ? p.GetString() ?? "" : "";
+
+            if (platform.Equals("Android", StringComparison.OrdinalIgnoreCase))
+            {
+                await RunAndroidJobAsync(client, json, identifier, serial, package, timeoutSeconds);
+                return;
+            }
+
+            // iOS / Mac Catalyst: the agent schedules the request and forces the launch in-process.
+            var result = await client.RunJobAsync(identifier, type);
+            var ok = result.TryGetProperty("success", out var okFlag) && okFlag.GetBoolean();
+
+            if (json) Output.WriteJsonElement(result, json);
+            else
+            {
+                var msg = result.TryGetProperty("message", out var m) ? m.GetString() : null;
+                var error = result.TryGetProperty("error", out var e) ? e.GetString() : null;
+                Console.WriteLine(ok ? $"SUCCESS: {msg ?? identifier}" : $"FAILED: {error ?? "unknown error"}");
+                if (ok && result.TryGetProperty("note", out var note)) Console.WriteLine($"  note: {note.GetString()}");
+            }
+
+            if (!ok) _errorOccurred = true;
+        }
+        catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
+    }
+
+    /// <summary>
+    /// Android jobs cannot be forced from inside the app — the original WorkRequest cannot be
+    /// reconstructed from a WorkInfo. adb can force them through JobScheduler, so this triggers
+    /// host-side and then reads the outcome back from the in-app WorkManager query, which is the
+    /// only place the real SUCCEEDED/FAILED result lives.
+    /// </summary>
+    private static async Task RunAndroidJobAsync(
+        Microsoft.Maui.DevFlow.Driver.AgentClient client, bool json,
+        string identifier, string? serial, string? package, int timeoutSeconds)
+    {
+        if (string.IsNullOrWhiteSpace(package))
+        {
+            var status = await client.GetStatusAsync();
+            package = status?.App?.PackageId;
+        }
+
+        if (string.IsNullOrWhiteSpace(package))
+        {
+            Output.WriteError("Could not determine the Android package name; pass --package.", json);
+            _errorOccurred = true;
+            return;
+        }
+
+        using var driver = new Microsoft.Maui.DevFlow.Driver.AndroidAppDriver { Serial = serial };
+        var scheduled = await driver.ListScheduledJobsAsync(package);
+
+        // WorkManager UUIDs are invisible to JobScheduler, so match by numeric job id or by the
+        // worker name carried in the job's debug tag, resolving a UUID via the in-app listing.
+        var worker = await ResolveWorkerNameAsync(client, identifier);
+        var target = scheduled.FirstOrDefault(x => x.JobId == identifier)
+            ?? scheduled.FirstOrDefault(x => x.Worker != null && x.Worker.EndsWith(identifier, StringComparison.OrdinalIgnoreCase))
+            ?? (worker == null ? null : scheduled.FirstOrDefault(x => x.Worker != null && worker.EndsWith(x.Worker, StringComparison.OrdinalIgnoreCase)));
+
+        if (target == null)
+        {
+            var known = scheduled.Count == 0 ? "none" : string.Join(", ", scheduled.Select(x => x.ToString()));
+            Output.WriteError($"No scheduled JobScheduler job matched '{identifier}'. Scheduled: {known}", json);
+            _errorOccurred = true;
+            return;
+        }
+
+        var (before, _) = await ReadWorkStateAsync(client, identifier, target.Worker);
+        var runOutput = await driver.RunScheduledJobAsync(package, target.JobId, target.Namespace);
+
+        // Poll the in-app WorkManager view until the work reaches a terminal state.
+        string? state = null;
+        var attemptCount = 0;
+        var deadline = DateTime.UtcNow.AddSeconds(Math.Max(1, timeoutSeconds));
+        while (DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(750);
+            var (s, count) = await ReadWorkStateAsync(client, identifier, target.Worker);
+            if (s != null) { state = s; attemptCount = count; }
+            if (state != null && TerminalJobStates.Contains(state, StringComparer.OrdinalIgnoreCase)) break;
+        }
+
+        var succeeded = string.Equals(state, "SUCCEEDED", StringComparison.OrdinalIgnoreCase);
+
+        if (json)
+        {
+            Output.WriteRawJson(CliJson.SerializeUntyped(new JsonObject
+            {
+                ["success"] = succeeded,
+                ["identifier"] = identifier,
+                ["jobId"] = target.JobId,
+                ["worker"] = target.Worker,
+                ["namespace"] = target.Namespace,
+                ["stateBefore"] = before,
+                ["state"] = state,
+                ["runAttemptCount"] = attemptCount,
+                ["triggeredVia"] = "adb cmd jobscheduler run -f",
+                ["adbOutput"] = runOutput
+            }, indented: false));
+        }
+        else
+        {
+            Console.WriteLine($"Forced job {target.JobId} ({target.Worker ?? identifier}) via adb — {runOutput}");
+            if (state == null)
+                Console.WriteLine($"FAILED: no state reported within {timeoutSeconds}s (was {before ?? "unknown"})");
+            else
+                Console.WriteLine($"{(succeeded ? "SUCCESS" : "FAILED")}: {state} after {attemptCount} attempt(s)");
+        }
+
+        if (!succeeded) _errorOccurred = true;
+    }
+
+    private static async Task<(string? State, int Attempts)> ReadWorkStateAsync(
+        Microsoft.Maui.DevFlow.Driver.AgentClient client, string identifier, string? worker)
+    {
+        try
+        {
+            var jobs = await client.GetJobsAsync();
+            if (!jobs.TryGetProperty("jobs", out var arr) || arr.ValueKind != JsonValueKind.Array)
+                return (null, 0);
+
+            foreach (var job in arr.EnumerateArray())
+            {
+                var id = job.TryGetProperty("identifier", out var i) ? i.GetString() : null;
+                var tags = job.TryGetProperty("tags", out var tg) && tg.ValueKind == JsonValueKind.Array
+                    ? tg.EnumerateArray().Select(x => x.GetString()).ToList()
+                    : [];
+
+                var matches = id == identifier
+                    || tags.Any(t => t == identifier)
+                    || (worker != null && tags.Any(t => t != null && t.EndsWith(worker, StringComparison.OrdinalIgnoreCase)));
+                if (!matches) continue;
+
+                var state = job.TryGetProperty("state", out var st) ? st.GetString() : null;
+                var count = job.TryGetProperty("runAttemptCount", out var rc) && rc.TryGetInt32(out var c) ? c : 0;
+                return (state, count);
+            }
+        }
+        catch { }
+        return (null, 0);
+    }
+
+    /// <summary>WorkManager auto-tags every request with its worker class name.</summary>
+    private static async Task<string?> ResolveWorkerNameAsync(Microsoft.Maui.DevFlow.Driver.AgentClient client, string identifier)
+    {
+        try
+        {
+            var jobs = await client.GetJobsAsync();
+            if (!jobs.TryGetProperty("jobs", out var arr) || arr.ValueKind != JsonValueKind.Array) return null;
+
+            foreach (var job in arr.EnumerateArray())
+            {
+                if ((job.TryGetProperty("identifier", out var i) ? i.GetString() : null) != identifier) continue;
+                if (!job.TryGetProperty("tags", out var tg) || tg.ValueKind != JsonValueKind.Array) return null;
+                return tg.EnumerateArray().Select(x => x.GetString()).FirstOrDefault(t => t != null && t.Contains('.'));
+            }
+        }
+        catch { }
+        return null;
     }
 
     private static async Task MauiFocusAsync(string host, int port, bool json, string elementId)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/DeviceTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/DeviceTests.cs
@@ -136,6 +136,7 @@ public class DeviceTests : IntegrationTestBase
     public async Task Jobs_ReturnsSupportedFlagAndJobArray()
     {
         var json = await Client.GetJobsAsync();
+        Output.WriteLine($"jobs payload: {json}");
 
         Assert.Equal(JsonValueKind.Object, json.ValueKind);
         Assert.True(json.TryGetProperty("supported", out var supported));
@@ -143,7 +144,33 @@ public class DeviceTests : IntegrationTestBase
         Assert.True(json.TryGetProperty("jobs", out var jobs));
         Assert.Equal(JsonValueKind.Array, jobs.ValueKind);
 
-        if (Platform is "android" or "ios" or "maccatalyst")
+        // BGTaskScheduler ships with the OS, so the capability is always present.
+        if (Platform is "ios" or "maccatalyst")
             Assert.True(supported.GetBoolean());
+
+        // WorkManager is an opt-in AndroidX dependency. The sample app does not reference it,
+        // so Android must report the capability as absent — and say why. An empty job array
+        // with supported=true would be indistinguishable from a healthy, idle queue.
+        if (Platform == "android")
+        {
+            Assert.False(supported.GetBoolean());
+            Assert.True(json.TryGetProperty("reason", out var reason));
+            Assert.Contains("androidx.work", reason.GetString());
+        }
+    }
+
+    [Fact]
+    public async Task Jobs_UnsupportedCapability_IsReportedConsistently()
+    {
+        // The jobs list and the capabilities document must not disagree about whether
+        // background jobs are available, or a caller feature-detecting via capabilities
+        // gets a different answer than one reading the list.
+        var jobs = await Client.GetJobsAsync();
+        var caps = await GetJsonAsync("/api/v1/agent/capabilities");
+
+        var listSupported = jobs.GetProperty("supported").GetBoolean();
+        var capsSupported = caps.GetProperty("jobs").GetProperty("supported").GetBoolean();
+
+        Assert.Equal(listSupported, capsSupported);
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/DeviceTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/DeviceTests.cs
@@ -144,19 +144,44 @@ public class DeviceTests : IntegrationTestBase
         Assert.True(json.TryGetProperty("jobs", out var jobs));
         Assert.Equal(JsonValueKind.Array, jobs.ValueKind);
 
-        // BGTaskScheduler ships with the OS, so the capability is always present.
-        if (Platform is "ios" or "maccatalyst")
+        // BGTaskScheduler ships with the OS and the sample references WorkManager, so both
+        // platforms must report the capability as present.
+        if (Platform is "ios" or "maccatalyst" or "android")
             Assert.True(supported.GetBoolean());
 
-        // WorkManager is an opt-in AndroidX dependency. The sample app does not reference it,
-        // so Android must report the capability as absent — and say why. An empty job array
-        // with supported=true would be indistinguishable from a healthy, idle queue.
-        if (Platform == "android")
-        {
-            Assert.False(supported.GetBoolean());
-            Assert.True(json.TryGetProperty("reason", out var reason));
-            Assert.Contains("androidx.work", reason.GetString());
-        }
+        // An empty list must never be the result of a failed query — if the query could not
+        // complete, the payload has to say so rather than looking like an idle queue.
+        if (json.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.String)
+            Assert.Fail($"Jobs query reported an error: {error.GetString()}");
+    }
+
+    [Fact]
+    public async Task Jobs_Android_ListsTheSampleWorker()
+    {
+        if (Platform != "android")
+            return;
+
+        // The sample enqueues SampleSyncWorker on every launch, so a working WorkManager query
+        // must return it. This is the assertion that actually exercises the reflection path —
+        // shape-only checks passed for months while the query silently returned nothing.
+        var json = await Client.GetJobsAsync();
+        Output.WriteLine($"jobs payload: {json}");
+
+        var jobs = json.GetProperty("jobs").EnumerateArray().ToList();
+        Assert.NotEmpty(jobs);
+
+        var sampleJob = jobs.FirstOrDefault(j =>
+            j.TryGetProperty("tags", out var tags) &&
+            tags.EnumerateArray().Any(t => t.GetString() == "devflow-sample-sync"));
+
+        Assert.True(sampleJob.ValueKind == JsonValueKind.Object,
+            "No job tagged 'devflow-sample-sync' was returned by WorkManager.");
+
+        // A real WorkInfo carries a UUID and a state; empty strings mean the reflected
+        // accessors silently returned nothing.
+        Assert.False(string.IsNullOrWhiteSpace(sampleJob.GetProperty("identifier").GetString()));
+        Assert.Contains(sampleJob.GetProperty("state").GetString(),
+            new[] { "ENQUEUED", "RUNNING", "SUCCEEDED", "FAILED", "BLOCKED", "CANCELLED" });
     }
 
     [Fact]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -583,23 +583,66 @@ public class PlatformAgentService : DevFlowAgentService
         try
         {
             var taskType = await ResolveBgTaskRequestTypeAsync(identifier, type);
-            BGTaskRequest taskRequest = taskType.Equals("refresh", StringComparison.OrdinalIgnoreCase)
-                ? new BGAppRefreshTaskRequest(identifier)
-                : new BGProcessingTaskRequest(identifier);
 
-            taskRequest.EarliestBeginDate = null;
-
-            BGTaskScheduler.Shared.Submit(taskRequest, out var error);
-            if (error != null)
-                return new { success = false, error = error.LocalizedDescription, identifier };
-
-            return await Task.FromResult<object?>(new
+            // The request must be pending before it can be launched: iOS launches a *submitted*
+            // task, and simulating a launch for an unscheduled identifier is a no-op.
+            var wasPending = await IsBgTaskPendingAsync(identifier);
+            string? submitError = null;
+            if (!wasPending)
             {
-                success = true,
-                message = $"BGTask '{identifier}' submitted",
+                BGTaskRequest taskRequest = taskType.Equals("refresh", StringComparison.OrdinalIgnoreCase)
+                    ? new BGAppRefreshTaskRequest(identifier)
+                    : new BGProcessingTaskRequest(identifier);
+                taskRequest.EarliestBeginDate = null;
+
+                BGTaskScheduler.Shared.Submit(taskRequest, out var error);
+                submitError = error?.LocalizedDescription;
+            }
+
+            if (submitError != null)
+            {
+                return new
+                {
+                    success = false,
+                    identifier,
+                    type = taskType,
+                    error = $"Could not schedule BGTask '{identifier}': {submitError}. " +
+                            "BGTaskScheduler is unavailable on the iOS Simulator — background jobs require a physical device."
+                };
+            }
+
+            // Submitting only *schedules*; iOS decides when to launch, which organically may be
+            // never. Forcing the launch is the only way to actually run the handler on demand.
+            var launched = TrySimulateBgTaskLaunch(identifier, out var launchError);
+            if (!launched)
+            {
+                return new
+                {
+                    success = false,
+                    identifier,
+                    type = taskType,
+                    scheduled = true,
+                    error = launchError
+                };
+            }
+
+            // The scheduler consumes the pending request when it launches it, so the request
+            // disappearing is the observable evidence that a launch really happened.
+            await Task.Delay(1500);
+            var stillPending = await IsBgTaskPendingAsync(identifier);
+
+            return new
+            {
+                success = !stillPending,
                 identifier,
-                type = taskType
-            });
+                type = taskType,
+                launched = true,
+                consumedPendingRequest = !stillPending,
+                message = stillPending
+                    ? $"BGTask '{identifier}' launch was requested but the request is still pending; the handler may not be registered."
+                    : $"BGTask '{identifier}' was launched and its pending request was consumed.",
+                note = "iOS does not expose a task's result; assert on what the handler itself records."
+            };
         }
         catch (Exception ex)
         {
@@ -611,6 +654,60 @@ public class PlatformAgentService : DevFlowAgentService
     }
 
 #if IOS || MACCATALYST
+    private static async Task<bool> IsBgTaskPendingAsync(string identifier)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        BGTaskScheduler.Shared.GetPending(requests =>
+            tcs.TrySetResult(requests.Any(r => string.Equals(r.Identifier, identifier, StringComparison.Ordinal))));
+        return await tcs.Task;
+    }
+
+#if DEBUG
+    [System.Runtime.InteropServices.DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+    private static extern void SendSimulateLaunch(IntPtr receiver, IntPtr selector, IntPtr identifier);
+#endif
+
+    /// <summary>
+    /// Forces a submitted BGTask to run via <c>_simulateLaunchForTaskWithIdentifier:</c> — the
+    /// selector Apple documents for triggering background tasks from LLDB, invoked here in-process.
+    ///
+    /// <para>
+    /// <b>Debug builds only.</b> This is a private selector, and the agent compiles into the host
+    /// app; shipping it would expose consumers to App Store review rejection. There is no public
+    /// API that runs a BGTask on demand, so release builds can schedule but not trigger.
+    /// </para>
+    /// </summary>
+    private static bool TrySimulateBgTaskLaunch(string identifier, out string? error)
+    {
+#if DEBUG
+        try
+        {
+            var selector = new ObjCRuntime.Selector("_simulateLaunchForTaskWithIdentifier:");
+            var scheduler = BGTaskScheduler.Shared;
+
+            if (!scheduler.RespondsToSelector(selector))
+            {
+                error = "BGTaskScheduler does not respond to _simulateLaunchForTaskWithIdentifier: on this OS version.";
+                return false;
+            }
+
+            using var nsIdentifier = new NSString(identifier);
+            SendSimulateLaunch(scheduler.Handle, selector.Handle, nsIdentifier.Handle);
+            error = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"Failed to launch BGTask: {ex.GetBaseException().Message}";
+            return false;
+        }
+#else
+        error = "Triggering a BGTask requires a private API and is only available in Debug builds of the DevFlow agent. " +
+                "The request has been scheduled; iOS will launch it at its own discretion.";
+        return false;
+#endif
+    }
+
     private static async Task<string> ResolveBgTaskRequestTypeAsync(string identifier, string? requestedType)
     {
         if (!string.IsNullOrWhiteSpace(requestedType))

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -396,7 +396,11 @@ public class PlatformAgentService : DevFlowAgentService
         get
         {
 #if IOS || MACCATALYST
-            return true;
+            // Triggering a BGTask needs a private selector that is compiled out of Release
+            // builds (see TrySimulateBgTaskLaunch), so a Release agent can list and schedule
+            // but never run. Advertising "run" there would hand callers a feature-detect that
+            // is guaranteed to fail.
+            return BgTaskRunSupported;
 #elif ANDROID
             return false;
 #else
@@ -554,13 +558,13 @@ public class PlatformAgentService : DevFlowAgentService
                         earliestBeginDate = req.EarliestBeginDate?.ToString() ?? ""
                     });
                 }
-                tcs.TrySetResult(new { platform = "iOS", type = "BGTaskScheduler", supported = true, runSupported = true, jobs });
+                tcs.TrySetResult(new { platform = "iOS", type = "BGTaskScheduler", supported = true, runSupported = IsJobRunSupported, jobs });
             });
             return await tcs.Task;
         }
         catch (Exception ex)
         {
-            return new { platform = "iOS", type = "BGTaskScheduler", supported = true, runSupported = true, error = ex.Message, jobs = Array.Empty<object>() };
+            return new { platform = "iOS", type = "BGTaskScheduler", supported = true, runSupported = IsJobRunSupported, error = ex.Message, jobs = Array.Empty<object>() };
         }
 #else
         return await base.GetPlatformJobsAsync();
@@ -654,6 +658,17 @@ public class PlatformAgentService : DevFlowAgentService
     }
 
 #if IOS || MACCATALYST
+    /// <summary>
+    /// Whether this build can actually trigger a BGTask. The only way to run one on demand is a
+    /// private selector, which is compiled out of Release builds, so the advertised capability
+    /// and <see cref="TrySimulateBgTaskLaunch"/> must be gated on the same condition.
+    /// </summary>
+#if DEBUG
+    private const bool BgTaskRunSupported = true;
+#else
+    private const bool BgTaskRunSupported = false;
+#endif
+
     /// <summary>
     /// Turns a BGTaskSchedulerErrorDomain code into the thing you actually need to go fix.
     /// The three codes have completely different causes and conflating them sends people

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -288,11 +288,58 @@ public class PlatformAgentService : DevFlowAgentService
 #endif
     }
 
+#if ANDROID
+    /// <summary>
+    /// Whether androidx.work is actually on the app's classpath. WorkManager is an opt-in
+    /// AndroidX dependency, not part of the platform, so an app that never referenced it has
+    /// no jobs capability at all — reporting "supported" for such an app would be a lie that
+    /// looks identical to "supported, but you have no jobs scheduled".
+    /// Probed once; the classpath cannot change while the process is alive.
+    /// </summary>
+    private static readonly Lazy<bool> s_workManagerAvailable = new(() => FindAndroidClass("androidx.work.WorkManager") != null);
+
+    /// <summary>
+    /// Resolves a Java class by name using the *application's* class loader.
+    ///
+    /// <para>
+    /// <c>Java.Lang.Class.ForName(string)</c> must not be used here. The single-argument
+    /// overload resolves against the calling class's loader, and when the call originates
+    /// from mono over JNI that is the boot class loader — which cannot see anything the app
+    /// or its AndroidX dependencies contribute. It therefore throws ClassNotFoundException
+    /// for <c>androidx.work.WorkManager</c> even in an app that plainly uses WorkManager.
+    /// </para>
+    /// </summary>
+    private static Java.Lang.Class? FindAndroidClass(string className)
+    {
+        try
+        {
+            var loader = global::Android.App.Application.Context?.ClassLoader;
+            if (loader == null) return null;
+            return Java.Lang.Class.ForName(className, initialize: false, loader);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[Microsoft.Maui.DevFlow] Java class '{className}' not resolvable: {ex.GetBaseException().Message}");
+            return null;
+        }
+    }
+
+    private const string WorkManagerMissingReason =
+        "androidx.work.WorkManager is not on the app's classpath. Add the Xamarin.AndroidX.Work.Runtime " +
+        "package (or a library that depends on it) to enable background job inspection.";
+#endif
+
     protected override bool IsJobsSupported
     {
         get
         {
-#if ANDROID || IOS || MACCATALYST
+#if ANDROID
+            // Gate on the real dependency rather than on the platform.
+            return s_workManagerAvailable.Value;
+#elif IOS || MACCATALYST
+            // BGTaskScheduler is part of the OS, so the capability always exists —
+            // whether any identifiers are registered is a separate question.
             return true;
 #else
             return base.IsJobsSupported;
@@ -317,18 +364,36 @@ public class PlatformAgentService : DevFlowAgentService
     protected override async Task<object?> GetPlatformJobsAsync()
     {
 #if ANDROID
+        // Distinguish "the app has no WorkManager" from "WorkManager returned no jobs".
+        // Both produce an empty array, and conflating them hides a missing dependency
+        // behind what looks like a healthy, idle queue.
+        if (!s_workManagerAvailable.Value)
+        {
+            return new
+            {
+                platform = "Android",
+                type = "WorkManager",
+                supported = false,
+                runSupported = false,
+                reason = WorkManagerMissingReason,
+                jobs = Array.Empty<object>()
+            };
+        }
+
         try
         {
             var context = global::Android.App.Application.Context;
-            var wmClass = Java.Lang.Class.ForName("androidx.work.WorkManager");
+            var wmClass = FindAndroidClass("androidx.work.WorkManager")!;
             var getInstanceMethod = wmClass.GetMethod("getInstance", Java.Lang.Class.FromType(typeof(global::Android.Content.Context)));
             var wm = getInstanceMethod?.Invoke(null, context);
+            // Present but not initialized is a configuration problem, not a missing capability,
+            // so this stays "supported" — the distinction tells you which thing to go fix.
             if (wm == null)
                 return new { platform = "Android", type = "WorkManager", supported = true, runSupported = false, error = "WorkManager not initialized", jobs = Array.Empty<object>() };
 
             // Build WorkQuery for all states
-            var queryBuilderClass = Java.Lang.Class.ForName("androidx.work.WorkQuery$Builder");
-            var stateClass = Java.Lang.Class.ForName("androidx.work.WorkInfo$State");
+            var queryBuilderClass = FindAndroidClass("androidx.work.WorkQuery$Builder")!;
+            var stateClass = FindAndroidClass("androidx.work.WorkInfo$State")!;
 
             var stateFields = new[] { "ENQUEUED", "RUNNING", "SUCCEEDED", "FAILED", "BLOCKED", "CANCELLED" };
             var stateList = new Java.Util.ArrayList();
@@ -348,7 +413,7 @@ public class PlatformAgentService : DevFlowAgentService
             var buildMethod = builder.Class.GetMethod("build");
             var query = buildMethod?.Invoke(builder);
 
-            var getWorkInfosMethod = wm.Class.GetMethod("getWorkInfos", Java.Lang.Class.ForName("androidx.work.WorkQuery"));
+            var getWorkInfosMethod = wm.Class.GetMethod("getWorkInfos", FindAndroidClass("androidx.work.WorkQuery")!);
             var future = getWorkInfosMethod?.Invoke(wm, query!) as Java.Lang.Object;
 
             // ListenableFuture.get()
@@ -436,7 +501,9 @@ public class PlatformAgentService : DevFlowAgentService
             success = false,
             supported = false,
             identifier,
-            error = $"Running job '{identifier}' is not supported on Android because the original WorkManager worker type and request parameters cannot be reconstructed safely from the listed identifier or tags."
+            error = s_workManagerAvailable.Value
+                ? $"Running job '{identifier}' is not supported on Android because the original WorkManager worker type and request parameters cannot be reconstructed safely from the listed identifier or tags."
+                : WorkManagerMissingReason
         });
 #elif IOS || MACCATALYST
         try

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -309,6 +309,50 @@ public class PlatformAgentService : DevFlowAgentService
     /// for <c>androidx.work.WorkManager</c> even in an app that plainly uses WorkManager.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// Re-wraps a Java object as a bound interface.
+    ///
+    /// <para>
+    /// <c>Java.Lang.Reflect.Method.Invoke</c> returns a plain <see cref="Java.Lang.Object"/>
+    /// wrapper regardless of the real runtime type, so <c>as Java.Util.IList</c> and
+    /// <c>is Java.Util.ICollection</c> always fail against it. Because those casts fail
+    /// quietly, the caller reads an empty collection instead of an error — which is exactly
+    /// how the jobs list came back empty while WorkManager plainly had work scheduled.
+    /// Re-wrapping by JNI handle produces the correctly typed proxy.
+    /// </para>
+    /// </summary>
+    private static T? AsJavaInterface<T>(Java.Lang.Object? value) where T : class, global::Android.Runtime.IJavaObject
+    {
+        if (value == null || value.Handle == IntPtr.Zero) return null;
+
+        if (value is T alreadyTyped) return alreadyTyped;
+
+        try
+        {
+            return Java.Lang.Object.GetObject<T>(value.Handle, global::Android.Runtime.JniHandleOwnership.DoNotTransfer);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[Microsoft.Maui.DevFlow] Could not re-wrap {value.Class?.Name} as {typeof(T).Name}: {ex.GetBaseException().Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// WorkManager is present but the query could not be completed. Reported as supported with
+    /// an explicit error, never as an empty job list — an empty list means "no work scheduled".
+    /// </summary>
+    private static object WorkManagerProblem(string error) => new
+    {
+        platform = "Android",
+        type = "WorkManager",
+        supported = true,
+        runSupported = false,
+        error,
+        jobs = Array.Empty<object>()
+    };
+
     private static Java.Lang.Class? FindAndroidClass(string className)
     {
         try
@@ -391,7 +435,8 @@ public class PlatformAgentService : DevFlowAgentService
             if (wm == null)
                 return new { platform = "Android", type = "WorkManager", supported = true, runSupported = false, error = "WorkManager not initialized", jobs = Array.Empty<object>() };
 
-            // Build WorkQuery for all states
+            // Query every terminal and non-terminal state — WorkQuery requires at least one
+            // filter, and the union of all states is the closest thing to "everything".
             var queryBuilderClass = FindAndroidClass("androidx.work.WorkQuery$Builder")!;
             var stateClass = FindAndroidClass("androidx.work.WorkInfo$State")!;
 
@@ -399,62 +444,91 @@ public class PlatformAgentService : DevFlowAgentService
             var stateList = new Java.Util.ArrayList();
             foreach (var fieldName in stateFields)
             {
-                var field = stateClass.GetField(fieldName);
-                var state = field?.Get(null);
+                var state = stateClass.GetField(fieldName)?.Get(null);
                 if (state != null)
                     stateList.Add(state);
             }
 
-            var fromStatesMethod = queryBuilderClass.GetMethod("fromStates", Java.Lang.Class.FromType(typeof(Java.Util.IList)));
+            if (stateList.Size() == 0)
+                return WorkManagerProblem("Could not read any androidx.work.WorkInfo$State enum values");
+
+            // The parameter type must be java.util.List. Class.FromType(typeof(Java.Util.IList))
+            // does not reliably resolve to it, so look the Java type up by name.
+            var listClass = FindAndroidClass("java.util.List");
+            if (listClass == null)
+                return WorkManagerProblem("Could not resolve java.util.List");
+
+            var fromStatesMethod = queryBuilderClass.GetMethod("fromStates", listClass);
             var builder = fromStatesMethod?.Invoke(null, stateList);
             if (builder == null)
-                return new { platform = "Android", type = "WorkManager", supported = true, runSupported = false, error = "Failed to create WorkQuery", jobs = Array.Empty<object>() };
+                return WorkManagerProblem("WorkQuery.Builder.fromStates returned null");
 
-            var buildMethod = builder.Class.GetMethod("build");
-            var query = buildMethod?.Invoke(builder);
+            var query = builder.Class.GetMethod("build")?.Invoke(builder);
+            if (query == null)
+                return WorkManagerProblem("WorkQuery.Builder.build returned null");
 
             var getWorkInfosMethod = wm.Class.GetMethod("getWorkInfos", FindAndroidClass("androidx.work.WorkQuery")!);
-            var future = getWorkInfosMethod?.Invoke(wm, query!) as Java.Lang.Object;
+            var future = getWorkInfosMethod?.Invoke(wm, query);
+            if (future == null)
+                return WorkManagerProblem("WorkManager.getWorkInfos returned null");
 
-            // ListenableFuture.get()
-            var getMethod = future?.Class.GetMethod("get");
-            var result = getMethod?.Invoke(future) as Java.Util.IList;
+            // ListenableFuture.get() blocks. Bound it here rather than via the
+            // get(long, TimeUnit) overload, whose primitive `long` parameter cannot be
+            // resolved with Class.FromType, and so a wedged future cannot hang the request.
+            var getMethod = future.Class.GetMethod("get");
+            if (getMethod == null)
+                return WorkManagerProblem("ListenableFuture has no get() method");
+
+            Java.Lang.Object? resultObject;
+            try
+            {
+                resultObject = await Task.Run(() => getMethod.Invoke(future))
+                    .WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                return WorkManagerProblem("Timed out after 5s waiting for WorkManager.getWorkInfos");
+            }
+
+            // Method.Invoke hands back a plain Java.Lang.Object wrapper, so `as Java.Util.IList`
+            // always fails and the list silently reads as empty. Re-wrap by handle instead.
+            var result = AsJavaInterface<Java.Util.IList>(resultObject);
+            if (result == null)
+                return WorkManagerProblem(
+                    $"Could not read the work-info list (got {resultObject?.Class?.Name ?? "null"})");
 
             var jobs = new List<object>();
-            if (result != null)
+            var iterator = result.Iterator();
+            while (iterator?.HasNext == true)
             {
-                var iterator = result.Iterator();
-                while (iterator.HasNext)
+                var info = iterator.Next();
+                if (info is not Java.Lang.Object infoObj) continue;
+                var infoClass = infoObj.Class;
+
+                var identifier = infoClass.GetMethod("getId")?.Invoke(infoObj)?.ToString() ?? "";
+                var state = infoClass.GetMethod("getState")?.Invoke(infoObj)?.ToString() ?? "";
+
+                var tags = new List<string>();
+                var tagSet = AsJavaInterface<Java.Util.ICollection>(infoClass.GetMethod("getTags")?.Invoke(infoObj));
+                if (tagSet != null)
                 {
-                    var info = iterator.Next()!;
-                    var infoClass = info.Class;
-
-                    var getId = infoClass.GetMethod("getId");
-                    var getTags = infoClass.GetMethod("getTags");
-                    var getState = infoClass.GetMethod("getState");
-                    var getRunAttemptCount = infoClass.GetMethod("getRunAttemptCount");
-
-                    var identifier = getId?.Invoke(info)?.ToString() ?? "";
-                    var tags = new List<string>();
-                    if (getTags?.Invoke(info) is Java.Util.ICollection tagSet)
-                    {
-                        var tagIter = tagSet.Iterator();
-                        while (tagIter.HasNext)
-                            tags.Add(tagIter.Next()?.ToString() ?? "");
-                    }
-                    var state = getState?.Invoke(info)?.ToString() ?? "";
-                    var runAttemptCount = 0;
-                    if (getRunAttemptCount?.Invoke(info) is Java.Lang.Integer countObj)
-                        runAttemptCount = countObj.IntValue();
-
-                    jobs.Add(new
-                    {
-                        identifier,
-                        tags = tags.ToArray(),
-                        state,
-                        runAttemptCount
-                    });
+                    var tagIter = tagSet.Iterator();
+                    while (tagIter?.HasNext == true)
+                        tags.Add(tagIter.Next()?.ToString() ?? "");
                 }
+
+                // Boxed primitives come back as opaque wrappers too, so parse the string form.
+                var runAttemptCount = 0;
+                var countValue = infoClass.GetMethod("getRunAttemptCount")?.Invoke(infoObj)?.ToString();
+                if (countValue != null) int.TryParse(countValue, out runAttemptCount);
+
+                jobs.Add(new
+                {
+                    identifier,
+                    tags = tags.ToArray(),
+                    state,
+                    runAttemptCount
+                });
             }
 
             return new { platform = "Android", type = "WorkManager", supported = true, runSupported = false, jobs };

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -596,7 +596,8 @@ public class PlatformAgentService : DevFlowAgentService
                 taskRequest.EarliestBeginDate = null;
 
                 BGTaskScheduler.Shared.Submit(taskRequest, out var error);
-                submitError = error?.LocalizedDescription;
+                if (error != null)
+                    submitError = $"{error.LocalizedDescription} {DescribeBgTaskSchedulerError(error, identifier)}".Trim();
             }
 
             if (submitError != null)
@@ -606,8 +607,7 @@ public class PlatformAgentService : DevFlowAgentService
                     success = false,
                     identifier,
                     type = taskType,
-                    error = $"Could not schedule BGTask '{identifier}': {submitError}. " +
-                            "BGTaskScheduler is unavailable on the iOS Simulator — background jobs require a physical device."
+                    error = $"Could not schedule BGTask '{identifier}': {submitError}"
                 };
             }
 
@@ -654,6 +654,30 @@ public class PlatformAgentService : DevFlowAgentService
     }
 
 #if IOS || MACCATALYST
+    /// <summary>
+    /// Turns a BGTaskSchedulerErrorDomain code into the thing you actually need to go fix.
+    /// The three codes have completely different causes and conflating them sends people
+    /// looking in the wrong place.
+    /// </summary>
+    private static string DescribeBgTaskSchedulerError(NSError error, string identifier)
+    {
+        if (error.Domain != "BGTaskSchedulerErrorDomain")
+            return string.Empty;
+
+        return error.Code switch
+        {
+            // BGTaskSchedulerErrorCodeUnavailable
+            1 => "Background task scheduling is unavailable. BGTaskScheduler does not work on the " +
+                 "iOS Simulator — use a physical device — and Background App Refresh must be enabled.",
+            // BGTaskSchedulerErrorCodeTooManyPendingTaskRequests
+            2 => "Too many pending task requests; cancel some before submitting another.",
+            // BGTaskSchedulerErrorCodeNotPermitted
+            3 => $"'{identifier}' is not permitted. Add it to BGTaskSchedulerPermittedIdentifiers " +
+                 "in Info.plist and register a launch handler for it before the app finishes launching.",
+            _ => string.Empty
+        };
+    }
+
     private static async Task<bool> IsBgTaskPendingAsync(string identifier)
     {
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
@@ -342,6 +342,135 @@ public class AndroidAppDriver : AppDriverBase
     }
 
     // ──────────────────────────────────────────────
+    // ──────────────────────────────────────────────
+    // Background jobs (WorkManager via JobScheduler)
+    // ──────────────────────────────────────────────
+
+    /// <summary>
+    /// The JobScheduler namespace WorkManager schedules into. Job lookups and the run command
+    /// both need it — without <c>-n</c> the job simply is not found.
+    /// </summary>
+    public const string WorkManagerNamespace = "androidx.work.systemjobscheduler";
+
+    /// <summary>
+    /// Lists the app's scheduled JobScheduler jobs by parsing <c>dumpsys jobscheduler</c>.
+    ///
+    /// <para>
+    /// This is the host-side counterpart to the in-app WorkManager query. It sees what the
+    /// system actually has scheduled rather than what the app's WorkManager database believes,
+    /// and it needs no cooperation from the app — but it reports JobScheduler's view, so the
+    /// identifier is a numeric job id rather than a WorkSpec UUID.
+    /// </para>
+    /// </summary>
+    public async Task<IReadOnlyList<AndroidScheduledJob>> ListScheduledJobsAsync(string packageName)
+    {
+        var dump = await RunAdbWithOutputAsync("shell dumpsys jobscheduler");
+        return ParseScheduledJobs(dump, packageName);
+    }
+
+    /// <summary>
+    /// Parses <c>dumpsys jobscheduler</c> output. Entries look like:
+    /// <code>
+    /// JOB androidx.work.systemjobscheduler:u0a233/1: 258ed68 #SampleSyncWorker#@androidx.work.systemjobscheduler@com.pkg/androidx.work.impl.background.systemjob.SystemJobService
+    /// JOB #1000/808: cb8ff9f android/com.android.server.MountServiceIdler
+    /// </code>
+    /// The namespaced form carries the WorkManager worker name in <c>#…#</c>.
+    /// </summary>
+    internal static IReadOnlyList<AndroidScheduledJob> ParseScheduledJobs(string dumpsysOutput, string packageName)
+    {
+        var jobs = new List<AndroidScheduledJob>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        // Two shapes occur, and both must parse:
+        //   JOB <namespace>:<uid>/<jobId>: <hash> #<worker>#@<namespace>@<package>/<service>
+        //   JOB #<uid>/<jobId>: <hash> <package>/<service>          (no namespace)
+        var pattern = new System.Text.RegularExpressions.Regex(
+            @"JOB\s+(?:(?<ns>[A-Za-z0-9_.\-]+):)?#?u?(?<uid>[0-9a-z]+)/(?<jobId>-?\d+):\s+\S+\s+(?<detail>.*)",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        foreach (var rawLine in dumpsysOutput.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith("JOB ", StringComparison.Ordinal)) continue;
+            if (!line.Contains(packageName, StringComparison.Ordinal)) continue;
+
+            var match = pattern.Match(line);
+            if (!match.Success) continue;
+
+            var detail = match.Groups["detail"].Value;
+            var jobId = match.Groups["jobId"].Value;
+
+            // A namespace appears as a "<ns>:" prefix, and again as "@<ns>@" inside the detail.
+            // The plain "JOB #<uid>/<id>" form has neither.
+            string? ns = match.Groups["ns"].Success && match.Groups["ns"].Value.Length > 0
+                ? match.Groups["ns"].Value
+                : null;
+            if (ns == null)
+            {
+                var atMatch = System.Text.RegularExpressions.Regex.Match(detail, @"@(?<ns>[^@]+)@");
+                if (atMatch.Success) ns = atMatch.Groups["ns"].Value;
+            }
+
+            var workerMatch = System.Text.RegularExpressions.Regex.Match(detail, @"#(?<worker>[^#]+)#");
+            var worker = workerMatch.Success ? workerMatch.Groups["worker"].Value : null;
+
+            var serviceMatch = System.Text.RegularExpressions.Regex.Match(
+                detail, System.Text.RegularExpressions.Regex.Escape(packageName) + @"/(?<service>\S+)");
+            var service = serviceMatch.Success ? serviceMatch.Groups["service"].Value : null;
+
+            var key = $"{ns}|{jobId}";
+            if (!seen.Add(key)) continue;
+
+            jobs.Add(new AndroidScheduledJob
+            {
+                JobId = jobId,
+                Namespace = ns,
+                Worker = worker,
+                Service = service,
+                IsWorkManager = ns == WorkManagerNamespace
+                    || service?.Contains("androidx.work", StringComparison.Ordinal) == true
+            });
+        }
+
+        return jobs;
+    }
+
+    /// <summary>
+    /// Returns JobScheduler's view of a job: pending / active / ready / waiting, etc.
+    /// </summary>
+    public async Task<string> GetJobStateAsync(string packageName, string jobId, string? jobNamespace = WorkManagerNamespace)
+    {
+        var ns = string.IsNullOrWhiteSpace(jobNamespace) ? "" : $"-n {jobNamespace} ";
+        var output = await RunAdbWithOutputAsync($"shell cmd jobscheduler get-job-state {ns}{packageName} {jobId}");
+        return output.Trim();
+    }
+
+    /// <summary>
+    /// Forces a scheduled job to run now.
+    /// </summary>
+    /// <param name="force">
+    /// Ignore unmet constraints. Required for anything with a delay or a network/charging
+    /// requirement, which is most real work; without it JobScheduler declines.
+    /// </param>
+    public async Task<string> RunScheduledJobAsync(string packageName, string jobId, string? jobNamespace = WorkManagerNamespace, bool force = true)
+    {
+        var ns = string.IsNullOrWhiteSpace(jobNamespace) ? "" : $"-n {jobNamespace} ";
+        var flag = force ? "-f " : "";
+        var output = await RunAdbWithOutputAsync($"shell cmd jobscheduler run {flag}{ns}{packageName} {jobId}");
+        return output.Trim();
+    }
+
+    /// <summary>
+    /// Stops a running job, delivering the given stop reason so <c>onStopped</c> paths are testable.
+    /// </summary>
+    public async Task<string> StopScheduledJobAsync(string packageName, string jobId, string? jobNamespace = WorkManagerNamespace)
+    {
+        var ns = string.IsNullOrWhiteSpace(jobNamespace) ? "" : $"-n {jobNamespace} ";
+        var output = await RunAdbWithOutputAsync($"shell cmd jobscheduler stop {ns}{packageName} {jobId}");
+        return output.Trim();
+    }
+
+    // ──────────────────────────────────────────────
     // adb helpers
     // ──────────────────────────────────────────────
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidScheduledJob.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidScheduledJob.cs
@@ -1,0 +1,32 @@
+namespace Microsoft.Maui.DevFlow.Driver;
+
+/// <summary>
+/// A job as JobScheduler sees it, parsed from <c>dumpsys jobscheduler</c>.
+///
+/// <para>
+/// This is deliberately JobScheduler's view rather than WorkManager's: it is what the system
+/// will actually run, it needs no cooperation from the app, and <see cref="JobId"/> is the
+/// numeric id that <c>cmd jobscheduler run</c> requires. The in-app WorkManager query returns
+/// the richer WorkSpec view (UUID, tags, state) — the two are complementary.
+/// </para>
+/// </summary>
+public sealed class AndroidScheduledJob
+{
+    /// <summary>Numeric JobScheduler id — the one <c>cmd jobscheduler run</c> takes.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>JobScheduler namespace, e.g. <c>androidx.work.systemjobscheduler</c>. Null when unnamespaced.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Worker class name from the job's debug tag, when WorkManager scheduled it.</summary>
+    public string? Worker { get; init; }
+
+    /// <summary>The service that will run the job, e.g. WorkManager's SystemJobService.</summary>
+    public string? Service { get; init; }
+
+    /// <summary>Whether this job was scheduled by WorkManager rather than direct JobScheduler use.</summary>
+    public bool IsWorkManager { get; init; }
+
+    public override string ToString() =>
+        $"{JobId}{(Worker is null ? "" : $" ({Worker})")}{(Namespace is null ? "" : $" [{Namespace}]")}";
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AndroidJobParsingTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AndroidJobParsingTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+/// <summary>
+/// Parsing of <c>adb shell dumpsys jobscheduler</c>. Real captured output — the format is
+/// load-bearing: the numeric job id and the namespace are both required by
+/// <c>cmd jobscheduler run</c>, and without the namespace the job is simply not found.
+/// </summary>
+public class AndroidJobParsingTests
+{
+    private const string Package = "com.companyname.mauitodo";
+
+    // Captured verbatim from an Android API 37 emulator.
+    private const string Dumpsys = """
+          JOB androidx.work.systemjobscheduler:u0a233/1: 258ed68 #SampleSyncWorker#@androidx.work.systemjobscheduler@com.companyname.mauitodo/androidx.work.impl.background.systemjob.SystemJobService
+            u0a233 tag=*job*r/#SampleSyncWorker#@androidx.work.systemjobscheduler@com.companyname.mauitodo/androidx.work.impl.background.systemjob.SystemJobService
+              Service: com.companyname.mauitodo/androidx.work.impl.background.systemjob.SystemJobService
+            JobStatus{258ed68 androidx.work.systemjobscheduler:u0a233/1 #SampleSyncWorker#@androidx.work.systemjobscheduler@com.companyname.mauitodo/androidx.work.impl.background.systemjob.SystemJobService u=0 s=10233 TIME=+23h59m9s913ms:none satisfied:0x3600000 unsatisfied:0x80000000}: 108722023
+          JOB #1000/808: cb8ff9f android/com.android.server.MountServiceIdler
+          JOB androidx.work.systemjobscheduler:u0a148/160: ef63ebc #LanguagePackAutoUpdateWorker#@androidx.work.systemjobscheduler@com.google.android.as/androidx.work.impl.background.systemjob.SystemJobService
+        """;
+
+    [Fact]
+    public void ParseScheduledJobs_FindsOnlyTheRequestedPackage()
+    {
+        var jobs = AndroidAppDriver.ParseScheduledJobs(Dumpsys, Package);
+
+        // The Google app's WorkManager job and the system MountServiceIdler must not leak in.
+        Assert.Single(jobs);
+        Assert.Equal("1", jobs[0].JobId);
+    }
+
+    [Fact]
+    public void ParseScheduledJobs_ExtractsNamespaceRequiredByRunCommand()
+    {
+        var job = AndroidAppDriver.ParseScheduledJobs(Dumpsys, Package).Single();
+
+        Assert.Equal(AndroidAppDriver.WorkManagerNamespace, job.Namespace);
+        Assert.True(job.IsWorkManager);
+    }
+
+    [Fact]
+    public void ParseScheduledJobs_ExtractsWorkerNameFromDebugTag()
+    {
+        var job = AndroidAppDriver.ParseScheduledJobs(Dumpsys, Package).Single();
+
+        // WorkSpec UUIDs are invisible to JobScheduler, so the worker name in the #…# debug
+        // tag is what lets a caller map a WorkManager job onto a numeric job id.
+        Assert.Equal("SampleSyncWorker", job.Worker);
+        Assert.Contains("SystemJobService", job.Service);
+    }
+
+    [Fact]
+    public void ParseScheduledJobs_DeduplicatesRepeatedEntries()
+    {
+        // dumpsys mentions the same job again under "Pending queue" / "Active jobs" sections.
+        var doubled = Dumpsys + "\n" + Dumpsys;
+
+        Assert.Single(AndroidAppDriver.ParseScheduledJobs(doubled, Package));
+    }
+
+    [Fact]
+    public void ParseScheduledJobs_ReturnsEmptyWhenPackageHasNoJobs()
+    {
+        Assert.Empty(AndroidAppDriver.ParseScheduledJobs(Dumpsys, "com.example.absent"));
+    }
+
+    [Fact]
+    public void ParseScheduledJobs_HandlesUnnamespacedJobs()
+    {
+        const string plain =
+            "  JOB #1000/808: cb8ff9f com.companyname.mauitodo/com.example.PlainJobService";
+
+        var job = AndroidAppDriver.ParseScheduledJobs(plain, Package).Single();
+
+        Assert.Equal("808", job.JobId);
+        Assert.Null(job.Namespace);
+        Assert.False(job.IsWorkManager);
+    }
+}


### PR DESCRIPTION
## Why

DevFlow's background-job API (`/api/v1/device/jobs`, `maui_jobs_list`, `maui_jobs_run`) was wired end to end but had never actually returned a job. Nothing in the repo exercised it: `DevFlow.Sample` registers no WorkManager Worker and no BGTask, so `Jobs_ReturnsSupportedFlagAndJobArray` asserted only *shape* — `supported` is a bool, `jobs` is an array. An empty array from a total failure passed identically to a working query.

Putting real jobs in the sample turned up three genuine bugs and one platform limit that were invisible until something real was on the other end. All three are fixed here.

## What this fixes

### 1. Android reported `supported: true` when WorkManager was absent

`IsJobsSupported` was hardcoded `true` for Android. WorkManager is an opt-in AndroidX dependency, not part of the platform, so an app that never referenced it was told the capability existed. Worse, the failure path *also* returned `supported: true` with an `error`, so a missing dependency was indistinguishable from a healthy, idle queue.

Now gated on an actual classpath probe, and three states are distinguishable:

| State | Response |
|---|---|
| WorkManager absent | `supported: false` + `reason` naming the package to add |
| Present, not initialized | `supported: true` + `error: "WorkManager not initialized"` |
| Present and queried | `supported: true` + jobs |

"Present but uninitialized" stays `supported: true` deliberately — that's a config problem in an app that *does* have the capability, and separating it from "dependency missing" tells you which thing to go fix.

### 2. `Java.Lang.Class.ForName(string)` could never find WorkManager — in any app

This is the more serious one, and it only surfaced once the sample genuinely had WorkManager: the agent *still* reported "not on the classpath".

The single-argument `Class.ForName` overload resolves against the **calling class's** loader. When the call originates from mono over JNI, that is the boot class loader, which cannot see anything the app or its AndroidX dependencies contribute. It throws `ClassNotFoundException` for `androidx.work.WorkManager` even in an app plainly using WorkManager.

All four call sites now resolve through `Application.Context.ClassLoader` via a `FindAndroidClass` helper. Verified on an emulator: `supported` flips to `true` once the app really has WorkManager.

### 3. Nothing to test against

- **Android** — `SampleSyncWorker`, a real `Worker` enqueued on launch with a long initial delay so it sits pending in JobScheduler rather than firing on its own. It records run count / result / timestamp in `Preferences` so a test can assert the job *executed*, not merely that it was triggered. Supports an input flag to force the failure path.
- **iOS** — `SampleBackgroundTask`, a real `BGProcessingTaskRequest` with a registered handler, `BGTaskSchedulerPermittedIdentifiers` and `UIBackgroundModes` added to `Info.plist`, and registration wired into `AppDelegate.FinishedLaunching` (it must happen before that returns). Exposed through `[DevFlowAction]`s so the whole flow is drivable over the existing invoke API.

### 4. Tests that can fail

The old test asserted only that `supported` was a bool and `jobs` was an array, which a totally broken query satisfies. Now:

- `Jobs_Android_ListsTheSampleWorker` asserts the sample worker actually comes back — by tag, with a non-empty UUID and a valid state. This is the assertion that exercises the reflection path; shape-only checks passed indefinitely while the query silently returned nothing.
- Any `error` in the payload now fails the test outright, so a degraded query can't pass as an idle queue.
- `Jobs_UnsupportedCapability_IsReportedConsistently` cross-checks the jobs list against the capabilities document, so a caller feature-detecting one way can't get a different answer than one reading the other.

### 5. Android job listing returned `[]` even with work scheduled

The third bug, and the one that made the feature useless. `Java.Lang.Reflect.Method.Invoke` hands back a plain `Java.Lang.Object` wrapper regardless of the real runtime type, so `as Java.Util.IList` and `is Java.Util.ICollection` **always** failed. The null checks then swallowed the result — an unreachable list was indistinguishable from an idle queue.

- Reflected results are re-wrapped by JNI handle (`AsJavaInterface`) so the work-info list and tag set bind to their real types.
- Boxed primitives are read via their string form; they are opaque wrappers too.
- `java.util.List` is resolved by name — `Class.FromType(typeof(Java.Util.IList))` does not reliably map to it.
- `ListenableFuture.get()` is bounded with a 5s timeout in C# rather than the `get(long, TimeUnit)` overload, whose primitive `long` parameter cannot be resolved by `Class.FromType`.
- **Every failure path now returns an explicit `error`.** An empty `jobs` array now means exactly one thing: no work is scheduled.

## Verified on real hardware

**Android emulator (API 37)** — forcing a WorkManager job over adb works, end to end:

```
GET /api/v1/device/jobs
  { "supported": true, "jobs": [ { "identifier": "c7c3961d-4c6d-49eb-aee1-2266229871ee",
                                   "tags": ["devflow-sample-sync", "…SampleSyncWorker"],
                                   "state": "ENQUEUED", "runAttemptCount": 0 } ] }

$ adb shell cmd jobscheduler run -f -n androidx.work.systemjobscheduler com.companyname.mauitodo 3
Running job [FORCED]

logcat: WM-WorkerWrapper: Worker result SUCCESS for Work [ id=…, tags={…, devflow-sample-sync} ]

GET /api/v1/device/jobs
  { … "state": "SUCCEEDED", "runAttemptCount": 1 }
```

The full loop — list, trigger, observe the outcome — now works on Android.

Notes for whoever builds on this: the `-n androidx.work.systemjobscheduler` namespace is **required** (WorkManager schedules into it; without `-n` the job isn't found), job ids are small per-app integers that must be read from `dumpsys jobscheduler` rather than assumed, and `cmd jobscheduler` also offers `get-job-state`, `stop` and `timeout` — so the `onStopped` and expiration paths are reachable too.

**iPhone 15 Pro / iOS 26.6** — the full BGTask chain:

```
[DevFlow.Sample] BGTask schedule: submitted

GET /api/v1/device/jobs
  { "supported": true, "runSupported": true,
    "jobs": [ { "identifier": "com.companyname.mauitodo.sync",
                "type": "processing",
                "earliestBeginDate": "2026-08-16 20:53:51 +0000" } ] }

POST /invoke/actions/bgtask-simulate-launch
[DevFlow.Sample] BGTask 'com.companyname.mauitodo.sync' executed.
  run count 0 → 1 · pending jobs 1 → 0   (request consumed, exactly as a real launch)
```

This is the first time the iOS listing path has returned a real job. Reaching the agent over USB needs `iproxy 19226:19226` — `devicectl` has no port forwarding, which is worth knowing for any physical-device DevFlow work, not just jobs.

**iOS Simulator — BGTasks do not work at all.** `BGTaskScheduler.Submit` fails with `BGTaskSchedulerErrorCodeUnavailable (1)`. Handlers register fine; nothing after that works, `GetPending` is permanently empty, and there is nothing for a simulated launch to find. **iOS background-job testing requires a physical device**; it cannot run on simulator CI. That is a platform constraint, not something DevFlow can engineer around.

*(If you ever see `NotPermitted (3)` instead: the incremental iOS build silently fails to re-copy `Info.plist` into the app bundle. Check the bundle's plist, not the source.)*

Also run: 226 DevFlow unit tests, 463 CLI unit tests, and the `DeviceTests` integration suite on both an Android emulator (13/13) and an iOS Simulator (13/13). Android and iOS sample builds clean.

## CLI: list and run

`maui devflow ui jobs list` and `maui devflow ui jobs run <id>`. Listing worked over the agent but had no CLI surface, so it was effectively unusable. Running reports the real outcome, and `run` returns its own exit code so it is usable as a CI assertion.

```
$ maui devflow ui jobs list
Android / WorkManager: 1 job(s)
  3025764d-c312-478c-8847-b154e8e7ae5a
    state:    ENQUEUED
    attempts: 0
    tags:     devflow-sample-sync, crc6448dcefd8c32368e1.SampleSyncWorker

$ maui devflow ui jobs run 3025764d-c312-478c-8847-b154e8e7ae5a
Forced job 9 (SampleSyncWorker) via adb — Running job [FORCED]
SUCCESS: SUCCEEDED after 1 attempt(s)                                    # exit 0

$ maui devflow ui jobs list          # on iPhone 15 Pro
iOS / BGTaskScheduler: 1 job(s)
  com.companyname.mauitodo.sync
    type:     processing
    earliest: 2026-08-16 21:50:38 +0000

$ maui devflow ui jobs run com.companyname.mauitodo.sync
SUCCESS: BGTask 'com.companyname.mauitodo.sync' was launched and its pending request was consumed.
```

**Android** — a job cannot be forced from inside the app, because the original `WorkRequest` cannot be reconstructed from a `WorkInfo`. adb can force it through JobScheduler, so `jobs run` triggers host-side and then polls the in-app WorkManager query for the terminal state — the only place the real SUCCEEDED/FAILED result lives. `AndroidAppDriver` gains `ListScheduledJobsAsync`, `GetJobStateAsync`, `RunScheduledJobAsync` and `StopScheduledJobAsync`; the `dumpsys` parser handles both the namespaced and plain job forms and is unit tested against captured emulator output. A WorkManager UUID is mapped to its numeric job id via the worker name WorkManager auto-tags onto every request.

**iOS** — `RunPlatformJobAsync` schedules the request only if it is not already pending, then forces the launch with `_simulateLaunchForTaskWithIdentifier:`. Submitting alone only *schedules*; iOS may never launch it. Success is judged by the pending request being consumed, which is the observable evidence a launch really happened. **The selector is compiled out of Release builds** — the agent ships inside consumer apps and App Store review scans for private selectors, so release builds can schedule but not trigger. The advertised capability is gated on the same condition: `runSupported` and the `run` feature both read `false` in a Release agent, so a caller feature-detecting the operation never gets an answer the binary cannot honour.

All four outcome paths verified on hardware:

| | result | exit |
|---|---|---|
| Android, succeeding worker | `SUCCESS: SUCCEEDED after 1 attempt(s)` | 0 |
| Android, failing worker | `FAILED: FAILED after 1 attempt(s)` | 1 |
| iOS, registered identifier | `SUCCESS: … pending request was consumed` | 0 |
| iOS, unregistered identifier | `FAILED: … not permitted. Add it to BGTaskSchedulerPermittedIdentifiers …` | 1 |

Two further fixes came out of that verification. Every BGTask submit failure had been reported as "unavailable on the iOS Simulator", true only for error code 1 — a real device returning code 3 (NotPermitted) was being blamed on the simulator. The three codes now map to their actual causes. And `jobs run` exited 0 on failure, because `_errorOccurred` is only consumed by the batch-script path; `jobs run` now returns its own exit code. That pre-existing behaviour is left alone for every other command rather than changing CLI-wide exit semantics here.

## Known gaps — deliberately not fixed here

- **The agent's `runSupported` flag still reads `false` on Android**, which is accurate for the in-app API but understates what the CLI can do via adb. Worth reconciling into a richer capability shape.
- **`maui devflow ui jobs list` needs an explicit `--agent-port`.** The option defaults to 9223 while the sample's agent starts on 9225, and the mismatch surfaces as `{"error":"Operation is not valid due to the current state of the object."}`, which says nothing about the real cause. Pre-existing and not specific to jobs.

## Dependency note

`Xamarin.AndroidX.Work.Runtime` is pinned to **2.10.0.5**, the newest version whose *complete* dependency graph is available on this repo's feeds.

`NuGet.config` clears all sources and restores from the dnceng feeds alone. From WorkManager 2.10.1 on, the graph pulls Room 2.7+, which AndroidX split into KMP-style sub-packages — `Room.Runtime.Android`, `Room.Common.JVM`, `Sqlite.Android`, `Sqlite.Framework.Android`. Those are **not mirrored to dotnet-public**, so a cold restore fails with NU1101 even though the same restore succeeds on a machine with a warm package cache. Room 2.6.x, which 2.10.0.5 uses, predates the split.

Two follow-on problems came with that pin, both settled by referencing the matching 1.3.0 packages the MAUI baseline already resolves:

| Problem | Cause | Fix |
|---|---|---|
| NU1107 | 2.10.0.5 wants `Concurrent.Futures.Ktx` 1.2.0.7, constraining the base to `< 1.2.1`, while its own `Core` dependency wants the base `>= 1.3.0.1` | reference `Concurrent.Futures.Ktx` 1.3.0.1 |
| D8 dexing | *"androidx.tracing.TraceKt$traceAsync$1 is defined multiple times"* — the same ktx-merged-into-base collision seen with Core 1.19 | reference `Tracing.Tracing.Ktx` 1.3.0.1 |

`Lifecycle.Service` is matched to the baseline `Lifecycle.Runtime` for the same reason, which clears the last NU1608. Rationale is documented inline in `eng/Versions.props`; revisit once the Room/Sqlite platform packages are mirrored, which would allow moving back to the 2.11 line.

Verified with an **empty package cache against the approved feeds only** — the CI condition — restore and Android build succeed with no errors and no NuGet warnings.

## Re-verified after the version change

Downgrading WorkManager moves Room from 2.8.x to 2.6.x, and Room is where WorkManager stores job state and input data, so the whole loop was re-run on an emulator (Pixel 9a, API 37):

```
GET /api/v1/device/jobs
  { "supported": true, "runSupported": false,
    "jobs": [ { "identifier": "b232656a-25aa-4fb2-a316-e955f8f65b59",
                "tags": ["devflow-sample-sync", "…SampleSyncWorker"],
                "state": "ENQUEUED", "runAttemptCount": 0 } ] }

$ maui devflow ui jobs run b232656a-… --agent-port 9225
Forced job 0 (SampleSyncWorker) via adb — Running job [FORCED]
SUCCESS: SUCCEEDED after 1 attempt(s)                                    # exit 0
```

`/api/v1/agent/capabilities` agrees with the listing (`supported: true`, `features: ["list"]`), and all four `jobs run` outcome paths still return the exit codes in the table above.

The part that actually mattered is what the worker recorded for itself, since that is the evidence the job *executed* rather than merely being triggered:

```
worker-last-result   success  →  failure     (after a shouldFail=true run)
worker-run-count     11       →  12
worker-last-run-utc  2026-08-31T12:16:26.5953422Z
```

The `shouldFail` flag round-tripped through Room storage into `DoWork`, the body ran, and the outcome came back out through the reflected query — so the older Room line carries the feature intact.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

