### PR TITLE
Add focus-safe macOS capture and cross-platform dialog automation

### DIFF
--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -86,6 +86,7 @@ If the tool calls a new agent endpoint, add the client method in `Microsoft.Maui
 | `JobTools.cs` | `maui_jobs_list`, `maui_jobs_run` | Background jobs |
 | `LogsTool.cs` | `maui_logs` | Log retrieval |
 | `NavigationTools.cs` | `maui_navigate`, `maui_back`, `maui_focus`, `maui_resize` | Navigation & window |
+| `NativeDialogTools.cs` | `maui_native_dialog_detect`, `maui_native_dialog_respond` | Focus-safe macOS native dialog handling |
 | `NetworkTool.cs` | `maui_network`, `maui_network_detail`, `maui_network_clear` | Network inspection |
 | `PlatformTools.cs` | `maui_app_info`, `maui_device_info`, `maui_display_info`, `maui_battery_info`, `maui_connectivity`, `maui_geolocation` | Device/app info |
 | `PreferencesTools.cs` | `maui_preferences_list`, `maui_preferences_get`, `maui_preferences_set`, `maui_preferences_delete`, `maui_preferences_clear`, `maui_secure_storage_get`, `maui_secure_storage_set`, `maui_secure_storage_delete`, `maui_secure_storage_clear` | Storage |

--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -86,7 +86,7 @@ If the tool calls a new agent endpoint, add the client method in `Microsoft.Maui
 | `JobTools.cs` | `maui_jobs_list`, `maui_jobs_run` | Background jobs |
 | `LogsTool.cs` | `maui_logs` | Log retrieval |
 | `NavigationTools.cs` | `maui_navigate`, `maui_back`, `maui_focus`, `maui_resize` | Navigation & window |
-| `NativeDialogTools.cs` | `maui_native_dialog_detect`, `maui_native_dialog_respond` | Focus-safe macOS native dialog handling |
+| `NativeDialogTools.cs` | `maui_native_dialog_detect`, `maui_native_dialog_respond` | Cross-platform native dialog detection and confirmed response |
 | `NetworkTool.cs` | `maui_network`, `maui_network_detail`, `maui_network_clear` | Network inspection |
 | `PlatformTools.cs` | `maui_app_info`, `maui_device_info`, `maui_display_info`, `maui_battery_info`, `maui_connectivity`, `maui_geolocation` | Device/app info |
 | `PreferencesTools.cs` | `maui_preferences_list`, `maui_preferences_get`, `maui_preferences_set`, `maui_preferences_delete`, `maui_preferences_clear`, `maui_secure_storage_get`, `maui_secure_storage_set`, `maui_secure_storage_delete`, `maui_secure_storage_clear` | Storage |

--- a/.github/workflows/devflow-integration.yml
+++ b/.github/workflows/devflow-integration.yml
@@ -278,6 +278,10 @@ jobs:
         # rotate out of the feeds -- which is exactly how tvos broke the Windows job.
         run: dotnet workload install maui ios macos maccatalyst android wasm-tools --version ${{ env.DOTNET_WORKLOAD_VERSION }}
 
+      - name: Install Apple simulator automation tool
+        if: matrix.framework == 'maui'
+        run: dotnet tool install --global AppleDev.Tools --version 0.8.10
+
       - name: List available iOS simulators
         run: xcrun simctl list devices available
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ Each product requires source setup **and** CI/CD configuration across two system
 
 ## DevFlow MCP Tools
 
-DevFlow exposes 67 MCP tools for AI agent integration (in `src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/`):
+DevFlow exposes 69 MCP tools for AI agent integration (in `src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/`):
 
 | Tool | Purpose |
 |------|---------|
