### PR TITLE
feat(devflow): add custom multi-touch pointer timelines

### DIFF
--- a/.github/instructions/devflow-architecture.instructions.md
+++ b/.github/instructions/devflow-architecture.instructions.md
@@ -152,7 +152,7 @@ Override virtual methods from `Agent.Abstractions/DevFlowAgentService.cs`:
 ## Gesture Injection
 
 `POST /api/v1/ui/actions/gesture` supports `tap`, `doubletap`, `longpress`, `swipe`, `pan`,
-`pinch` and `rotate`. Resolution is two-tier, and the response reports which tier ran via
+`pinch`, `rotate` and capability-gated `actions`. Resolution is two-tier, and the response reports which tier ran via
 `handledBy` (`recognizer` | `native` | `action` | `scroll` | `none`) plus a `detail` string:
 
 1. **Managed recognizer** (`Agent.Core`, all platforms) — walks the target element and its
@@ -181,6 +181,14 @@ with native touch injection. Named gestures target MAUI `VisualElement` IDs (or 
 for non-tap gestures; tap requires an element ID);
 registered native-only element IDs remain supported by the dedicated tap action, but are not
 targets for multi-pointer gesture synthesis.
+
+The `actions` gesture is the low-level escape hatch. It uses W3C-style pointer sources: each
+source is an independent touch track, and actions at the same array index form a synchronized
+timeline tick. A tick can move one pointer while another pauses, so tracks overlap without a
+global sequential `pause` list. Coordinates are element-relative 0..1 values. Backends advertise
+this through the `custom-pointer-actions` feature; Android currently implements it with real
+multi-pointer `MotionEvent` sequences. Named gestures remain the portable API and may share this
+timeline engine in future implementations.
 
 Gestures against `samples/DevFlow.Sample` → `GestureTestPage` (`//gestures`) write what they
 received to `AutomationId`'d status labels, so tests assert the gesture actually reached the app.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,7 @@ DevFlow exposes 67 MCP tools for AI agent integration (in `src/Cli/Microsoft.Mau
 | `maui_fill` | Fill text into Entry/Editor |
 | `maui_focus` | Set focus to an element |
 | `maui_geolocation` | GPS coordinates |
-| `maui_gesture` | Pinch/zoom, rotate, pan, swipe, double-tap, long-press |
+| `maui_gesture` | Pinch/zoom, rotate, pan, swipe, double-tap, long-press, custom multi-touch timelines |
 | `maui_get_property` | Read any element property |
 | `maui_get_theme` | Get the current app-scoped light/dark theme |
 | `maui_hittest` | Find elements at screen coordinates |

--- a/docs/DevFlow/spec/examples/gesture-actions-request.json
+++ b/docs/DevFlow/spec/examples/gesture-actions-request.json
@@ -1,0 +1,28 @@
+{
+  "type": "actions",
+  "elementId": "pinch-target",
+  "sources": [
+    {
+      "id": "finger1",
+      "pointerType": "touch",
+      "actions": [
+        { "type": "pointerMove", "x": 0.45, "y": 0.5 },
+        { "type": "pointerDown" },
+        { "type": "pointerMove", "x": 0.2, "y": 0.5, "durationMs": 300 },
+        { "type": "pause", "durationMs": 150 },
+        { "type": "pointerUp" }
+      ]
+    },
+    {
+      "id": "finger2",
+      "pointerType": "touch",
+      "actions": [
+        { "type": "pointerMove", "x": 0.55, "y": 0.5 },
+        { "type": "pointerDown" },
+        { "type": "pause", "durationMs": 300 },
+        { "type": "pointerMove", "x": 0.8, "y": 0.5, "durationMs": 150 },
+        { "type": "pointerUp" }
+      ]
+    }
+  ]
+}

--- a/docs/DevFlow/spec/openapi.yaml
+++ b/docs/DevFlow/spec/openapi.yaml
@@ -630,13 +630,16 @@ paths:
       tags: [ui-actions]
       summary: Perform a gesture
       description: >
-        Performs a named gesture — pinch, rotate, pan, swipe, doubletap, longpress or tap.
+        Performs a named gesture — pinch, rotate, pan, swipe, doubletap, longpress or tap —
+        or an actions gesture containing synchronized W3C-style touch pointer sources.
         The gesture is first offered to a matching MAUI gesture recognizer on the target
         element or its ancestors. If there is none, it is injected natively at the platform
         view, which is how pinch-to-zoom reaches controls that handle gestures internally
         such as Map, WebView and native scroll views. The response reports which tier
         serviced the gesture so callers can tell a real recognizer hit from a native fallback.
         Tap requires elementId; other gesture types target the current page when it is omitted.
+        Custom actions are capability-gated through ui.actions/custom-pointer-actions and are
+        currently implemented by the Android backend.
       requestBody:
         required: true
         content:

--- a/docs/DevFlow/spec/schemas/actions.json
+++ b/docs/DevFlow/spec/schemas/actions.json
@@ -299,13 +299,130 @@
         "swipe",
         "pan",
         "pinch",
-        "rotate"
+        "rotate",
+        "actions"
       ],
-      "description": "The kind of gesture to perform."
+      "description": "The kind of gesture to perform. 'actions' executes synchronized low-level touch pointer sources when advertised by the backend."
+    },
+    "PointerAction": {
+      "type": "object",
+      "description": "One action in a synchronized pointer-source tick, following the W3C WebDriver pointer action model.",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "pointerMove",
+            "pointerDown",
+            "pointerUp",
+            "pause"
+          ]
+        },
+        "x": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Element-relative X coordinate from 0 (left) to 1 (right). Omitted coordinates retain the pointer's current axis.",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "y": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Element-relative Y coordinate from 0 (top) to 1 (bottom). Omitted coordinates retain the pointer's current axis.",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "durationMs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Duration of pointerMove interpolation or a pause in milliseconds.",
+          "minimum": 0,
+          "maximum": 15000
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "pointerDown",
+                  "pointerUp",
+                  "pause"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "x": {
+                "type": "null"
+              },
+              "y": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "pointerDown",
+                  "pointerUp"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "durationMs": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "PointerActionSource": {
+      "type": "object",
+      "description": "An independent touch pointer track. Actions at the same array index across all sources execute in the same synchronized tick.",
+      "required": [
+        "id",
+        "pointerType",
+        "actions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique pointer identifier within the request."
+        },
+        "pointerType": {
+          "const": "touch"
+        },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/$defs/PointerAction"
+          }
+        }
+      }
     },
     "GestureRequest": {
       "type": "object",
-      "description": "Request to perform a named gesture. The gesture is first offered to a matching MAUI gesture recognizer on the target element or its ancestors; if none exists it is injected natively at the platform view, which is how pinch-to-zoom reaches controls that own their gestures internally (Map, WebView, native scroll views).",
+      "description": "Request to perform a named gesture or a capability-gated synchronized pointer timeline. Named gestures are first offered to a matching MAUI gesture recognizer; actions gestures are injected natively.",
       "required": [
         "type"
       ],
@@ -404,6 +521,15 @@
           "minimum": 1,
           "maximum": 120
         },
