### PR TITLE
fix(devflow): invoke API crashes on Android when any DevFlowAction exists

### DIFF
--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowActionAttribute.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowActionAttribute.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Maui.DevFlow.Agent.Core;
 /// </list>
 ///
 /// <para>
-/// Methods must be <c>public static</c>. Return type should be <c>void</c>,
+/// Methods must be <c>public static</c> and must not contain generic parameters; this excludes
+/// generic methods and methods declared on generic types. Return type should be <c>void</c>,
 /// <c>Task</c>, or <c>Task&lt;T&gt;</c> where T is a supported type or any
 /// type whose <c>ToString()</c> produces a meaningful result.
 /// </para>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Invoke.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Invoke.cs
@@ -69,8 +69,12 @@ public partial class DevFlowAgentService
 			{
 				foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
 				{
+					if (method.ContainsGenericParameters)
+						continue;
+
 					var attr = method.GetCustomAttribute<DevFlowActionAttribute>();
-					if (attr == null) continue;
+					if (attr == null)
+						continue;
 
 					actions.Add(new InvokeActionEntry
 					{
@@ -137,19 +141,19 @@ public partial class DevFlowAgentService
 		if (string.IsNullOrEmpty(assemblyLocation) || string.IsNullOrEmpty(appBaseDirectory))
 			return false;
 
-		// Empty, not null, when the location carries no directory component.
-		var directory = Path.GetDirectoryName(assemblyLocation);
-		if (string.IsNullOrEmpty(directory))
-			return false;
-
 		try
 		{
+			// Empty, not null, when the location carries no directory component.
+			var directory = Path.GetDirectoryName(assemblyLocation);
+			if (string.IsNullOrEmpty(directory))
+				return false;
+
 			return string.Equals(
 				Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar),
 				Path.GetFullPath(appBaseDirectory).TrimEnd(Path.DirectorySeparatorChar),
 				StringComparison.OrdinalIgnoreCase);
 		}
-		catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+		catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or System.Security.SecurityException)
 		{
 			// Malformed or non-filesystem paths are not worth failing action discovery over.
 			return false;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Invoke.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Invoke.cs
@@ -116,15 +116,44 @@ public partial class DevFlowAgentService
 			.First();
 
 	private static bool IsAssemblyInAppBaseDirectory(Assembly assembly)
+		=> IsInAppBaseDirectory(assembly.Location, AppContext.BaseDirectory);
+
+	/// <summary>
+	/// Whether an assembly location sits in the app base directory. This is only a tie-breaker
+	/// for ranking duplicate action names, so anything it cannot determine is simply "no".
+	///
+	/// <para>
+	/// It must never throw. Every DevFlow action is ranked through here, so an exception takes
+	/// down <c>GET /api/v1/invoke/actions</c> and every <c>POST …/actions/{name}</c> with it.
+	/// On Android, assemblies loaded from the APK report a bare file name with no directory
+	/// component, and <see cref="Path.GetDirectoryName(string)"/> returns an empty string rather
+	/// than null for those — which the previous <c>?? string.Empty</c> could not catch, so
+	/// <see cref="Path.GetFullPath(string)"/> threw
+	/// <c>ArgumentException: The value cannot be an empty string. (Parameter 'path')</c>.
+	/// </para>
+	/// </summary>
+	internal static bool IsInAppBaseDirectory(string? assemblyLocation, string? appBaseDirectory)
 	{
-		var location = assembly.Location;
-		if (string.IsNullOrEmpty(location))
+		if (string.IsNullOrEmpty(assemblyLocation) || string.IsNullOrEmpty(appBaseDirectory))
 			return false;
 
-		return string.Equals(
-			Path.GetFullPath(Path.GetDirectoryName(location) ?? string.Empty).TrimEnd(Path.DirectorySeparatorChar),
-			Path.GetFullPath(AppContext.BaseDirectory).TrimEnd(Path.DirectorySeparatorChar),
-			StringComparison.OrdinalIgnoreCase);
+		// Empty, not null, when the location carries no directory component.
+		var directory = Path.GetDirectoryName(assemblyLocation);
+		if (string.IsNullOrEmpty(directory))
+			return false;
+
+		try
+		{
+			return string.Equals(
+				Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar),
+				Path.GetFullPath(appBaseDirectory).TrimEnd(Path.DirectorySeparatorChar),
+				StringComparison.OrdinalIgnoreCase);
+		}
+		catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+		{
+			// Malformed or non-filesystem paths are not worth failing action discovery over.
+			return false;
+		}
 	}
 
 	private static InvokeParameterInfo[] BuildParameterInfoList(MethodInfo method)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Analyzers/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,4 @@ MAUI_DFA002 | DevFlow | Error | [DevFlowAction] method must be public static
 MAUI_DFA003 | DevFlow | Warning | Return type may not serialize cleanly
 MAUI_DFA004 | DevFlow | Info | Parameter missing [Description] attribute
 MAUI_DFA005 | DevFlow | Warning | Duplicate [DevFlowAction] name
+MAUI_DFA006 | DevFlow | Error | [DevFlowAction] method must not contain generic parameters

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Analyzers/DevFlowActionAnalyzer.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Analyzers/DevFlowActionAnalyzer.cs
@@ -68,8 +68,18 @@ public sealed class DevFlowActionAnalyzer : DiagnosticAnalyzer
 		description: "Each [DevFlowAction] name must be unique. At runtime, duplicate names cause the second registration to be silently ignored.",
 		customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 
+	// MAUI_DFA006: Must not contain generic parameters
+	private static readonly DiagnosticDescriptor MustNotContainGenericParameters = new(
+		id: "MAUI_DFA006",
+		title: "[DevFlowAction] method must not contain generic parameters",
+		messageFormat: "Method '{0}' cannot be a DevFlow Action because it is generic or is declared on a generic type",
+		category: "DevFlow",
+		defaultSeverity: DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: "DevFlow Actions are invoked without type arguments and therefore cannot contain generic parameters.");
+
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-		ImmutableArray.Create(UnsupportedParameterType, MustBePublicStatic, ReturnTypeMayNotSerialize, MissingParameterDescription, DuplicateActionName);
+		ImmutableArray.Create(UnsupportedParameterType, MustBePublicStatic, ReturnTypeMayNotSerialize, MissingParameterDescription, DuplicateActionName, MustNotContainGenericParameters);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -132,6 +142,15 @@ public sealed class DevFlowActionAnalyzer : DiagnosticAnalyzer
 				method.Name));
 		}
 