@@ -261,6 +261,8 @@ DevFlow exposes 67 MCP tools for AI agent integration (in `src/Cli/Microsoft.Mau
 | `maui_list_agents` | List connected MAUI DevFlow agents (running apps) |
 | `maui_logs` | Retrieve app logs (ILogger + WebView console) |
 | `maui_navigate` | Shell navigation to a route |
+| `maui_native_dialog_detect` | Detect app or macOS permission dialogs without changing focus |
+| `maui_native_dialog_respond` | Invoke an exact confirmed dialog button using AXPress |
 | `maui_network` | List captured HTTP requests |
 | `maui_network_clear` | Clear captured request buffer |
 | `maui_network_detail` | Full request/response details |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,8 +261,8 @@ DevFlow exposes 69 MCP tools for AI agent integration (in `src/Cli/Microsoft.Mau
 | `maui_list_agents` | List connected MAUI DevFlow agents (running apps) |
 | `maui_logs` | Retrieve app logs (ILogger + WebView console) |
 | `maui_navigate` | Shell navigation to a route |
-| `maui_native_dialog_detect` | Detect app or macOS permission dialogs without changing focus |
-| `maui_native_dialog_respond` | Invoke an exact confirmed dialog button using AXPress |
+| `maui_native_dialog_detect` | Detect app or system permission dialogs without changing host focus |
+| `maui_native_dialog_respond` | Invoke an exact confirmed dialog button with safe platform automation |
 | `maui_network` | List captured HTTP requests |
 | `maui_network_clear` | Clear captured request buffer |
 | `maui_network_detail` | Full request/response details |

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/NativeDialogToolsTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/NativeDialogToolsTests.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class NativeDialogToolsTests
+{
+    [Fact]
+    public async Task Respond_WithoutUserConfirmation_RequiresUserAction()
+    {
+        var json = await NativeDialogTools.Respond(
+            null!,
+            "reviewed-prompt",
+            "Allow",
+            confirmedByUser: false);
+        using var document = JsonDocument.Parse(json);
+
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(document.RootElement.GetProperty("userActionRequired").GetBoolean());
+        Assert.Contains(
+            "confirm",
+            document.RootElement.GetProperty("instruction").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -4176,24 +4176,9 @@ public class DevFlowCommands
             var appName = status?.App?.Name ?? status?.AppName;
             if (!string.IsNullOrWhiteSpace(appName))
             {
-                foreach (var process in System.Diagnostics.Process.GetProcesses())
-                {
-                    using (process)
-                    {
-                        try
-                        {
-                            if (process.ProcessName.Equals(appName, StringComparison.OrdinalIgnoreCase) ||
-                                process.ProcessName.Contains(appName, StringComparison.OrdinalIgnoreCase))
-                            {
-                                return process.Id;
-                            }
-                        }
-                        catch
-                        {
-                            // A process may exit or deny metadata access while enumerating.
-                        }
-                    }
-                }
+                var matchedProcessId = Microsoft.Maui.DevFlow.Driver.ProcessNameResolver.FindUniqueProcessId(appName);
+                if (matchedProcessId.HasValue)
+                    return matchedProcessId.Value;
             }
         }
         catch { }
@@ -4315,6 +4300,13 @@ public class DevFlowCommands
 
             if (plat == "maccatalyst")
             {
+                if (string.IsNullOrWhiteSpace(buttonLabel))
+                {
+                    throw new ArgumentException(
+                        "An exact button label is required when dismissing a macOS alert. Run 'maui devflow ui alert detect' and pass one of its visible button labels.",
+                        nameof(buttonLabel));
+                }
+
                 var resolvedPid = await ResolveMacCatalystPidAsync(pid, host, port);
                 var driver = new Microsoft.Maui.DevFlow.Driver.MacCatalystAppDriver { ProcessId = resolvedPid };
                 alert = await driver.HandleAlertIfPresentAsync(buttonLabel);

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -764,7 +764,7 @@ public class DevFlowCommands
         // dismiss
         var dismissUdid = new Option<string?>("--udid") { Description = "Simulator UDID (auto-detects booted simulator if omitted)" };
         var dismissPid = new Option<int?>("--pid") { Description = "Mac Catalyst app PID (auto-detects if omitted)" };
-        var dismissButtonArg = new Argument<string?>("button") { Description = "Button label to tap (default: first accept-style button)", DefaultValueFactory = _ => null };
+        var dismissButtonArg = new Argument<string?>("button") { Description = "Exact visible button label to invoke (required on macOS)", DefaultValueFactory = _ => null };
         var alertDismissCmd = new Command("dismiss", "Dismiss the current alert/dialog") { dismissButtonArg, dismissUdid, dismissPid };
         alertDismissCmd.SetAction(async (ctx, ct) =>
         {
@@ -4170,14 +4170,30 @@ public class DevFlowCommands
         {
             using var client = await CreateAgentClientAsync(host, port);
             var status = await client.GetStatusAsync();
+            if (status?.App?.ProcessId is int processId)
+                return processId;
+
             var appName = status?.App?.Name ?? status?.AppName;
             if (!string.IsNullOrWhiteSpace(appName))
             {
-                // Find process by app name
-                var pgrepResult = await ProcessRunner.RunAsync("pgrep", new[] { "-f", appName });
-                var lines = pgrepResult.StandardOutput.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries);
-                if (lines.Length > 0 && int.TryParse(lines[0].Trim(), out var resolved))
-                    return resolved;
+                foreach (var process in System.Diagnostics.Process.GetProcesses())
+                {
+                    using (process)
+                    {
+                        try
+                        {
+                            if (process.ProcessName.Equals(appName, StringComparison.OrdinalIgnoreCase) ||
+                                process.ProcessName.Contains(appName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                return process.Id;
+                            }
+                        }
+                        catch
+                        {
+                            // A process may exit or deny metadata access while enumerating.
+                        }
+                    }
+                }
             }
         }
         catch { }
@@ -4269,11 +4285,20 @@ public class DevFlowCommands
             Output.WriteResult(new JsonObject
             {
                 ["detected"] = true,
+                ["promptId"] = alert.PromptId,
                 ["title"] = alert.Title,
-                ["buttons"] = buttons
+                ["text"] = new JsonArray(alert.Text.Select(text => (JsonNode)text).ToArray()),
+                ["buttons"] = buttons,
+                ["sourceProcessId"] = alert.SourceProcessId,
+                ["sourceProcessName"] = alert.SourceProcessName,
+                ["isSystemDialog"] = alert.IsSystemDialog,
+                ["requiresUserConfirmation"] = alert.RequiresUserConfirmation,
+                ["canRespond"] = alert.CanRespond
             }, json, _ =>
             {
                 Console.WriteLine($"Alert: {alert.Title ?? "(no title)"}");
+                if (!string.IsNullOrEmpty(alert.SourceProcessName))
+                    Console.WriteLine($"  Source: {alert.SourceProcessName} ({alert.SourceProcessId})");
                 foreach (var btn in alert.Buttons)
                     Console.WriteLine($"  Button: \"{btn.Label}\"");
             });

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpAgentSession.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpAgentSession.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Maui.Cli.DevFlow.Broker;
 using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Maui.DevFlow.Driver;
@@ -8,6 +9,7 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp;
 public class McpAgentSession
 {
 	int? _defaultAgentPort;
+	readonly ConcurrentDictionary<int, string> _androidSerialByAgentPort = new();
 
 	public int? DefaultAgentPort
 	{
@@ -30,6 +32,9 @@ public class McpAgentSession
 			await TryEnsureAndroidForwardingForAgentPortAsync(port, ensureBrokerReverse: false);
 		return new AgentClient(DefaultAgentHost, port);
 	}
+
+	public string? GetAndroidDeviceSerial(int agentPort)
+		=> _androidSerialByAgentPort.GetValueOrDefault(agentPort);
 
 	public void SetDefaultAgent(AgentRegistration agent)
 	{
@@ -101,20 +106,37 @@ public class McpAgentSession
 		return agents?.FirstOrDefault(a => a.Port == agentPort);
 	}
 
-	static async Task TryEnsureAndroidForwardingAsync(int[] agentPorts, bool ensureBrokerReverse)
+	async Task TryEnsureAndroidForwardingAsync(int[] agentPorts, bool ensureBrokerReverse)
 	{
 		if (!AndroidDevFlowPortForwarder.IsAdbLikelyAvailable())
 			return;
 
 		try
 		{
-			await AndroidDevFlowPortForwarder.CreateDefault().EnsureAsync(new AndroidDevFlowForwardingRequest
+			var report = await AndroidDevFlowPortForwarder.CreateDefault().EnsureAsync(new AndroidDevFlowForwardingRequest
 			{
 				AgentPorts = agentPorts,
 				EnsureBrokerReverse = ensureBrokerReverse,
 				BrokerPort = BrokerClient.ReadBrokerPortPublic() ?? Broker.BrokerServer.DefaultPort,
 				Repair = true
 			});
+			var confirmedPorts = report.AgentForwards
+				.Where(static forward => forward.PresentAfter)
+				.Select(static forward => forward.Port)
+				.ToHashSet();
+			foreach (var agentPort in agentPorts)
+			{
+				if (report.IsReady
+					&& !string.IsNullOrWhiteSpace(report.SelectedSerial)
+					&& confirmedPorts.Contains(agentPort))
+				{
+					_androidSerialByAgentPort[agentPort] = report.SelectedSerial;
+				}
+				else
+				{
+					_androidSerialByAgentPort.TryRemove(agentPort, out _);
+				}
+			}
 		}
 		catch (Exception ex)
 		{

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -65,6 +65,7 @@ public static class McpServerHost
 			.WithTools<FileTools>()
 			.WithTools<BatchTools>()
 			.WithTools<InvokeTools>()
+			.WithTools<NativeDialogTools>()
 			.WithTools<ExtensionTools>();
 
 		await builder.Build().RunAsync();

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NativeDialogTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NativeDialogTools.cs
@@ -71,6 +71,22 @@ public sealed class NativeDialogTools
                 ["platform"] = target.Platform
             });
         }
+        if (target.Kind == DialogPlatformKind.Android)
+        {
+            using var androidDriver = new AndroidAppDriver { Serial = target.AndroidDevice };
+            var attributedToTarget = dialog.IsSystemDialog
+                ? AndroidAppDriver.PermissionPromptNamesTarget(
+                    dialog.Title,
+                    target.AppName ?? string.Empty)
+                : !string.IsNullOrWhiteSpace(target.PackageId)
+                    && await androidDriver.IsTargetAppForegroundAsync(target.PackageId);
+            if (!attributedToTarget)
+            {
+                return SerializeManualAction(
+                    "The visible Android dialog could not be safely attributed to the connected app.",
+                    "dialog-attribution-failed");
+            }
+        }
 
         var platformPromptId = dialog.PromptId;
         var canRespond = dialog.CanRespond || target.Kind != DialogPlatformKind.MacOS;
@@ -201,18 +217,6 @@ public sealed class NativeDialogTools
                 }
                 else
                 {
-                    if (lease.Target.Kind == DialogPlatformKind.Android)
-                    {
-                        using var androidDriver = new AndroidAppDriver { Serial = lease.Target.AndroidDevice };
-                        if (string.IsNullOrWhiteSpace(lease.Target.PackageId)
-                            || !await androidDriver.IsTargetAppForegroundAsync(lease.Target.PackageId))
-                        {
-                            return SerializeResponseManualAction(
-                                "The connected Android app is no longer focused. Detect the prompt again after returning to that app.",
-                                "target-app-not-focused");
-                        }
-                    }
-
                     var currentDialog = await DetectDialogAsync(lease.Target);
                     if (currentDialog is null)
                     {
@@ -292,10 +296,6 @@ public sealed class NativeDialogTools
             }
             if (string.IsNullOrWhiteSpace(status.App?.PackageId))
                 return DialogTarget.Unsupported(platform, identity, "The connected Android agent did not report its package identifier.");
-
-            using var driver = new AndroidAppDriver { Serial = selectedDevice };
-            if (!await driver.IsTargetAppForegroundAsync(status.App.PackageId))
-                return DialogTarget.Unsupported(platform, identity, "The connected Android app is not the focused app behind the visible system UI.");
 
             return new DialogTarget(
                 DialogPlatformKind.Android,
@@ -399,7 +399,9 @@ public sealed class NativeDialogTools
                         dialog,
                         buttonLabel,
                         target.PackageId
-                            ?? throw new McpException("The Android dialog target has no package identifier."));
+                            ?? throw new McpException("The Android dialog target has no package identifier."),
+                        target.AppName
+                            ?? throw new McpException("The Android dialog target has no app name."));
             case DialogPlatformKind.IosSimulator:
                 using (var driver = new iOSSimulatorAppDriver
                 {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NativeDialogTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NativeDialogTools.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text.Json.Nodes;
 using Microsoft.Maui.DevFlow.Driver;
@@ -274,7 +273,7 @@ public sealed class NativeDialogTools
         var identity = CreateTargetIdentity(agent.BaseUrl, status);
         if (platform.Contains("mac", StringComparison.OrdinalIgnoreCase))
         {
-            var processId = status.App?.ProcessId ?? FindProcessId(status.AppName);
+            var processId = status.App?.ProcessId ?? ProcessNameResolver.FindUniqueProcessId(status.AppName);
             return processId.HasValue
                 ? new DialogTarget(DialogPlatformKind.MacOS, platform, identity, "ax-press", processId, status.AppName, status.App?.PackageId, null, null, agent.BaseUrl)
                 : DialogTarget.Unsupported(platform, identity, "Unable to determine the connected macOS app process.");
@@ -314,7 +313,7 @@ public sealed class NativeDialogTools
         if (platform.Contains("windows", StringComparison.OrdinalIgnoreCase)
             || platform.Contains("winui", StringComparison.OrdinalIgnoreCase))
         {
-            var processId = status.App?.ProcessId ?? FindProcessId(status.AppName);
+            var processId = status.App?.ProcessId ?? ProcessNameResolver.FindUniqueProcessId(status.AppName);
             return processId.HasValue
                 ? new DialogTarget(DialogPlatformKind.Windows, platform, identity, "uia-invoke", processId, status.AppName, status.App?.PackageId, null, null, agent.BaseUrl)
                 : DialogTarget.Unsupported(platform, identity, "Unable to determine the connected Windows app process.");
@@ -523,40 +522,6 @@ public sealed class NativeDialogTools
                     sibling.Dispose();
             }
         }
-    }
-
-    private static int? FindProcessId(string? appName)
-    {
-        if (string.IsNullOrWhiteSpace(appName))
-            return null;
-
-        var candidates = new List<(int ProcessId, string ProcessName)>();
-        foreach (var process in Process.GetProcesses())
-        {
-            using (process)
-            {
-                try
-                {
-                    if (process.ProcessName.Equals(appName, StringComparison.OrdinalIgnoreCase)
-                        || process.ProcessName.Contains(appName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        candidates.Add((process.Id, process.ProcessName));
-                    }
-                }
-                catch
-                {
-                    // A process may exit or deny metadata access while enumerating.
-                }
-            }
-        }
-
-        var exactMatches = candidates
-            .Where(candidate => candidate.ProcessName.Equals(appName, StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-        if (exactMatches.Length == 1)
-            return exactMatches[0].ProcessId;
-
-        return candidates.Count == 1 ? candidates[0].ProcessId : null;
     }
 
     private enum DialogPlatformKind

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NativeDialogTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NativeDialogTools.cs
@@ -1,0 +1,171 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json.Nodes;
+using Microsoft.Maui.DevFlow.Driver;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class NativeDialogTools
+{
+    [McpServerTool(Name = "maui_native_dialog_detect"), Description(
+        "Detect an app-owned or macOS system permission dialog using Accessibility APIs without changing focus or sending input. " +
+        "If a dialog is returned, pause and ask the user which exact button to press before calling maui_native_dialog_respond.")]
+    public static async Task<string> Detect(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent is connected)")] int? agentPort = null)
+    {
+        using var driver = await CreateMacDriverAsync(session, agentPort);
+        if (!driver.IsAccessibilityAuthorized())
+        {
+            return Serialize(new JsonObject
+            {
+                ["detected"] = false,
+                ["canRespond"] = false,
+                ["userActionRequired"] = true,
+                ["reason"] = "accessibility-permission-required",
+                ["instruction"] = "Pause and ask the user to grant macOS Accessibility access to the terminal or host running maui. Do not use mouse, keyboard, focus, osascript, or CGEvent fallbacks."
+            });
+        }
+
+        var dialog = await driver.DetectAlertAsync();
+        if (dialog is null)
+        {
+            return Serialize(new JsonObject
+            {
+                ["detected"] = false,
+                ["canRespond"] = false,
+                ["userActionRequired"] = false
+            });
+        }
+
+        var result = CreateDialogJson(dialog);
+        result["detected"] = true;
+        result["userActionRequired"] = true;
+        result["instruction"] = dialog.CanRespond
+            ? "Pause and ask the user which exact button to press. After they answer, call maui_native_dialog_respond with this promptId, the exact button label, and confirmedByUser=true."
+            : "This system dialog could not be safely attributed to the connected app. Pause and ask the user to respond manually. Do not call maui_native_dialog_respond.";
+        return Serialize(result);
+    }
+
+    [McpServerTool(Name = "maui_native_dialog_respond"), Description(
+        "Invoke AXPress on an exact button of the exact native dialog returned by maui_native_dialog_detect. " +
+        "Call only after the user explicitly confirms the button choice. Never infer consent for permission prompts.")]
+    public static async Task<string> Respond(
+        McpAgentSession session,
+        [Description("Prompt fingerprint returned by maui_native_dialog_detect")] string promptId,
+        [Description("Exact visible button label chosen by the user, such as Allow or Don't Allow")] string buttonLabel,
+        [Description("Must be true only after the user explicitly confirmed this exact button choice")] bool confirmedByUser,
+        [Description("Agent HTTP port (optional if only one agent is connected)")] int? agentPort = null)
+    {
+        if (!confirmedByUser)
+        {
+            return Serialize(new JsonObject
+            {
+                ["success"] = false,
+                ["userActionRequired"] = true,
+                ["instruction"] = "Pause and ask the user to confirm the exact button. Do not press a permission button without confirmation."
+            });
+        }
+
+        using var driver = await CreateMacDriverAsync(session, agentPort);
+        if (!driver.IsAccessibilityAuthorized())
+        {
+            return Serialize(new JsonObject
+            {
+                ["success"] = false,
+                ["userActionRequired"] = true,
+                ["reason"] = "accessibility-permission-required",
+                ["instruction"] = "Pause and ask the user to grant macOS Accessibility access to the terminal or host running maui."
+            });
+        }
+
+        var action = await driver.PressAlertButtonAsync(promptId, buttonLabel);
+        var result = new JsonObject
+        {
+            ["success"] = action.Success,
+            ["userActionRequired"] = action.UserActionRequired,
+            ["message"] = action.Message
+        };
+        if (action.Dialog is not null)
+            result["dialog"] = CreateDialogJson(action.Dialog);
+        return Serialize(result);
+    }
+
+    private static JsonObject CreateDialogJson(AlertInfo dialog)
+        => new()
+        {
+            ["promptId"] = dialog.PromptId,
+            ["title"] = dialog.Title,
+            ["text"] = new JsonArray(dialog.Text.Select(text => (JsonNode?)text).ToArray()),
+            ["buttons"] = new JsonArray(dialog.Buttons.Select(button => (JsonNode?)button.Label).ToArray()),
+            ["sourceProcessId"] = dialog.SourceProcessId,
+            ["sourceProcessName"] = dialog.SourceProcessName,
+            ["isSystemDialog"] = dialog.IsSystemDialog,
+            ["canRespond"] = dialog.CanRespond
+        };
+
+    private static string Serialize(JsonObject value)
+        => CliJson.SerializeUntyped(value, indented: false);
+
+    private static async Task<MacCatalystAppDriver> CreateMacDriverAsync(
+        McpAgentSession session,
+        int? agentPort)
+    {
+        if (!OperatingSystem.IsMacOS())
+            throw new McpException("Native macOS dialog interaction is only available on macOS.");
+
+        using var agent = await session.GetAgentClientAsync(agentPort);
+        var status = await agent.GetStatusAsync()
+            ?? throw new McpException("Unable to read agent status.");
+        var platform = status.Platform ?? string.Empty;
+        if (!platform.Contains("mac", StringComparison.OrdinalIgnoreCase))
+            throw new McpException($"Native macOS dialog interaction is unavailable for platform '{platform}'.");
+
+        var processId = status.App?.ProcessId ?? FindProcessId(status.AppName);
+        if (!processId.HasValue)
+            throw new McpException("Unable to determine the connected macOS app process.");
+
+        return new MacCatalystAppDriver
+        {
+            ProcessId = processId,
+            AppName = status.App?.Name ?? status.AppName
+        };
+    }
+
+    private static int? FindProcessId(string? appName)
+    {
+        if (string.IsNullOrWhiteSpace(appName))
+            return null;
+
+        var candidates = new List<(int ProcessId, string ProcessName)>();
+        foreach (var process in Process.GetProcesses())
+        {
+            using (process)
+            {
+                try
+                {
+                    if (process.ProcessName.Equals(appName, StringComparison.OrdinalIgnoreCase) ||
+                        process.ProcessName.Contains(appName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        candidates.Add((process.Id, process.ProcessName));
+                    }
+                }
+                catch
+                {
+                    // A process may exit or deny metadata access while enumerating.
+                }
+            }
+        }
+
+        var exactMatches = candidates
+            .Where(candidate => candidate.ProcessName.Equals(appName, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (exactMatches.Length == 1)
+            return exactMatches[0].ProcessId;
+
+        return candidates.Count == 1 ? candidates[0].ProcessId : null;
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NativeDialogTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/NativeDialogTools.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Security.Cryptography;
 using System.Text.Json.Nodes;
 using Microsoft.Maui.DevFlow.Driver;
 using ModelContextProtocol;
@@ -10,56 +12,127 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class NativeDialogTools
 {
+    private static readonly ConcurrentDictionary<string, DialogLease> DialogLeases = new();
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> TargetLocks = new();
+    private static readonly TimeSpan DialogLeaseLifetime = TimeSpan.FromMinutes(2);
+
     [McpServerTool(Name = "maui_native_dialog_detect"), Description(
-        "Detect an app-owned or macOS system permission dialog using Accessibility APIs without changing focus or sending input. " +
+        "Detect an app-owned or system permission dialog without changing host focus or sending host keyboard/pointer input. " +
+        "Supports macOS AppKit/Mac Catalyst, Windows, Android, iOS Simulator, and Linux when their safe platform automation is available. " +
         "If a dialog is returned, pause and ask the user which exact button to press before calling maui_native_dialog_respond.")]
     public static async Task<string> Detect(
         McpAgentSession session,
-        [Description("Agent HTTP port (optional if only one agent is connected)")] int? agentPort = null)
+        [Description("Agent HTTP port (optional if only one agent is connected)")] int? agentPort = null,
+        [Description("Android adb device/emulator serial to validate against the device mapped to this agent. Usually omitted.")] string? androidDevice = null,
+        [Description("iOS Simulator UDID to validate against the simulator reported by this agent. Usually omitted.")] string? simulatorUdid = null)
     {
-        using var driver = await CreateMacDriverAsync(session, agentPort);
-        if (!driver.IsAccessibilityAuthorized())
+        using var agent = await session.GetAgentClientAsync(agentPort);
+        var status = await agent.GetStatusAsync()
+            ?? throw new McpException("Unable to read agent status.");
+        var target = await CreateTargetAsync(session, agent, status, androidDevice, simulatorUdid);
+        if (!target.CanDetect)
+            return SerializeManualAction(target.UnsupportedReason!);
+
+        var targetLock = TargetLocks.GetOrAdd(target.TargetIdentity, static _ => new SemaphoreSlim(1, 1));
+        await targetLock.WaitAsync();
+        try
         {
-            return Serialize(new JsonObject
+            return await DetectForTargetAsync(target);
+        }
+        finally
+        {
+            targetLock.Release();
+        }
+    }
+
+    private static async Task<string> DetectForTargetAsync(DialogTarget target)
+    {
+        if (target.Kind == DialogPlatformKind.MacOS && !OperatingSystem.IsMacOS())
+            return SerializeManualAction("macOS native dialog automation requires running maui on macOS.");
+
+        if (target.Kind == DialogPlatformKind.MacOS)
+        {
+            using var macDriver = CreateMacDriver(target);
+            if (!macDriver.IsAccessibilityAuthorized())
             {
-                ["detected"] = false,
-                ["canRespond"] = false,
-                ["userActionRequired"] = true,
-                ["reason"] = "accessibility-permission-required",
-                ["instruction"] = "Pause and ask the user to grant macOS Accessibility access to the terminal or host running maui. Do not use mouse, keyboard, focus, osascript, or CGEvent fallbacks."
-            });
+                return SerializeManualAction(
+                    "Grant macOS Accessibility access to the terminal or host running maui, then retry.",
+                    "accessibility-permission-required");
+            }
         }
 
-        var dialog = await driver.DetectAlertAsync();
+        var dialog = await DetectDialogAsync(target);
         if (dialog is null)
         {
             return Serialize(new JsonObject
             {
                 ["detected"] = false,
                 ["canRespond"] = false,
-                ["userActionRequired"] = false
+                ["userActionRequired"] = false,
+                ["platform"] = target.Platform
             });
         }
 
-        var result = CreateDialogJson(dialog);
+        var platformPromptId = dialog.PromptId;
+        var canRespond = dialog.CanRespond || target.Kind != DialogPlatformKind.MacOS;
+        dialog = dialog with
+        {
+            CanRespond = canRespond,
+            RequiresUserConfirmation = true
+        };
+
+        if (canRespond)
+        {
+            var promptId = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+            var fingerprint = NativeDialogIdentity.CreateFingerprint(
+                target.Platform,
+                target.TargetIdentity,
+                dialog);
+            var lease = new DialogLease(
+                platformPromptId,
+                target,
+                fingerprint,
+                DateTimeOffset.UtcNow.Add(DialogLeaseLifetime),
+                platformPromptId is null
+                    ? null
+                    : () => MacCatalystAppDriver.CancelAlertResponse(platformPromptId));
+            RemoveMatchingDialogLeases(target.TargetIdentity, fingerprint);
+            if (!DialogLeases.TryAdd(promptId, lease))
+                throw new McpException("Unable to create a unique native-dialog response token.");
+            _ = ExpireDialogLeaseAsync(promptId);
+            dialog = dialog with { PromptId = promptId };
+        }
+
+        var result = CreateDialogJson(dialog, target);
         result["detected"] = true;
         result["userActionRequired"] = true;
-        result["instruction"] = dialog.CanRespond
+        result["instruction"] = canRespond
             ? "Pause and ask the user which exact button to press. After they answer, call maui_native_dialog_respond with this promptId, the exact button label, and confirmedByUser=true."
-            : "This system dialog could not be safely attributed to the connected app. Pause and ask the user to respond manually. Do not call maui_native_dialog_respond.";
+            : "This dialog cannot be safely automated on the current platform. Pause and ask the user to respond manually.";
         return Serialize(result);
     }
 
     [McpServerTool(Name = "maui_native_dialog_respond"), Description(
-        "Invoke AXPress on an exact button of the exact native dialog returned by maui_native_dialog_detect. " +
+        "Invoke an exact button on the exact native dialog returned by maui_native_dialog_detect, using the safest platform primitive available. " +
+        "Uses AXPress on macOS, UI Automation Invoke on Windows, app-agent actions on Linux, and device/simulator-scoped input on Android/iOS Simulator. " +
         "Call only after the user explicitly confirms the button choice. Never infer consent for permission prompts.")]
     public static async Task<string> Respond(
         McpAgentSession session,
-        [Description("Prompt fingerprint returned by maui_native_dialog_detect")] string promptId,
+        [Description("One-time prompt token returned by maui_native_dialog_detect")] string promptId,
         [Description("Exact visible button label chosen by the user, such as Allow or Don't Allow")] string buttonLabel,
         [Description("Must be true only after the user explicitly confirmed this exact button choice")] bool confirmedByUser,
         [Description("Agent HTTP port (optional if only one agent is connected)")] int? agentPort = null)
     {
+        if (string.IsNullOrWhiteSpace(promptId) || string.IsNullOrWhiteSpace(buttonLabel))
+        {
+            return Serialize(new JsonObject
+            {
+                ["success"] = false,
+                ["userActionRequired"] = true,
+                ["instruction"] = "Provide the one-time promptId and an exact visible button label from maui_native_dialog_detect."
+            });
+        }
+
         if (!confirmedByUser)
         {
             return Serialize(new JsonObject
@@ -70,31 +143,298 @@ public sealed class NativeDialogTools
             });
         }
 
-        using var driver = await CreateMacDriverAsync(session, agentPort);
-        if (!driver.IsAccessibilityAuthorized())
-        {
-            return Serialize(new JsonObject
-            {
-                ["success"] = false,
-                ["userActionRequired"] = true,
-                ["reason"] = "accessibility-permission-required",
-                ["instruction"] = "Pause and ask the user to grant macOS Accessibility access to the terminal or host running maui."
-            });
-        }
+        PurgeExpiredDialogLeases();
+        if (!DialogLeases.TryGetValue(promptId, out var candidateLease))
+            return SerializeExpiredPrompt();
 
-        var action = await driver.PressAlertButtonAsync(promptId, buttonLabel);
-        var result = new JsonObject
+        var targetLock = TargetLocks.GetOrAdd(
+            candidateLease.Target.TargetIdentity,
+            static _ => new SemaphoreSlim(1, 1));
+        await targetLock.WaitAsync();
+        try
         {
-            ["success"] = action.Success,
-            ["userActionRequired"] = action.UserActionRequired,
-            ["message"] = action.Message
-        };
-        if (action.Dialog is not null)
-            result["dialog"] = CreateDialogJson(action.Dialog);
-        return Serialize(result);
+            if (!DialogLeases.TryRemove(promptId, out var lease))
+                return SerializeExpiredPrompt();
+
+            using (lease)
+            {
+                RemoveTargetDialogLeases(lease.Target.TargetIdentity);
+
+                using var agent = await session.GetAgentClientAsync(agentPort);
+                var status = await agent.GetStatusAsync()
+                    ?? throw new McpException("Unable to read agent status.");
+                var currentIdentity = CreateTargetIdentity(agent.BaseUrl, status);
+                if (!currentIdentity.Equals(lease.Target.TargetIdentity, StringComparison.Ordinal))
+                {
+                    return Serialize(new JsonObject
+                    {
+                        ["success"] = false,
+                        ["userActionRequired"] = true,
+                        ["instruction"] = "The connected app changed after the prompt was reviewed. Detect the current prompt again."
+                    });
+                }
+                if (lease.Target.Kind == DialogPlatformKind.Android)
+                {
+                    var currentSerial = session.GetAndroidDeviceSerial(new Uri(agent.BaseUrl).Port);
+                    if (!string.Equals(currentSerial, lease.Target.AndroidDevice, StringComparison.Ordinal))
+                    {
+                        return SerializeResponseManualAction(
+                            "The Android device mapping changed after the prompt was reviewed. Detect the prompt again.",
+                            "target-device-changed");
+                    }
+                }
+
+                AlertActionResult action;
+                if (lease.Target.Kind == DialogPlatformKind.MacOS)
+                {
+                    using var driver = CreateMacDriver(lease.Target);
+                    if (!driver.IsAccessibilityAuthorized())
+                    {
+                        return SerializeResponseManualAction(
+                            "Grant macOS Accessibility access to the terminal or host running maui, then detect the prompt again.",
+                            "accessibility-permission-required");
+                    }
+
+                    action = await driver.PressAlertButtonAsync(
+                        lease.PlatformPromptId
+                            ?? throw new McpException("The macOS dialog response token is invalid."),
+                        buttonLabel);
+                }
+                else
+                {
+                    if (lease.Target.Kind == DialogPlatformKind.Android)
+                    {
+                        using var androidDriver = new AndroidAppDriver { Serial = lease.Target.AndroidDevice };
+                        if (string.IsNullOrWhiteSpace(lease.Target.PackageId)
+                            || !await androidDriver.IsTargetAppForegroundAsync(lease.Target.PackageId))
+                        {
+                            return SerializeResponseManualAction(
+                                "The connected Android app is no longer focused. Detect the prompt again after returning to that app.",
+                                "target-app-not-focused");
+                        }
+                    }
+
+                    var currentDialog = await DetectDialogAsync(lease.Target);
+                    if (currentDialog is null)
+                    {
+                        return Serialize(new JsonObject
+                        {
+                            ["success"] = false,
+                            ["userActionRequired"] = true,
+                            ["instruction"] = "The reviewed prompt is no longer visible. Detect again before acting."
+                        });
+                    }
+
+                    var currentFingerprint = NativeDialogIdentity.CreateFingerprint(
+                        lease.Target.Platform,
+                        lease.Target.TargetIdentity,
+                        currentDialog);
+                    if (!currentFingerprint.Equals(lease.Fingerprint, StringComparison.Ordinal))
+                    {
+                        return Serialize(new JsonObject
+                        {
+                            ["success"] = false,
+                            ["userActionRequired"] = true,
+                            ["instruction"] = "The visible prompt changed after it was reviewed. Detect it again and ask the user what to do.",
+                            ["dialog"] = CreateDialogJson(currentDialog, lease.Target)
+                        });
+                    }
+
+                    action = await PressDialogButtonAsync(lease.Target, currentDialog, buttonLabel);
+                }
+
+                var result = new JsonObject
+                {
+                    ["success"] = action.Success,
+                    ["userActionRequired"] = action.UserActionRequired,
+                    ["message"] = action.Message,
+                    ["platform"] = lease.Target.Platform,
+                    ["interactionMethod"] = lease.Target.InteractionMethod,
+                    ["hostInputIsolated"] = true
+                };
+                if (action.Dialog is not null)
+                    result["dialog"] = CreateDialogJson(action.Dialog, lease.Target);
+                return Serialize(result);
+            }
+        }
+        finally
+        {
+            targetLock.Release();
+        }
     }
 
-    private static JsonObject CreateDialogJson(AlertInfo dialog)
+    private static async Task<DialogTarget> CreateTargetAsync(
+        McpAgentSession session,
+        AgentClient agent,
+        AgentStatus status,
+        string? androidDevice,
+        string? simulatorUdid)
+    {
+        var platform = status.Platform ?? string.Empty;
+        var identity = CreateTargetIdentity(agent.BaseUrl, status);
+        if (platform.Contains("mac", StringComparison.OrdinalIgnoreCase))
+        {
+            var processId = status.App?.ProcessId ?? FindProcessId(status.AppName);
+            return processId.HasValue
+                ? new DialogTarget(DialogPlatformKind.MacOS, platform, identity, "ax-press", processId, status.AppName, status.App?.PackageId, null, null, agent.BaseUrl)
+                : DialogTarget.Unsupported(platform, identity, "Unable to determine the connected macOS app process.");
+        }
+
+        if (platform.Contains("android", StringComparison.OrdinalIgnoreCase))
+        {
+            var agentPort = new Uri(agent.BaseUrl).Port;
+            var selectedDevice = session.GetAndroidDeviceSerial(agentPort);
+            if (string.IsNullOrWhiteSpace(selectedDevice))
+                return DialogTarget.Unsupported(platform, identity, "The Android device associated with the connected agent could not be determined safely.");
+            if (!string.IsNullOrWhiteSpace(androidDevice)
+                && !selectedDevice.Equals(androidDevice, StringComparison.Ordinal))
+            {
+                return DialogTarget.Unsupported(platform, identity, "The requested Android device does not match the device associated with the connected agent.");
+            }
+            if (string.IsNullOrWhiteSpace(status.App?.PackageId))
+                return DialogTarget.Unsupported(platform, identity, "The connected Android agent did not report its package identifier.");
+
+            using var driver = new AndroidAppDriver { Serial = selectedDevice };
+            if (!await driver.IsTargetAppForegroundAsync(status.App.PackageId))
+                return DialogTarget.Unsupported(platform, identity, "The connected Android app is not the focused app behind the visible system UI.");
+
+            return new DialogTarget(
+                DialogPlatformKind.Android,
+                platform,
+                identity,
+                "adb-device-input",
+                null,
+                status.AppName,
+                status.App.PackageId,
+                selectedDevice,
+                null,
+                agent.BaseUrl);
+        }
+
+        if (platform.Contains("windows", StringComparison.OrdinalIgnoreCase)
+            || platform.Contains("winui", StringComparison.OrdinalIgnoreCase))
+        {
+            var processId = status.App?.ProcessId ?? FindProcessId(status.AppName);
+            return processId.HasValue
+                ? new DialogTarget(DialogPlatformKind.Windows, platform, identity, "uia-invoke", processId, status.AppName, status.App?.PackageId, null, null, agent.BaseUrl)
+                : DialogTarget.Unsupported(platform, identity, "Unable to determine the connected Windows app process.");
+        }
+
+        if (platform.Contains("linux", StringComparison.OrdinalIgnoreCase))
+            return new DialogTarget(DialogPlatformKind.Linux, platform, identity, "agent-action", status.App?.ProcessId, status.AppName, status.App?.PackageId, null, null, agent.BaseUrl);
+
+        if (platform.Contains("ios", StringComparison.OrdinalIgnoreCase))
+        {
+            var isSimulator = status.DeviceType?.Equals("Virtual", StringComparison.OrdinalIgnoreCase) == true;
+            if (!isSimulator)
+                return DialogTarget.Unsupported(platform, identity, "Physical iOS native dialogs are not safely automatable by the current host driver.");
+            if (string.IsNullOrWhiteSpace(status.Device?.Id))
+                return DialogTarget.Unsupported(platform, identity, "The connected iOS Simulator agent did not report its simulator UDID.");
+            if (!string.IsNullOrWhiteSpace(simulatorUdid)
+                && !status.Device.Id.Equals(simulatorUdid, StringComparison.Ordinal))
+            {
+                return DialogTarget.Unsupported(platform, identity, "The requested simulator does not match the simulator associated with the connected agent.");
+            }
+            if (string.IsNullOrWhiteSpace(status.AppName))
+                return DialogTarget.Unsupported(platform, identity, "The connected iOS Simulator agent did not report its app name.");
+
+            return new DialogTarget(
+                DialogPlatformKind.IosSimulator,
+                platform,
+                identity,
+                "simulator-hid",
+                null,
+                status.AppName,
+                status.App?.PackageId,
+                null,
+                status.Device.Id,
+                agent.BaseUrl);
+        }
+
+        return DialogTarget.Unsupported(platform, identity, $"Native dialog automation is not available for platform '{platform}'.");
+    }
+
+    private static async Task<AlertInfo?> DetectDialogAsync(DialogTarget target)
+    {
+        switch (target.Kind)
+        {
+            case DialogPlatformKind.MacOS:
+                using (var driver = CreateMacDriver(target))
+                    return await driver.DetectAlertAsync();
+            case DialogPlatformKind.Android:
+                using (var driver = new AndroidAppDriver { Serial = target.AndroidDevice })
+                    return await driver.DetectAlertAsync();
+            case DialogPlatformKind.IosSimulator:
+                using (var driver = new iOSSimulatorAppDriver
+                {
+                    DeviceUdid = target.SimulatorUdid,
+                    BundleId = target.PackageId,
+                    ExpectedAppName = target.AppName
+                })
+                    return await driver.DetectAlertAsync();
+            case DialogPlatformKind.Windows:
+                using (var driver = new WindowsAppDriver { ProcessId = target.ProcessId })
+                    return await driver.DetectAlertAsync();
+            case DialogPlatformKind.Linux:
+                using (var driver = new LinuxAppDriver { ProcessId = target.ProcessId, AppName = target.AppName })
+                {
+                    var endpoint = new Uri(target.AgentBaseUrl);
+                    await driver.ConnectAsync(endpoint.Host, endpoint.Port);
+                    return await driver.DetectAlertAsync();
+                }
+            default:
+                return null;
+        }
+    }
+
+    private static async Task<AlertActionResult> PressDialogButtonAsync(
+        DialogTarget target,
+        AlertInfo dialog,
+        string buttonLabel)
+    {
+        switch (target.Kind)
+        {
+            case DialogPlatformKind.Android:
+                using (var driver = new AndroidAppDriver { Serial = target.AndroidDevice })
+                    return await driver.PressAlertButtonSafelyAsync(
+                        dialog,
+                        buttonLabel,
+                        target.PackageId
+                            ?? throw new McpException("The Android dialog target has no package identifier."));
+            case DialogPlatformKind.IosSimulator:
+                using (var driver = new iOSSimulatorAppDriver
+                {
+                    DeviceUdid = target.SimulatorUdid,
+                    BundleId = target.PackageId,
+                    ExpectedAppName = target.AppName
+                })
+                    return await driver.PressAlertButtonSafelyAsync(dialog, buttonLabel);
+            case DialogPlatformKind.Windows:
+                using (var driver = new WindowsAppDriver { ProcessId = target.ProcessId })
+                    return await driver.PressAlertButtonSafelyAsync(buttonLabel);
+            case DialogPlatformKind.Linux:
+                using (var driver = new LinuxAppDriver { ProcessId = target.ProcessId, AppName = target.AppName })
+                {
+                    var endpoint = new Uri(target.AgentBaseUrl);
+                    await driver.ConnectAsync(endpoint.Host, endpoint.Port);
+                    return await driver.PressAlertButtonSafelyAsync(dialog, buttonLabel);
+                }
+            default:
+                return new AlertActionResult(false, true, "This platform cannot safely respond to native dialogs.", dialog);
+        }
+    }
+
+    private static MacCatalystAppDriver CreateMacDriver(DialogTarget target)
+        => new()
+        {
+            ProcessId = target.ProcessId,
+            AppName = target.AppName
+        };
+
+    private static string CreateTargetIdentity(string baseUrl, AgentStatus status)
+        => $"{baseUrl}|{status.Platform}|{status.Device?.Id}|{status.App?.ProcessId}|{status.App?.PackageId}|{status.AppName}";
+
+    private static JsonObject CreateDialogJson(AlertInfo dialog, DialogTarget target)
         => new()
         {
             ["promptId"] = dialog.PromptId,
@@ -104,35 +444,85 @@ public sealed class NativeDialogTools
             ["sourceProcessId"] = dialog.SourceProcessId,
             ["sourceProcessName"] = dialog.SourceProcessName,
             ["isSystemDialog"] = dialog.IsSystemDialog,
-            ["canRespond"] = dialog.CanRespond
+            ["canRespond"] = dialog.CanRespond,
+            ["platform"] = target.Platform,
+            ["interactionMethod"] = target.InteractionMethod,
+            ["hostInputIsolated"] = true
         };
+
+    private static string SerializeManualAction(string instruction, string reason = "platform-automation-unavailable")
+        => Serialize(new JsonObject
+        {
+            ["detected"] = false,
+            ["canRespond"] = false,
+            ["userActionRequired"] = true,
+            ["reason"] = reason,
+            ["instruction"] = instruction
+        });
+
+    private static string SerializeResponseManualAction(string instruction, string reason)
+        => Serialize(new JsonObject
+        {
+            ["success"] = false,
+            ["userActionRequired"] = true,
+            ["reason"] = reason,
+            ["instruction"] = instruction
+        });
+
+    private static string SerializeExpiredPrompt()
+        => Serialize(new JsonObject
+        {
+            ["success"] = false,
+            ["userActionRequired"] = true,
+            ["instruction"] = "The reviewed prompt expired or was already used. Detect it again and ask the user what to do."
+        });
 
     private static string Serialize(JsonObject value)
         => CliJson.SerializeUntyped(value, indented: false);
 
-    private static async Task<MacCatalystAppDriver> CreateMacDriverAsync(
-        McpAgentSession session,
-        int? agentPort)
+    private static async Task ExpireDialogLeaseAsync(string promptId)
     {
-        if (!OperatingSystem.IsMacOS())
-            throw new McpException("Native macOS dialog interaction is only available on macOS.");
+        await Task.Delay(DialogLeaseLifetime).ConfigureAwait(false);
+        if (DialogLeases.TryRemove(promptId, out var expired))
+            expired.Dispose();
+    }
 
-        using var agent = await session.GetAgentClientAsync(agentPort);
-        var status = await agent.GetStatusAsync()
-            ?? throw new McpException("Unable to read agent status.");
-        var platform = status.Platform ?? string.Empty;
-        if (!platform.Contains("mac", StringComparison.OrdinalIgnoreCase))
-            throw new McpException($"Native macOS dialog interaction is unavailable for platform '{platform}'.");
-
-        var processId = status.App?.ProcessId ?? FindProcessId(status.AppName);
-        if (!processId.HasValue)
-            throw new McpException("Unable to determine the connected macOS app process.");
-
-        return new MacCatalystAppDriver
+    private static void PurgeExpiredDialogLeases()
+    {
+        var now = DateTimeOffset.UtcNow;
+        foreach (var entry in DialogLeases)
         {
-            ProcessId = processId,
-            AppName = status.App?.Name ?? status.AppName
-        };
+            if (entry.Value.ExpiresAt <= now)
+            {
+                if (DialogLeases.TryRemove(entry.Key, out var expired))
+                    expired.Dispose();
+            }
+        }
+    }
+
+    private static void RemoveMatchingDialogLeases(string targetIdentity, string fingerprint)
+    {
+        foreach (var entry in DialogLeases)
+        {
+            if (entry.Value.Target.TargetIdentity.Equals(targetIdentity, StringComparison.Ordinal)
+                && entry.Value.Fingerprint.Equals(fingerprint, StringComparison.Ordinal))
+            {
+                if (DialogLeases.TryRemove(entry.Key, out var replaced))
+                    replaced.Dispose();
+            }
+        }
+    }
+
+    private static void RemoveTargetDialogLeases(string targetIdentity)
+    {
+        foreach (var entry in DialogLeases)
+        {
+            if (entry.Value.Target.TargetIdentity.Equals(targetIdentity, StringComparison.Ordinal))
+            {
+                if (DialogLeases.TryRemove(entry.Key, out var sibling))
+                    sibling.Dispose();
+            }
+        }
     }
 
     private static int? FindProcessId(string? appName)
@@ -147,8 +537,8 @@ public sealed class NativeDialogTools
             {
                 try
                 {
-                    if (process.ProcessName.Equals(appName, StringComparison.OrdinalIgnoreCase) ||
-                        process.ProcessName.Contains(appName, StringComparison.OrdinalIgnoreCase))
+                    if (process.ProcessName.Equals(appName, StringComparison.OrdinalIgnoreCase)
+                        || process.ProcessName.Contains(appName, StringComparison.OrdinalIgnoreCase))
                     {
                         candidates.Add((process.Id, process.ProcessName));
                     }
@@ -167,5 +557,49 @@ public sealed class NativeDialogTools
             return exactMatches[0].ProcessId;
 
         return candidates.Count == 1 ? candidates[0].ProcessId : null;
+    }
+
+    private enum DialogPlatformKind
+    {
+        Unsupported,
+        MacOS,
+        Android,
+        IosSimulator,
+        Windows,
+        Linux
+    }
+
+    private sealed record DialogTarget(
+        DialogPlatformKind Kind,
+        string Platform,
+        string TargetIdentity,
+        string InteractionMethod,
+        int? ProcessId,
+        string? AppName,
+        string? PackageId,
+        string? AndroidDevice,
+        string? SimulatorUdid,
+        string AgentBaseUrl,
+        string? UnsupportedReason = null)
+    {
+        public bool CanDetect => Kind != DialogPlatformKind.Unsupported;
+
+        public static DialogTarget Unsupported(string platform, string identity, string reason)
+            => new(DialogPlatformKind.Unsupported, platform, identity, "manual", null, null, null, null, null, string.Empty, reason);
+    }
+
+    private sealed class DialogLease(
+        string? platformPromptId,
+        DialogTarget target,
+        string fingerprint,
+        DateTimeOffset expiresAt,
+        Action? cleanup) : IDisposable
+    {
+        public string? PlatformPromptId { get; } = platformPromptId;
+        public DialogTarget Target { get; } = target;
+        public string Fingerprint { get; } = fingerprint;
+        public DateTimeOffset ExpiresAt { get; } = expiresAt;
+
+        public void Dispose() => cleanup?.Invoke();
     }
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ScreenshotTool.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/ScreenshotTool.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 [McpServerToolType]
 public sealed class ScreenshotTool
 {
-	[McpServerTool(Name = "maui_screenshot"), Description("Capture a screenshot of the running MAUI app. Returns the image directly for visual verification of layout, colors, contrast, and rendering.")]
+	[McpServerTool(Name = "maui_screenshot"), Description("Capture the running MAUI app directly. On macOS AppKit this includes native window chrome without activating the app or changing keyboard focus. Always use this tool instead of osascript, screencapture, mouse clicks, or app activation. Returns the image directly for visual verification of layout, colors, contrast, and rendering.")]
 	public static async Task<ContentBlock[]> Screenshot(
 		McpAgentSession session,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Handlers.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Handlers.cs
@@ -517,7 +517,7 @@ public partial class DevFlowAgentService
 
         var message = string.IsNullOrWhiteSpace(failure.Message) ? defaultMessage : failure.Message;
 
-        // 409 Conflict signals a transient, retryable precondition (window focus/visibility);
+        // 409 Conflict signals a transient, retryable precondition (such as window visibility);
         // the structured body carries the authoritative retryable flag for clients.
         return HttpResponse.Error(
             message,
@@ -2721,10 +2721,10 @@ public sealed class ScreenshotCaptureFailure
     /// <summary>Human-readable, actionable error message.</summary>
     public string Message { get; }
 
-    /// <summary>Machine-readable cause identifier (e.g. <c>window-not-frontmost</c>).</summary>
+    /// <summary>Machine-readable cause identifier (e.g. <c>window-not-visible</c>).</summary>
     public string Reason { get; }
 
-    /// <summary>Whether retrying (e.g. after foregrounding the app) may succeed.</summary>
+    /// <summary>Whether retrying after correcting the reported precondition may succeed.</summary>
     public bool Retryable { get; }
 
     /// <summary>Optional actionable suggestions for the caller.</summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.cs
@@ -224,6 +224,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                     packageId = packageId,
                     version = appVersion,
                     build = appBuild,
+                    processId = Environment.ProcessId,
                 },
                 capabilities = new
                 {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.cs
@@ -96,6 +96,9 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
     /// <summary>Device type ("Physical" / "Virtual") reported to clients.</summary>
     protected virtual string DeviceTypeName => "Unknown";
 
+    /// <summary>Platform-specific device identifier when the app can report one safely.</summary>
+    protected virtual string? DeviceIdentifier => null;
+
     /// <summary>Device idiom ("Phone" / "Tablet" / "Desktop") reported to clients.</summary>
     protected virtual string IdiomName => "Unknown";
 
@@ -210,6 +213,7 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                 },
                 device = new
                 {
+                    id = DeviceIdentifier,
                     platform = PlatformName,
                     deviceType = DeviceTypeName,
                     idiom = IdiomName,

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.cs
@@ -2168,9 +2168,9 @@ public partial class MauiDevFlowAgentService : DevFlowAgentService
 
     /// <summary>
     /// Describes why a screenshot capture returned null, when the platform can determine an
-    /// actionable, often-retryable cause (e.g. the app window is not the frontmost application
-    /// on macOS). Returns <c>null</c> when no specific cause is known, in which case the caller
-    /// falls back to a generic error.
+    /// actionable, often-retryable cause (e.g. the app window is minimized). Returns
+    /// <c>null</c> when no specific cause is known, in which case the caller falls back to a
+    /// generic error.
     /// <para>
     /// Invoked on the UI thread within the same dispatch as the failed capture (see
     /// <see cref="ScreenshotCaptureOutcome"/>), so the probed window/app state reflects the

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AndroidEmulatorFixture.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
 
@@ -27,6 +28,8 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
     string _sdkRoot = null!;
 
     public override string Platform => "android";
+    public override string? DeviceId => _serialNumber;
+    public override string? AppIdentifier => PackageId;
 
     protected override async Task InitializePlatformAsync()
     {
@@ -124,6 +127,31 @@ public sealed class AndroidEmulatorFixture : AppFixtureBase
         }
 
         _emulatorProcess?.Dispose();
+    }
+
+    public override async Task ResetPermissionAsync(PermissionService permission)
+    {
+        var platformPermissions = permission switch
+        {
+            PermissionService.Contacts => new[] { "android.permission.READ_CONTACTS" },
+            PermissionService.Location => new[]
+            {
+                "android.permission.ACCESS_FINE_LOCATION",
+                "android.permission.ACCESS_COARSE_LOCATION"
+            },
+            _ => throw new NotSupportedException($"Permission reset for {permission} is not configured on Android.")
+        };
+
+        foreach (var platformPermission in platformPermissions)
+        {
+            await AdbAsync($"shell pm revoke {PackageId} {platformPermission}", timeoutSeconds: 10);
+            await AdbAsync(
+                $"shell pm clear-permission-flags {PackageId} {platformPermission} user-set user-fixed",
+                timeoutSeconds: 10);
+        }
+
+        await LaunchAppAsync();
+        await WaitForAgentAsync(timeoutSeconds: 60);
     }
 
     void StartAppMonitor()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixture.cs
@@ -24,9 +24,12 @@ public sealed class AppFixture : IAppFixture, IAsyncLifetime
     public int AgentPort => _inner.AgentPort;
     public string AgentBaseUrl => _inner.AgentBaseUrl;
     public string Platform => _inner.Platform;
+    public string? DeviceId => _inner.DeviceId;
+    public string? AppIdentifier => _inner.AppIdentifier;
 
     public Task InitializeAsync() => _inner.InitializeAsync();
     public Task DisposeAsync() => _inner.DisposeAsync();
+    public Task ResetPermissionAsync(PermissionService permission) => _inner.ResetPermissionAsync(permission);
 
     /// <summary>
     /// Navigates to the //blazor Shell route (if not already there), waits for the

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureBase.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/AppFixtureBase.cs
@@ -19,6 +19,8 @@ public abstract class AppFixtureBase : IAppFixture
     public int AgentPort { get; private set; }
     public string AgentBaseUrl => $"http://localhost:{AgentPort}";
     public abstract string Platform { get; }
+    public virtual string? DeviceId => null;
+    public virtual string? AppIdentifier => null;
 
     protected AppFixtureBase()
     {
@@ -60,6 +62,9 @@ public abstract class AppFixtureBase : IAppFixture
 
     protected abstract Task InitializePlatformAsync();
     protected abstract Task DisposePlatformAsync();
+
+    public virtual Task ResetPermissionAsync(PermissionService permission)
+        => throw new NotSupportedException($"Permission reset is not supported by the {Platform} integration fixture.");
 
     void SetupClients()
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IAppFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/IAppFixture.cs
@@ -11,4 +11,7 @@ public interface IAppFixture : IAsyncLifetime
     int AgentPort { get; }
     string AgentBaseUrl { get; }
     string Platform { get; }
+    string? DeviceId { get; }
+    string? AppIdentifier { get; }
+    Task ResetPermissionAsync(Driver.PermissionService permission);
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/iOSSimulatorFixture.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/Fixtures/iOSSimulatorFixture.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Runtime.InteropServices;
+using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
 
@@ -14,6 +15,8 @@ public sealed class iOSSimulatorFixture : AppFixtureBase
     string? _appBundleId;
 
     public override string Platform => "ios";
+    public override string? DeviceId => _simulatorUdid;
+    public override string? AppIdentifier => _appBundleId;
 
     protected override async Task InitializePlatformAsync()
     {
@@ -58,6 +61,33 @@ public sealed class iOSSimulatorFixture : AppFixtureBase
             {
             }
         }
+    }
+
+    public override async Task ResetPermissionAsync(PermissionService permission)
+    {
+        if (_simulatorUdid == null || _appBundleId == null)
+            throw new InvalidOperationException("The iOS Simulator app is not initialized.");
+
+        using var driver = new iOSSimulatorAppDriver
+        {
+            DeviceUdid = _simulatorUdid,
+            BundleId = _appBundleId
+        };
+        await driver.ResetPermissionAsync(permission);
+
+        try
+        {
+            await RunProcessAsync(
+                "xcrun",
+                $"simctl terminate {_simulatorUdid} {_appBundleId}",
+                timeoutSeconds: 10);
+        }
+        catch
+        {
+        }
+
+        await LaunchAppAsync();
+        await WaitForAgentAsync(timeoutSeconds: 60);
     }
 
     async Task<(string Udid, bool AlreadyBooted)> FindOrBootSimulatorAsync()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/NativePermissionDialogTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/NativePermissionDialogTests.cs
@@ -1,0 +1,204 @@
+using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
+using Microsoft.Maui.DevFlow.Driver;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.DevFlow.Agent.IntegrationTests;
+
+[Collection("AgentIntegration")]
+[Trait("Category", "NativeDialogs")]
+public class NativePermissionDialogTests : IntegrationTestBase
+{
+    public NativePermissionDialogTests(AppFixture app, ITestOutputHelper output)
+        : base(app, output) { }
+
+    [Trait(TestFramework.Trait, TestFramework.Maui)]
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Android_ContactsPermissionDialog_CanConfirmExactChoice(bool allow)
+    {
+        if (!Platform.Equals("android", StringComparison.OrdinalIgnoreCase))
+        {
+            Output.WriteLine("Android permission dialog test skipped on non-Android platform.");
+            return;
+        }
+
+        await App.ResetPermissionAsync(PermissionService.Contacts);
+        await NavigateToPageAsync("//dialogs", "RequestContactsBtn", timeoutMs: 15000);
+
+        var trigger = await FindElementAsync("RequestContactsBtn");
+        Assert.True(await Client.TapAsync(trigger.Id));
+
+        using var driver = new AndroidAppDriver
+        {
+            Serial = App.DeviceId
+                ?? throw new InvalidOperationException("Android fixture did not report its device serial.")
+        };
+        var dialog = await WaitForDialogAsync(
+            driver.DetectAlertAsync,
+            driver.GetAccessibilityTreeAsync);
+        LogDialog(dialog);
+
+        var button = allow
+            ? FindButton(dialog, label =>
+                label.Contains("Allow", StringComparison.OrdinalIgnoreCase)
+                && !label.Contains("Don't", StringComparison.OrdinalIgnoreCase)
+                && !label.Contains("Don\u2019t", StringComparison.OrdinalIgnoreCase))
+            : FindButton(dialog, label =>
+                label.Contains("Don't", StringComparison.OrdinalIgnoreCase)
+                || label.Contains("Don\u2019t", StringComparison.OrdinalIgnoreCase));
+
+        var result = await driver.PressAlertButtonSafelyAsync(
+            dialog,
+            button.Label,
+            App.AppIdentifier
+                ?? throw new InvalidOperationException("Android fixture did not report its package identifier."),
+            (await Client.GetStatusAsync())?.AppName
+                ?? throw new InvalidOperationException("Android agent did not report its app name."));
+        Assert.True(result.Success, result.Message);
+
+        await WaitForStatusAsync(
+            allow ? "contacts: Granted" : "contacts: Denied",
+            timeoutMs: 15000);
+    }
+
+    [Trait(TestFramework.Trait, TestFramework.Maui)]
+    [Fact]
+    public async Task Ios_ContactsPermissionDialog_OffersAndAcceptsDenyChoice()
+    {
+        // iOS 18+ follows Continue with a system contact-selection surface that idb does not
+        // expose as an actionable AX tree. This test covers the permission sheet itself;
+        // the location test below covers a successful iOS allow response.
+        if (!Platform.Equals("ios", StringComparison.OrdinalIgnoreCase))
+        {
+            Output.WriteLine("iOS contacts permission dialog test skipped on non-iOS platform.");
+            return;
+        }
+
+        await App.ResetPermissionAsync(PermissionService.Contacts);
+        var driver = await CreateIosDriverAsync();
+        using (driver)
+        {
+            await NavigateToPageAsync("//dialogs", "RequestContactsBtn", timeoutMs: 15000);
+            var trigger = await FindElementAsync("RequestContactsBtn");
+            Assert.True(await Client.TapAsync(trigger.Id));
+
+            var dialog = await WaitForDialogAsync(
+                driver.DetectAlertAsync,
+                driver.GetAccessibilityTreeAsync);
+            LogDialog(dialog);
+            Assert.Contains(dialog.Buttons, button =>
+                button.Label.Equals("Continue", StringComparison.OrdinalIgnoreCase));
+            var deny = FindButton(dialog, label =>
+                label.Contains("Don't", StringComparison.OrdinalIgnoreCase)
+                || label.Contains("Don\u2019t", StringComparison.OrdinalIgnoreCase));
+
+            var result = await driver.PressAlertButtonSafelyAsync(dialog, deny.Label);
+            Assert.True(result.Success, result.Message);
+        }
+
+        await WaitForStatusAsync("contacts: Denied", timeoutMs: 15000);
+    }
+
+    [Trait(TestFramework.Trait, TestFramework.Maui)]
+    [Fact]
+    public async Task Ios_LocationPermissionDialog_OffersAndAcceptsWhileUsingChoice()
+    {
+        if (!Platform.Equals("ios", StringComparison.OrdinalIgnoreCase))
+        {
+            Output.WriteLine("iOS location permission dialog test skipped on non-iOS platform.");
+            return;
+        }
+
+        await App.ResetPermissionAsync(PermissionService.Location);
+        var driver = await CreateIosDriverAsync();
+        using (driver)
+        {
+            await NavigateToPageAsync("//dialogs", "RequestLocationBtn", timeoutMs: 15000);
+            var trigger = await FindElementAsync("RequestLocationBtn");
+            Assert.True(await Client.TapAsync(trigger.Id));
+
+            var dialog = await WaitForDialogAsync(
+                driver.DetectAlertAsync,
+                driver.GetAccessibilityTreeAsync);
+            LogDialog(dialog);
+            var whileUsing = FindButton(dialog, label =>
+                label.Contains("While Using", StringComparison.OrdinalIgnoreCase));
+
+            var result = await driver.PressAlertButtonSafelyAsync(dialog, whileUsing.Label);
+            Assert.True(result.Success, result.Message);
+        }
+
+        await WaitForStatusAsync("location: Granted", timeoutMs: 15000);
+    }
+
+    async Task<iOSSimulatorAppDriver> CreateIosDriverAsync()
+    {
+        var status = await Client.GetStatusAsync()
+            ?? throw new InvalidOperationException("Agent status was unavailable.");
+        return new iOSSimulatorAppDriver
+        {
+            DeviceUdid = App.DeviceId ?? status.Device?.Id
+                ?? throw new InvalidOperationException("iOS fixture did not report its simulator UDID."),
+            BundleId = App.AppIdentifier ?? status.App?.PackageId,
+            ExpectedAppName = status.AppName
+        };
+    }
+
+    async Task<AlertInfo> WaitForDialogAsync(
+        Func<Task<AlertInfo?>> detect,
+        Func<Task<string>>? dumpAccessibility = null,
+        int timeoutMs = 15000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        AlertInfo? dialog = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            dialog = await detect();
+            if (dialog is not null)
+                return dialog;
+            await Task.Delay(250);
+        }
+
+        if (dumpAccessibility is not null)
+        {
+            try
+            {
+                Output.WriteLine("Accessibility tree at timeout:");
+                Output.WriteLine(await dumpAccessibility());
+            }
+            catch (Exception ex)
+            {
+                Output.WriteLine($"Accessibility tree dump failed: {ex.Message}");
+            }
+        }
+
+        throw new TimeoutException($"Native permission dialog was not detected within {timeoutMs}ms.");
+    }
+
+    async Task WaitForStatusAsync(string expected, int timeoutMs)
+    {
+        await WaitForAsync(async () =>
+        {
+            try
+            {
+                var results = await Client.QueryAsync(automationId: "DialogStatusLabel");
+                return results.Any(element =>
+                    element.Text?.Contains(expected, StringComparison.OrdinalIgnoreCase) == true);
+            }
+            catch
+            {
+                return false;
+            }
+        }, timeoutMs);
+    }
+
+    static AlertButton FindButton(AlertInfo dialog, Func<string, bool> predicate)
+        => dialog.Buttons.FirstOrDefault(button => predicate(button.Label))
+            ?? throw new InvalidOperationException(
+                $"Expected permission choice was not present. Available: {string.Join(", ", dialog.Buttons.Select(button => button.Label))}");
+
+    void LogDialog(AlertInfo dialog)
+        => Output.WriteLine(
+            $"Detected permission dialog '{dialog.Title}' with buttons: {string.Join(", ", dialog.Buttons.Select(button => button.Label))}");
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeDevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeDevFlowAgentService.cs
@@ -47,6 +47,9 @@ public class NativeDevFlowAgentService : DevFlowAgentService
     protected override string DeviceTypeName => NativeUi.DeviceTypeName;
 
     /// <inheritdoc />
+    protected override string? DeviceIdentifier => NativeUi.DeviceIdentifier;
+
+    /// <inheritdoc />
     protected override bool IsUiSupported => true;
 
     /// <inheritdoc />

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeDevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeDevFlowAgentService.cs
@@ -447,7 +447,7 @@ public class NativeDevFlowAgentService : DevFlowAgentService
 
         try
         {
-            var result = await DispatchAsync(() =>
+            var result = await DispatchAsync(async () =>
             {
                 byte[]? png;
                 if (hasElementId && !string.IsNullOrEmpty(elementId))
@@ -457,13 +457,13 @@ public class NativeDevFlowAgentService : DevFlowAgentService
                 }
                 else
                 {
-                    png = NativeUi.CaptureScreen();
+                    png = await NativeUi.CaptureScreen();
                 }
 
                 return new ScreenshotCaptureResult(png, NativeUi.DisplayDensity);
             });
 
-            if (result.Png == null)
+            if (result?.Png == null)
             {
                 return hasElementId
                     ? HttpResponse.NotFound($"Element '{elementId}' not found or has no size")

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.Android.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.Android.cs
@@ -539,10 +539,10 @@ internal static partial class NativeUi
         return stream.ToArray();
     }
 
-    public static byte[]? CaptureScreen()
+    public static Task<byte[]?> CaptureScreen()
     {
         var decor = CurrentActivity?.Window?.DecorView;
-        return decor == null ? null : CaptureView(decor);
+        return Task.FromResult(decor == null ? null : CaptureView(decor));
     }
 
     public static IReadOnlyDictionary<string, string?> GetProperties(object viewObject)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.Android.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.Android.cs
@@ -21,6 +21,8 @@ internal static partial class NativeUi
     public static string DeviceTypeName =>
         Build.Fingerprint?.Contains("generic", StringComparison.OrdinalIgnoreCase) == true ? "virtual" : "physical";
 
+    public static string? DeviceIdentifier => null;
+
     private static Activity? _currentActivity;
 
     /// <summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.AppKit.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.AppKit.cs
@@ -331,7 +331,7 @@ internal static partial class NativeUi
         return CaptureViewViaCacheDisplay(view) ?? CaptureViewViaPdf(view);
     }
 
-    public static byte[]? CaptureScreen()
+    public static async Task<byte[]?> CaptureScreen()
     {
         var window = GetWindows().FirstOrDefault(candidate =>
                 candidate.IsVisible && candidate.WindowNumber > 0)
@@ -339,9 +339,7 @@ internal static partial class NativeUi
 
         if (window != null)
         {
-            var screenCaptureKitBytes = CaptureWindowViaScreenCaptureKitAsync(window)
-                .GetAwaiter()
-                .GetResult();
+            var screenCaptureKitBytes = await CaptureWindowViaScreenCaptureKitAsync(window);
             if (screenCaptureKitBytes != null)
                 return screenCaptureKitBytes;
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.AppKit.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.AppKit.cs
@@ -1,5 +1,6 @@
 #if MACOS
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using AppKit;
 using CoreGraphics;
 using Foundation;
@@ -330,20 +331,27 @@ internal static partial class NativeUi
 
     public static byte[]? CaptureScreen()
     {
-        var window = NSApplication.SharedApplication.KeyWindow
-            ?? GetWindows().FirstOrDefault(w => w.IsVisible);
-
-        if (window?.AttachedSheet is NSWindow sheet)
-            window = sheet;
+        var window = GetWindows().FirstOrDefault(candidate =>
+                candidate.IsVisible && candidate.WindowNumber > 0)
+            ?? NSApplication.SharedApplication.KeyWindow;
 
         if (window != null)
         {
+            var screenCaptureKitBytes = CaptureWindowViaScreenCaptureKitAsync(window)
+                .GetAwaiter()
+                .GetResult();
+            if (screenCaptureKitBytes != null)
+                return screenCaptureKitBytes;
+
+            if (window.AttachedSheet is NSWindow sheet)
+                window = sheet;
+
             var windowPng = CaptureWindowViaCG(window);
             if (windowPng != null)
                 return windowPng;
 
             if (window.ContentView is { } content)
-                return CaptureView(content);
+                return CaptureView(content.Superview ?? content);
         }
 
         return GetRoots().FirstOrDefault() is { } root ? CaptureView(root) : null;
@@ -422,6 +430,112 @@ internal static partial class NativeUi
         using var data = rep.RepresentationUsingTypeProperties(NSBitmapImageFileType.Png, new NSDictionary());
         return data?.ToArray();
     }
+
+    private static async Task<byte[]?> CaptureWindowViaScreenCaptureKitAsync(NSWindow window)
+    {
+        if (!OperatingSystem.IsMacOSVersionAtLeast(14) ||
+            (!OperatingSystem.IsMacOSVersionAtLeast(14, 4) && !CGPreflightScreenCaptureAccess()))
+        {
+            return null;
+        }
+
+        return await CaptureWindowViaScreenCaptureKitSupportedAsync(window);
+    }
+
+    [SupportedOSPlatform("macos14.0")]
+    private static async Task<byte[]?> CaptureWindowViaScreenCaptureKitSupportedAsync(NSWindow window)
+    {
+        try
+        {
+            using var content = await GetShareableContentAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            var windowId = (uint)window.WindowNumber;
+            var shareableWindow = content.Windows.FirstOrDefault(candidate => candidate.WindowId == windowId);
+            if (shareableWindow == null)
+                return null;
+
+            using var filter = new ScreenCaptureKit.SCContentFilter(shareableWindow);
+            using var configuration = new ScreenCaptureKit.SCStreamConfiguration
+            {
+                Width = (nuint)Math.Max(1, Math.Ceiling(shareableWindow.Frame.Width * window.BackingScaleFactor)),
+                Height = (nuint)Math.Max(1, Math.Ceiling(shareableWindow.Frame.Height * window.BackingScaleFactor)),
+                ShowsCursor = false,
+                PreservesAspectRatio = true,
+                IgnoreShadowsSingleWindow = true,
+                IgnoreGlobalClipSingleWindow = true,
+                CaptureResolution = ScreenCaptureKit.SCCaptureResolutionType.Best
+            };
+
+            if (OperatingSystem.IsMacOSVersionAtLeast(14, 2))
+                configuration.IncludeChildWindows = true;
+
+            var completion = new TaskCompletionSource<byte[]?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            ScreenCaptureKit.SCScreenshotManager.CaptureImage(
+                filter,
+                configuration,
+                (image, error) =>
+                {
+                    if (error != null || image == null)
+                    {
+                        completion.TrySetResult(null);
+                        return;
+                    }
+
+                    try
+                    {
+                        using var bitmapRep = new NSBitmapImageRep(image);
+                        using var properties = new NSDictionary();
+                        using var pngData = bitmapRep.RepresentationUsingTypeProperties(
+                            NSBitmapImageFileType.Png,
+                            properties);
+                        completion.TrySetResult(pngData?.ToArray());
+                    }
+                    catch
+                    {
+                        completion.TrySetResult(null);
+                    }
+                });
+
+            return await completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [SupportedOSPlatform("macos14.0")]
+    private static Task<ScreenCaptureKit.SCShareableContent> GetShareableContentAsync()
+    {
+        var completion = new TaskCompletionSource<ScreenCaptureKit.SCShareableContent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void Complete(
+            ScreenCaptureKit.SCShareableContent content,
+            NSError error)
+        {
+            if (error != null)
+                completion.TrySetException(new InvalidOperationException(error.LocalizedDescription));
+            else if (content == null)
+                completion.TrySetException(new InvalidOperationException("ScreenCaptureKit returned no shareable content."));
+            else
+                completion.TrySetResult(content);
+        }
+
+        if (OperatingSystem.IsMacOSVersionAtLeast(14, 4))
+            ScreenCaptureKit.SCShareableContent.GetCurrentProcessShareableContent(Complete);
+        else
+            ScreenCaptureKit.SCShareableContent.GetShareableContent(
+                excludeDesktopWindows: true,
+                onScreenWindowsOnly: false,
+                Complete);
+
+        return completion.Task;
+    }
+
+    [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    [return: MarshalAs(UnmanagedType.U1)]
+    private static extern bool CGPreflightScreenCaptureAccess();
 
     [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
     private static extern IntPtr CGWindowListCreateImage(

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.AppKit.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.AppKit.cs
@@ -20,6 +20,8 @@ internal static partial class NativeUi
 
     public static string DeviceTypeName => "physical";
 
+    public static string? DeviceIdentifier => null;
+
     public static IAgentDispatcher CreateDispatcher() => new DelegateAgentDispatcher(
         () => !NSThread.IsMain,
         action => NSApplication.SharedApplication.InvokeOnMainThread(action));

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.UIKit.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.UIKit.cs
@@ -18,6 +18,18 @@ internal static partial class NativeUi
     public static string PlatformName => "iOS";
 #endif
 
+    public static string? DeviceIdentifier
+    {
+        get
+        {
+#if IOS
+            return Environment.GetEnvironmentVariable("SIMULATOR_UDID");
+#else
+            return null;
+#endif
+        }
+    }
+
     public static string UiFrameworkName => "uikit";
 
 #if MACCATALYST

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.UIKit.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Native/NativeUi.UIKit.cs
@@ -423,8 +423,8 @@ internal static partial class NativeUi
         return data?.ToArray();
     }
 
-    public static byte[]? CaptureScreen()
-        => GetRoots().FirstOrDefault() is { } window ? CaptureView(window) : null;
+    public static Task<byte[]?> CaptureScreen()
+        => Task.FromResult(GetRoots().FirstOrDefault() is { } window ? CaptureView(window) : null);
 
     public static IReadOnlyDictionary<string, string?> GetProperties(object viewObject)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -1114,25 +1114,30 @@ public class PlatformAgentService : MauiDevFlowAgentService
             var attachedSheet = parentWindow?.AttachedSheet
                 ?? parentWindow?.Sheets.LastOrDefault()
                 ?? FindRegisteredDialogWindow(parentWindow);
-            if (parentWindow != null && attachedSheet != null)
-            {
-                var composited = CaptureWindowsViaCG(parentWindow, attachedSheet);
-                if (composited != null)
-                    return composited;
-
-                window = attachedSheet;
-            }
-            else
-            {
-                window = parentWindow;
-            }
-
+            window = parentWindow;
             if (window != null)
             {
+                // ScreenCaptureKit captures the complete AppKit window, including native
+                // chrome and attached child windows, without activating or ordering it.
+                var screenCaptureKitBytes = await CaptureWindowViaScreenCaptureKitAsync(window);
+                if (screenCaptureKitBytes != null)
+                    return screenCaptureKitBytes;
+
+                if (attachedSheet != null)
+                {
+                    var composited = CaptureWindowsViaCG(window, attachedSheet);
+                    if (composited != null)
+                        return composited;
+
+                    // Quartz can only capture one window ID. Prefer the sheet when
+                    // compositing is unavailable so modal UI remains visible.
+                    window = attachedSheet;
+                }
+
                 // Primary: CGWindowListCreateImage gives a composited capture including
                 // layer-backed controls and WebView content. This can return null when the
-                // window is not frontmost / fully occluded (the window server may have purged
-                // its backing store), so we fall through to occlusion-independent paths below.
+                // window is fully occluded (the window server may have purged its backing
+                // store), so we fall through to occlusion-independent paths below.
                 var pngBytes = CaptureWindowViaCG(window);
                 if (pngBytes != null)
                     return pngBytes;
@@ -1142,7 +1147,9 @@ public class PlatformAgentService : MauiDevFlowAgentService
                 {
                     // Occlusion-independent fallback: CacheDisplay re-renders the view
                     // hierarchy directly, so it works even when the window is not frontmost.
-                    var cached = CaptureNSView(contentView);
+                    // Capture the theme frame when possible so native title-bar chrome is
+                    // included instead of limiting the result to the content view.
+                    var cached = CaptureNSView(contentView.Superview ?? contentView);
                     if (cached != null)
                         return cached;
 
@@ -1275,10 +1282,6 @@ public class PlatformAgentService : MauiDevFlowAgentService
         _ => null
     };
 
-    /// <summary>
-    /// On macOS, reports an actionable cause when a screenshot fails because the app window
-    /// is not the frontmost application (a common reason CGWindowListCreateImage returns null).
-    /// </summary>
     protected override ScreenshotCaptureFailure? DescribeScreenshotFailure()
     {
         try
@@ -1289,20 +1292,16 @@ public class PlatformAgentService : MauiDevFlowAgentService
             var nsWindow = NSWindowFromPlatformView(mauiWindow?.Handler?.PlatformView)
                 ?? app.KeyWindow ?? app.MainWindow;
 
-            var appActive = app.Active;
-            var windowVisible = nsWindow == null || nsWindow.IsVisible;
-
-            if (!appActive || !windowVisible)
+            if (nsWindow != null && (!nsWindow.IsVisible || nsWindow.IsMiniaturized))
             {
                 return new ScreenshotCaptureFailure(
-                    "Failed to capture screenshot because the app window is not frontmost (the app is not the active application). " +
-                    "Bring the app to the foreground and retry.",
-                    "window-not-frontmost",
+                    "Failed to capture the app window because it is hidden or minimized.",
+                    "window-not-visible",
                     retryable: true,
                     suggestions: new[]
                     {
-                        "Bring the MAUI app window to the foreground (click it or use the app switcher / Cmd+Tab), then retry.",
-                        "Ensure the app window is visible and not minimized."
+                        "Restore the app window without activating it, then retry.",
+                        "Ensure Screen & System Audio Recording permission is granted if native window capture is required."
                     });
             }
         }
@@ -1394,6 +1393,105 @@ public class PlatformAgentService : MauiDevFlowAgentService
             NSBitmapImageFileType.Png, new NSDictionary());
         return pngData?.ToArray();
     }
+
+    private static async Task<byte[]?> CaptureWindowViaScreenCaptureKitAsync(NSWindow window)
+    {
+        // Never trigger the system screen-recording prompt from automation. Preflight is
+        // non-interactive; when access is absent we use the in-process rendering fallbacks.
+        if (!OperatingSystem.IsMacOSVersionAtLeast(14) ||
+            (!OperatingSystem.IsMacOSVersionAtLeast(14, 4) && !CGPreflightScreenCaptureAccess()))
+            return null;
+
+        try
+        {
+            using var content = await GetShareableContentAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            var windowId = (uint)window.WindowNumber;
+            var shareableWindow = content.Windows.FirstOrDefault(candidate => candidate.WindowId == windowId);
+            if (shareableWindow == null)
+                return null;
+
+            using var filter = new ScreenCaptureKit.SCContentFilter(shareableWindow);
+            using var configuration = new ScreenCaptureKit.SCStreamConfiguration
+            {
+                Width = (nuint)Math.Max(1, Math.Ceiling(shareableWindow.Frame.Width * window.BackingScaleFactor)),
+                Height = (nuint)Math.Max(1, Math.Ceiling(shareableWindow.Frame.Height * window.BackingScaleFactor)),
+                ShowsCursor = false,
+                PreservesAspectRatio = true,
+                IgnoreShadowsSingleWindow = true,
+                IgnoreGlobalClipSingleWindow = true,
+                CaptureResolution = ScreenCaptureKit.SCCaptureResolutionType.Best
+            };
+
+            if (OperatingSystem.IsMacOSVersionAtLeast(14, 2))
+                configuration.IncludeChildWindows = true;
+
+            var completion = new TaskCompletionSource<byte[]?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            ScreenCaptureKit.SCScreenshotManager.CaptureImage(
+                filter,
+                configuration,
+                (image, error) =>
+                {
+                    if (error != null || image == null)
+                    {
+                        completion.TrySetResult(null);
+                        return;
+                    }
+
+                    try
+                    {
+                        using var bitmapRep = new NSBitmapImageRep(image);
+                        using var properties = new NSDictionary();
+                        using var pngData = bitmapRep.RepresentationUsingTypeProperties(
+                            NSBitmapImageFileType.Png, properties);
+                        completion.TrySetResult(pngData?.ToArray());
+                    }
+                    catch
+                    {
+                        completion.TrySetResult(null);
+                    }
+                });
+
+            return await completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static Task<ScreenCaptureKit.SCShareableContent> GetShareableContentAsync()
+    {
+        var completion = new TaskCompletionSource<ScreenCaptureKit.SCShareableContent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void Complete(
+            ScreenCaptureKit.SCShareableContent content,
+            Foundation.NSError error)
+        {
+            if (error != null)
+                completion.TrySetException(new InvalidOperationException(error.LocalizedDescription));
+            else if (content == null)
+                completion.TrySetException(new InvalidOperationException("ScreenCaptureKit returned no shareable content."));
+            else
+                completion.TrySetResult(content);
+        }
+
+        if (OperatingSystem.IsMacOSVersionAtLeast(14, 4))
+            ScreenCaptureKit.SCShareableContent.GetCurrentProcessShareableContent(Complete);
+        else
+            ScreenCaptureKit.SCShareableContent.GetShareableContent(
+                excludeDesktopWindows: true,
+                onScreenWindowsOnly: false,
+                Complete);
+
+        return completion.Task;
+    }
+
+    [System.Runtime.InteropServices.DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.U1)]
+    static extern bool CGPreflightScreenCaptureAccess();
 
     [System.Runtime.InteropServices.DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
     static extern IntPtr CGWindowListCreateImage(

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/DevFlowAgentService.cs
@@ -35,6 +35,18 @@ public class PlatformAgentService : MauiDevFlowAgentService
             ? new PlatformVisualTreeWalker()
             : new PlatformVisualTreeWalker(NativeElementRegistry);
 
+    protected override string? DeviceIdentifier
+    {
+        get
+        {
+#if IOS
+            return Environment.GetEnvironmentVariable("SIMULATOR_UDID");
+#else
+            return null;
+#endif
+        }
+    }
+
     protected override double GetWindowDisplayDensity(IWindow? window)
     {
         try

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -2185,6 +2185,8 @@ public class AppDescriptor
     public string? Version { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("build")]
     public string? Build { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("processId")]
+    public int? ProcessId { get; set; }
 }
 
 public class AgentCapabilities

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -2159,6 +2159,8 @@ public class AgentDescriptor
 
 public class DeviceDescriptor
 {
+    [System.Text.Json.Serialization.JsonPropertyName("id")]
+    public string? Id { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("platform")]
     public string? Platform { get; set; }
     [System.Text.Json.Serialization.JsonPropertyName("deviceType")]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AlertInfo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AlertInfo.cs
@@ -19,13 +19,14 @@ public record AlertButton(string Label, double X, double Y, double Width, double
 public record AlertInfo(string? Title, IReadOnlyList<AlertButton> Buttons)
 {
     /// <summary>
-    /// Stable fingerprint for this exact visible prompt. Use it when responding so a stale
-    /// automation step cannot act on a different dialog that appeared later.
+    /// One-time response token for this reviewed prompt. Use it when responding so a stale
+    /// automation step cannot act on a different dialog.
     /// </summary>
     public string? PromptId { get; init; }
 
     public int? SourceProcessId { get; init; }
     public string? SourceProcessName { get; init; }
+    public string? InstanceId { get; init; }
     public IReadOnlyList<string> Text { get; init; } = Array.Empty<string>();
     public bool IsSystemDialog { get; init; }
     public bool RequiresUserConfirmation { get; init; }
@@ -38,29 +39,41 @@ public record AlertActionResult(
     string Message,
     AlertInfo? Dialog = null);
 
-internal static class NativeDialogSafety
+public static class NativeDialogIdentity
 {
-    internal static string CreateFingerprint(
-        int sourceProcessId,
-        string sourceProcessName,
+    public static string CreateFingerprint(
+        string platform,
+        string targetIdentity,
         AlertInfo dialog)
     {
         var identity = new StringBuilder()
-            .Append(sourceProcessId).Append('\n')
-            .Append(sourceProcessName).Append('\n')
+            .Append(platform).Append('\n')
+            .Append(targetIdentity).Append('\n')
+            .Append(dialog.InstanceId).Append('\n')
             .Append(dialog.Title).Append('\n');
 
         foreach (var text in dialog.Text)
             identity.Append(text).Append('\n');
 
         foreach (var button in dialog.Buttons)
-            identity.Append(button.Label).Append(':').Append(button.Identifier).Append('\n');
+        {
+            identity
+                .Append(button.Label).Append(':')
+                .Append(button.Identifier).Append(':')
+                .Append(button.X).Append(',')
+                .Append(button.Y).Append(',')
+                .Append(button.Width).Append(',')
+                .Append(button.Height).Append('\n');
+        }
 
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(identity.ToString())))
             [..16]
             .ToLowerInvariant();
     }
+}
 
+internal static class NativeDialogSafety
+{
     internal static bool IsSystemDialogForTarget(
         AlertInfo dialog,
         params string?[] targetNames)
@@ -80,7 +93,7 @@ internal static class NativeDialogSafety
         return false;
     }
 
-    private static bool ContainsWholeName(string promptText, string? targetName)
+    internal static bool ContainsWholeName(string promptText, string? targetName)
     {
         if (string.IsNullOrWhiteSpace(targetName))
             return false;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AlertInfo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AlertInfo.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace Microsoft.Maui.DevFlow.Driver;
 
 /// <summary>
@@ -5,6 +8,7 @@ namespace Microsoft.Maui.DevFlow.Driver;
 /// </summary>
 public record AlertButton(string Label, double X, double Y, double Width, double Height)
 {
+    public string? Identifier { get; init; }
     public int CenterX => (int)(X + Width / 2);
     public int CenterY => (int)(Y + Height / 2);
 }
@@ -12,4 +16,100 @@ public record AlertButton(string Label, double X, double Y, double Width, double
 /// <summary>
 /// Information about a detected alert dialog.
 /// </summary>
-public record AlertInfo(string? Title, IReadOnlyList<AlertButton> Buttons);
+public record AlertInfo(string? Title, IReadOnlyList<AlertButton> Buttons)
+{
+    /// <summary>
+    /// Stable fingerprint for this exact visible prompt. Use it when responding so a stale
+    /// automation step cannot act on a different dialog that appeared later.
+    /// </summary>
+    public string? PromptId { get; init; }
+
+    public int? SourceProcessId { get; init; }
+    public string? SourceProcessName { get; init; }
+    public IReadOnlyList<string> Text { get; init; } = Array.Empty<string>();
+    public bool IsSystemDialog { get; init; }
+    public bool RequiresUserConfirmation { get; init; }
+    public bool CanRespond { get; init; }
+}
+
+public record AlertActionResult(
+    bool Success,
+    bool UserActionRequired,
+    string Message,
+    AlertInfo? Dialog = null);
+
+internal static class NativeDialogSafety
+{
+    internal static string CreateFingerprint(
+        int sourceProcessId,
+        string sourceProcessName,
+        AlertInfo dialog)
+    {
+        var identity = new StringBuilder()
+            .Append(sourceProcessId).Append('\n')
+            .Append(sourceProcessName).Append('\n')
+            .Append(dialog.Title).Append('\n');
+
+        foreach (var text in dialog.Text)
+            identity.Append(text).Append('\n');
+
+        foreach (var button in dialog.Buttons)
+            identity.Append(button.Label).Append(':').Append(button.Identifier).Append('\n');
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(identity.ToString())))
+            [..16]
+            .ToLowerInvariant();
+    }
+
+    internal static bool IsSystemDialogForTarget(
+        AlertInfo dialog,
+        params string?[] targetNames)
+    {
+        var promptText = string.Join(
+            "\n",
+            dialog.Text.Prepend(dialog.Title ?? string.Empty));
+        if (string.IsNullOrWhiteSpace(promptText))
+            return false;
+
+        foreach (var targetName in targetNames)
+        {
+            if (ContainsWholeName(promptText, targetName))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsWholeName(string promptText, string? targetName)
+    {
+        if (string.IsNullOrWhiteSpace(targetName))
+            return false;
+
+        var name = targetName.EndsWith(".app", StringComparison.OrdinalIgnoreCase)
+            ? targetName[..^4]
+            : targetName;
+        if (name.Length < 3)
+            return false;
+
+        var searchIndex = 0;
+        while (searchIndex < promptText.Length)
+        {
+            var matchIndex = promptText.IndexOf(
+                name,
+                searchIndex,
+                StringComparison.OrdinalIgnoreCase);
+            if (matchIndex < 0)
+                return false;
+
+            var beforeIsWord = matchIndex > 0 && char.IsLetterOrDigit(promptText[matchIndex - 1]);
+            var afterIndex = matchIndex + name.Length;
+            var afterIsWord = afterIndex < promptText.Length && char.IsLetterOrDigit(promptText[afterIndex]);
+            if (!beforeIsWord && !afterIsWord)
+                return true;
+
+            searchIndex = matchIndex + 1;
+        }
+
+        return false;
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
@@ -163,7 +163,8 @@ public class AndroidAppDriver : AppDriverBase
     public async Task<AlertActionResult> PressAlertButtonSafelyAsync(
         AlertInfo reviewedDialog,
         string buttonLabel,
-        string expectedPackageId)
+        string expectedPackageId,
+        string expectedAppName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
         var matches = reviewedDialog.Buttons
@@ -180,12 +181,15 @@ public class AndroidAppDriver : AppDriverBase
                 reviewedDialog);
         }
 
-        if (!await IsTargetAppForegroundAsync(expectedPackageId))
+        var attributedToTarget = reviewedDialog.IsSystemDialog
+            ? PermissionPromptNamesTarget(reviewedDialog.Title, expectedAppName)
+            : await IsTargetAppForegroundAsync(expectedPackageId);
+        if (!attributedToTarget)
         {
             return new AlertActionResult(
                 false,
                 true,
-                "The connected Android app is no longer focused. Detect the prompt again.",
+                "The visible Android dialog cannot be safely attributed to the connected app. Detect the prompt again.",
                 reviewedDialog);
         }
 
@@ -359,8 +363,23 @@ public class AndroidAppDriver : AppDriverBase
         if (buttons.Count == 0) return null;
         return new AlertInfo(title ?? "Permission Request", buttons)
         {
-            Text = CollectVisibleText(root)
+            Text = CollectVisibleText(root),
+            IsSystemDialog = true,
+            SourceProcessName = "com.google.android.permissioncontroller"
         };
+    }
+
+    internal static bool PermissionPromptNamesTarget(string? promptText, string targetName)
+    {
+        if (string.IsNullOrWhiteSpace(promptText) || string.IsNullOrWhiteSpace(targetName))
+            return false;
+
+        var match = Regex.Match(
+            promptText,
+            @"^Allow\s+(?<app>.+?)\s+to\b",
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        return match.Success
+            && match.Groups["app"].Value.Equals(targetName, StringComparison.OrdinalIgnoreCase);
     }
 
     private static IReadOnlyList<string> CollectVisibleText(XElement root)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Xml.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Maui.DevFlow.Driver;
 
@@ -116,7 +117,34 @@ public class AndroidAppDriver : AppDriverBase
     {
         var xml = await DumpUiHierarchyAsync().ConfigureAwait(false);
         if (xml is null) return null;
-        return ParseAlertFromHierarchy(xml);
+        var alert = ParseAlertFromHierarchy(xml);
+        if (alert is null) return null;
+        return alert with { InstanceId = await GetFocusedWindowInstanceIdAsync() };
+    }
+
+    public async Task<bool> IsTargetAppForegroundAsync(string packageId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        var windowState = await RunAdbWithOutputAsync("shell dumpsys window windows");
+        if (string.IsNullOrWhiteSpace(windowState))
+            return false;
+
+        return IsFocusedPackage(windowState, packageId);
+    }
+
+    internal static bool IsFocusedPackage(string windowState, string packageId)
+    {
+        var focusedAppLine = windowState
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(line => line.Contains("mFocusedApp", StringComparison.Ordinal));
+        if (focusedAppLine is null)
+            return false;
+        var component = Regex.Match(
+            focusedAppLine,
+            @"(?<package>[A-Za-z0-9._]+)/[A-Za-z0-9._$]+",
+            RegexOptions.CultureInvariant);
+        return component.Success
+            && component.Groups["package"].Value.Equals(packageId, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -130,6 +158,43 @@ public class AndroidAppDriver : AppDriverBase
 
         var btn = FindButtonToTap(alert, buttonLabel);
         await RunAdbAsync($"shell input tap {btn.CenterX} {btn.CenterY}");
+    }
+
+    public async Task<AlertActionResult> PressAlertButtonSafelyAsync(
+        AlertInfo reviewedDialog,
+        string buttonLabel,
+        string expectedPackageId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
+        var matches = reviewedDialog.Buttons
+            .Where(button => button.Label.Equals(buttonLabel, StringComparison.Ordinal))
+            .ToArray();
+        if (matches.Length != 1)
+        {
+            return new AlertActionResult(
+                false,
+                true,
+                matches.Length == 0
+                    ? $"Button '{buttonLabel}' was not found by exact label."
+                    : $"More than one button has the exact label '{buttonLabel}'.",
+                reviewedDialog);
+        }
+
+        if (!await IsTargetAppForegroundAsync(expectedPackageId))
+        {
+            return new AlertActionResult(
+                false,
+                true,
+                "The connected Android app is no longer focused. Detect the prompt again.",
+                reviewedDialog);
+        }
+
+        await RunAdbAsync($"shell input tap {matches[0].CenterX} {matches[0].CenterY}");
+        return new AlertActionResult(
+            true,
+            false,
+            $"Pressed '{buttonLabel}' using Android device input without moving the host pointer.",
+            reviewedDialog);
     }
 
     /// <summary>
@@ -167,6 +232,22 @@ public class AndroidAppDriver : AppDriverBase
 
         try { return XElement.Parse(content); }
         catch { return null; }
+    }
+
+    private async Task<string?> GetFocusedWindowInstanceIdAsync()
+    {
+        var windowState = await RunAdbWithOutputAsync("shell dumpsys window windows");
+        var focusedWindowLine = windowState
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(line => line.Contains("mCurrentFocus", StringComparison.Ordinal));
+        if (focusedWindowLine is null)
+            return null;
+
+        var window = Regex.Match(
+            focusedWindowLine,
+            @"Window\{(?<token>[^\s}]+)",
+            RegexOptions.CultureInvariant);
+        return window.Success ? window.Groups["token"].Value : null;
     }
 
     /// <summary>
@@ -207,7 +288,10 @@ public class AndroidAppDriver : AppDriverBase
                 var label = btn.Attribute("text")?.Value;
                 if (string.IsNullOrEmpty(label)) continue;
                 if (TryParseBounds(btn.Attribute("bounds")?.Value, out var r))
-                    buttons.Add(new AlertButton(label, r.x, r.y, r.w, r.h));
+                    buttons.Add(new AlertButton(label, r.x, r.y, r.w, r.h)
+                    {
+                        Identifier = btn.Attribute("resource-id")?.Value
+                    });
             }
         }
 
@@ -221,11 +305,17 @@ public class AndroidAppDriver : AppDriverBase
                 var label = item.Attribute("text")?.Value;
                 if (string.IsNullOrEmpty(label)) continue;
                 if (TryParseBounds(item.Attribute("bounds")?.Value, out var r))
-                    buttons.Add(new AlertButton(label, r.x, r.y, r.w, r.h));
+                    buttons.Add(new AlertButton(label, r.x, r.y, r.w, r.h)
+                    {
+                        Identifier = item.Attribute("resource-id")?.Value
+                    });
             }
         }
 
-        return new AlertInfo(title, buttons);
+        return new AlertInfo(title, buttons)
+        {
+            Text = CollectVisibleText(parentPanel)
+        };
     }
 
     /// <summary>
@@ -260,12 +350,30 @@ public class AndroidAppDriver : AppDriverBase
             var label = btn.Attribute("text")?.Value ?? btn.Attribute("content-desc")?.Value ?? "";
             if (string.IsNullOrEmpty(label)) continue;
             if (TryParseBounds(btn.Attribute("bounds")?.Value, out var r))
-                buttons.Add(new AlertButton(label, r.x, r.y, r.w, r.h));
+                buttons.Add(new AlertButton(label, r.x, r.y, r.w, r.h)
+                {
+                    Identifier = btn.Attribute("resource-id")?.Value
+                });
         }
 
         if (buttons.Count == 0) return null;
-        return new AlertInfo(title ?? "Permission Request", buttons);
+        return new AlertInfo(title ?? "Permission Request", buttons)
+        {
+            Text = CollectVisibleText(root)
+        };
     }
+
+    private static IReadOnlyList<string> CollectVisibleText(XElement root)
+        => root.DescendantsAndSelf("node")
+            .SelectMany(node => new[]
+            {
+                node.Attribute("text")?.Value,
+                node.Attribute("content-desc")?.Value
+            })
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Select(text => text!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
 
     private static XElement? FindByResourceId(XElement root, string shortId)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/LinuxAppDriver.cs
@@ -68,6 +68,35 @@ public class LinuxAppDriver : AppDriverBase
             await client.TapAsync(buttons[0].Id);
     }
 
+    public async Task<AlertActionResult> PressAlertButtonSafelyAsync(
+        AlertInfo reviewedDialog,
+        string buttonLabel)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
+        var matches = reviewedDialog.Buttons
+            .Where(button => button.Label.Equals(buttonLabel, StringComparison.Ordinal))
+            .ToArray();
+        if (matches.Length != 1 || string.IsNullOrEmpty(matches[0].Identifier))
+        {
+            return new AlertActionResult(
+                false,
+                true,
+                matches.Length == 0
+                    ? $"Button '{buttonLabel}' was not found by exact label."
+                    : "The exact dialog button could not be resolved safely.",
+                reviewedDialog);
+        }
+
+        var pressed = await EnsureClient().TapAsync(matches[0].Identifier!);
+        return new AlertActionResult(
+            pressed,
+            !pressed,
+            pressed
+                ? $"Pressed '{buttonLabel}' through the connected app agent."
+                : $"The connected app agent could not invoke '{buttonLabel}'. Ask the user to respond manually.",
+            reviewedDialog);
+    }
+
     /// <summary>
     /// Convenience: detect and dismiss an alert if present.
     /// </summary>
@@ -338,7 +367,15 @@ public class LinuxAppDriver : AppDriverBase
             var title = element.Text;
             CollectButtons(element, buttons);
             if (buttons.Count > 0)
-                return new AlertInfo(title, buttons);
+            {
+                var text = new List<string>();
+                CollectText(element, text);
+                return new AlertInfo(title, buttons)
+                {
+                    InstanceId = element.Id,
+                    Text = text.Distinct(StringComparer.Ordinal).ToArray()
+                };
+            }
         }
 
         if (element.Children != null)
@@ -357,13 +394,27 @@ public class LinuxAppDriver : AppDriverBase
     {
         if (element.Type == "Button" && element.Text != null)
         {
-            buttons.Add(new AlertButton(element.Text, 0, 0, 0, 0));
+            buttons.Add(new AlertButton(element.Text, 0, 0, 0, 0)
+            {
+                Identifier = element.Id
+            });
         }
 
         if (element.Children != null)
         {
             foreach (var child in element.Children)
                 CollectButtons(child, buttons);
+        }
+    }
+
+    private static void CollectText(ElementInfo element, List<string> text)
+    {
+        if (!string.IsNullOrWhiteSpace(element.Text))
+            text.Add(element.Text);
+        if (element.Children != null)
+        {
+            foreach (var child in element.Children)
+                CollectText(child, text);
         }
     }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Mac/AXElement.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Mac/AXElement.cs
@@ -168,15 +168,7 @@ internal sealed class AXElement : IDisposable
             {
                 var found = child.FindFirstInternal(predicate, depth + 1, maxDepth);
                 if (found is not null)
-                {
-                    // Dispose remaining children
-                    foreach (var c in children)
-                        if (!ReferenceEquals(c, child)) c.Dispose();
-                    // Don't dispose the child that contains the match
-                    // (its subtree was already explored and the found element is independent)
-                    child.Dispose();
                     return found;
-                }
             }
         }
         finally

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Mac/MacAccessibility.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Mac/MacAccessibility.cs
@@ -61,6 +61,13 @@ internal static class MacAccessibility
     internal static extern nint CFArrayGetValueAtIndex(nint theArray, long idx);
 
     [DllImport(CoreFoundationLib)]
+    internal static extern nint CFDictionaryGetValue(nint theDictionary, nint key);
+
+    [DllImport(CoreFoundationLib)]
+    [return: MarshalAs(UnmanagedType.U1)]
+    internal static extern bool CFNumberGetValue(nint number, int numberType, out int value);
+
+    [DllImport(CoreFoundationLib)]
     internal static extern void CFRelease(nint cf);
 
     [DllImport(CoreFoundationLib)]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Mac/MacWindowServer.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Mac/MacWindowServer.cs
@@ -1,0 +1,63 @@
+using System.Runtime.InteropServices;
+using static Microsoft.Maui.DevFlow.Driver.Mac.MacAccessibility;
+
+namespace Microsoft.Maui.DevFlow.Driver.Mac;
+
+internal static class MacWindowServer
+{
+    private const string CoreGraphics =
+        "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
+
+    private const uint WindowListOptionOnScreenOnly = 1;
+    private const int CFNumberSInt32Type = 3;
+
+    internal static int? TryGetWindowId(int processId)
+    {
+        var windows = CGWindowListCopyWindowInfo(WindowListOptionOnScreenOnly, 0);
+        if (windows == 0)
+            return null;
+
+        var ownerPidKey = AXElement.CreateCFString("kCGWindowOwnerPID");
+        var windowNumberKey = AXElement.CreateCFString("kCGWindowNumber");
+        var windowLayerKey = AXElement.CreateCFString("kCGWindowLayer");
+
+        try
+        {
+            var count = CFArrayGetCount(windows);
+            for (long index = 0; index < count; index++)
+            {
+                var window = CFArrayGetValueAtIndex(windows, index);
+                if (window == 0 ||
+                    !TryGetInt(window, ownerPidKey, out var ownerPid) ||
+                    ownerPid != processId ||
+                    !TryGetInt(window, windowLayerKey, out var layer) ||
+                    layer != 0 ||
+                    !TryGetInt(window, windowNumberKey, out var windowId))
+                {
+                    continue;
+                }
+
+                return windowId;
+            }
+
+            return null;
+        }
+        finally
+        {
+            CFRelease(windowLayerKey);
+            CFRelease(windowNumberKey);
+            CFRelease(ownerPidKey);
+            CFRelease(windows);
+        }
+    }
+
+    private static bool TryGetInt(nint dictionary, nint key, out int value)
+    {
+        value = 0;
+        var number = CFDictionaryGetValue(dictionary, key);
+        return number != 0 && CFNumberGetValue(number, CFNumberSInt32Type, out value);
+    }
+
+    [DllImport(CoreGraphics)]
+    private static extern nint CGWindowListCopyWindowInfo(uint option, uint relativeToWindow);
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/MacCatalystAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/MacCatalystAppDriver.cs
@@ -157,7 +157,7 @@ public class MacCatalystAppDriver : AppDriverBase
                 AXElement target;
                 try
                 {
-                    target = PickExactButton(lease.Buttons, buttonLabel);
+                    target = PickExactButton(currentButtons, buttonLabel);
                 }
                 catch (InvalidOperationException ex)
                 {
@@ -181,7 +181,7 @@ public class MacCatalystAppDriver : AppDriverBase
                     true,
                     false,
                     $"Pressed '{buttonLabel}' using AXPress without synthesizing mouse or keyboard input.",
-                    lease.Info));
+                    info));
             }
             finally
             {
@@ -193,7 +193,8 @@ public class MacCatalystAppDriver : AppDriverBase
     /// <summary>
     /// Dismiss the current alert by pressing an exact button label via AXPress.
     /// </summary>
-    public Task DismissAlertAsync(string? buttonLabel = null)
+    /// <param name="buttonLabel">The exact visible button label. A label is always required on macOS.</param>
+    public Task DismissAlertAsync(string buttonLabel)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
         EnsureMacOS();
@@ -222,7 +223,8 @@ public class MacCatalystAppDriver : AppDriverBase
     /// Convenience: detect and dismiss an alert if present, no-op if not.
     /// Single AX tree walk — detects and dismisses in one pass to avoid stale coordinates.
     /// </summary>
-    public Task<AlertInfo?> HandleAlertIfPresentAsync(string? buttonLabel = null)
+    /// <param name="buttonLabel">The exact visible button label. A label is always required on macOS.</param>
+    public Task<AlertInfo?> HandleAlertIfPresentAsync(string buttonLabel)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
         EnsureMacOS();
@@ -725,7 +727,7 @@ public class MacCatalystAppDriver : AppDriverBase
             throw new InvalidOperationException("No buttons found in dialog.");
 
         var matches = buttons
-            .Where(button => GetBestLabel(button).Equals(buttonLabel, StringComparison.Ordinal))
+            .Where(button => ButtonLabelsMatch(GetBestLabel(button), buttonLabel))
             .ToList();
         if (matches.Count == 1)
             return matches[0];
@@ -740,6 +742,13 @@ public class MacCatalystAppDriver : AppDriverBase
         throw new InvalidOperationException(
             $"More than one button has the exact label '{buttonLabel}'. No action was performed.");
     }
+
+    internal static bool ButtonLabelsMatch(string visibleLabel, string requestedLabel)
+        => NormalizeQuotes(visibleLabel).Equals(NormalizeQuotes(requestedLabel), StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizeQuotes(string value)
+        => value.Replace('\u2018', '\'').Replace('\u2019', '\'')
+            .Replace('\u201C', '"').Replace('\u201D', '"');
 
     private static List<AlertButton> ToAlertButtons(List<AXElement> elements)
         => elements.Select(button => new AlertButton(GetBestLabel(button), 0, 0, 0, 0)
@@ -764,28 +773,16 @@ public class MacCatalystAppDriver : AppDriverBase
 
         if (!string.IsNullOrEmpty(AppName))
         {
-            foreach (var process in Process.GetProcesses())
+            var processId = ProcessNameResolver.FindUniqueProcessId(AppName);
+            if (processId.HasValue)
             {
-                using (process)
-                {
-                    try
-                    {
-                        if (process.ProcessName.Equals(AppName, StringComparison.OrdinalIgnoreCase) ||
-                            process.ProcessName.Contains(AppName, StringComparison.OrdinalIgnoreCase))
-                        {
-                            ProcessId = process.Id;
-                            return process.Id;
-                        }
-                    }
-                    catch
-                    {
-                        // A process may exit or deny metadata access while enumerating.
-                    }
-                }
+                ProcessId = processId.Value;
+                return processId.Value;
             }
         }
 
-        throw new InvalidOperationException("ProcessId or AppName must be set for Mac Catalyst operations.");
+        throw new InvalidOperationException(
+            "Unable to uniquely resolve the Mac Catalyst process. Set ProcessId explicitly.");
     }
 
     private static IReadOnlyList<DialogProcess> GetDialogProcesses(

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/MacCatalystAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/MacCatalystAppDriver.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Security.Cryptography;
 using Microsoft.Maui.DevFlow.Driver.Mac;
 
 namespace Microsoft.Maui.DevFlow.Driver;
@@ -11,7 +13,8 @@ namespace Microsoft.Maui.DevFlow.Driver;
 ///
 /// Detection strategy:
 ///   1. AXModalAlert subrole — standard macOS alert sheets (alerts, action sheets, confirm dialogs).
-///   2. Generic "dialog cluster" scan — recursively walks the AX tree looking for any subtree that
+///   2. Explicit AX dialog and sheet containers.
+///   3. Generic "dialog cluster" scan — recursively walks the AX tree looking for any subtree that
 ///      contains ≥1 AXButton plus either AXStaticText or AXTextField, without relying on specific
 ///      nesting depths or container subroles. This catches inline prompt dialogs and any future
 ///      layout changes Apple may introduce.
@@ -23,6 +26,17 @@ namespace Microsoft.Maui.DevFlow.Driver;
 /// </summary>
 public class MacCatalystAppDriver : AppDriverBase
 {
+    private static readonly HashSet<string> SystemDialogProcessNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "CoreServicesUIAgent",
+            "NetAuthAgent",
+            "SecurityAgent",
+            "authorizationhost"
+        };
+    private static readonly ConcurrentDictionary<string, DialogLease> DialogLeases = new();
+    private static readonly TimeSpan DialogLeaseLifetime = TimeSpan.FromMinutes(2);
+
     public override string Platform => "MacCatalyst";
 
     /// <summary>
@@ -41,35 +55,153 @@ public class MacCatalystAppDriver : AppDriverBase
 
     /// <summary>
     /// Detect a native dialog (alert, action sheet, or prompt) using macOS Accessibility API.
+    /// The target app is checked first, followed by known macOS system prompt hosts.
     /// </summary>
     public Task<AlertInfo?> DetectAlertAsync()
     {
         EnsureMacOS();
-        var pid = ResolveProcessId();
-        using var app = AXElement.CreateForApplication(pid);
-        return Task.FromResult(DetectDialog(app));
+        EnsureAccessibilityAuthorized();
+
+        var match = FindDialogMatch();
+        if (match is null)
+            return Task.FromResult<AlertInfo?>(null);
+
+        if (!match.Value.info.CanRespond)
+        {
+            DisposeAll(match.Value.buttons);
+            return Task.FromResult<AlertInfo?>(match.Value.info);
+        }
+
+        return Task.FromResult<AlertInfo?>(CreateDialogLease(match.Value));
+    }
+
+    public bool IsAccessibilityAuthorized()
+    {
+        EnsureMacOS();
+        return MacAccessibility.AXIsProcessTrusted();
     }
 
     /// <summary>
-    /// Dismiss the current alert by pressing a button via AXPress action.
-    /// If buttonLabel is null, presses the first button found.
+    /// Presses an exact button on the exact prompt previously returned by
+    /// <see cref="DetectAlertAsync"/>. If the prompt changed, no action is performed.
+    /// </summary>
+    public Task<AlertActionResult> PressAlertButtonAsync(string promptId, string buttonLabel)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(promptId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
+        EnsureMacOS();
+        EnsureAccessibilityAuthorized();
+
+        PurgeExpiredDialogLeases();
+        if (!DialogLeases.TryRemove(promptId, out var lease))
+        {
+            return Task.FromResult(new AlertActionResult(
+                false,
+                true,
+                "The reviewed prompt expired or was already used. Detect the visible prompt again and ask the user what to do."));
+        }
+
+        using (lease)
+        {
+            if (lease.TargetProcessId != ResolveProcessId())
+            {
+                return Task.FromResult(new AlertActionResult(
+                    false,
+                    true,
+                    "The connected app changed after the prompt was reviewed. Detect the prompt again.",
+                    lease.Info));
+            }
+
+            var match = FindDialogMatch();
+            if (match is null)
+            {
+                return Task.FromResult(new AlertActionResult(
+                    false,
+                    true,
+                    "The reviewed prompt is no longer visible. Ask the user before acting on any new prompt."));
+            }
+
+            var (info, currentButtons) = match.Value;
+            try
+            {
+                var currentFingerprint = NativeDialogSafety.CreateFingerprint(
+                    info.SourceProcessId ?? 0,
+                    info.SourceProcessName ?? string.Empty,
+                    info);
+                if (!string.Equals(lease.Fingerprint, currentFingerprint, StringComparison.Ordinal))
+                {
+                    return Task.FromResult(new AlertActionResult(
+                        false,
+                        true,
+                        "The visible prompt changed after it was reviewed. Detect it again and ask the user what to do.",
+                        info));
+                }
+
+                if (!info.CanRespond)
+                {
+                    return Task.FromResult(new AlertActionResult(
+                        false,
+                        true,
+                        "The visible system dialog cannot be safely attributed to the target app. Ask the user to respond manually.",
+                        info));
+                }
+
+                AXElement target;
+                try
+                {
+                    target = PickExactButton(lease.Buttons, buttonLabel);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    return Task.FromResult(new AlertActionResult(
+                        false,
+                        true,
+                        $"{ex.Message} Ask the user to choose one of the currently visible buttons.",
+                        info));
+                }
+
+                if (!target.Press())
+                {
+                    return Task.FromResult(new AlertActionResult(
+                        false,
+                        true,
+                        $"macOS did not allow the '{buttonLabel}' AXPress action. Ask the user to respond manually.",
+                        info));
+                }
+
+                return Task.FromResult(new AlertActionResult(
+                    true,
+                    false,
+                    $"Pressed '{buttonLabel}' using AXPress without synthesizing mouse or keyboard input.",
+                    lease.Info));
+            }
+            finally
+            {
+                DisposeAll(currentButtons);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Dismiss the current alert by pressing an exact button label via AXPress.
     /// </summary>
     public Task DismissAlertAsync(string? buttonLabel = null)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
         EnsureMacOS();
-        var pid = ResolveProcessId();
-        using var app = AXElement.CreateForApplication(pid);
+        EnsureAccessibilityAuthorized();
 
-        var (_, buttonEls) = FindDialogButtons(app);
-        if (buttonEls is null || buttonEls.Count == 0)
-        {
-            DisposeAll(buttonEls);
+        var match = FindDialogMatch();
+        if (match is null)
             throw new InvalidOperationException("No alert detected to dismiss.");
-        }
 
+        var (info, buttonEls) = match.Value;
         try
         {
-            var target = PickButton(buttonEls, buttonLabel);
+            if (!info.CanRespond)
+                throw new InvalidOperationException("The visible system dialog cannot be safely attributed to the target app. Ask the user to respond manually.");
+
+            var target = PickExactButton(buttonEls, buttonLabel);
             if (!target.Press())
                 throw new InvalidOperationException("AXPress action failed.");
         }
@@ -84,21 +216,23 @@ public class MacCatalystAppDriver : AppDriverBase
     /// </summary>
     public Task<AlertInfo?> HandleAlertIfPresentAsync(string? buttonLabel = null)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
         EnsureMacOS();
-        var pid = ResolveProcessId();
-        using var app = AXElement.CreateForApplication(pid);
+        EnsureAccessibilityAuthorized();
 
-        var (info, buttonEls) = FindDialogButtons(app);
-        if (info is null || buttonEls is null || buttonEls.Count == 0)
-        {
-            DisposeAll(buttonEls);
+        var match = FindDialogMatch();
+        if (match is null)
             return Task.FromResult<AlertInfo?>(null);
-        }
 
+        var (info, buttonEls) = match.Value;
         try
         {
-            var target = PickButton(buttonEls, buttonLabel);
-            target.Press();
+            if (!info.CanRespond)
+                throw new InvalidOperationException("The visible system dialog cannot be safely attributed to the target app. Ask the user to respond manually.");
+
+            var target = PickExactButton(buttonEls, buttonLabel);
+            if (!target.Press())
+                throw new InvalidOperationException("AXPress action failed.");
         }
         finally { DisposeAll(buttonEls); }
 
@@ -111,6 +245,7 @@ public class MacCatalystAppDriver : AppDriverBase
     public Task<string> GetAccessibilityTreeAsync()
     {
         EnsureMacOS();
+        EnsureAccessibilityAuthorized();
         var pid = ResolveProcessId();
         using var app = AXElement.CreateForApplication(pid);
         var children = app.GetChildren();
@@ -141,11 +276,10 @@ public class MacCatalystAppDriver : AppDriverBase
         if (!fullPath.EndsWith(".mov", StringComparison.OrdinalIgnoreCase))
             fullPath = Path.ChangeExtension(fullPath, ".mov");
 
-        // Try to capture just the app window using -l windowID
-        var args = $"-v \"{fullPath}\"";
-        var windowId = TryGetWindowId();
-        if (windowId.HasValue)
-            args = $"-v -l {windowId.Value} \"{fullPath}\"";
+        var windowId = TryGetWindowId()
+            ?? throw new InvalidOperationException(
+                "No visible app window was found. Refusing to record the entire desktop.");
+        var args = $"-v -l {windowId} \"{fullPath}\"";
 
         var psi = new ProcessStartInfo("screencapture", args)
         {
@@ -195,34 +329,15 @@ public class MacCatalystAppDriver : AppDriverBase
     }
 
     /// <summary>
-    /// Resolves the CGWindowID for the app's main window via the macOS window list.
-    /// Uses a small Python script to call CoreGraphics, avoiding native P/Invoke complexity.
+    /// Resolves the CGWindowID for the app's frontmost visible normal window via
+    /// CoreGraphics without activating the application.
     /// Returns null if the window cannot be found.
     /// </summary>
     private int? TryGetWindowId()
     {
         try
         {
-            var pid = ResolveProcessId();
-            var script = $"""
-                import Quartz
-                wl = Quartz.CGWindowListCopyWindowInfo(Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID)
-                for w in wl:
-                    if w.get('kCGWindowOwnerPID') == {pid} and w.get('kCGWindowLayer', 99) == 0:
-                        print(w['kCGWindowNumber'])
-                        break
-                """;
-            var psi = new ProcessStartInfo("python3", $"-c \"{script.Replace("\"", "\\\"")}\"")
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-            using var proc = Process.Start(psi);
-            if (proc == null) return null;
-            var output = proc.StandardOutput.ReadToEnd().Trim();
-            proc.WaitForExit(5000);
-            return int.TryParse(output, out var wid) ? wid : null;
+            return MacWindowServer.TryGetWindowId(ResolveProcessId());
         }
         catch
         {
@@ -231,14 +346,117 @@ public class MacCatalystAppDriver : AppDriverBase
     }
 
     // ──────────────────────────────────────────────
-    // Detection: returns AlertInfo only (for detect command)
+    // Detection
     // ──────────────────────────────────────────────
 
-    private static AlertInfo? DetectDialog(AXElement app)
+    private (AlertInfo info, List<AXElement> buttons)? FindDialogMatch()
     {
-        var (info, buttonEls) = FindDialogButtons(app);
-        DisposeAll(buttonEls);
-        return info;
+        var targetPid = ResolveProcessId();
+        var targetProcessName = GetProcessName(targetPid) ?? AppName ?? "Target App";
+        (AlertInfo info, List<AXElement> buttons)? unattributedSystemDialog = null;
+
+        foreach (var candidate in GetDialogProcesses(targetPid, targetProcessName))
+        {
+            try
+            {
+                using var app = AXElement.CreateForApplication(candidate.ProcessId);
+                var match = FindDialogButtons(app);
+                var isRecognizedDialog = match.isRecognizedDialog;
+                if ((match.info is null || match.buttons is null || match.buttons.Count == 0) &&
+                    candidate.IsSystemDialog)
+                {
+                    DisposeAll(match.buttons);
+                    match = FindSystemDialogButtons(app);
+                    isRecognizedDialog = false;
+                }
+
+                if (match.info is null || match.buttons is null || match.buttons.Count == 0)
+                {
+                    DisposeAll(match.buttons);
+                    continue;
+                }
+
+                var canRespond = !candidate.IsSystemDialog ||
+                    (isRecognizedDialog &&
+                    NativeDialogSafety.IsSystemDialogForTarget(
+                        match.info,
+                        AppName,
+                        targetProcessName));
+                var info = match.info with
+                {
+                    SourceProcessId = candidate.ProcessId,
+                    SourceProcessName = candidate.ProcessName,
+                    IsSystemDialog = candidate.IsSystemDialog,
+                    RequiresUserConfirmation = true,
+                    CanRespond = canRespond
+                };
+
+                if (canRespond)
+                {
+                    DisposeAll(unattributedSystemDialog?.buttons);
+                    return (info, match.buttons);
+                }
+
+                if (unattributedSystemDialog is null)
+                    unattributedSystemDialog = (info, match.buttons);
+                else
+                    DisposeAll(match.buttons);
+            }
+            catch when (candidate.IsSystemDialog)
+            {
+                // System prompt hosts are short-lived; continue if one exits during the scan.
+            }
+        }
+
+        return unattributedSystemDialog;
+    }
+
+    private AlertInfo CreateDialogLease(
+        (AlertInfo info, List<AXElement> buttons) match)
+    {
+        PurgeExpiredDialogLeases();
+
+        var promptId = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+        var leasedInfo = match.info with { PromptId = promptId };
+        var fingerprint = NativeDialogSafety.CreateFingerprint(
+            match.info.SourceProcessId ?? 0,
+            match.info.SourceProcessName ?? string.Empty,
+            match.info);
+        var lease = new DialogLease(
+            ResolveProcessId(),
+            fingerprint,
+            leasedInfo,
+            match.buttons,
+            DateTimeOffset.UtcNow.Add(DialogLeaseLifetime));
+
+        if (!DialogLeases.TryAdd(promptId, lease))
+        {
+            lease.Dispose();
+            throw new InvalidOperationException("Unable to create a unique native-dialog response token.");
+        }
+
+        _ = ExpireDialogLeaseAsync(promptId);
+        return leasedInfo;
+    }
+
+    private static async Task ExpireDialogLeaseAsync(string promptId)
+    {
+        await Task.Delay(DialogLeaseLifetime).ConfigureAwait(false);
+        if (DialogLeases.TryRemove(promptId, out var expired))
+            expired.Dispose();
+    }
+
+    private static void PurgeExpiredDialogLeases()
+    {
+        var now = DateTimeOffset.UtcNow;
+        foreach (var entry in DialogLeases)
+        {
+            if (entry.Value.ExpiresAt <= now &&
+                DialogLeases.TryRemove(entry.Key, out var expired))
+            {
+                expired.Dispose();
+            }
+        }
     }
 
     // ──────────────────────────────────────────────
@@ -250,9 +468,10 @@ public class MacCatalystAppDriver : AppDriverBase
     /// Caller MUST dispose the button elements.
     ///
     /// Strategy 1: Find an AXModalAlert subrole node — collect its direct-child text and buttons.
-    /// Strategy 2 (fallback): Generic dialog cluster scan via <see cref="FindDialogCluster"/>.
+    /// Strategy 2: Find an explicit dialog or sheet container.
+    /// Strategy 3: Generic dialog cluster scan via <see cref="FindDialogCluster"/>.
     /// </summary>
-    private static (AlertInfo? info, List<AXElement>? buttons) FindDialogButtons(AXElement app)
+    private static (AlertInfo? info, List<AXElement>? buttons, bool isRecognizedDialog) FindDialogButtons(AXElement app)
     {
         // Strategy 1: AXModalAlert — the standard, most reliable signal
         using var modalAlert = app.FindFirst(el => el.Subrole == "AXModalAlert");
@@ -260,16 +479,52 @@ public class MacCatalystAppDriver : AppDriverBase
         {
             var result = CollectButtonsAndText(modalAlert);
             if (result.buttons.Count > 0)
-                return (new AlertInfo(result.title, ToAlertButtons(result.buttons)), result.buttons);
+                return (CreateAlertInfo(result.texts, result.buttons), result.buttons, true);
             DisposeAll(result.buttons);
         }
 
-        // Strategy 2: Generic dialog cluster — handles inline prompts and any other dialog shape
+        // Strategy 2: Explicit AX dialog/sheet containers.
+        using var dialog = app.FindFirst(el =>
+            el.Role == "AXSheet" ||
+            el.Subrole is "AXDialog" or "AXSystemDialog");
+        if (dialog is not null)
+        {
+            var result = CollectButtonsAndText(dialog);
+            if (result.buttons.Count > 0)
+                return (CreateAlertInfo(result.texts, result.buttons), result.buttons, true);
+            DisposeAll(result.buttons);
+        }
+
+        // Strategy 3: Generic dialog cluster — handles inline prompts and any other dialog shape
         var cluster = FindDialogCluster(app);
         if (cluster is not null)
-            return cluster.Value;
+            return (cluster.Value.info, cluster.Value.buttons, false);
 
-        return (null, null);
+        return (null, null, false);
+    }
+
+    private static (AlertInfo? info, List<AXElement>? buttons, bool isRecognizedDialog) FindSystemDialogButtons(AXElement app)
+    {
+        var windows = app.GetChildren();
+        try
+        {
+            foreach (var window in windows)
+            {
+                if (window.Role != "AXWindow")
+                    continue;
+
+                var result = CollectButtonsAndText(window);
+                if (result.buttons.Count > 0)
+                    return (CreateAlertInfo(result.texts, result.buttons), result.buttons, false);
+                DisposeAll(result.buttons);
+            }
+        }
+        finally
+        {
+            DisposeAll(windows);
+        }
+
+        return (null, null, false);
     }
 
     /// <summary>
@@ -277,14 +532,14 @@ public class MacCatalystAppDriver : AppDriverBase
     /// Returns retained AXButton elements — caller must dispose.
     /// Reads label from ALL attributes (Title, Description, Value) for maximum resilience.
     /// </summary>
-    private static (string? title, List<AXElement> buttons) CollectButtonsAndText(AXElement container)
+    private static (List<string> texts, List<AXElement> buttons) CollectButtonsAndText(AXElement container)
     {
         var texts = new List<string>();
         var buttonEls = new List<AXElement>();
 
         CollectRecursive(container, texts, buttonEls, depth: 0, maxDepth: 6);
 
-        return (texts.Count > 0 ? texts[0] : null, buttonEls);
+        return (texts, buttonEls);
     }
 
     private static void CollectRecursive(AXElement el, List<string> texts, List<AXElement> buttonEls, int depth, int maxDepth)
@@ -376,7 +631,7 @@ public class MacCatalystAppDriver : AppDriverBase
 
                 if (buttonEls.Count > 0)
                 {
-                    var info = new AlertInfo(texts.Count > 0 ? texts[0] : null, ToAlertButtons(buttonEls));
+                    var info = CreateAlertInfo(texts, buttonEls);
                     return (info, buttonEls);
                 }
                 DisposeAll(buttonEls);
@@ -454,40 +709,41 @@ public class MacCatalystAppDriver : AppDriverBase
     }
 
     /// <summary>
-    /// Normalizes smart/curly quotes to ASCII for reliable matching across locales.
+    /// Picks one button by exact visible label and rejects ambiguous matches.
     /// </summary>
-    private static string NormalizeQuotes(string s)
-        => s.Replace('\u2018', '\'').Replace('\u2019', '\'')
-            .Replace('\u201C', '"').Replace('\u201D', '"');
-
-    /// <summary>
-    /// Picks the button to press. If a label is specified, matches case-insensitively
-    /// with quote normalization. Otherwise picks the first button.
-    /// </summary>
-    private static AXElement PickButton(List<AXElement> buttons, string? buttonLabel)
+    private static AXElement PickExactButton(List<AXElement> buttons, string buttonLabel)
     {
         if (buttons.Count == 0)
             throw new InvalidOperationException("No buttons found in dialog.");
 
-        if (buttonLabel is not null)
+        var matches = buttons
+            .Where(button => GetBestLabel(button).Equals(buttonLabel, StringComparison.Ordinal))
+            .ToList();
+        if (matches.Count == 1)
+            return matches[0];
+
+        var available = string.Join(", ", buttons.Select(GetBestLabel));
+        if (matches.Count == 0)
         {
-            var normalized = NormalizeQuotes(buttonLabel);
-            var match = buttons.FirstOrDefault(b =>
-                NormalizeQuotes(GetBestLabel(b)).Equals(normalized, StringComparison.OrdinalIgnoreCase));
-            if (match is null)
-            {
-                var available = string.Join(", ", buttons.Select(b => GetBestLabel(b)));
-                throw new InvalidOperationException($"Button '{buttonLabel}' not found. Available: {available}");
-            }
-            return match;
+            throw new InvalidOperationException(
+                $"Button '{buttonLabel}' was not found by exact label. Available: {available}");
         }
 
-        // No label specified — return first button
-        return buttons[0];
+        throw new InvalidOperationException(
+            $"More than one button has the exact label '{buttonLabel}'. No action was performed.");
     }
 
     private static List<AlertButton> ToAlertButtons(List<AXElement> elements)
-        => elements.Select(b => new AlertButton(GetBestLabel(b), 0, 0, 0, 0)).ToList();
+        => elements.Select(button => new AlertButton(GetBestLabel(button), 0, 0, 0, 0)
+        {
+            Identifier = button.Identifier
+        }).ToList();
+
+    private static AlertInfo CreateAlertInfo(List<string> texts, List<AXElement> buttons)
+        => new(texts.FirstOrDefault(), ToAlertButtons(buttons))
+        {
+            Text = texts
+        };
 
     // ──────────────────────────────────────────────
     // Helpers
@@ -500,27 +756,79 @@ public class MacCatalystAppDriver : AppDriverBase
 
         if (!string.IsNullOrEmpty(AppName))
         {
-            var psi = new ProcessStartInfo("pgrep", $"-f {AppName}")
+            foreach (var process in Process.GetProcesses())
             {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-            using var proc = Process.Start(psi);
-            if (proc is not null)
-            {
-                var output = proc.StandardOutput.ReadToEnd();
-                proc.WaitForExit();
-                var lines = output.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries);
-                if (lines.Length > 0 && int.TryParse(lines[0].Trim(), out var pid))
+                using (process)
                 {
-                    ProcessId = pid;
-                    return pid;
+                    try
+                    {
+                        if (process.ProcessName.Equals(AppName, StringComparison.OrdinalIgnoreCase) ||
+                            process.ProcessName.Contains(AppName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            ProcessId = process.Id;
+                            return process.Id;
+                        }
+                    }
+                    catch
+                    {
+                        // A process may exit or deny metadata access while enumerating.
+                    }
                 }
             }
         }
 
         throw new InvalidOperationException("ProcessId or AppName must be set for Mac Catalyst operations.");
+    }
+
+    private static IReadOnlyList<DialogProcess> GetDialogProcesses(
+        int targetPid,
+        string targetProcessName)
+    {
+        var processes = new List<DialogProcess>
+        {
+            new(targetPid, targetProcessName, false)
+        };
+
+        foreach (var process in Process.GetProcesses())
+        {
+            using (process)
+            {
+                try
+                {
+                    if (process.Id != targetPid && SystemDialogProcessNames.Contains(process.ProcessName))
+                        processes.Add(new DialogProcess(process.Id, process.ProcessName, true));
+                }
+                catch
+                {
+                    // A process may exit or deny metadata access while enumerating.
+                }
+            }
+        }
+
+        return processes;
+    }
+
+    private static string? GetProcessName(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return process.ProcessName;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void EnsureAccessibilityAuthorized()
+    {
+        if (!MacAccessibility.AXIsProcessTrusted())
+        {
+            throw new InvalidOperationException(
+                "macOS Accessibility permission is required for native dialog interaction. " +
+                "Pause and ask the user to grant Accessibility access to the terminal or host running maui, then retry.");
+        }
     }
 
     private static void EnsureMacOS()
@@ -533,5 +841,26 @@ public class MacCatalystAppDriver : AppDriverBase
     {
         if (elements is null) return;
         foreach (var el in elements) el.Dispose();
+    }
+
+    private readonly record struct DialogProcess(
+        int ProcessId,
+        string ProcessName,
+        bool IsSystemDialog);
+
+    private sealed class DialogLease(
+        int targetProcessId,
+        string fingerprint,
+        AlertInfo info,
+        List<AXElement> buttons,
+        DateTimeOffset expiresAt) : IDisposable
+    {
+        public int TargetProcessId { get; } = targetProcessId;
+        public string Fingerprint { get; } = fingerprint;
+        public AlertInfo Info { get; } = info;
+        public List<AXElement> Buttons { get; } = buttons;
+        public DateTimeOffset ExpiresAt { get; } = expiresAt;
+
+        public void Dispose() => DisposeAll(Buttons);
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/MacCatalystAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/MacCatalystAppDriver.cs
@@ -81,6 +81,14 @@ public class MacCatalystAppDriver : AppDriverBase
         return MacAccessibility.AXIsProcessTrusted();
     }
 
+    public static void CancelAlertResponse(string promptId)
+    {
+        if (string.IsNullOrWhiteSpace(promptId))
+            return;
+        if (DialogLeases.TryRemove(promptId, out var lease))
+            lease.Dispose();
+    }
+
     /// <summary>
     /// Presses an exact button on the exact prompt previously returned by
     /// <see cref="DetectAlertAsync"/>. If the prompt changed, no action is performed.
@@ -124,9 +132,9 @@ public class MacCatalystAppDriver : AppDriverBase
             var (info, currentButtons) = match.Value;
             try
             {
-                var currentFingerprint = NativeDialogSafety.CreateFingerprint(
-                    info.SourceProcessId ?? 0,
-                    info.SourceProcessName ?? string.Empty,
+                var currentFingerprint = NativeDialogIdentity.CreateFingerprint(
+                    Platform,
+                    $"{info.SourceProcessId ?? 0}:{info.SourceProcessName}",
                     info);
                 if (!string.Equals(lease.Fingerprint, currentFingerprint, StringComparison.Ordinal))
                 {
@@ -418,9 +426,9 @@ public class MacCatalystAppDriver : AppDriverBase
 
         var promptId = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
         var leasedInfo = match.info with { PromptId = promptId };
-        var fingerprint = NativeDialogSafety.CreateFingerprint(
-            match.info.SourceProcessId ?? 0,
-            match.info.SourceProcessName ?? string.Empty,
+        var fingerprint = NativeDialogIdentity.CreateFingerprint(
+            Platform,
+            $"{match.info.SourceProcessId ?? 0}:{match.info.SourceProcessName}",
             match.info);
         var lease = new DialogLease(
             ResolveProcessId(),

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ProcessNameResolver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ProcessNameResolver.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+
+namespace Microsoft.Maui.DevFlow.Driver;
+
+internal static class ProcessNameResolver
+{
+    internal static int? FindUniqueProcessId(string? processName)
+    {
+        if (string.IsNullOrWhiteSpace(processName))
+            return null;
+
+        var candidates = new List<(int ProcessId, string ProcessName)>();
+        foreach (var process in Process.GetProcesses())
+        {
+            using (process)
+            {
+                try
+                {
+                    if (process.ProcessName.Contains(processName, StringComparison.OrdinalIgnoreCase))
+                        candidates.Add((process.Id, process.ProcessName));
+                }
+                catch
+                {
+                    // A process may exit or deny metadata access while enumerating.
+                }
+            }
+        }
+
+        return FindUniqueProcessId(processName, candidates);
+    }
+
+    internal static int? FindUniqueProcessId(
+        string? processName,
+        IEnumerable<(int ProcessId, string ProcessName)> candidates)
+    {
+        if (string.IsNullOrWhiteSpace(processName))
+            return null;
+
+        var matches = candidates
+            .Where(candidate => candidate.ProcessName.Contains(processName, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        var exactMatches = matches
+            .Where(candidate => candidate.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (exactMatches.Length == 1)
+            return exactMatches[0].ProcessId;
+        if (exactMatches.Length > 1)
+            return null;
+
+        return matches.Length == 1 ? matches[0].ProcessId : null;
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Properties/InternalsVisibleTo.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Properties/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Maui.DevFlow.Tests")]
+[assembly: InternalsVisibleTo("maui")]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ScreenshotResult.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/ScreenshotResult.cs
@@ -20,7 +20,7 @@ public sealed class ScreenshotResult
     /// <summary>Human-readable, actionable error message when the capture failed.</summary>
     public string? Error { get; init; }
 
-    /// <summary>Machine-readable cause identifier (e.g. <c>window-not-frontmost</c>) when available.</summary>
+    /// <summary>Machine-readable cause identifier (e.g. <c>window-not-visible</c>) when available.</summary>
     public string? Reason { get; init; }
 
     /// <summary>Whether retrying (e.g. after foregrounding the app) may succeed.</summary>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/WindowsAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/WindowsAppDriver.cs
@@ -257,6 +257,37 @@ public class WindowsAppDriver : AppDriverBase
         return Task.CompletedTask;
     }
 
+    public Task<AlertActionResult> PressAlertButtonSafelyAsync(string buttonLabel)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
+        EnsureWindows();
+        var windows = ResolveTargetWindows();
+        var buttons = FindDialogButtonsCore(windows);
+        var matches = buttons
+            .Where(button => button.name.Equals(buttonLabel, StringComparison.Ordinal))
+            .ToArray();
+        var info = DetectDialog(windows);
+        if (matches.Length != 1)
+        {
+            return Task.FromResult(new AlertActionResult(
+                false,
+                true,
+                matches.Length == 0
+                    ? $"Button '{buttonLabel}' was not found by exact label."
+                    : $"More than one button has the exact label '{buttonLabel}'.",
+                info));
+        }
+
+        var pressed = UIAutomationInterop.InvokeElement(matches[0].element);
+        return Task.FromResult(new AlertActionResult(
+            pressed,
+            !pressed,
+            pressed
+                ? $"Pressed '{buttonLabel}' using UI Automation Invoke without synthesizing pointer input."
+                : $"UI Automation could not invoke '{buttonLabel}'. Ask the user to respond manually.",
+            info));
+    }
+
     public Task<AlertInfo?> HandleAlertIfPresentAsync(string? buttonLabel = null)
     {
         EnsureWindows();
@@ -267,7 +298,11 @@ public class WindowsAppDriver : AppDriverBase
 
         var alertButtons = buttons.Select(ToAlertButton).ToList();
         var texts = FindDialogTextsCore(windows);
-        var info = new AlertInfo(texts.FirstOrDefault(), alertButtons);
+        var info = new AlertInfo(texts.FirstOrDefault(), alertButtons)
+        {
+            InstanceId = FindDialogCandidate(windows)?.InstanceId,
+            Text = texts
+        };
 
         var target = PickButton(buttons, buttonLabel);
         if (!UIAutomationInterop.InvokeElement(target.element))
@@ -294,7 +329,11 @@ public class WindowsAppDriver : AppDriverBase
 
         var alertButtons = buttons.Select(ToAlertButton).ToList();
         var texts = FindDialogTextsCore(windows);
-        return new AlertInfo(texts.FirstOrDefault(), alertButtons);
+        return new AlertInfo(texts.FirstOrDefault(), alertButtons)
+        {
+            InstanceId = FindDialogCandidate(windows)?.InstanceId,
+            Text = texts
+        };
     }
 
     private static List<(IUIAutomationElement element, string name)> FindDialogButtonsCore(IReadOnlyList<IUIAutomationElement> windows)
@@ -321,7 +360,10 @@ public class WindowsAppDriver : AppDriverBase
                 {
                     var texts = UIAutomationInterop.FindTexts(childWindow);
                     if (texts.Count > 0)
-                        return new DialogCandidate(buttons, texts);
+                        return new DialogCandidate(
+                            buttons,
+                            texts,
+                            UIAutomationInterop.GetNativeWindowHandle(childWindow).ToInt64().ToString("X"));
                 }
             }
         }
@@ -333,7 +375,10 @@ public class WindowsAppDriver : AppDriverBase
             {
                 var texts = UIAutomationInterop.FindTexts(window);
                 if (texts.Count > 0)
-                    return new DialogCandidate(buttons, texts);
+                    return new DialogCandidate(
+                        buttons,
+                        texts,
+                        UIAutomationInterop.GetNativeWindowHandle(window).ToInt64().ToString("X"));
             }
         }
 
@@ -343,14 +388,18 @@ public class WindowsAppDriver : AppDriverBase
     private static AlertButton ToAlertButton((IUIAutomationElement element, string name) button)
     {
         var rect = UIAutomationInterop.GetBoundingRectangle(button.element);
-        return rect is null
+        return (rect is null
             ? new AlertButton(button.name, 0, 0, 0, 0)
-            : new AlertButton(button.name, rect.Value.X, rect.Value.Y, rect.Value.Width, rect.Value.Height);
+            : new AlertButton(button.name, rect.Value.X, rect.Value.Y, rect.Value.Width, rect.Value.Height)) with
+        {
+            Identifier = UIAutomationInterop.GetAutomationId(button.element)
+        };
     }
 
     private sealed record DialogCandidate(
         List<(IUIAutomationElement element, string name)> Buttons,
-        List<string> Texts);
+        List<string> Texts,
+        string InstanceId);
 
     private static readonly HashSet<string> CommonDialogButtonLabels = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -382,6 +431,7 @@ public class WindowsAppDriver : AppDriverBase
     public Task<AlertInfo?> DetectAlertAsync() => throw new PlatformNotSupportedException("Windows operations require Windows.");
     public Task DismissAlertAsync(string? buttonLabel = null) => throw new PlatformNotSupportedException("Windows operations require Windows.");
     public Task<AlertInfo?> HandleAlertIfPresentAsync(string? buttonLabel = null) => throw new PlatformNotSupportedException("Windows operations require Windows.");
+    public Task<AlertActionResult> PressAlertButtonSafelyAsync(string buttonLabel) => throw new PlatformNotSupportedException("Windows operations require Windows.");
     public Task<string> GetAccessibilityTreeAsync() => throw new PlatformNotSupportedException("Windows operations require Windows.");
 #endif
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/iOSSimulatorAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/iOSSimulatorAppDriver.cs
@@ -35,6 +35,8 @@ public class iOSSimulatorAppDriver : AppDriverBase
     /// </summary>
     public string? BundleId { get; set; }
 
+    public string? ExpectedAppName { get; set; }
+
     public override async Task<ThemeResult> SetThemeAsync(DevFlowTheme theme, ThemeSetScope scope = ThemeSetScope.Auto)
     {
         if (scope == ThemeSetScope.App || (scope == ThemeSetScope.Auto && theme == DevFlowTheme.System))
@@ -125,6 +127,12 @@ public class iOSSimulatorAppDriver : AppDriverBase
                 json = SanitizeJson(json);
                 using var doc = JsonDocument.Parse(json);
                 var elements = ParseElements(doc.RootElement);
+                if (!string.IsNullOrWhiteSpace(ExpectedAppName)
+                    && !ApplicationRootMatchesTarget(elements, ExpectedAppName))
+                {
+                    return null;
+                }
+
                 var alert = FindAlert(elements);
                 if (alert is not null)
                     return alert;
@@ -158,6 +166,33 @@ public class iOSSimulatorAppDriver : AppDriverBase
                 ?? alert.Buttons[0];
 
         await TapCoordinateAsync(button.CenterX, button.CenterY).ConfigureAwait(false);
+    }
+
+    public async Task<AlertActionResult> PressAlertButtonSafelyAsync(
+        AlertInfo reviewedDialog,
+        string buttonLabel)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(buttonLabel);
+        var matches = reviewedDialog.Buttons
+            .Where(button => button.Label.Equals(buttonLabel, StringComparison.Ordinal))
+            .ToArray();
+        if (matches.Length != 1)
+        {
+            return new AlertActionResult(
+                false,
+                true,
+                matches.Length == 0
+                    ? $"Button '{buttonLabel}' was not found by exact label."
+                    : $"More than one button has the exact label '{buttonLabel}'.",
+                reviewedDialog);
+        }
+
+        await TapCoordinateAsync(matches[0].CenterX, matches[0].CenterY).ConfigureAwait(false);
+        return new AlertActionResult(
+            true,
+            false,
+            $"Pressed '{buttonLabel}' using simulator HID input without moving the host pointer.",
+            reviewedDialog);
     }
 
     /// <summary>
@@ -454,7 +489,7 @@ public class iOSSimulatorAppDriver : AppDriverBase
 
     // --- Accessibility tree parsing ---
 
-    private record AccessibilityElement(string? Label, string? Value, string? Type, string? Description,
+    private record AccessibilityElement(string? Label, string? Value, string? Type, string? Description, string? Identifier,
         double X, double Y, double Width, double Height, IReadOnlyList<AccessibilityElement> Children);
 
     private static IReadOnlyList<AccessibilityElement> ParseElements(JsonElement element)
@@ -472,6 +507,9 @@ public class iOSSimulatorAppDriver : AppDriverBase
         var value = el.TryGetProperty("AXValue", out var v) ? v.GetString() : null;
         var type = el.TryGetProperty("type", out var t) ? t.GetString() : null;
         var description = el.TryGetProperty("AXDescription", out var d) ? d.GetString() : null;
+        var identifier = el.TryGetProperty("AXUniqueId", out var uniqueId)
+            ? uniqueId.GetString()
+            : el.TryGetProperty("AXIdentifier", out var id) ? id.GetString() : null;
 
         double x = 0, y = 0, w = 0, h = 0;
         if (el.TryGetProperty("frame", out var f) && f.ValueKind == JsonValueKind.Object)
@@ -486,7 +524,7 @@ public class iOSSimulatorAppDriver : AppDriverBase
         if (el.TryGetProperty("children", out var c) && c.ValueKind == JsonValueKind.Array)
             children = c.EnumerateArray().Select(ParseElement).ToList();
 
-        return new AccessibilityElement(label, value, type, description, x, y, w, h, children);
+        return new AccessibilityElement(label, value, type, description, identifier, x, y, w, h, children);
     }
 
     private static AlertInfo? FindAlert(IReadOnlyList<AccessibilityElement> elements)
@@ -501,7 +539,11 @@ public class iOSSimulatorAppDriver : AppDriverBase
                 if (buttons.Count > 0)
                 {
                     var title = FindFirstLabelOfType(el, "StaticText");
-                    return new AlertInfo(title, buttons);
+                    return new AlertInfo(title, buttons)
+                    {
+                        InstanceId = el.Identifier,
+                        Text = CollectText(el)
+                    };
                 }
             }
 
@@ -540,7 +582,11 @@ public class iOSSimulatorAppDriver : AppDriverBase
                 if (buttons.Count > 0)
                 {
                     var title = FindFirstLabelOfType(app, "StaticText");
-                    return new AlertInfo(title, buttons);
+                    return new AlertInfo(title, buttons)
+                    {
+                        InstanceId = app.Identifier,
+                        Text = CollectText(app)
+                    };
                 }
             }
         }
@@ -557,7 +603,10 @@ public class iOSSimulatorAppDriver : AppDriverBase
         if (el.Type is not null && el.Type.Contains("Button", StringComparison.OrdinalIgnoreCase)
             && el.Label is not null && el.Width > 0)
         {
-            buttons.Add(new AlertButton(el.Label, el.X, el.Y, el.Width, el.Height));
+            buttons.Add(new AlertButton(el.Label, el.X, el.Y, el.Width, el.Height)
+            {
+                Identifier = el.Identifier
+            });
         }
 
         foreach (var child in el.Children)
@@ -574,5 +623,40 @@ public class iOSSimulatorAppDriver : AppDriverBase
             if (found is not null) return found;
         }
         return null;
+    }
+
+    private static IReadOnlyList<string> CollectText(AccessibilityElement element)
+    {
+        var text = new List<string>();
+        CollectText(element, text);
+        return text.Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static void CollectText(AccessibilityElement element, List<string> text)
+    {
+        if (!string.IsNullOrWhiteSpace(element.Label))
+            text.Add(element.Label);
+        if (!string.IsNullOrWhiteSpace(element.Value))
+            text.Add(element.Value);
+        if (!string.IsNullOrWhiteSpace(element.Description))
+            text.Add(element.Description);
+        foreach (var child in element.Children)
+            CollectText(child, text);
+    }
+
+    private static bool ApplicationRootMatchesTarget(
+        IReadOnlyList<AccessibilityElement> elements,
+        string targetName)
+    {
+        var application = elements.FirstOrDefault(element =>
+            element.Type?.Equals("Application", StringComparison.OrdinalIgnoreCase) == true);
+        if (application is null)
+            return false;
+
+        var normalizedTarget = targetName.EndsWith(".app", StringComparison.OrdinalIgnoreCase)
+            ? targetName[..^4]
+            : targetName;
+        return new[] { application.Label, application.Value, application.Description }
+            .Any(value => value?.Equals(normalizedTarget, StringComparison.OrdinalIgnoreCase) == true);
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/iOSSimulatorAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/iOSSimulatorAppDriver.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Maui.DevFlow.Driver;
 
@@ -563,10 +564,13 @@ public class iOSSimulatorAppDriver : AppDriverBase
         // versions don't break detection.
         var app = elements.FirstOrDefault(e =>
             string.Equals(e.Type, "Application", StringComparison.OrdinalIgnoreCase));
-        if (app is not null && app.Children.Count >= 2)
+        if (app is not null && app.Children.Count is >= 2 and <= 8)
         {
             var childTypes = app.Children.Select(c => c.Type).ToList();
-            bool hasButtons = childTypes.Any(t => string.Equals(t, "Button", StringComparison.OrdinalIgnoreCase));
+            var buttonCount = childTypes.Count(t =>
+                string.Equals(t, "Button", StringComparison.OrdinalIgnoreCase));
+            var hasPromptText = childTypes.Any(t =>
+                string.Equals(t, "StaticText", StringComparison.OrdinalIgnoreCase));
             bool hasAppContainer = childTypes.Any(t =>
                 string.Equals(t, "Window", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(t, "NavigationBar", StringComparison.OrdinalIgnoreCase)
@@ -575,7 +579,7 @@ public class iOSSimulatorAppDriver : AppDriverBase
                 || string.Equals(t, "ScrollView", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(t, "ScrollArea", StringComparison.OrdinalIgnoreCase));
 
-            if (hasButtons && !hasAppContainer)
+            if (buttonCount is >= 1 and <= 4 && hasPromptText && !hasAppContainer)
             {
                 var buttons = new List<AlertButton>();
                 CollectButtons(app, buttons);
@@ -656,7 +660,27 @@ public class iOSSimulatorAppDriver : AppDriverBase
         var normalizedTarget = targetName.EndsWith(".app", StringComparison.OrdinalIgnoreCase)
             ? targetName[..^4]
             : targetName;
-        return new[] { application.Label, application.Value, application.Description }
-            .Any(value => value?.Equals(normalizedTarget, StringComparison.OrdinalIgnoreCase) == true);
+        if (new[] { application.Label, application.Value, application.Description }
+            .Any(value => value?.Equals(normalizedTarget, StringComparison.OrdinalIgnoreCase) == true))
+        {
+            return true;
+        }
+
+        return application.Children.Any(child =>
+            child.Type?.Contains("StaticText", StringComparison.OrdinalIgnoreCase) == true
+            && PermissionPromptNamesTarget(child.Label, normalizedTarget));
+    }
+
+    internal static bool PermissionPromptNamesTarget(string? promptText, string targetName)
+    {
+        if (string.IsNullOrWhiteSpace(promptText) || string.IsNullOrWhiteSpace(targetName))
+            return false;
+
+        var match = Regex.Match(
+            promptText,
+            "^(?:Allow\\s+[\\u201c\"](?<app>.+?)[\\u201d\"]\\s+to\\b|[\\u201c\"](?<app>.+?)[\\u201d\"]\\s+Would Like to\\b)",
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        return match.Success
+            && match.Groups["app"].Value.Equals(targetName, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/NativeDialogSafetyTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/NativeDialogSafetyTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class NativeDialogSafetyTests
+{
+    [Fact]
+    public void CreatePromptId_SameSemanticDialog_IsStable()
+    {
+        var first = CreateDialog();
+        var second = CreateDialog();
+
+        var firstId = NativeDialogSafety.CreateFingerprint(42, "CoreServicesUIAgent", first);
+        var secondId = NativeDialogSafety.CreateFingerprint(42, "CoreServicesUIAgent", second);
+
+        Assert.Equal(firstId, secondId);
+    }
+
+    [Fact]
+    public void CreatePromptId_ChangedDialogText_ChangesFingerprint()
+    {
+        var first = CreateDialog();
+        var second = CreateDialog() with
+        {
+            Text = ["Other App would like to find devices on your local network."]
+        };
+
+        var firstId = NativeDialogSafety.CreateFingerprint(42, "CoreServicesUIAgent", first);
+        var secondId = NativeDialogSafety.CreateFingerprint(42, "CoreServicesUIAgent", second);
+
+        Assert.NotEqual(firstId, secondId);
+    }
+
+    [Fact]
+    public void IsSystemDialogForTarget_MatchingAppName_ReturnsTrue()
+    {
+        Assert.True(NativeDialogSafety.IsSystemDialogForTarget(CreateDialog(), "Sample App"));
+    }
+
+    [Fact]
+    public void IsSystemDialogForTarget_UnrelatedApp_ReturnsFalse()
+    {
+        Assert.False(NativeDialogSafety.IsSystemDialogForTarget(CreateDialog(), "Other App"));
+    }
+
+    [Fact]
+    public void IsSystemDialogForTarget_NameInsideAnotherWord_ReturnsFalse()
+    {
+        var dialog = CreateDialog() with
+        {
+            Title = "An application would like network access",
+            Text = ["An application would like network access."]
+        };
+
+        Assert.False(NativeDialogSafety.IsSystemDialogForTarget(dialog, "App"));
+    }
+
+    private static AlertInfo CreateDialog()
+        => new(
+            "\"Sample App\" Would Like to Find Devices",
+            [
+                new AlertButton("Don't Allow", 0, 0, 0, 0) { Identifier = "deny" },
+                new AlertButton("Allow", 0, 0, 0, 0) { Identifier = "allow" }
+            ])
+        {
+            Text = ["\"Sample App\" would like to find devices on your local network."]
+        };
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/NativeDialogSafetyTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/NativeDialogSafetyTests.cs
@@ -145,6 +145,38 @@ public class NativeDialogSafetyTests
         Assert.Null(processId);
     }
 
+    [Theory]
+    [InlineData("Allow \u201cMauiTodo\u201d to access your contacts?", "MauiTodo")]
+    [InlineData("\"MauiTodo\" Would Like to Access the Microphone", "MauiTodo")]
+    public void IosPermissionPrompt_ExactAppName_ReturnsTrue(string prompt, string appName)
+    {
+        Assert.True(iOSSimulatorAppDriver.PermissionPromptNamesTarget(prompt, appName));
+    }
+
+    [Fact]
+    public void IosPermissionPrompt_AppNamePrefix_ReturnsFalse()
+    {
+        Assert.False(iOSSimulatorAppDriver.PermissionPromptNamesTarget(
+            "Allow \u201cMauiTodo Beta\u201d to access your contacts?",
+            "MauiTodo"));
+    }
+
+    [Fact]
+    public void AndroidPermissionPrompt_ExactAppName_ReturnsTrue()
+    {
+        Assert.True(AndroidAppDriver.PermissionPromptNamesTarget(
+            "Allow MauiTodo to access your contacts?",
+            "MauiTodo"));
+    }
+
+    [Fact]
+    public void AndroidPermissionPrompt_AppNamePrefix_ReturnsFalse()
+    {
+        Assert.False(AndroidAppDriver.PermissionPromptNamesTarget(
+            "Allow MauiTodo Beta to access your contacts?",
+            "MauiTodo"));
+    }
+
     private static AlertInfo CreateDialog()
         => new(
             "\"Sample App\" Would Like to Find Devices",

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/NativeDialogSafetyTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/NativeDialogSafetyTests.cs
@@ -78,6 +78,17 @@ public class NativeDialogSafetyTests
         Assert.False(NativeDialogSafety.IsSystemDialogForTarget(dialog, "App"));
     }
 
+    [Theory]
+    [InlineData("Don\u2019t Allow", "Don't Allow")]
+    [InlineData("\u201cSample App\u201d", "\"Sample App\"")]
+    [InlineData("ALLOW", "Allow")]
+    public void MacButtonLabelsMatch_EquivalentQuotesAndCase_ReturnsTrue(
+        string visibleLabel,
+        string requestedLabel)
+    {
+        Assert.True(MacCatalystAppDriver.ButtonLabelsMatch(visibleLabel, requestedLabel));
+    }
+
     [Fact]
     public void AndroidFocusedPackage_ExactComponent_ReturnsTrue()
     {
@@ -92,6 +103,46 @@ public class NativeDialogSafetyTests
         const string state = "mFocusedApp=ActivityRecord{123 u0 com.example.app.beta/.MainActivity t42}";
 
         Assert.False(AndroidAppDriver.IsFocusedPackage(state, "com.example.app"));
+    }
+
+    [Fact]
+    public void FindUniqueProcessId_UniqueExactMatch_PrefersExactMatch()
+    {
+        var processId = ProcessNameResolver.FindUniqueProcessId(
+            "SampleApp",
+            [(1, "SampleApp.Helper"), (2, "sampleapp")]);
+
+        Assert.Equal(2, processId);
+    }
+
+    [Fact]
+    public void FindUniqueProcessId_DuplicateExactMatches_ReturnsNull()
+    {
+        var processId = ProcessNameResolver.FindUniqueProcessId(
+            "SampleApp",
+            [(1, "SampleApp"), (2, "sampleapp")]);
+
+        Assert.Null(processId);
+    }
+
+    [Fact]
+    public void FindUniqueProcessId_UniqueSubstringMatch_ReturnsProcessId()
+    {
+        var processId = ProcessNameResolver.FindUniqueProcessId(
+            "SampleApp",
+            [(1, "SampleApp.Helper"), (2, "OtherApp")]);
+
+        Assert.Equal(1, processId);
+    }
+
+    [Fact]
+    public void FindUniqueProcessId_AmbiguousSubstringMatches_ReturnsNull()
+    {
+        var processId = ProcessNameResolver.FindUniqueProcessId(
+            "SampleApp",
+            [(1, "SampleApp.Helper"), (2, "SampleApp.Worker")]);
+
+        Assert.Null(processId);
     }
 
     private static AlertInfo CreateDialog()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/NativeDialogSafetyTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/NativeDialogSafetyTests.cs
@@ -10,8 +10,8 @@ public class NativeDialogSafetyTests
         var first = CreateDialog();
         var second = CreateDialog();
 
-        var firstId = NativeDialogSafety.CreateFingerprint(42, "CoreServicesUIAgent", first);
-        var secondId = NativeDialogSafety.CreateFingerprint(42, "CoreServicesUIAgent", second);
+        var firstId = NativeDialogIdentity.CreateFingerprint("macOS", "42:CoreServicesUIAgent", first);
+        var secondId = NativeDialogIdentity.CreateFingerprint("macOS", "42:CoreServicesUIAgent", second);
 
         Assert.Equal(firstId, secondId);
     }
@@ -25,8 +25,31 @@ public class NativeDialogSafetyTests
             Text = ["Other App would like to find devices on your local network."]
         };
 
-        var firstId = NativeDialogSafety.CreateFingerprint(42, "CoreServicesUIAgent", first);
-        var secondId = NativeDialogSafety.CreateFingerprint(42, "CoreServicesUIAgent", second);
+        var firstId = NativeDialogIdentity.CreateFingerprint("macOS", "42:CoreServicesUIAgent", first);
+        var secondId = NativeDialogIdentity.CreateFingerprint("macOS", "42:CoreServicesUIAgent", second);
+
+        Assert.NotEqual(firstId, secondId);
+    }
+
+    [Fact]
+    public void CreatePromptId_DifferentPlatform_ChangesFingerprint()
+    {
+        var dialog = CreateDialog();
+
+        var macId = NativeDialogIdentity.CreateFingerprint("macOS", "target", dialog);
+        var windowsId = NativeDialogIdentity.CreateFingerprint("Windows", "target", dialog);
+
+        Assert.NotEqual(macId, windowsId);
+    }
+
+    [Fact]
+    public void CreatePromptId_DifferentNativeInstance_ChangesFingerprint()
+    {
+        var first = CreateDialog() with { InstanceId = "window-a" };
+        var second = CreateDialog() with { InstanceId = "window-b" };
+
+        var firstId = NativeDialogIdentity.CreateFingerprint("Android", "target", first);
+        var secondId = NativeDialogIdentity.CreateFingerprint("Android", "target", second);
 
         Assert.NotEqual(firstId, secondId);
     }
@@ -53,6 +76,22 @@ public class NativeDialogSafetyTests
         };
 
         Assert.False(NativeDialogSafety.IsSystemDialogForTarget(dialog, "App"));
+    }
+
+    [Fact]
+    public void AndroidFocusedPackage_ExactComponent_ReturnsTrue()
+    {
+        const string state = "mFocusedApp=ActivityRecord{123 u0 com.example.app/.MainActivity t42}";
+
+        Assert.True(AndroidAppDriver.IsFocusedPackage(state, "com.example.app"));
+    }
+
+    [Fact]
+    public void AndroidFocusedPackage_PackagePrefix_ReturnsFalse()
+    {
+        const string state = "mFocusedApp=ActivityRecord{123 u0 com.example.app.beta/.MainActivity t42}";
+
+        Assert.False(AndroidAppDriver.IsFocusedPackage(state, "com.example.app"));
     }
 
     private static AlertInfo CreateDialog()

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ScreenshotAgentClientTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/ScreenshotAgentClientTests.cs
@@ -70,7 +70,7 @@ public class ScreenshotAgentClientTests
     }
 
     [Fact]
-    public async Task ScreenshotResultAsync_WindowNotFrontmost_ReturnsRetryableFailureWithSuggestions()
+    public async Task ScreenshotResultAsync_WindowNotVisible_ReturnsRetryableFailureWithSuggestions()
     {
         using var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
@@ -79,13 +79,13 @@ public class ScreenshotAgentClientTests
         const string body = """
         {
           "success": false,
-          "error": "Failed to capture screenshot because the app window is not frontmost (the app is not the active application). Bring the app to the foreground and retry.",
-          "reason": "window-not-frontmost",
+          "error": "Failed to capture the app window because it is hidden or minimized.",
+          "reason": "window-not-visible",
           "details": {
             "retryable": true,
             "suggestions": [
-              "Bring the MAUI app window to the foreground (click it or use the app switcher / Cmd+Tab), then retry.",
-              "Ensure the app window is visible and not minimized."
+              "Restore the app window without activating it, then retry.",
+              "Ensure Screen & System Audio Recording permission is granted if native window capture is required."
             ]
           }
         }
@@ -105,13 +105,13 @@ public class ScreenshotAgentClientTests
 
         Assert.False(result.Success);
         Assert.Null(result.Data);
-        Assert.Equal("window-not-frontmost", result.Reason);
+        Assert.Equal("window-not-visible", result.Reason);
         Assert.True(result.Retryable);
         Assert.NotNull(result.Error);
-        Assert.Contains("not frontmost", result.Error!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("hidden or minimized", result.Error!, StringComparison.OrdinalIgnoreCase);
         Assert.NotNull(result.Suggestions);
         Assert.Equal(2, result.Suggestions!.Count);
-        Assert.Contains(result.Suggestions, s => s.Contains("foreground", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Suggestions, s => s.Contains("without activating", StringComparison.OrdinalIgnoreCase));
 
         await serverTask;
     }
@@ -170,7 +170,7 @@ public class ScreenshotAgentClientTests
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
         const string body = """
-        { "success": false, "error": "Failed to capture screenshot", "reason": "window-not-frontmost", "details": { "retryable": true } }
+        { "success": false, "error": "Failed to capture screenshot", "reason": "window-not-visible", "details": { "retryable": true } }
         """;
 
         var serverTask = Task.Run(async () =>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
@@ -382,13 +382,14 @@ public class AgentStatusTests
     [Fact]
     public void Deserialization_Works()
     {
-        var json = """{"agent":{"name":"Microsoft.Maui.DevFlow.Agent","version":"1.0.0","framework":".NET MAUI","frameworkVersion":"10.0"},"device":{"platform":"MacCatalyst","deviceType":"Virtual","idiom":"Desktop"},"app":{"name":"SampleMauiApp"},"running":true}""";
+        var json = """{"agent":{"name":"Microsoft.Maui.DevFlow.Agent","version":"1.0.0","framework":".NET MAUI","frameworkVersion":"10.0"},"device":{"platform":"MacCatalyst","deviceType":"Virtual","idiom":"Desktop"},"app":{"name":"SampleMauiApp","processId":4242},"running":true}""";
         var status = System.Text.Json.JsonSerializer.Deserialize<AgentStatus>(json);
 
         Assert.NotNull(status);
         Assert.Equal("Microsoft.Maui.DevFlow.Agent", status.Agent?.Name);
         Assert.Equal("1.0.0", status.Version);
         Assert.Equal("MacCatalyst", status.Platform);
+        Assert.Equal(4242, status.App?.ProcessId);
         Assert.True(status.Running);
     }
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/WebViewDriverTests.cs
@@ -382,13 +382,14 @@ public class AgentStatusTests
     [Fact]
     public void Deserialization_Works()
     {
-        var json = """{"agent":{"name":"Microsoft.Maui.DevFlow.Agent","version":"1.0.0","framework":".NET MAUI","frameworkVersion":"10.0"},"device":{"platform":"MacCatalyst","deviceType":"Virtual","idiom":"Desktop"},"app":{"name":"SampleMauiApp","processId":4242},"running":true}""";
+        var json = """{"agent":{"name":"Microsoft.Maui.DevFlow.Agent","version":"1.0.0","framework":".NET MAUI","frameworkVersion":"10.0"},"device":{"id":"simulator-123","platform":"MacCatalyst","deviceType":"Virtual","idiom":"Desktop"},"app":{"name":"SampleMauiApp","processId":4242},"running":true}""";
         var status = System.Text.Json.JsonSerializer.Deserialize<AgentStatus>(json);
 
         Assert.NotNull(status);
         Assert.Equal("Microsoft.Maui.DevFlow.Agent", status.Agent?.Name);
         Assert.Equal("1.0.0", status.Version);
         Assert.Equal("MacCatalyst", status.Platform);
+        Assert.Equal("simulator-123", status.Device?.Id);
         Assert.Equal(4242, status.App?.ProcessId);
         Assert.True(status.Running);
     }


### PR DESCRIPTION
DevFlow needs to capture complete AppKit windows and handle native permission prompts without stealing focus or competing with the human user's keyboard and mouse. Native dialog intent is cross-platform, so the same confirmation workflow should use the safest primitive each platform exposes rather than introducing platform-specific MCP calls.

This change:

- captures exact AppKit windows with ScreenCaptureKit, using CoreGraphics and in-process rendering as focus-independent fallbacks
- applies the capture path to both MAUI and plain .NET native AppKit agents
- replaces subprocess-based macOS window discovery with direct CoreGraphics interop
- keeps one `maui_native_dialog_detect` / `maui_native_dialog_respond` workflow across supported platforms
- routes confirmed responses through AXPress on macOS, UI Automation Invoke on Windows, app-agent actions on Linux, ADB device input on Android, and simulator HID on iOS Simulator
- binds Android and iOS Simulator actions to the exact device associated with the connected agent and rejects mismatches
- rejects physical iOS and any target that cannot be safely attributed instead of guessing
- requires exact button labels, explicit user confirmation, expiring one-time prompt leases, per-target serialization, native instance fingerprints, and revalidation immediately before action
- reports process and platform device identifiers through the shared agent status contract
- refuses desktop-wide recording when the target app window cannot be resolved
- adds real Android/iOS permission-dialog integration tests that reset permission state before triggering each OS prompt

No fallback activates or reorders windows, sends host keyboard or pointer events, or uses AppleScript. Android and iOS Simulator input is scoped to the validated device rather than the host desktop.

## Permission integration coverage

- Android contacts: real permission-controller prompt, both Allow and Don't allow
- iOS location: real prompt, Allow While Using App
- iOS contacts: real prompt, Don't Allow

On current iOS, choosing Continue for contacts transitions into Apple's contact-selection surface, which `idb accessibility` exposes only as a status bar rather than actionable controls. The initial permission sheet is automated and tested, while selecting individual/full contact access still requires manual interaction.

## Validation

- DevFlow tests: 426 passed
- CLI tests: 806 passed
- Android contacts allow/deny integration tests passed on an emulator
- iOS contacts deny and location while-in-use integration tests passed on an iOS Simulator
- MAUI iOS, Mac Catalyst, and AppKit agent builds succeeded
- Native iOS, Mac Catalyst, and AppKit agent builds succeeded
- Native AppKit agent build is warning-free