+        "sources": {
+          "type": "array",
+          "description": "Synchronized touch pointer sources. Required when type is 'actions'. The first action from every source forms tick 0, the second forms tick 1, and so on; shorter tracks implicitly pause. The sum of tick durations cannot exceed 15000 ms.",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/$defs/PointerActionSource"
+          }
+        },
         "captureEpoch": {
           "$ref": "#/$defs/CaptureEpoch"
         },
@@ -414,7 +540,23 @@
           "$ref": "#/$defs/IncludeOption",
           "description": "Optional data to include in the response."
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "actions"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "sources"
+            ]
+          }
+        }
+      ]
     },
     "GestureResponse": {
       "type": "object",
@@ -728,8 +870,33 @@
           "description": "Interpolation steps between gesture start and end.",
           "minimum": 1,
           "maximum": 120
+        },
+        "sources": {
+          "type": "array",
+          "description": "Synchronized pointer sources for a gesture batch item whose type is 'actions'.",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/$defs/PointerActionSource"
+          }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "actions"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "sources"
+            ]
+          }
+        }
+      ]
     },
     "BatchRequest": {
       "type": "object",

--- a/docs/DevFlow/spec/schemas/agent-capabilities.json
+++ b/docs/DevFlow/spec/schemas/agent-capabilities.json
@@ -70,7 +70,8 @@
                 "swipe",
                 "pan",
                 "pinch",
-                "rotate"
+                "rotate",
+                "actions"
               ]
             },
             "description": "Named gestures accepted by ui.actions/gesture when the backend exposes gesture automation."

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/DevFlowCliCommandTests.cs
@@ -333,6 +333,30 @@ public class DevFlowCliCommandTests
     }
 
     [Fact]
+    public async Task UiGesture_Actions_SendsPointerSources()
+    {
+        var (server, cli) = await CreateFixturesAsync();
+        await using var _ = server;
+        var sources = """
+            [{"id":"finger1","pointerType":"touch","actions":[{"type":"pointerMove","x":0.5,"y":0.5},{"type":"pointerDown"},{"type":"pause","durationMs":100},{"type":"pointerUp"}]}]
+            """;
+
+        var result = await cli.InvokeAsync(
+            "devflow", "ui", "gesture", "actions",
+            "--element", "el-1",
+            "--sources-json", sources,
+            "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var request = Assert.Single(
+            server.RecordedRequests,
+            recorded => recorded.Path == "/api/v1/ui/actions/gesture");
+        Assert.Contains("\"type\":\"actions\"", request.Body);
+        Assert.Contains("\"id\":\"finger1\"", request.Body);
+        Assert.Contains("\"type\":\"pause\"", request.Body);
+    }
+
+    [Fact]
     public async Task UiResize_SendsResizeAction()
     {
         var (server, cli) = await CreateFixturesAsync();

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -700,7 +700,7 @@ public class DevFlowCommands
         // already taken by element resolution.
         var gestureTypeArg = new Argument<string>("gestureType")
         {
-            Description = "Gesture: pinch, rotate, pan, swipe, doubletap, longpress, or tap"
+            Description = "Gesture: pinch, rotate, pan, swipe, doubletap, longpress, tap, or actions"
         };
         var gestureElementOption = new Option<string?>("--element") { Description = "Target element ID (required for tap; other gestures default to the current page)" };
         var gestureDirectionOption = new Option<string?>("--direction") { Description = "Direction for swipe/pan: up, down, left, right" };
@@ -713,12 +713,13 @@ public class DevFlowCommands
         var gestureOriginYOption = new Option<double?>("--origin-y") { Description = "Focal point Y, element-relative 0..1 (default: 0.5)" };
         var gestureDurationOption = new Option<int?>("--duration") { Description = "Gesture duration in milliseconds (default: 200)" };
         var gestureStepsOption = new Option<int?>("--steps") { Description = "Interpolation steps between start and end (default: 10)" };
-        var mauiGestureCmd = new Command("gesture", "Perform a gesture: pinch, rotate, pan, swipe, doubletap, longpress, tap")
+        var gestureSourcesOption = new Option<string?>("--sources-json") { Description = "JSON array of synchronized touch pointer sources (required for actions)" };
+        var mauiGestureCmd = new Command("gesture", "Perform a gesture: pinch, rotate, pan, swipe, doubletap, longpress, tap, actions")
         {
             gestureTypeArg, gestureElementOption, resolveAutoIdOption, resolveTextOption, resolveIndexOption,
             gestureDirectionOption, gestureDistanceOption, gestureScaleOption, gestureRotationOption,
             gestureDxOption, gestureDyOption, gestureOriginXOption, gestureOriginYOption,
-            gestureDurationOption, gestureStepsOption
+            gestureDurationOption, gestureStepsOption, gestureSourcesOption
         };
         mauiGestureCmd.SetAction(async (ctx, ct) =>
         {
@@ -761,7 +762,8 @@ public class DevFlowCommands
                 ctx.GetValue(gestureDyOption),
                 ctx.GetValue(gestureOriginXOption),
                 ctx.GetValue(gestureOriginYOption),
-                ctx.GetValue(gestureStepsOption));
+                ctx.GetValue(gestureStepsOption),
+                ctx.GetValue(gestureSourcesOption));
         });
         mauiCommand.Add(mauiGestureCmd);
 
@@ -3535,12 +3537,13 @@ public class DevFlowCommands
         catch (Exception ex) { Output.WriteError(ex.Message, json); _errorOccurred = true; }
     }
 
-    private static readonly string[] GestureTypes = ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate"];
+    private static readonly string[] GestureTypes = ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate", "actions"];
 
     private static async Task MauiGestureAsync(
         string host, int port, bool json, string gestureType, ElementInfo? element,
         string? direction, double? distance, int? durationMs, double? scale, double? rotation,
-        double? deltaX, double? deltaY, double? originX, double? originY, int? steps)
+        double? deltaX, double? deltaY, double? originX, double? originY, int? steps,
+        string? sourcesJson)
     {
         var normalizedType = gestureType.Trim().ToLowerInvariant().Replace("-", "").Replace("_", "");
         if (normalizedType == "zoom") normalizedType = "pinch";
@@ -3579,16 +3582,49 @@ public class DevFlowCommands
             return;
         }
 