+		// DFA006: Reflection cannot invoke an open generic method.
+		if (method.IsGenericMethod || HasGenericContainingType(method.ContainingType))
+		{
+			context.ReportDiagnostic(Diagnostic.Create(
+				MustNotContainGenericParameters,
+				method.Locations.FirstOrDefault(),
+				method.Name));
+		}
+
 		// DFA001 + DFA004: Check parameters
 		foreach (var param in method.Parameters)
 		{
@@ -162,6 +181,17 @@ public sealed class DevFlowActionAnalyzer : DiagnosticAnalyzer
 				method.Locations.FirstOrDefault(),
 				returnType.ToDisplayString()));
 		}
+	}
+
+	private static bool HasGenericContainingType(INamedTypeSymbol? type)
+	{
+		for (var current = type; current != null; current = current.ContainingType)
+		{
+			if (current.IsGenericType)
+				return true;
+		}
+
+		return false;
 	}
 
 	private static string? GetDevFlowActionName(IMethodSymbol method)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/DevFlowActionAnalyzerTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/DevFlowActionAnalyzerTests.cs
@@ -117,6 +117,46 @@ public class DevFlowActionAnalyzerTests
 	}
 
 	[Fact]
+	public async Task DFA006_GenericMethod_ReportsDiagnostic()
+	{
+		const string source = """
+			using Microsoft.Maui.DevFlow.Agent.Core;
+
+			public static class Actions
+			{
+				[DevFlowAction("generic-action")]
+				public static void {|#0:GenericAction|}<T>() { }
+			}
+			""";
+
+		var expected = new DiagnosticResult("MAUI_DFA006", DiagnosticSeverity.Error)
+			.WithLocation(0)
+			.WithArguments("GenericAction");
+
+		await CreateTest(source, expected).RunAsync();
+	}
+
+	[Fact]
+	public async Task DFA006_MethodOnGenericType_ReportsDiagnostic()
+	{
+		const string source = """
+			using Microsoft.Maui.DevFlow.Agent.Core;
+
+			public static class Actions<T>
+			{
+				[DevFlowAction("generic-type-action")]
+				public static void {|#0:GenericTypeAction|}() { }
+			}
+			""";
+
+		var expected = new DiagnosticResult("MAUI_DFA006", DiagnosticSeverity.Error)
+			.WithLocation(0)
+			.WithArguments("GenericTypeAction");
+
+		await CreateTest(source, expected).RunAsync();
+	}
+
+	[Fact]
 	public async Task DFA003_ComplexReturnType_ReportsWarning()
 	{
 		const string source = """

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/InvokeActionRankingTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/InvokeActionRankingTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Maui.DevFlow.Agent.Core;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+/// <summary>
+/// The app-base-directory tie-breaker used when ranking DevFlow actions.
+///
+/// <para>
+/// Every action is ranked through this helper, so throwing here takes down the whole invoke
+/// API. It ran fine on desktop and iOS but crashed on Android, where assemblies loaded from
+/// the APK report a bare file name with no directory component.
+/// </para>
+/// </summary>
+public class InvokeActionRankingTests
+{
+    [Theory]
+    // The Android case: Path.GetDirectoryName returns "" (not null) for a bare file name,
+    // and Path.GetFullPath("") throws ArgumentException.
+    [InlineData("Microsoft.Maui.DevFlow.Agent.Core.dll", "/data/user/0/com.example.app/files")]
+    // Assemblies embedded in a single-file bundle report no location at all.
+    [InlineData("", "/data/user/0/com.example.app/files")]
+    [InlineData(null, "/data/user/0/com.example.app/files")]
+    // AppContext.BaseDirectory is not guaranteed to be populated on every host.
+    [InlineData("/data/user/0/com.example.app/files/App.dll", "")]
+    [InlineData("/data/user/0/com.example.app/files/App.dll", null)]
+    public void IsInAppBaseDirectory_ReturnsFalseInsteadOfThrowing(string? location, string? baseDirectory)
+    {
+        // The contract that matters is "never throw" — action discovery must survive
+        // any assembly whose location it cannot make sense of.
+        var result = Record.Exception(() => DevFlowAgentService.IsInAppBaseDirectory(location, baseDirectory));
+
+        Assert.Null(result);
+        Assert.False(DevFlowAgentService.IsInAppBaseDirectory(location, baseDirectory));
+    }
+
+    [Fact]
+    public void IsInAppBaseDirectory_MatchesWhenAssemblySitsInTheBaseDirectory()
+    {
+        var baseDir = Path.GetDirectoryName(typeof(DevFlowAgentService).Assembly.Location);
+        Assert.False(string.IsNullOrEmpty(baseDir));
+
+        var assemblyPath = Path.Combine(baseDir!, "Some.Assembly.dll");
+
+        Assert.True(DevFlowAgentService.IsInAppBaseDirectory(assemblyPath, baseDir));
+    }
+
+    [Fact]
+    public void IsInAppBaseDirectory_IgnoresTrailingSeparatorDifferences()
+    {
+        var baseDir = Path.GetDirectoryName(typeof(DevFlowAgentService).Assembly.Location)!;
+        var assemblyPath = Path.Combine(baseDir, "Some.Assembly.dll");
+
+        Assert.True(DevFlowAgentService.IsInAppBaseDirectory(assemblyPath, baseDir + Path.DirectorySeparatorChar));
+    }
+
+    [Fact]
+    public void IsInAppBaseDirectory_DoesNotMatchADifferentDirectory()
+    {
+        var baseDir = Path.GetDirectoryName(typeof(DevFlowAgentService).Assembly.Location)!;
+        var elsewhere = Path.Combine(baseDir, "plugins", "Other.Assembly.dll");
+
+        Assert.False(DevFlowAgentService.IsInAppBaseDirectory(elsewhere, baseDir));
+    }
+
+    [Fact]
+    public void IsInAppBaseDirectory_ToleratesMalformedPaths()
+    {
+        // Not a filesystem path at all; must be rejected rather than thrown on.
+        Assert.False(DevFlowAgentService.IsInAppBaseDirectory("::::/not/a/path\0/x.dll", "/tmp"));
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/InvokeTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/InvokeTests.cs
@@ -39,6 +39,21 @@ public class InvokeTests
 	}
 
 	[Fact]
+	public async Task ListActions_DoesNotAdvertiseActionsContainingGenericParameters()
+	{
+		using var harness = await InvokeTestHarness.CreateAsync();
+
+		var actions = await harness.Client.ListActionsAsync();
+		var actionNames = actions.GetProperty("actions")
+			.EnumerateArray()
+			.Select(action => action.GetProperty("name").GetString())
+			.ToArray();
+
+		Assert.DoesNotContain("test-generic-method", actionNames);
+		Assert.DoesNotContain("test-generic-type", actionNames);
+	}
+
+	[Fact]
 	public async Task InvokeAction_CallsRegisteredAction_ReturnsResult()
 	{
 		using var harness = await InvokeTestHarness.CreateAsync();
@@ -496,6 +511,19 @@ public static class TestInvokeHelpers
 	public static string FormatNullable(
 		[System.ComponentModel.Description("Nullable value")] int? value)
 		=> value.HasValue ? value.Value.ToString() : "null";
+
+	[DevFlowAction("test-generic-method")]
+	public static void GenericMethod<T>()
+	{
+	}
+}
+
+public static class GenericTestInvokeHelpers<T>
+{
+	[DevFlowAction("test-generic-type")]
+	public static void GenericTypeMethod()
+	{
+	}
 }
 
 public enum Priority


### PR DESCRIPTION
Fixes #433

## The bug

On Android, the whole invoke API fails as soon as the app declares **any** `[DevFlowAction]`:

```
GET  /api/v1/invoke/actions          → empty response
POST /api/v1/invoke/actions/{name}   → empty response

logcat: [Microsoft.Maui.DevFlow.Agent] Request error:
        ArgumentException: The value cannot be an empty string. (Parameter 'path')
```

`Path.GetDirectoryName` returns an **empty string, not null**, when a path has no directory component, so the `?? string.Empty` never fired and `Path.GetFullPath("")` threw. Android assemblies loaded from the APK report a bare file name with no directory, so this was hit on every request. `AppContext.BaseDirectory` is likewise not guaranteed to be populated and would fail identically.

The blast radius is wider than the helper looks. `SelectPreferredAction` is applied by `ScanActions` to **every** action group, not just duplicated names:

```csharp
return actions
    .GroupBy(a => a.Name, StringComparer.OrdinalIgnoreCase)
    .Select(SelectPreferredAction)     // ← every action, even a single one
    .ToArray();
```

So one unrankable assembly failed discovery entirely — and since `s_cachedActions` is a `Lazy<T>` created with `ExecutionAndPublication`, the faulted result was cached and every subsequent request rethrew it.

## The fix

This value is only a **tie-breaker for ordering duplicate action names**. It should never be able to fail a request, so it now guards both empty inputs and swallows malformed-path exceptions.

The path comparison is extracted into `internal static bool IsInAppBaseDirectory(string?, string?)` so the logic is testable without a device — the previous form needed a real `Assembly` with a pathological `Location`, which is why it had no coverage.

## Why this was never caught

There is **no `[DevFlowAction]` anywhere in `samples/` or `playground/`** on `main`, and the crash only fires when at least one action exists. With zero actions the ranking code is never reached, so everything passed. The first action added to the sample broke the endpoint immediately.

## Tests

9 new tests in `InvokeActionRankingTests`, covering the Android bare-filename case, empty and null locations, empty and null base directories, malformed paths, and the positive match and trailing-separator cases.

I verified they actually catch the bug rather than just passing: reverting the helper to the previous implementation fails **4 of the 9**; the fix takes it back to 9/9. Full suite 233/233.

## Device verification

Android emulator, API 37 (Pixel 9a), with a `[DevFlowAction]` present:

```
$ curl .../api/v1/invoke/actions
{ "actions": [ { "name": "workmanager-enqueue", "declaringType": "DevFlow.Sample.SampleSyncWorker",
                 "parameters": [ { "name": "shouldFail", "type": "bool", … } ] } ] }

$ curl -X POST .../api/v1/invoke/actions/workmanager-enqueue -d '{"args":[true]}'
{ "success": true, "returnValue": "enqueued 'devflow-sample-sync' (shouldFail=True)" }

logcat "empty string" errors: 0
```

## Note on scope

The sample app still declares no `[DevFlowAction]`, so this endpoint remains uncovered by the integration suite on `main`. #432 adds the first ones (`workmanager-enqueue`, and the iOS BGTask actions) — that is the branch I used to reproduce and verify this fix, since a bare `main` cannot trigger the bug at all. Worth adding a sample action plus an integration assertion regardless of which PR lands first, so this cannot regress silently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
