### PR TITLE
Remove Publish-Build-Assets variable group from main

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -58,7 +58,6 @@ jobs:
     parameters:
       is1ESPipeline: ${{ parameters.is1ESPipeline }}
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: Publish-Build-Assets
     - group: AzureDevOps-Artifact-Feeds-Pats
     - name: runCodesignValidationInjection
       value: false

--- a/eng/common/core-templates/jobs/codeql-build.yml
+++ b/eng/common/core-templates/jobs/codeql-build.yml
@@ -18,7 +18,6 @@ jobs:
     enableTelemetry: true
 
     variables:
-      - group: Publish-Build-Assets
       # The Guardian version specified in 'eng/common/sdl/packages.config'. This value must be kept in
       # sync with the packages.config file.
       - name: DefaultGuardianVersion

--- a/eng/common/core-templates/post-build/common-variables.yml
+++ b/eng/common/core-templates/post-build/common-variables.yml
@@ -1,6 +1,4 @@
 variables:
-  - group: Publish-Build-Assets
-
   # Whether the build is internal or not
   - name: IsInternalBuild
     value: ${{ and(ne(variables['System.TeamProject'], 'public'), contains(variables['Build.SourceBranch'], 'internal')) }}

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -30,9 +30,7 @@ steps:
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
       -runtimeSourceFeed https://ci.dot.net/internal 
       -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
-      '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
-      '$(akams-client-id)'
       '$(dn-bot-all-orgs-build-rw-code-rw)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}


### PR DESCRIPTION
Synchronizes the relevant Arcade credential-removal changes on `main` so the pipeline no longer imports VG20 or passes its obsolete log-redaction values.

Tracked by https://dev.azure.com/dnceng/internal/_workitems/edit/12131