+        JsonArray? sources = null;
+        if (normalizedType == "actions")
+        {
+            if (string.IsNullOrWhiteSpace(sourcesJson))
+            {
+                Output.WriteError("Actions gesture requires --sources-json.", json, "ValidationError");
+                _errorOccurred = true;
+                return;
+            }
+
+            try
+            {
+                sources = JsonNode.Parse(sourcesJson) as JsonArray;
+                if (sources == null)
+                    throw new JsonException("--sources-json must contain a JSON array.");
+            }
+            catch (JsonException ex)
+            {
+                Output.WriteError($"Invalid --sources-json: {ex.Message}", json, "ValidationError");
+                _errorOccurred = true;
+                return;
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(sourcesJson))
+        {
+            Output.WriteError("--sources-json is only valid with the actions gesture.", json, "ValidationError");
+            _errorOccurred = true;
+            return;
+        }
+
         try
         {
             using var client = await CreateAgentClientAsync(host, port);
             var (captureEpoch, registryGeneration) = element is null
                 ? (null, null)
                 : GetCaptureMetadata(element);
-            var result = await client.GestureDetailedAsync(
-                normalizedType, element?.Id, direction, distance, durationMs,
-                scale, rotation, deltaX, deltaY, originX, originY, steps,
-                captureEpoch, registryGeneration);
+            var result = sources != null
+                ? await client.PointerActionsAsync(
+                    sources, element?.Id, captureEpoch, registryGeneration)
+                : await client.GestureDetailedAsync(
+                    normalizedType, element?.Id, direction, distance, durationMs,
+                    scale, rotation, deltaX, deltaY, originX, originY, steps,
+                    captureEpoch, registryGeneration);
 
             if (json)
             {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/BatchTools.cs
@@ -25,12 +25,13 @@ public sealed class BatchTools
 		- {"action":"gesture", "type":"swipe", "elementId":"<id>", "direction":"up"}
 		- {"action":"gesture", "type":"pinch", "elementId":"<id>", "scale":2.0}
 		- {"action":"gesture", "type":"pan", "elementId":"<id>", "deltaX":0, "deltaY":-150}
+		- {"action":"gesture", "type":"actions", "elementId":"<id>", "sources":[{"id":"finger1","pointerType":"touch","actions":[...]}]}
 		- {"action":"navigate", "route":"//page"}
 		- {"action":"back"}
 
 		Note: The backend accepts both "action" and "type" fields. For gesture actions,
 		use "action":"gesture" with a separate "type" field for the gesture kind
-		(tap, doubletap, longpress, swipe, pan, pinch, rotate).
+		(tap, doubletap, longpress, swipe, pan, pinch, rotate, actions).
 
 		Example: [{"action":"fill","elementId":"entry1","text":"hello"},{"action":"tap","elementId":"btn1"}]
 		""")]

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/InteractionTools.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
 
@@ -86,13 +88,14 @@ public sealed class InteractionTools
 			$"Failed to send key '{key}'. The target element may not support keyboard input, or no target element was provided.");
 	}
 
-	private static readonly string[] ValidGestureTypes = ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate"];
+	private static readonly string[] ValidGestureTypes = ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate", "actions"];
 	private static readonly string[] ValidGestureDirections = ["up", "down", "left", "right"];
 
 	[McpServerTool(Name = "maui_gesture"), Description(
 		"Perform a touch gesture on the app. Types: 'pinch' (zoom — use 'scale', e.g. 2.0 to zoom in, 0.5 to zoom out), " +
 		"'rotate' (use 'rotation' in degrees), 'pan' (drag — use deltaX/deltaY, or direction + distance), " +
-		"'swipe' (flick — requires direction), 'doubletap', 'longpress', and 'tap'. " +
+		"'swipe' (flick — requires direction), 'doubletap', 'longpress', 'tap', and 'actions'. " +
+		"Actions uses 'sourcesJson', a JSON array of synchronized W3C-style touch pointer tracks. " +
 		"Use maui_tap for simple taps and maui_scroll for scrolling a list; this tool is for real gestures. " +
 		"Each gesture is first sent to a matching MAUI gesture recognizer on the element or its ancestors, and if there is " +
 		"none it is injected natively at the platform view — which is how pinch-to-zoom works on Maps, WebViews and other " +
@@ -100,7 +103,7 @@ public sealed class InteractionTools
 		"element lists the recognizers it has. Omitting elementId aims non-tap gestures at the current page; tap requires an element ID.")]
 	public static async Task<string> Gesture(
 		McpAgentSession session,
-		[Description("Gesture type: 'pinch', 'rotate', 'pan', 'swipe', 'doubletap', 'longpress', or 'tap'")] string type,
+		[Description("Gesture type: 'pinch', 'rotate', 'pan', 'swipe', 'doubletap', 'longpress', 'tap', or 'actions'")] string type,
 		[Description("Target element ID from maui_tree. Required for tap; other gestures target the current page when omitted.")] string? elementId = null,
 		[Description("Direction for swipe/pan: 'up', 'down', 'left', or 'right'. Required for swipe.")] string? direction = null,
 		[Description("Travel distance in device-independent pixels for swipe/pan when using 'direction'. Defaults to 120.")] double? distance = null,
@@ -112,6 +115,7 @@ public sealed class InteractionTools
 		[Description("Gesture focal point X, element-relative from 0 (left) to 1 (right). Defaults to 0.5 (centre).")] double? originX = null,
 		[Description("Gesture focal point Y, element-relative from 0 (top) to 1 (bottom). Defaults to 0.5 (centre).")] double? originY = null,
 		[Description("Number of interpolation steps between gesture start and end. More steps are smoother. Defaults to 10.")] int? steps = null,
+		[Description("For actions: JSON array of synchronized touch sources. Each source has id, pointerType='touch', and actions containing pointerMove, pointerDown, pointerUp, or pause.")] string? sourcesJson = null,
 		[Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
 		[Description("Capture epoch from maui_tree or maui_hittest; stale epochs are rejected")] long? captureEpoch = null,
 		[Description("Native registry generation from maui_tree or maui_hittest")] long? registryGeneration = null)
@@ -139,11 +143,35 @@ public sealed class InteractionTools
 		if (normalizedType == "pinch" && scale is <= 0)
 			return "Pinch 'scale' must be greater than 0 — use 2.0 to zoom in or 0.5 to zoom out.";
 
+		JsonArray? sources = null;
+		if (normalizedType == "actions")
+		{
+			if (string.IsNullOrWhiteSpace(sourcesJson))
+				return "Actions gesture requires 'sourcesJson'.";
+			try
+			{
+				sources = JsonNode.Parse(sourcesJson) as JsonArray;
+				if (sources == null)
+					return "Invalid sourcesJson: expected a JSON array.";
+			}
+			catch (JsonException ex)
+			{
+				return $"Invalid sourcesJson: {ex.Message}";
+			}
+		}
+		else if (!string.IsNullOrWhiteSpace(sourcesJson))
+		{
+			return "sourcesJson is only valid for the actions gesture.";
+		}
+
 		var agent = await session.GetAgentClientAsync(agentPort);
-		var result = await agent.GestureDetailedAsync(
-			normalizedType, elementId, normalizedDirection, distance, durationMs,
-			scale, rotation, deltaX, deltaY, originX, originY, steps,
-			captureEpoch, registryGeneration);
+		var result = sources != null
+			? await agent.PointerActionsAsync(
+				sources, elementId, captureEpoch, registryGeneration)
+			: await agent.GestureDetailedAsync(
+				normalizedType, elementId, normalizedDirection, distance, durationMs,
+				scale, rotation, deltaX, deltaY, originX, originY, steps,
+				captureEpoch, registryGeneration);
 
 		var target = elementId is not null ? $" on element '{elementId}'" : " on the current page";
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Handlers.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.Handlers.cs
@@ -592,6 +592,22 @@ public partial class DevFlowAgentService
         public double? OriginX { get; set; }
         public double? OriginY { get; set; }
         public int? Steps { get; set; }
+        public List<PointerActionSourceRequest?>? Sources { get; set; }
+    }
+
+    protected sealed class PointerActionSourceRequest
+    {
+        public string? Id { get; set; }
+        public string? PointerType { get; set; }
+        public List<PointerActionStepRequest?>? Actions { get; set; }
+    }
+
+    protected sealed class PointerActionStepRequest
+    {
+        public string? Type { get; set; }
+        public double? X { get; set; }
+        public double? Y { get; set; }
+        public int? DurationMs { get; set; }
     }
 
     protected sealed class BatchRequest : CaptureBoundRequest
@@ -626,6 +642,7 @@ public partial class DevFlowAgentService
         public double? OriginX { get; set; }
         public double? OriginY { get; set; }
         public int? Steps { get; set; }
+        public List<PointerActionSourceRequest?>? Sources { get; set; }
         public JsonElement[]? Args { get; set; }
         public string? Name { get; set; }
     }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Abstractions/DevFlowAgentService.cs
@@ -522,7 +522,8 @@ public partial class DevFlowAgentService : IDisposable, IMarkerPublisher
                             DeltaY = action.DeltaY,
                             OriginX = action.OriginX,
                             OriginY = action.OriginY,
-                            Steps = action.Steps
+                            Steps = action.Steps,
+                            Sources = action.Sources
                         })
                     });
                     break;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.Gestures.cs
@@ -9,7 +9,13 @@ namespace Microsoft.Maui.DevFlow.Agent.Core;
 public partial class MauiDevFlowAgentService
 {
     internal static readonly string[] SupportedGestures =
-        ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate"];
+        ["tap", "doubletap", "longpress", "swipe", "pan", "pinch", "rotate", "actions"];
+
+    protected virtual bool SupportsNativePointerActions => false;
+
+    private string[] AdvertisedGestures => SupportsNativePointerActions
+        ? SupportedGestures
+        : SupportedGestures.Where(static gesture => gesture != "actions").ToArray();
 
     private const int DefaultGestureSteps = 10;
     private int _panGestureId;
@@ -60,6 +66,7 @@ public partial class MauiDevFlowAgentService
                 "swipe" => await PerformSwipeAsync(body, windowIndex, reservedCapture),
                 "doubletap" => await PerformDoubleTapAsync(body, windowIndex, reservedCapture),
                 "longpress" => await PerformLongPressAsync(body, windowIndex, reservedCapture),
+                "actions" => await PerformPointerActionsAsync(body, windowIndex, reservedCapture),
                 _ => GestureOutcome.NotHandled(
                     $"Gesture '{body.Type}' is not supported. Supported types: {string.Join(", ", SupportedGestures)}")
             };
@@ -426,6 +433,128 @@ public partial class MauiDevFlowAgentService
         return outcome ?? GestureOutcome.NotHandled("Long-press dispatch failed");
     }
 
+    private async Task<GestureOutcome> PerformPointerActionsAsync(
+        GestureActionRequest body,
+        int? windowIndex,
+        UiCaptureContext capture)
+    {
+        if (!SupportsNativePointerActions)
+        {
+            return GestureOutcome.NotHandled(
+                $"custom pointer actions are not available on {DeviceInfo.Platform}");
+        }
+
+        if (ValidatePointerActions(body.Sources) is { } validationError)
+            return GestureOutcome.NotHandled(validationError);
+        var sources = body.Sources!
+            .Select(static source => source!)
+            .ToArray();
+
+        var outcome = await DispatchAsync(async () =>
+        {
+            var target = ResolveGestureTarget(body.ElementId, windowIndex, capture, out var error);
+            if (target == null)
+                return GestureOutcome.NotHandled(error!);
+
+            var detail = await TryNativePointerActions(target, sources);
+            return detail != null
+                ? GestureOutcome.Native(detail)
+                : GestureOutcome.NotHandled(
+                    $"custom pointer actions were rejected by {target.GetType().Name} on {DeviceInfo.Platform}");
+        });
+
+        return outcome ?? GestureOutcome.NotHandled("Custom pointer action dispatch failed");
+    }
+
+    private static string? ValidatePointerActions(IReadOnlyList<PointerActionSourceRequest?>? sources)
+    {
+        if (sources == null || sources.Count is < 1 or > 10)
+            return "actions gesture requires between 1 and 10 pointer sources";
+
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        var hasPointerDown = false;
+        var maxTicks = 0;
+        foreach (var source in sources)
+        {
+            if (source == null)
+                return "pointer sources cannot contain null entries";
+            if (string.IsNullOrWhiteSpace(source.Id))
+                return "each pointer source requires a non-empty id";
+            if (!ids.Add(source.Id))
+                return $"pointer source id '{source.Id}' is duplicated";
+            if (!string.Equals(source.PointerType, "touch", StringComparison.Ordinal))
+                return $"pointer source '{source.Id}' has unsupported pointerType '{source.PointerType}'; only 'touch' is supported";
+            if (source.Actions == null || source.Actions.Count is < 1 or > 100)
+                return $"pointer source '{source.Id}' requires between 1 and 100 actions";
+
+            maxTicks = Math.Max(maxTicks, source.Actions.Count);
+            var pressed = false;
+            foreach (var action in source.Actions)
+            {
+                if (action == null)
+                    return $"pointer source '{source.Id}' actions cannot contain null entries";
+                var actionType = NormalizePointerActionType(action.Type);
+                if (actionType == null)
+                    return $"pointer source '{source.Id}' has unsupported action type '{action.Type}'";
+                if (action.DurationMs is < 0 or > 30_000)
+                    return $"pointer source '{source.Id}' action durationMs must be between 0 and 30000";
+                if (action.X is < 0 or > 1 || action.Y is < 0 or > 1)
+                    return $"pointer source '{source.Id}' coordinates must be element-relative values between 0 and 1";
+                if (actionType != "pointerMove" && (action.X.HasValue || action.Y.HasValue))
+                    return $"pointer source '{source.Id}' action '{actionType}' cannot specify coordinates";
+                if (actionType is "pointerDown" or "pointerUp" && action.DurationMs.HasValue)
+                    return $"pointer source '{source.Id}' action '{actionType}' cannot specify durationMs; use a pause tick";
+
+                switch (actionType)
+                {
+                    case "pointerDown" when pressed:
+                        return $"pointer source '{source.Id}' cannot press down while already down";
+                    case "pointerDown":
+                        pressed = true;
+                        hasPointerDown = true;
+                        break;
+                    case "pointerUp" when !pressed:
+                        return $"pointer source '{source.Id}' cannot release before pointerDown";
+                    case "pointerUp":
+                        pressed = false;
+                        break;
+                }
+            }
+
+            if (pressed)
+                return $"pointer source '{source.Id}' must end with pointerUp";
+        }
+
+        if (!hasPointerDown)
+            return "actions gesture must contain at least one pointerDown";
+        if (maxTicks > 100)
+            return "actions gesture cannot exceed 100 synchronized ticks";
+
+        long totalDurationMs = 0;
+        for (var tick = 0; tick < maxTicks; tick++)
+        {
+            totalDurationMs += sources.Max(source =>
+                tick < source!.Actions!.Count ? source.Actions[tick]!.DurationMs ?? 0 : 0);
+        }
+        if (totalDurationMs > 15_000)
+            return "actions gesture timeline cannot exceed 15000ms";
+
+        return null;
+    }
+
+    protected static string? NormalizePointerActionType(string? type)
+    {
+        var normalized = type?.Trim().ToLowerInvariant().Replace("-", "").Replace("_", "");
+        return normalized switch
+        {
+            "pointermove" or "move" => "pointerMove",
+            "pointerdown" or "down" => "pointerDown",
+            "pointerup" or "up" => "pointerUp",
+            "pause" => "pause",
+            _ => null
+        };
+    }
+
     private static string NoHandlerMessage(string gesture, VisualElement target, string recognizerName) =>
         $"No {gesture} handler for {target.GetType().Name}: no {recognizerName} on the element or its " +
         $"ancestors, and native {gesture} injection is not available on {DeviceInfo.Platform}.";
@@ -505,5 +634,10 @@ public partial class MauiDevFlowAgentService
         => Task.FromResult<string?>(null);
 
     protected virtual Task<string?> TryNativeDoubleTap(VisualElement element)
+        => Task.FromResult<string?>(null);
+
+    protected virtual Task<string?> TryNativePointerActions(
+        VisualElement element,
+        IReadOnlyList<PointerActionSourceRequest> sources)
         => Task.FromResult<string?>(null);
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.Core/MauiDevFlowAgentService.cs
@@ -104,12 +104,15 @@ public partial class MauiDevFlowAgentService : DevFlowAgentService
         capabilities["ui.hit-test"] = Capability(2, supported: true,
             ["native-first", "capture-epoch", "window-logical-coordinates"],
             reason: null);
+        var actionFeatures = SupportsNativePointerActions
+            ? new[] { "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "capture-bound-batch", "properties", "stale-capture-rejection", "custom-pointer-actions" }
+            : new[] { "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "capture-bound-batch", "properties", "stale-capture-rejection" };
         capabilities["ui.actions"] = new
         {
             version = 2,
             supported = true,
-            features = new[] { "tap", "fill", "clear", "focus", "scroll", "navigate", "resize", "back", "key", "gesture", "batch", "capture-bound-batch", "properties", "stale-capture-rejection" },
-            gestures = SupportedGestures,
+            features = actionFeatures,
+            gestures = AdvertisedGestures,
             reason = (string?)null
         };
         capabilities["ui.screenshot"] = Capability(2, supported: true,
@@ -3495,7 +3498,8 @@ public partial class MauiDevFlowAgentService : DevFlowAgentService
                                     DeltaY = action.DeltaY,
                                     OriginX = action.OriginX,
                                     OriginY = action.OriginY,
-                                    Steps = action.Steps
+                                    Steps = action.Steps,
+                                    Sources = action.Sources
                                 })
                             });
                             break;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent.IntegrationTests/UiActionTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Net;
+using System.Text.Json.Nodes;
 using Microsoft.Maui.DevFlow.Agent.IntegrationTests.Fixtures;
 using Microsoft.Maui.DevFlow.Driver;
 using Xunit.Abstractions;
@@ -334,6 +335,18 @@ public class UiActionTests : IntegrationTestBase
         Assert.Contains("pinch", gestures);
         Assert.Contains("pan", gestures);
         Assert.Contains("rotate", gestures);
+        var features = caps.GetProperty("capabilities").GetProperty("ui.actions").GetProperty("features")
+            .EnumerateArray().Select(feature => feature.GetString()).ToArray();
+        if (Platform.Equals("android", StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Contains("actions", gestures);
+            Assert.Contains("custom-pointer-actions", features);
+        }
+        else
+        {
+            Assert.DoesNotContain("actions", gestures);
+            Assert.DoesNotContain("custom-pointer-actions", features);
+        }
     }
 
     // ========== gestures against GestureTestPage ==========
@@ -341,6 +354,33 @@ public class UiActionTests : IntegrationTestBase
     // point is that the gesture genuinely reached the app's own recognizer.
 
     private Task NavigateToGesturePageAsync() => NavigateToPageAsync("//gestures", "PinchTarget");
+
+    private static JsonArray CreateIndependentPinchSources() => JsonNode.Parse("""
+        [
+          {
+            "id": "finger1",
+            "pointerType": "touch",
+            "actions": [
+              { "type": "pointerMove", "x": 0.45, "y": 0.5 },
+              { "type": "pointerDown" },
+              { "type": "pointerMove", "x": 0.2, "y": 0.5, "durationMs": 300 },
+              { "type": "pause", "durationMs": 150 },
+              { "type": "pointerUp" }
+            ]
+          },
+          {
+            "id": "finger2",
+            "pointerType": "touch",
+            "actions": [
+              { "type": "pointerMove", "x": 0.55, "y": 0.5 },
+              { "type": "pointerDown" },
+              { "type": "pause", "durationMs": 300 },
+              { "type": "pointerMove", "x": 0.8, "y": 0.5, "durationMs": 150 },
+              { "type": "pointerUp" }
+            ]
+          }
+        ]
+        """)!.AsArray();
 
     [Fact]
     public async Task Pinch_FiresPinchGestureRecognizer()
@@ -482,6 +522,116 @@ public class UiActionTests : IntegrationTestBase
             double.TryParse(elapsedText, NumberStyles.Number, CultureInfo.InvariantCulture, out var elapsedMs)
                 && elapsedMs >= 500,
             $"Expected a native long press of at least 500ms, got '{status.Text}'.");
+    }
+
+    [Trait(TestFramework.Trait, TestFramework.Maui)]
+    [Fact]
+    public async Task PointerActions_OnAndroid_DriveARealTwoTouchPinchTimeline()
+    {
+        if (!Platform.Equals("android", StringComparison.OrdinalIgnoreCase))
+        {
+            Output.WriteLine("Custom pointer actions are capability-gated to Android.");
+            return;
+        }
+
+        await NavigateToGesturePageAsync();
+        var status = await FindElementAsync("PinchStatusLabel");
+        Assert.True(await Client.SetPropertyAsync(status.Id, "Text", "pinch: none"));
+        await SettleAsync();
+        var target = await FindElementAsync("PinchTarget");
+        var sources = CreateIndependentPinchSources();
+
+        var result = await Client.PointerActionsAsync(
+            sources,
+            target.Id,
+            target.CaptureEpoch,
+            target.RegistryGeneration);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("native", result.HandledBy);
+        Assert.Contains("2 touch sources", result.Detail);
+
+        await SettleAsync();
+        status = await FindElementAsync("PinchStatusLabel");
+        Assert.NotEqual("pinch: none", status.Text);
+        Assert.Contains("scale=", status.Text);
+    }
+
+    [Trait(TestFramework.Trait, TestFramework.Maui)]
+    [Fact]
+    public async Task PointerActions_InBatch_PreserveTheMultiTouchSources()
+    {
+        if (!Platform.Equals("android", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        await NavigateToGesturePageAsync();
+        var status = await FindElementAsync("PinchStatusLabel");
+        Assert.True(await Client.SetPropertyAsync(status.Id, "Text", "pinch: none"));
+        await SettleAsync();
+        var target = await FindElementAsync("PinchTarget");
+        var result = await Client.BatchAsync(
+            [
+                new JsonObject
+                {
+                    ["action"] = "gesture",
+                    ["type"] = "actions",
+                    ["elementId"] = target.Id,
+                    ["sources"] = CreateIndependentPinchSources()
+                }
+            ],
+            continueOnError: false,
+            captureEpoch: target.CaptureEpoch,
+            registryGeneration: target.RegistryGeneration);
+
+        Assert.True(result.GetProperty("success").GetBoolean());
+        await SettleAsync();
+        status = await FindElementAsync("PinchStatusLabel");
+        Assert.NotEqual("pinch: none", status.Text);
+        Assert.Contains("scale=", status.Text);
+    }
+
+    [Trait(TestFramework.Trait, TestFramework.Maui)]
+    [Fact]
+    public async Task PointerActions_OnAndroid_RejectInvalidPointerStateBeforeInjection()
+    {
+        if (!Platform.Equals("android", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        await NavigateToGesturePageAsync();
+        var target = await FindElementAsync("PinchTarget");
+        var sources = JsonNode.Parse("""
+            [
+              {
+                "id": "finger1",
+                "pointerType": "touch",
+                "actions": [
+                  { "type": "pointerUp" }
+                ]
+              }
+            ]
+            """)!.AsArray();
+
+        var result = await Client.PointerActionsAsync(sources, target.Id);
+
+        Assert.False(result.Success);
+        Assert.Equal("none", result.HandledBy);
+        Assert.Contains("cannot release before pointerDown", result.Error);
+    }
+
+    [Trait(TestFramework.Trait, TestFramework.Maui)]
+    [Fact]
+    public async Task PointerActions_OnAndroid_RejectNullSourcesWithAResponse()
+    {
+        if (!Platform.Equals("android", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        using var response = await PostRawAsync(
+            "/api/v1/ui/actions/gesture",
+            new { type = "actions", sources = (object?)null });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("between 1 and 10 pointer sources", body);
     }
 
     [Fact]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Agent/PlatformAgentService.Gestures.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Agent/PlatformAgentService.Gestures.cs
@@ -35,6 +35,18 @@ namespace Microsoft.Maui.DevFlow.Agent;
 /// </summary>
 public partial class PlatformAgentService
 {
+    protected override bool SupportsNativePointerActions
+    {
+        get
+        {
+#if ANDROID
+            return true;
+#else
+            return false;
+#endif
+        }
+    }
+
     protected override async Task<string?> TryNativePinch(VisualElement element, double scale, Point origin, int durationMs, int steps)
     {
 #if ANDROID
@@ -112,6 +124,18 @@ public partial class PlatformAgentService
 #endif
     }
 
+    protected override async Task<string?> TryNativePointerActions(
+        VisualElement element,
+        IReadOnlyList<PointerActionSourceRequest> sources)
+    {
+#if ANDROID
+        var view = GetAndroidView(element);
+        return view == null ? null : await AndroidPointerActionsAsync(view, sources);
+#else
+        return await base.TryNativePointerActions(element, sources);
+#endif
+    }
+
 #if ANDROID
     // MotionEvent.ACTION_POINTER_INDEX_SHIFT — the pointer index is packed into the
     // high bits of the action for ACTION_POINTER_DOWN/UP.
@@ -151,6 +175,92 @@ public partial class PlatformAgentService
         return (center, radius, density);
     }
 
+    private sealed class AndroidPointerState(int id, PointF position)
+    {
+        public int Id { get; } = id;
+        public PointF Position { get; set; } = position;
+        public bool Pressed { get; set; }
+    }
+
+    private static bool DispatchAndroidMotionEvent(
+        global::Android.Views.View targetView,
+        long downTime,
+        long eventTime,
+        MotionEventActions action,
+        IReadOnlyList<AndroidPointerState> pointers)
+    {
+        var activity = global::Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+        var targetLocation = new int[2];
+        targetView.GetLocationInWindow(targetLocation);
+
+        var properties = new MotionEvent.PointerProperties[pointers.Count];
+        var windowCoords = new MotionEvent.PointerCoords[pointers.Count];
+        var localCoords = new MotionEvent.PointerCoords[pointers.Count];
+        for (var i = 0; i < pointers.Count; i++)
+        {
+            properties[i] = new MotionEvent.PointerProperties
+            {
+                Id = pointers[i].Id,
+                ToolType = MotionEventToolType.Finger
+            };
+            windowCoords[i] = new MotionEvent.PointerCoords
+            {
+                X = pointers[i].Position.X,
+                Y = pointers[i].Position.Y,
+                Pressure = 1f,
+                Size = 1f
+            };
+            localCoords[i] = new MotionEvent.PointerCoords
+            {
+                X = pointers[i].Position.X - targetLocation[0],
+                Y = pointers[i].Position.Y - targetLocation[1],
+                Pressure = 1f,
+                Size = 1f
+            };
+        }
+
+        static MotionEvent? CreateEvent(
+            long downTime,
+            long eventTime,
+            MotionEventActions action,
+            MotionEvent.PointerProperties[] properties,
+            MotionEvent.PointerCoords[] coords)
+            => MotionEvent.Obtain(
+                downTime, eventTime, action, properties.Length,
+                properties, coords,
+                0, (MotionEventButtonState)0, 1f, 1f, 0, (Edge)0,
+                InputSourceType.Touchscreen, (MotionEventFlags)0);
+
+        if (activity != null)
+        {
+            var windowEvent = CreateEvent(downTime, eventTime, action, properties, windowCoords);
+            if (windowEvent != null)
+            {
+                try
+                {
+                    if (activity.DispatchTouchEvent(windowEvent))
+                        return true;
+                }
+                finally
+                {
+                    windowEvent.Recycle();
+                }
+            }
+        }
+
+        var localEvent = CreateEvent(downTime, eventTime, action, properties, localCoords);
+        if (localEvent == null)
+            return false;
+        try
+        {
+            return targetView.DispatchTouchEvent(localEvent);
+        }
+        finally
+        {
+            localEvent.Recycle();
+        }
+    }
+
     /// <summary>
     /// Dispatches a full touch sequence (down → moves → up) through the activity so the
     /// real hit-test and gesture-detection pipeline runs. <paramref name="positionsAt"/>
@@ -164,17 +274,10 @@ public partial class PlatformAgentService
         int steps,
         int holdMs = 0)
     {
-        var activity = global::Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
-        var targetLocation = new int[2];
-        targetView.GetLocationInWindow(targetLocation);
-
-        var properties = new MotionEvent.PointerProperties[pointerCount];
-        var coords = new MotionEvent.PointerCoords[pointerCount];
+        var initial = positionsAt(0);
+        var states = new AndroidPointerState[pointerCount];
         for (var i = 0; i < pointerCount; i++)
-        {
-            properties[i] = new MotionEvent.PointerProperties { Id = i, ToolType = MotionEventToolType.Finger };
-            coords[i] = new MotionEvent.PointerCoords { Pressure = 1f, Size = 1f };
-        }
+            states[i] = new AndroidPointerState(i, initial[i]);
 
         var downTime = global::Android.OS.SystemClock.UptimeMillis();
         var stepDelay = steps > 0 && durationMs > 0 ? Math.Max(1, durationMs / steps) : 0;
@@ -183,75 +286,19 @@ public partial class PlatformAgentService
         void Apply(PointF[] points)
         {
             for (var i = 0; i < pointerCount; i++)
-            {
-                coords[i].X = points[i].X;
-                coords[i].Y = points[i].Y;
-            }
+                states[i].Position = points[i];
         }
 
         bool Send(MotionEventActions action, int activePointers)
-        {
-            static MotionEvent? CreateEvent(
-                long downTime,
-                long eventTime,
-                MotionEventActions action,
-                int activePointers,
-                MotionEvent.PointerProperties[] properties,
-                MotionEvent.PointerCoords[] coords)
-                => MotionEvent.Obtain(
-                    downTime, eventTime, action, activePointers,
-                    properties[..activePointers], coords[..activePointers],
-                    0, (MotionEventButtonState)0, 1f, 1f, 0, (Edge)0,
-                    InputSourceType.Touchscreen, (MotionEventFlags)0);
-
-            if (activity != null)
-            {
-                var windowEvent = CreateEvent(
-                    downTime, eventTime, action, activePointers, properties, coords);
-                if (windowEvent != null)
-                {
-                    try
-                    {
-                        if (activity.DispatchTouchEvent(windowEvent))
-                            return true;
-                    }
-                    finally
-                    {
-                        windowEvent.Recycle();
-                    }
-                }
-            }
-
-            var localCoords = new MotionEvent.PointerCoords[activePointers];
-            for (var i = 0; i < activePointers; i++)
-            {
-                localCoords[i] = new MotionEvent.PointerCoords
-                {
-                    X = coords[i].X - targetLocation[0],
-                    Y = coords[i].Y - targetLocation[1],
-                    Pressure = coords[i].Pressure,
-                    Size = coords[i].Size
-                };
-            }
-
-            var localEvent = CreateEvent(
-                downTime, eventTime, action, activePointers, properties, localCoords);
-            if (localEvent == null)
-                return false;
-            try
-            {
-                return targetView.DispatchTouchEvent(localEvent);
-            }
-            finally
-            {
-                localEvent.Recycle();
-            }
-        }
+            => DispatchAndroidMotionEvent(
+                targetView,
+                downTime,
+                eventTime,
+                action,
+                states[..activePointers]);
 
         try
         {
-            Apply(positionsAt(0));
-
             var handled = Send(MotionEventActions.Down, 1);
             for (var i = 1; i < pointerCount; i++)
                 handled |= Send(
@@ -274,7 +321,9 @@ public partial class PlatformAgentService
 
             eventTime += 1;
             for (var i = pointerCount - 1; i >= 1; i--)
-                Send((MotionEventActions)((int)MotionEventActions.PointerUp | (i << PointerIndexShift)), i + 1);
+                Send(
+                    (MotionEventActions)((int)MotionEventActions.PointerUp | (i << PointerIndexShift)),
+                    i + 1);
             Send(MotionEventActions.Up, 1);
             return handled;
         }
@@ -282,6 +331,191 @@ public partial class PlatformAgentService
         {
             System.Diagnostics.Debug.WriteLine($"[Microsoft.Maui.DevFlow] Android touch injection failed: {ex.GetBaseException().Message}");
             return false;
+        }
+    }
+
+    private static async Task<string?> AndroidPointerActionsAsync(
+        global::Android.Views.View view,
+        IReadOnlyList<PointerActionSourceRequest> sources)
+    {
+        if (view.Width <= 0 || view.Height <= 0)
+            return null;
+
+        var location = new int[2];
+        view.GetLocationInWindow(location);
+        var center = new PointF(location[0] + view.Width / 2f, location[1] + view.Height / 2f);
+        var states = sources
+            .Select((_, index) => new AndroidPointerState(index, center))
+            .ToArray();
+        var maxTicks = sources.Max(static source => source.Actions!.Count);
+        var downTime = 0L;
+        var downAccepted = true;
+        var rejectedEvents = 0;
+
+        List<AndroidPointerState> ActivePointers()
+            => states.Where(static state => state.Pressed).ToList();
+
+        PointF ToWindowPoint(PointerActionStepRequest action, PointF current)
+            => new(
+                action.X.HasValue ? location[0] + (float)(view.Width * action.X.Value) : current.X,
+                action.Y.HasValue ? location[1] + (float)(view.Height * action.Y.Value) : current.Y);
+
+        void RecordDispatch(bool accepted, bool requiredDown = false)
+        {
+            if (accepted)
+                return;
+            rejectedEvents++;
+            if (requiredDown)
+                downAccepted = false;
+        }
+
+        try
+        {
+            for (var tick = 0; tick < maxTicks; tick++)
+            {
+                var tickActions = sources
+                    .Select(source => tick < source.Actions!.Count ? source.Actions[tick] : null)
+                    .ToArray();
+                var tickDuration = tickActions.Max(static action => action?.DurationMs ?? 0);
+
+                for (var sourceIndex = 0; sourceIndex < sources.Count; sourceIndex++)
+                {
+                    var action = tickActions[sourceIndex];
+                    if (NormalizePointerActionType(action?.Type) != "pointerDown")
+                        continue;
+
+                    var state = states[sourceIndex];
+                    state.Pressed = true;
+                    var active = ActivePointers();
+                    if (active.Count == 1)
+                    {
+                        downTime = global::Android.OS.SystemClock.UptimeMillis();
+                        RecordDispatch(
+                            DispatchAndroidMotionEvent(
+                                view, downTime, downTime, MotionEventActions.Down, active),
+                            requiredDown: true);
+                    }
+                    else
+                    {
+                        var pointerIndex = active.IndexOf(state);
+                        var pointerDown = (MotionEventActions)(
+                            (int)MotionEventActions.PointerDown | (pointerIndex << PointerIndexShift));
+                        RecordDispatch(
+                            DispatchAndroidMotionEvent(
+                                view,
+                                downTime,
+                                global::Android.OS.SystemClock.UptimeMillis(),
+                                pointerDown,
+                                active),
+                            requiredDown: true);
+                    }
+                }
+
+                for (var sourceIndex = sources.Count - 1; sourceIndex >= 0; sourceIndex--)
+                {
+                    var action = tickActions[sourceIndex];
+                    if (NormalizePointerActionType(action?.Type) != "pointerUp")
+                        continue;
+
+                    var state = states[sourceIndex];
+                    var active = ActivePointers();
+                    var pointerIndex = active.IndexOf(state);
+                    var eventAction = active.Count == 1
+                        ? MotionEventActions.Up
+                        : (MotionEventActions)(
+                            (int)MotionEventActions.PointerUp | (pointerIndex << PointerIndexShift));
+                    RecordDispatch(DispatchAndroidMotionEvent(
+                        view,
+                        downTime,
+                        global::Android.OS.SystemClock.UptimeMillis(),
+                        eventAction,
+                        active));
+                    state.Pressed = false;
+                }
+
+                var moveSources = Enumerable.Range(0, sources.Count)
+                    .Where(index => NormalizePointerActionType(tickActions[index]?.Type) == "pointerMove")
+                    .ToArray();
+                if (moveSources.Length > 0)
+                {
+                    var starts = states.Select(static state => state.Position).ToArray();
+                    var ends = states.Select(static state => state.Position).ToArray();
+                    foreach (var sourceIndex in moveSources)
+                        ends[sourceIndex] = ToWindowPoint(tickActions[sourceIndex]!, starts[sourceIndex]);
+
+                    var hasPressedMove = moveSources.Any(index =>
+                        states[index].Pressed
+                        && (Math.Abs(ends[index].X - starts[index].X) > 0.01f
+                            || Math.Abs(ends[index].Y - starts[index].Y) > 0.01f));
+                    var steps = tickDuration <= 0 ? 1 : Math.Clamp((int)Math.Ceiling(tickDuration / 16d), 1, 120);
+                    var previousElapsed = 0;
+                    for (var step = 1; step <= steps; step++)
+                    {
+                        var elapsed = tickDuration <= 0
+                            ? 0
+                            : (int)Math.Round(tickDuration * step / (double)steps);
+                        var delay = elapsed - previousElapsed;
+                        if (delay > 0)
+                            await Task.Delay(delay);
+                        previousElapsed = elapsed;
+
+                        foreach (var sourceIndex in moveSources)
+                        {
+                            var actionDuration = tickActions[sourceIndex]!.DurationMs ?? 0;
+                            var progress = actionDuration <= 0
+                                ? 1d
+                                : Math.Min(1d, (double)elapsed / actionDuration);
+                            states[sourceIndex].Position = new PointF(
+                                starts[sourceIndex].X + (ends[sourceIndex].X - starts[sourceIndex].X) * (float)progress,
+                                starts[sourceIndex].Y + (ends[sourceIndex].Y - starts[sourceIndex].Y) * (float)progress);
+                        }
+
+                        var active = ActivePointers();
+                        if (hasPressedMove && active.Count > 0)
+                        {
+                            RecordDispatch(DispatchAndroidMotionEvent(
+                                view,
+                                downTime,
+                                global::Android.OS.SystemClock.UptimeMillis(),
+                                MotionEventActions.Move,
+                                active));
+                        }
+                    }
+                }
+                else if (tickDuration > 0)
+                {
+                    await Task.Delay(tickDuration);
+                }
+            }
+
+            return downAccepted
+                ? $"MotionEvent actions ({sources.Count} touch sources, {maxTicks} synchronized ticks, {rejectedEvents} unconsumed events)"
+                : null;
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                var active = ActivePointers();
+                if (active.Count > 0 && downTime > 0)
+                {
+                    DispatchAndroidMotionEvent(
+                        view,
+                        downTime,
+                        global::Android.OS.SystemClock.UptimeMillis(),
+                        MotionEventActions.Cancel,
+                        active);
+                }
+            }
+            catch (Exception cancelException)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[Microsoft.Maui.DevFlow] Android pointer cancel failed: {cancelException.GetBaseException().Message}");
+            }
+
+            System.Diagnostics.Debug.WriteLine(
+                $"[Microsoft.Maui.DevFlow] Android pointer actions failed: {ex.GetBaseException().Message}");
+            return null;
         }
     }
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AgentClient.cs
@@ -519,7 +519,7 @@ public class AgentClient : IDisposable
     }
 
     /// <summary>
-    /// Performs a gesture. Supported types: tap, doubletap, longpress, swipe, pan, pinch, rotate.
+    /// Performs a named gesture. Supported types: tap, doubletap, longpress, swipe, pan, pinch, rotate.
     /// </summary>
     public async Task<bool> GestureAsync(
         string type,
@@ -584,6 +584,33 @@ public class AgentClient : IDisposable
         if (steps.HasValue) payload["steps"] = steps.Value;
         AddCaptureMetadata(payload, captureEpoch, registryGeneration);
 
+        return await SendGesturePayloadAsync(payload, type);
+    }
+
+    /// <summary>
+    /// Performs synchronized low-level touch actions. Each source is a touch pointer track whose
+    /// action at a given array index runs in the same timeline tick as the other sources.
+    /// </summary>
+    public Task<GestureResult> PointerActionsAsync(
+        JsonArray sources,
+        string? elementId = null,
+        long? captureEpoch = null,
+        long? registryGeneration = null)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        var payload = new JsonObject
+        {
+            ["type"] = "actions",
+            ["sources"] = sources.DeepClone()
+        };
+        if (elementId is not null)
+            payload["elementId"] = elementId;
+        AddCaptureMetadata(payload, captureEpoch, registryGeneration);
+        return SendGesturePayloadAsync(payload, "actions");
+    }
+
+    private async Task<GestureResult> SendGesturePayloadAsync(JsonObject payload, string type)
+    {
         try
         {
             using var response = await SendWithTransientRetriesAsync(HttpMethod.Post, async () =>

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AgentIntegrationTests.cs
@@ -231,6 +231,69 @@ public class AgentHttpServerTests : IDisposable
     }
 
     [Fact]
+    public async Task PointerActionsEndpoint_SendsSynchronizedSources()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, _port);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buffer = new byte[8192];
+            var read = await stream.ReadAsync(buffer);
+            var request = Encoding.UTF8.GetString(buffer, 0, read);
+
+            Assert.Contains("POST /api/v1/ui/actions/gesture", request);
+            Assert.Contains("\"type\":\"actions\"", request);
+            Assert.Contains("\"id\":\"finger1\"", request);
+            Assert.Contains("\"id\":\"finger2\"", request);
+            Assert.Contains("\"type\":\"pointerMove\"", request);
+            Assert.Contains("\"durationMs\":300", request);
+
+            var body = """{"success":true,"type":"actions","elementId":"canvas1","handledBy":"native","platform":"Android","detail":"MotionEvent actions (2 touch sources, 5 synchronized ticks)"}""";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(response));
+        });
+
+        var sources = JsonNode.Parse("""
+            [
+              {
+                "id": "finger1",
+                "pointerType": "touch",
+                "actions": [
+                  { "type": "pointerMove", "x": 0.45, "y": 0.5 },
+                  { "type": "pointerDown" },
+                  { "type": "pointerMove", "x": 0.2, "y": 0.5, "durationMs": 300 },
+                  { "type": "pause", "durationMs": 150 },
+                  { "type": "pointerUp" }
+                ]
+              },
+              {
+                "id": "finger2",
+                "pointerType": "touch",
+                "actions": [
+                  { "type": "pointerMove", "x": 0.55, "y": 0.5 },
+                  { "type": "pointerDown" },
+                  { "type": "pause", "durationMs": 300 },
+                  { "type": "pointerMove", "x": 0.8, "y": 0.5, "durationMs": 150 },
+                  { "type": "pointerUp" }
+                ]
+              }
+            ]
+            """)!.AsArray();
+
+        using var agentClient = new Microsoft.Maui.DevFlow.Driver.AgentClient("localhost", _port);
+        var result = await agentClient.PointerActionsAsync(sources, "canvas1");
+
+        Assert.True(result.Success);
+        Assert.Equal("actions", result.Type);
+        Assert.Equal("native", result.HandledBy);
+        await acceptTask;
+        listener.Stop();
+    }
+
+    [Fact]
     public async Task FillEndpoint_SendsPostWithText()
     {
         using var listener = new TcpListener(IPAddress.Loopback, _port);


### PR DESCRIPTION
Follow-up to #431.

## Summary
- adds a capability-gated `actions` gesture with synchronized W3C-style touch pointer sources
- supports independent per-pointer moves and pauses across overlapping timeline ticks
- implements real Android multi-pointer `MotionEvent` injection with pointer-state validation and cancellation cleanup
- exposes custom timelines through AgentClient, CLI, MCP, batches, OpenAPI/JSON Schema, examples, and capabilities
- keeps named gestures as the portable cross-platform API; custom pointer actions are currently advertised only on Android

## Validation
- all DevFlow Agent platform TFMs build
- 408 DevFlow tests pass
- 813 CLI tests pass
- 20 gesture integration tests pass on Mac Catalyst
- 20 gesture integration tests pass on Android, including direct and batched multi-touch timelines reaching the MAUI pinch recognizer