### PR TITLE
Add MAUI device testing package and templates

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,0 +1,83 @@
+name: CI - MAUI Testing
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Testing/**'
+      - 'eng/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'NuGet.config'
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+    paths:
+      - 'src/Testing/**'
+      - 'eng/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'NuGet.config'
+
+jobs:
+  build:
+    env:
+      Configuration: Release
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: src/Testing
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET 11 Preview
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui
+
+      - name: Build runtime
+        run: dotnet build Microsoft.Maui.Testing/Microsoft.Maui.Testing.csproj
+
+      - name: Run tests
+        run: dotnet test Microsoft.Maui.Testing.Tests/Microsoft.Maui.Testing.Tests.csproj
+
+      - name: Pack
+        shell: pwsh
+        run: |
+          dotnet pack Microsoft.Maui.Testing/Microsoft.Maui.Testing.csproj -o artifacts/packages
+          dotnet pack templates/Microsoft.Maui.Testing.Templates.csproj -o artifacts/packages
+
+      - name: Validate packed template
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $validationRoot = Join-Path $env:RUNNER_TEMP 'maui-testing-template'
+          $hive = Join-Path $validationRoot 'hive'
+          $project = Join-Path $validationRoot 'MauiTestingSmoke'
+          $templatePackage = Resolve-Path 'artifacts/packages/Microsoft.Maui.Testing.Templates.*.nupkg'
+          $localPackages = (Resolve-Path 'artifacts/packages').Path
+
+          dotnet new install $templatePackage --debug:custom-hive $hive
+          dotnet new mauitest -n MauiTestingSmoke -o $project --debug:custom-hive $hive --no-restore
+          dotnet restore (Join-Path $project 'MauiTestingSmoke.csproj') `
+            --configfile ../../NuGet.config `
+            "-p:RestoreAdditionalProjectSources=$localPackages"
+          dotnet build (Join-Path $project 'MauiTestingSmoke.csproj') --no-restore
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: packages-testing-${{ matrix.os }}
+          path: src/Testing/artifacts/packages/*.nupkg

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,7 @@
   <!-- Roslyn (for source generators) -->
   <ItemGroup Label="Roslyn">
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
   </ItemGroup>
 
@@ -100,6 +101,11 @@
   <!-- Testing (Microsoft.NET.Test.Sdk and xunit.runner.visualstudio are
        implicitly provided by the Arcade SDK — do not define PackageVersion for them) -->
   <ItemGroup Label="Testing">
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
+    <PackageVersion Include="MSTest" Version="$(MSTestVersion)" />
+    <PackageVersion Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterVersion)" />
     <PackageVersion Include="xunit" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.runner.utility" Version="$(XunitVersion)" />
     <PackageVersion Include="coverlet.collector" Version="$(CoverletCollectorVersion)" />

--- a/MauiLabs.slnx
+++ b/MauiLabs.slnx
@@ -74,6 +74,7 @@
     <Project Path="tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Microsoft.Maui.Essentials.AI.UnitTests.csproj" />
   </Folder>
   <Folder Name="/tests/DevFlow/" />
+  <Folder Name="/platforms/" />
   <Folder Name="/platforms/MacOS/">
     <Project Path="platforms/MacOS/src/MacOS/MacOS.csproj" />
     <Project Path="platforms/MacOS/src/MacOS.Essentials/MacOS.Essentials.csproj" />

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ At a glance:
 | [WPF Backend](#wpf-backend) | WPF-based Windows desktop backend for .NET MAUI apps. |
 | [Essentials.AI](#essentialsai) | On-device AI APIs for chat completion, embeddings, and tool calling in MAUI apps. |
 | [AppProjectReference](#appprojectreference) | MSBuild package for referencing MAUI app projects and consuming their platform artifacts. |
+| [MAUI Testing](#maui-testing) | MTP-based Android, iOS, and Mac Catalyst test lifecycle and single-project template. |
 
 ### Cli
 
@@ -157,6 +158,22 @@ Built artifacts are exposed as `@(MauiAppArtifact)` items with `ArtifactType`, `
 | Package | Description |
 |---------|-------------|
 | [![NuGet: Microsoft.Maui.Build.AppProjectReference](https://img.shields.io/nuget/v/Microsoft.Maui.Build.AppProjectReference.svg?label=Microsoft.Maui.Build.AppProjectReference)](https://www.nuget.org/packages/Microsoft.Maui.Build.AppProjectReference/) | Build-time app project reference with artifact discovery |
+
+### MAUI Testing
+
+Framework-neutral Microsoft.Testing.Platform lifecycle support for device tests, with a `mauitest` single-project template modeled after `dotnet new maui`.
+
+- Shared `MauiProgram.CreateMauiTestApp()` and dependency-injection builder
+- Android instrumentation and native Apple status UI
+- MSTest by default, with an NUnit configuration path and framework-neutral builder
+- Requires .NET 11
+
+| Package | Description |
+|---------|-------------|
+| [![NuGet: Microsoft.Maui.Testing](https://img.shields.io/nuget/v/Microsoft.Maui.Testing.svg?label=Microsoft.Maui.Testing)](https://www.nuget.org/packages/Microsoft.Maui.Testing/) | Runtime builder and platform lifecycle |
+| [![NuGet: Microsoft.Maui.Testing.Templates](https://img.shields.io/nuget/v/Microsoft.Maui.Testing.Templates.svg?label=Microsoft.Maui.Testing.Templates)](https://www.nuget.org/packages/Microsoft.Maui.Testing.Templates/) | `dotnet new mauitest` template pack |
+
+See [src/Testing/README.md](src/Testing/README.md) for installation, execution, and framework conversion instructions.
 
 ## Agent Skills
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,6 +97,10 @@
   </PropertyGroup>
   <PropertyGroup Label="Testing">
     <MicrosoftNETTestSdkVersion>18.3.0</MicrosoftNETTestSdkVersion>
+    <MicrosoftTestingPlatformVersion>2.3.2</MicrosoftTestingPlatformVersion>
+    <MSTestVersion>4.3.2</MSTestVersion>
+    <NUnitVersion>4.4.0</NUnitVersion>
+    <NUnit3TestAdapterVersion>6.2.0</NUnit3TestAdapterVersion>
     <XunitVersion>2.9.3</XunitVersion>
     <XunitRunnerVisualstudioVersion>3.1.5</XunitRunnerVisualstudioVersion>
     <CoverletCollectorVersion>8.0.0</CoverletCollectorVersion>

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -44,6 +44,10 @@ parameters:
   displayName: 'Publish EssentialsAI packages to NuGet.org'
   type: boolean
   default: false
+- name: publishTestingNuget
+  displayName: 'Publish MAUI Testing packages to NuGet.org'
+  type: boolean
+  default: false
 
 variables:
 - template: /eng/pipelines/common-variables.yml@self
@@ -400,6 +404,37 @@ extends:
                 -projects $(Build.SourcesDirectory)\platforms\MacOS\MacOS-libs.slnf
                 $(_OfficialBuildArgs)
               displayName: Build, Test and Pack macOS AppKit
+
+          - job: Testing
+            displayName: MAUI Testing - Windows
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals windows.vs2026.amd64
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+                  _OfficialBuildArgs: /p:DotNetSignType=$(_SignType)
+                    /p:TeamName=$(_TeamName)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            steps:
+            - task: UseDotNet@2
+              displayName: Install .NET 11 SDK
+              inputs:
+                version: 11.0.x
+                includePreviewVersions: true
+            - powershell: |
+                dotnet workload install maui
+                if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              displayName: Install MAUI workload
+              workingDirectory: $(Build.SourcesDirectory)\src\Testing
+            - script: $(Build.SourcesDirectory)\eng\common\cibuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                -projects $(Build.SourcesDirectory)\src\Testing\Testing.slnx
+                $(_OfficialBuildArgs)
+              displayName: Build, Test and Pack MAUI Testing
+              workingDirectory: $(Build.SourcesDirectory)\src\Testing
        
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
@@ -845,5 +880,60 @@ extends:
               useDotNetTask: false
               packagesToPush: '$(Pipeline.Workspace)/MacOSPackages/*.nupkg'
               packageParentPath: '$(Pipeline.Workspace)/MacOSPackages'
+              nuGetFeedType: external
+              publishFeedCredentials: 'nuget.org (dotnetframework)'
+
+    # Publish MAUI Testing packages to NuGet.org
+    - ${{ if eq(parameters.publishTestingNuget, true) }}:
+      - stage: publish_testing_nuget
+        displayName: 'Publish MAUI Testing to NuGet.org'
+        dependsOn:
+        - Validate
+        - publish_using_darc
+        jobs:
+        - job: PrepareArtifacts
+          displayName: 'Prepare MAUI Testing Artifacts'
+          timeoutInMinutes: 15
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026.amd64
+            os: windows
+          templateContext:
+            outputs:
+            - output: pipelineArtifact
+              displayName: Publish MAUI Testing Packages
+              targetPath: '$(Pipeline.Workspace)/TestingPackages'
+              artifactName: TestingPackagesForNuGet
+          steps:
+          - download: current
+            artifact: PackageArtifacts
+            displayName: Download PackageArtifacts
+          - powershell: |
+              New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/TestingPackages'
+              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Testing*.nupkg' '$(Pipeline.Workspace)/TestingPackages/' -Verbose -ErrorAction Stop
+            displayName: Filter MAUI Testing packages
+
+        - job: PublishNuGet
+          displayName: 'Push MAUI Testing to NuGet.org'
+          dependsOn: PrepareArtifacts
+          timeoutInMinutes: 30
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026.amd64
+            os: windows
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              artifactName: TestingPackagesForNuGet
+              targetPath: '$(Pipeline.Workspace)/TestingPackages'
+          steps:
+          - task: 1ES.PublishNuget@1
+            displayName: 'Push MAUI Testing to NuGet.org'
+            inputs:
+              useDotNetTask: false
+              packagesToPush: '$(Pipeline.Workspace)/TestingPackages/*.nupkg'
+              packageParentPath: '$(Pipeline.Workspace)/TestingPackages'
               nuGetFeedType: external
               publishFeedCredentials: 'nuget.org (dotnetframework)'

--- a/src/Testing/Directory.Packages.props
+++ b/src/Testing/Directory.Packages.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\..\eng\Versions.props" />
+  <Import Project="..\..\Directory.Packages.props" />
+</Project>

--- a/src/Testing/Microsoft.Maui.Testing.Tests/MauiTestAppBuilderTests.cs
+++ b/src/Testing/Microsoft.Maui.Testing.Tests/MauiTestAppBuilderTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Maui.Testing.Tests;
+
+[TestClass]
+public sealed class MauiTestAppBuilderTests
+{
+    [TestMethod]
+    public void Build_WithoutTestFramework_Throws()
+    {
+        var builder = MauiTestApp.CreateBuilder();
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(() => builder.Build());
+
+        StringAssert.Contains(exception.Message, "No test framework is configured");
+    }
+
+    [TestMethod]
+    public void ConfigureTestApplication_Twice_Throws()
+    {
+        var builder = MauiTestApp.CreateBuilder()
+            .ConfigureTestApplication(_ => { });
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => builder.ConfigureTestApplication(_ => { }));
+
+        StringAssert.Contains(exception.Message, "already been configured");
+    }
+
+    [TestMethod]
+    public void ConfigureTestApplication_WithRunner_Builds()
+    {
+        var builder = MauiTestApp.CreateBuilder()
+            .ConfigureTestApplication((_, _) => Task.FromResult(0));
+
+        using var app = builder.Build();
+
+        Assert.IsNotNull(app);
+    }
+
+    [TestMethod]
+    public void Build_RegistersServices()
+    {
+        var options = new MauiTestAppOptions
+        {
+            ResultsDirectoryName = "CustomResults",
+            GenerateTrxReport = false,
+        };
+        var builder = MauiTestApp.CreateBuilder(options)
+            .ConfigureTestApplication(_ => { });
+        builder.Services.AddSingleton(new TestService("registered"));
+
+        using var app = builder.Build();
+
+        Assert.AreEqual("registered", app.Services.GetRequiredService<TestService>().Value);
+        Assert.AreSame(options, app.Services.GetRequiredService<MauiTestAppOptions>());
+    }
+
+    [TestMethod]
+    public void CreateArguments_AddsDefaults()
+    {
+        var arguments = MauiTestApp.CreateArguments([], "C:\\results", generateTrxReport: true);
+
+        CollectionAssert.AreEqual(
+            new[] { "--results-directory", "C:\\results", "--report-trx" },
+            arguments);
+    }
+
+    [TestMethod]
+    public void CreateArguments_PreservesExplicitOptions()
+    {
+        string[] input = ["--results-directory", "D:\\custom", "--report-trx", "--filter", "Test1"];
+
+        var arguments = MauiTestApp.CreateArguments(input, "C:\\results", generateTrxReport: true);
+
+        CollectionAssert.AreEqual(input, arguments);
+    }
+
+    [TestMethod]
+    [DataRow("--results-directory=D:\\custom")]
+    [DataRow("--results-directory:D:\\custom")]
+    public void CreateArguments_DelimitedResultsDirectory_PreservesExplicitOption(string option)
+    {
+        string[] input = [option];
+
+        var arguments = MauiTestApp.CreateArguments(input, "C:\\results", generateTrxReport: false);
+
+        CollectionAssert.AreEqual(input, arguments);
+    }
+
+    private sealed record TestService(string Value);
+}

--- a/src/Testing/Microsoft.Maui.Testing.Tests/MauiTestArgumentParserTests.cs
+++ b/src/Testing/Microsoft.Maui.Testing.Tests/MauiTestArgumentParserTests.cs
@@ -1,0 +1,33 @@
+namespace Microsoft.Maui.Testing.Tests;
+
+[TestClass]
+public sealed class MauiTestArgumentParserTests
+{
+    [TestMethod]
+    public void Parse_QuotedFilter_PreservesArgumentBoundaries()
+    {
+        var arguments = MauiTestArgumentParser.Parse(
+            "--filter \"FullyQualifiedName~Smoke Test\" --report-trx");
+
+        CollectionAssert.AreEqual(
+            new[] { "--filter", "FullyQualifiedName~Smoke Test", "--report-trx" },
+            arguments);
+    }
+
+    [TestMethod]
+    public void Parse_UnmatchedQuote_ThrowsFormatException()
+    {
+        Assert.ThrowsExactly<FormatException>(() =>
+            MauiTestArgumentParser.Parse("--filter \"unterminated"));
+    }
+
+    [TestMethod]
+    public void Parse_EmptyQuotedArgument_PreservesArgument()
+    {
+        var arguments = MauiTestArgumentParser.Parse("--filter \"\" --report-trx");
+
+        CollectionAssert.AreEqual(
+            new[] { "--filter", string.Empty, "--report-trx" },
+            arguments);
+    }
+}

--- a/src/Testing/Microsoft.Maui.Testing.Tests/MauiTestResultConsumerTests.cs
+++ b/src/Testing/Microsoft.Maui.Testing.Tests/MauiTestResultConsumerTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.TestHost;
+
+namespace Microsoft.Maui.Testing.Tests;
+
+[TestClass]
+public sealed class MauiTestResultConsumerTests
+{
+    [TestMethod]
+    public void CreateCompletedEvent_ParameterizedFailure_PreservesIdentityAndDiagnostics()
+    {
+        Exception exception;
+        try
+        {
+            throw new InvalidOperationException("boom");
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        var node = new TestNode
+        {
+            Uid = new TestNodeUid("TestMethod(row: 2)"),
+            DisplayName = "TestMethod(row: 2)",
+            Properties = new PropertyBag(
+                new FailedTestNodeStateProperty(exception, "assertion failed")),
+        };
+
+        var completed = MauiTestResultConsumer.CreateCompletedEvent(node);
+
+        Assert.IsNotNull(completed);
+        Assert.AreEqual("TestMethod(row: 2)", completed.Uid);
+        Assert.AreEqual("TestMethod(row: 2)", completed.Name);
+        Assert.AreEqual("failed", completed.Outcome);
+        Assert.AreEqual("assertion failed", completed.Message);
+        StringAssert.Contains(completed.StackTrace, nameof(CreateCompletedEvent_ParameterizedFailure_PreservesIdentityAndDiagnostics));
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_MultipleFileArtifacts_KeepsFirstTrxReport()
+    {
+        var consumer = new MauiTestResultConsumer();
+        var session = new SessionUid("session");
+        var firstTrx = Path.GetFullPath("first.trx");
+
+        await consumer.ConsumeAsync(
+            null!,
+            new SessionFileArtifact(session, new FileInfo("diagnostics.log"), "diagnostics"),
+            CancellationToken.None);
+        await consumer.ConsumeAsync(
+            null!,
+            new SessionFileArtifact(session, new FileInfo(firstTrx), "TRX report"),
+            CancellationToken.None);
+        await consumer.ConsumeAsync(
+            null!,
+            new SessionFileArtifact(session, new FileInfo("second.trx"), "another TRX report"),
+            CancellationToken.None);
+
+        Assert.AreEqual(firstTrx, consumer.TrxReportPath);
+    }
+}

--- a/src/Testing/Microsoft.Maui.Testing.Tests/Microsoft.Maui.Testing.Tests.csproj
+++ b/src/Testing/Microsoft.Maui.Testing.Tests/Microsoft.Maui.Testing.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Maui.Testing\Microsoft.Maui.Testing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/src/Testing/Microsoft.Maui.Testing/MauiTestApp.cs
+++ b/src/Testing/Microsoft.Maui.Testing/MauiTestApp.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Extensions;
+
+namespace Microsoft.Maui.Testing;
+
+public sealed class MauiTestApp : IDisposable
+{
+    private readonly Action<ITestApplicationBuilder>? _configureTestApplication;
+    private readonly MauiTestApplicationRunner? _testApplicationRunner;
+    private readonly MauiTestAppOptions _options;
+    private bool _disposed;
+
+    internal MauiTestApp(
+        MauiApp mauiApp,
+        Action<ITestApplicationBuilder>? configureTestApplication,
+        MauiTestApplicationRunner? testApplicationRunner,
+        MauiTestAppOptions options)
+    {
+        MauiApp = mauiApp;
+        _configureTestApplication = configureTestApplication;
+        _testApplicationRunner = testApplicationRunner;
+        _options = options;
+    }
+
+    public MauiApp MauiApp { get; }
+
+    public IServiceProvider Services => MauiApp.Services;
+
+    public static MauiTestAppBuilder CreateBuilder() => new(new MauiTestAppOptions());
+
+    public static MauiTestAppBuilder CreateBuilder(MauiTestAppOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return new(options);
+    }
+
+    internal async Task<MauiTestRunResult> RunAsync(
+        string[] args,
+        string defaultResultsDirectory,
+        MauiTestResultConsumer consumer,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultResultsDirectory);
+        ArgumentNullException.ThrowIfNull(consumer);
+
+        Directory.CreateDirectory(defaultResultsDirectory);
+
+        var effectiveArgs = CreateArguments(args, defaultResultsDirectory, _options.GenerateTrxReport);
+        if (_testApplicationRunner is not null)
+        {
+            var exitCode = await _testApplicationRunner(
+                effectiveArgs,
+                (builder, _) => ConfigureMauiTesting(builder, consumer));
+            cancellationToken.ThrowIfCancellationRequested();
+            return consumer.CreateResult(exitCode);
+        }
+
+        var builder = await TestApplication.CreateBuilderAsync(effectiveArgs);
+        _configureTestApplication!(builder);
+        ConfigureMauiTesting(builder, consumer);
+
+        using ITestApplication application = await builder.BuildAsync();
+        var result = await application.RunAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+        return consumer.CreateResult(result);
+    }
+
+    private void ConfigureMauiTesting(
+        ITestApplicationBuilder builder,
+        MauiTestResultConsumer consumer)
+    {
+        builder.TestHost.AddDataConsumer(_ => consumer);
+        if (_options.GenerateTrxReport)
+        {
+            builder.AddTrxReportProvider();
+        }
+    }
+
+    internal static string[] CreateArguments(
+        IEnumerable<string> args,
+        string defaultResultsDirectory,
+        bool generateTrxReport)
+    {
+        var result = args.ToList();
+        if (!ContainsOption(result, "--results-directory"))
+        {
+            result.Add("--results-directory");
+            result.Add(defaultResultsDirectory);
+        }
+
+        if (generateTrxReport &&
+            !ContainsOption(result, "--report-trx"))
+        {
+            result.Add("--report-trx");
+        }
+
+        return [.. result];
+    }
+
+    private static bool ContainsOption(IEnumerable<string> args, string option) =>
+        args.Any(argument =>
+            argument.Equals(option, StringComparison.OrdinalIgnoreCase) ||
+            argument.StartsWith($"{option}=", StringComparison.OrdinalIgnoreCase) ||
+            argument.StartsWith($"{option}:", StringComparison.OrdinalIgnoreCase));
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        MauiApp.Dispose();
+    }
+}

--- a/src/Testing/Microsoft.Maui.Testing/MauiTestAppBuilder.cs
+++ b/src/Testing/Microsoft.Maui.Testing/MauiTestAppBuilder.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Hosting;
+using Microsoft.Testing.Platform.Builder;
+
+namespace Microsoft.Maui.Testing;
+
+public sealed class MauiTestAppBuilder
+{
+    private readonly MauiAppBuilder _mauiAppBuilder;
+    private Action<ITestApplicationBuilder>? _configureTestApplication;
+    private MauiTestApplicationRunner? _testApplicationRunner;
+
+    internal MauiTestAppBuilder(MauiTestAppOptions options)
+    {
+        _mauiAppBuilder = MauiApp.CreateBuilder()
+            .UseMauiApp<MauiTestApplication>();
+        Options = options;
+    }
+
+    public IServiceCollection Services => _mauiAppBuilder.Services;
+
+    internal MauiTestAppOptions Options { get; }
+
+    public MauiTestAppBuilder ConfigureTestApplication(Action<ITestApplicationBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        EnsureTestApplicationIsNotConfigured();
+        _configureTestApplication = configure;
+        return this;
+    }
+
+    public MauiTestAppBuilder ConfigureTestApplication(MauiTestApplicationRunner runner)
+    {
+        ArgumentNullException.ThrowIfNull(runner);
+
+        EnsureTestApplicationIsNotConfigured();
+        _testApplicationRunner = runner;
+        return this;
+    }
+
+    private void EnsureTestApplicationIsNotConfigured()
+    {
+        if (_configureTestApplication is not null || _testApplicationRunner is not null)
+        {
+            throw new InvalidOperationException("The test application has already been configured.");
+        }
+    }
+
+    public MauiTestApp Build()
+    {
+        if (_configureTestApplication is null && _testApplicationRunner is null)
+        {
+            throw new InvalidOperationException(
+                "No test framework is configured. Call ConfigureTestApplication and register a framework such as MSTest.");
+        }
+
+        Services.AddSingleton(Options);
+        return new MauiTestApp(
+            _mauiAppBuilder.Build(),
+            _configureTestApplication,
+            _testApplicationRunner,
+            Options);
+    }
+}
+
+internal sealed class MauiTestApplication : Application;

--- a/src/Testing/Microsoft.Maui.Testing/MauiTestAppOptions.cs
+++ b/src/Testing/Microsoft.Maui.Testing/MauiTestAppOptions.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.Maui.Testing;
+
+public sealed class MauiTestAppOptions
+{
+    public string ResultsDirectoryName { get; init; } = "TestResults";
+
+    public bool GenerateTrxReport { get; init; } = true;
+}

--- a/src/Testing/Microsoft.Maui.Testing/MauiTestAppleHost.cs
+++ b/src/Testing/Microsoft.Maui.Testing/MauiTestAppleHost.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Maui.Testing;
+
+internal static class MauiTestAppleHost
+{
+    public static void Run(MauiTestApp application)
+    {
+        var consumer = new MauiTestResultConsumer();
+        consumer.TestCompleted += result =>
+            Console.WriteLine($"[{result.Outcome.ToUpperInvariant()}] {result.Name}");
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                var options = application.Services.GetRequiredService<MauiTestAppOptions>();
+                var resultsPath = Path.Combine(documentsPath, options.ResultsDirectoryName);
+                var args = Environment.GetCommandLineArgs().Skip(1).ToArray();
+                var result = await application.RunAsync(args, resultsPath, consumer);
+                Console.WriteLine(
+                    $"Results: passed={result.Passed}, failed={result.Failed}, skipped={result.Skipped}");
+                Console.WriteLine($"TRX report: {result.TrxReportPath}");
+                Environment.Exit(result.ExitCode);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error running tests: {ex}");
+                Environment.Exit(1);
+            }
+        });
+    }
+}

--- a/src/Testing/Microsoft.Maui.Testing/MauiTestApplicationRunner.cs
+++ b/src/Testing/Microsoft.Maui.Testing/MauiTestApplicationRunner.cs
@@ -1,0 +1,7 @@
+using Microsoft.Testing.Platform.Builder;
+
+namespace Microsoft.Maui.Testing;
+
+public delegate Task<int> MauiTestApplicationRunner(
+    string[] args,
+    Action<ITestApplicationBuilder, string[]> configure);

--- a/src/Testing/Microsoft.Maui.Testing/MauiTestArgumentParser.cs
+++ b/src/Testing/Microsoft.Maui.Testing/MauiTestArgumentParser.cs
@@ -1,0 +1,81 @@
+using System.Text;
+
+namespace Microsoft.Maui.Testing;
+
+internal static class MauiTestArgumentParser
+{
+    public static string[] Parse(string? commandLine)
+    {
+        if (string.IsNullOrWhiteSpace(commandLine))
+        {
+            return [];
+        }
+
+        var arguments = new List<string>();
+        var current = new StringBuilder();
+        char? quote = null;
+        var tokenStarted = false;
+
+        for (var index = 0; index < commandLine.Length; index++)
+        {
+            var character = commandLine[index];
+            if (quote is not null)
+            {
+                if (character == quote)
+                {
+                    quote = null;
+                }
+                else if (character == '\\' &&
+                    index + 1 < commandLine.Length &&
+                    (commandLine[index + 1] == quote || commandLine[index + 1] == '\\'))
+                {
+                    current.Append(commandLine[++index]);
+                }
+                else
+                {
+                    current.Append(character);
+                }
+
+                continue;
+            }
+
+            if (character is '"' or '\'')
+            {
+                quote = character;
+                tokenStarted = true;
+            }
+            else if (char.IsWhiteSpace(character))
+            {
+                AddArgument(arguments, current, ref tokenStarted);
+            }
+            else
+            {
+                current.Append(character);
+                tokenStarted = true;
+            }
+        }
+
+        if (quote is not null)
+        {
+            throw new FormatException("The MTP argument string contains an unmatched quote.");
+        }
+
+        AddArgument(arguments, current, ref tokenStarted);
+        return [.. arguments];
+    }
+
+    private static void AddArgument(
+        List<string> arguments,
+        StringBuilder current,
+        ref bool tokenStarted)
+    {
+        if (!tokenStarted)
+        {
+            return;
+        }
+
+        arguments.Add(current.ToString());
+        current.Clear();
+        tokenStarted = false;
+    }
+}

--- a/src/Testing/Microsoft.Maui.Testing/MauiTestResultConsumer.cs
+++ b/src/Testing/Microsoft.Maui.Testing/MauiTestResultConsumer.cs
@@ -1,0 +1,112 @@
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+
+namespace Microsoft.Maui.Testing;
+
+internal sealed class MauiTestResultConsumer : IDataConsumer
+{
+    private int _passed;
+    private int _failed;
+    private int _skipped;
+    private string? _trxReportPath;
+
+    public int Passed => _passed;
+
+    public int Failed => _failed;
+
+    public int Skipped => _skipped;
+
+    public string? TrxReportPath => _trxReportPath;
+
+    public event Action<MauiTestCompletedEvent>? TestCompleted;
+
+    public string Uid => nameof(MauiTestResultConsumer);
+
+    public string DisplayName => "MAUI test results";
+
+    public string Description => "Collects test outcomes and report artifacts.";
+
+    public string Version => "1.0";
+
+    public Type[] DataTypesConsumed => [typeof(TestNodeUpdateMessage), typeof(SessionFileArtifact)];
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task ConsumeAsync(
+        IDataProducer dataProducer,
+        IData value,
+        CancellationToken cancellationToken)
+    {
+        if (value is SessionFileArtifact artifact)
+        {
+            if (string.Equals(artifact.FileInfo.Extension, ".trx", StringComparison.OrdinalIgnoreCase))
+            {
+                Interlocked.CompareExchange(ref _trxReportPath, artifact.FileInfo.FullName, null);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        if (value is not TestNodeUpdateMessage { TestNode: var node })
+        {
+            return Task.CompletedTask;
+        }
+
+        var completed = CreateCompletedEvent(node);
+        if (completed is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        _ = completed.Outcome switch
+        {
+            "passed" => Interlocked.Increment(ref _passed),
+            "failed" => Interlocked.Increment(ref _failed),
+            _ => Interlocked.Increment(ref _skipped),
+        };
+
+        TestCompleted?.Invoke(completed);
+        return Task.CompletedTask;
+    }
+
+    internal static MauiTestCompletedEvent? CreateCompletedEvent(TestNode node)
+    {
+        var state = node.Properties.SingleOrDefault<TestNodeStateProperty>();
+        var outcome = state switch
+        {
+            PassedTestNodeStateProperty => "passed",
+            FailedTestNodeStateProperty or ErrorTestNodeStateProperty or TimeoutTestNodeStateProperty => "failed",
+            SkippedTestNodeStateProperty => "skipped",
+            _ => null,
+        };
+        if (outcome is null)
+        {
+            return null;
+        }
+
+        var identifier = node.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+        var className = identifier is null
+            ? null
+            : string.Join(
+                ".",
+                new[] { identifier.Namespace, identifier.TypeName }
+                    .Where(value => !string.IsNullOrWhiteSpace(value)));
+        var exception = state switch
+        {
+            FailedTestNodeStateProperty failed => failed.Exception,
+            ErrorTestNodeStateProperty error => error.Exception,
+            TimeoutTestNodeStateProperty timeout => timeout.Exception,
+            _ => null,
+        };
+        return new MauiTestCompletedEvent(
+            node.Uid.Value,
+            node.DisplayName,
+            className,
+            outcome,
+            state?.Explanation ?? exception?.Message,
+            exception?.StackTrace);
+    }
+
+    public MauiTestRunResult CreateResult(int exitCode) =>
+        new(exitCode, Passed, Failed, Skipped, TrxReportPath);
+}

--- a/src/Testing/Microsoft.Maui.Testing/MauiTestRunResult.cs
+++ b/src/Testing/Microsoft.Maui.Testing/MauiTestRunResult.cs
@@ -1,0 +1,16 @@
+namespace Microsoft.Maui.Testing;
+
+internal sealed record MauiTestRunResult(
+    int ExitCode,
+    int Passed,
+    int Failed,
+    int Skipped,
+    string? TrxReportPath);
+
+internal sealed record MauiTestCompletedEvent(
+    string Uid,
+    string Name,
+    string? ClassName,
+    string Outcome,
+    string? Message,
+    string? StackTrace);

--- a/src/Testing/Microsoft.Maui.Testing/Microsoft.Maui.Testing.csproj
+++ b/src/Testing/Microsoft.Maui.Testing/Microsoft.Maui.Testing.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net11.0;net11.0-android;net11.0-ios;net11.0-maccatalyst</TargetFrameworks>
+    <SingleProject>true</SingleProject>
+    <UseMaui>true</UseMaui>
+    <RootNamespace>Microsoft.Maui.Testing</RootNamespace>
+    <PackageId>Microsoft.Maui.Testing</PackageId>
+    <Description>.NET MAUI device test application lifecycle and builder for Android, iOS, and Mac Catalyst.</Description>
+    <PackageTags>$(PackageTags) testing mtp android ios maccatalyst</PackageTags>
+    <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
+    <IsTrimmable>true</IsTrimmable>
+    <PackRepoRootReadme>false</PackRepoRootReadme>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">13.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">17.0</SupportedOSPlatformVersion>
+    <AndroidGenerateResourceDesigner Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">false</AndroidGenerateResourceDesigner>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Maui.Testing.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Testing/Microsoft.Maui.Testing/Platforms/Android/MauiTestInstrumentation.cs
+++ b/src/Testing/Microsoft.Maui.Testing/Platforms/Android/MauiTestInstrumentation.cs
@@ -1,0 +1,104 @@
+using Android.App;
+using Android.OS;
+using Android.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.Testing;
+
+public abstract class MauiTestInstrumentation : Instrumentation
+{
+    public const string ArgumentsExtra = "mtp-arguments";
+
+    private Bundle? _arguments;
+
+    protected MauiTestInstrumentation(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
+
+    protected abstract MauiTestApp CreateMauiTestApp();
+
+    public override void OnCreate(Bundle? arguments)
+    {
+        _arguments = arguments;
+        base.OnCreate(arguments);
+        Start();
+    }
+
+    public override async void OnStart()
+    {
+        base.OnStart();
+
+        var bundle = new Bundle();
+        try
+        {
+            using var app = CreateMauiTestApp();
+            var writablePath = global::Android.App.Application.Context
+                .GetExternalFilesDir(null)?.AbsolutePath ?? Path.GetTempPath();
+            var resultsPath = Path.Combine(
+                writablePath,
+                app.Services.GetRequiredService<MauiTestAppOptions>().ResultsDirectoryName);
+            var consumer = new MauiTestResultConsumer();
+            consumer.TestCompleted += result =>
+            {
+                var status = new Bundle();
+                status.PutString("event", "finish");
+                status.PutString("test", result.Uid);
+                status.PutString("name", result.Name);
+                status.PutString("class", result.ClassName);
+                status.PutString("outcome", result.Outcome);
+                if (result.Message is not null)
+                {
+                    status.PutString("message-b64", Encode(result.Message));
+                }
+                if (result.StackTrace is not null)
+                {
+                    status.PutString("stack-b64", Encode(result.StackTrace));
+                }
+                var statusCode = result.Outcome switch
+                {
+                    "failed" => (Result)(-2),
+                    "skipped" => (Result)(-3),
+                    _ => (Result)0,
+                };
+                SendStatus(statusCode, status);
+            };
+
+            var argumentsJson = _arguments?.GetString(ArgumentsExtra);
+            var arguments = string.IsNullOrWhiteSpace(argumentsJson)
+                ? MauiTestArgumentParser.Parse(_arguments?.GetString("args"))
+                : JsonSerializer.Deserialize(
+                    argumentsJson,
+                    MauiTestJsonSerializerContext.Default.StringArray)
+                    ?? throw new FormatException(
+                        $"Instrumentation extra '{ArgumentsExtra}' must contain a JSON string array.");
+            var result = await app.RunAsync(arguments, resultsPath, consumer);
+            bundle.PutInt("passed", result.Passed);
+            bundle.PutInt("failed", result.Failed);
+            bundle.PutInt("skipped", result.Skipped);
+            bundle.PutString("resultsPath", result.TrxReportPath);
+            Finish(Result.Ok, bundle);
+        }
+        catch (Exception ex)
+        {
+            bundle.PutString("error", ex.ToString());
+            Finish(Result.Canceled, bundle);
+        }
+        finally
+        {
+            _arguments?.Dispose();
+            _arguments = null;
+        }
+    }
+
+    private static string Encode(string value) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+}
+
+[JsonSerializable(typeof(string[]))]
+internal partial class MauiTestJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/Testing/Microsoft.Maui.Testing/Platforms/MacCatalyst/MauiTestAppDelegate.cs
+++ b/src/Testing/Microsoft.Maui.Testing/Platforms/MacCatalyst/MauiTestAppDelegate.cs
@@ -1,0 +1,20 @@
+using Foundation;
+using UIKit;
+
+namespace Microsoft.Maui.Testing;
+
+public abstract class MauiTestAppDelegate : UIApplicationDelegate
+{
+    private MauiTestApp? _application;
+
+    protected abstract MauiTestApp CreateMauiTestApp();
+
+    public override bool FinishedLaunching(
+        UIApplication application,
+        NSDictionary? launchOptions)
+    {
+        _application ??= CreateMauiTestApp();
+        MauiTestAppleHost.Run(_application);
+        return true;
+    }
+}

--- a/src/Testing/Microsoft.Maui.Testing/Platforms/iOS/MauiTestAppDelegate.cs
+++ b/src/Testing/Microsoft.Maui.Testing/Platforms/iOS/MauiTestAppDelegate.cs
@@ -1,0 +1,20 @@
+using Foundation;
+using UIKit;
+
+namespace Microsoft.Maui.Testing;
+
+public abstract class MauiTestAppDelegate : UIApplicationDelegate
+{
+    private MauiTestApp? _application;
+
+    protected abstract MauiTestApp CreateMauiTestApp();
+
+    public override bool FinishedLaunching(
+        UIApplication application,
+        NSDictionary? launchOptions)
+    {
+        _application ??= CreateMauiTestApp();
+        MauiTestAppleHost.Run(_application);
+        return true;
+    }
+}

--- a/src/Testing/Microsoft.Maui.Testing/Properties/AssemblyInfo.cs
+++ b/src/Testing/Microsoft.Maui.Testing/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Maui.Testing.Tests")]

--- a/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
+++ b/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,26 @@
+#nullable enable
+Microsoft.Maui.Testing.MauiTestApp
+Microsoft.Maui.Testing.MauiTestApp.Dispose() -> void
+Microsoft.Maui.Testing.MauiTestApp.MauiApp.get -> Microsoft.Maui.Hosting.MauiApp!
+Microsoft.Maui.Testing.MauiTestApp.Services.get -> System.IServiceProvider!
+Microsoft.Maui.Testing.MauiTestAppBuilder
+Microsoft.Maui.Testing.MauiTestAppBuilder.Build() -> Microsoft.Maui.Testing.MauiTestApp!
+Microsoft.Maui.Testing.MauiTestAppBuilder.ConfigureTestApplication(Microsoft.Maui.Testing.MauiTestApplicationRunner! runner) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+Microsoft.Maui.Testing.MauiTestAppBuilder.ConfigureTestApplication(System.Action<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!>! configure) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+Microsoft.Maui.Testing.MauiTestAppBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Microsoft.Maui.Testing.MauiTestApplicationRunner
+Microsoft.Maui.Testing.MauiTestInstrumentation
+Microsoft.Maui.Testing.MauiTestInstrumentation.MauiTestInstrumentation(nint handle, Android.Runtime.JniHandleOwnership ownership) -> void
+Microsoft.Maui.Testing.MauiTestAppOptions
+Microsoft.Maui.Testing.MauiTestAppOptions.GenerateTrxReport.get -> bool
+Microsoft.Maui.Testing.MauiTestAppOptions.GenerateTrxReport.init -> void
+Microsoft.Maui.Testing.MauiTestAppOptions.MauiTestAppOptions() -> void
+Microsoft.Maui.Testing.MauiTestAppOptions.ResultsDirectoryName.get -> string!
+Microsoft.Maui.Testing.MauiTestAppOptions.ResultsDirectoryName.init -> void
+static Microsoft.Maui.Testing.MauiTestApp.CreateBuilder() -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+static Microsoft.Maui.Testing.MauiTestApp.CreateBuilder(Microsoft.Maui.Testing.MauiTestAppOptions! options) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+abstract Microsoft.Maui.Testing.MauiTestInstrumentation.CreateMauiTestApp() -> Microsoft.Maui.Testing.MauiTestApp!
+const Microsoft.Maui.Testing.MauiTestInstrumentation.ArgumentsExtra = "mtp-arguments" -> string!
+override Microsoft.Maui.Testing.MauiTestInstrumentation.OnCreate(Android.OS.Bundle? arguments) -> void
+override Microsoft.Maui.Testing.MauiTestInstrumentation.OnStart() -> void
+virtual Microsoft.Maui.Testing.MauiTestApplicationRunner.Invoke(string![]! args, System.Action<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!, string![]!>! configure) -> System.Threading.Tasks.Task<int>!

--- a/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
+++ b/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,24 @@
+#nullable enable
+Microsoft.Maui.Testing.MauiTestApp
+Microsoft.Maui.Testing.MauiTestApp.Dispose() -> void
+Microsoft.Maui.Testing.MauiTestApp.MauiApp.get -> Microsoft.Maui.Hosting.MauiApp!
+Microsoft.Maui.Testing.MauiTestApp.Services.get -> System.IServiceProvider!
+Microsoft.Maui.Testing.MauiTestAppBuilder
+Microsoft.Maui.Testing.MauiTestAppBuilder.Build() -> Microsoft.Maui.Testing.MauiTestApp!
+Microsoft.Maui.Testing.MauiTestAppBuilder.ConfigureTestApplication(Microsoft.Maui.Testing.MauiTestApplicationRunner! runner) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+Microsoft.Maui.Testing.MauiTestAppBuilder.ConfigureTestApplication(System.Action<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!>! configure) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+Microsoft.Maui.Testing.MauiTestAppBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Microsoft.Maui.Testing.MauiTestApplicationRunner
+Microsoft.Maui.Testing.MauiTestAppDelegate
+Microsoft.Maui.Testing.MauiTestAppDelegate.MauiTestAppDelegate() -> void
+Microsoft.Maui.Testing.MauiTestAppOptions
+Microsoft.Maui.Testing.MauiTestAppOptions.GenerateTrxReport.get -> bool
+Microsoft.Maui.Testing.MauiTestAppOptions.GenerateTrxReport.init -> void
+Microsoft.Maui.Testing.MauiTestAppOptions.MauiTestAppOptions() -> void
+Microsoft.Maui.Testing.MauiTestAppOptions.ResultsDirectoryName.get -> string!
+Microsoft.Maui.Testing.MauiTestAppOptions.ResultsDirectoryName.init -> void
+static Microsoft.Maui.Testing.MauiTestApp.CreateBuilder() -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+static Microsoft.Maui.Testing.MauiTestApp.CreateBuilder(Microsoft.Maui.Testing.MauiTestAppOptions! options) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+abstract Microsoft.Maui.Testing.MauiTestAppDelegate.CreateMauiTestApp() -> Microsoft.Maui.Testing.MauiTestApp!
+override Microsoft.Maui.Testing.MauiTestAppDelegate.FinishedLaunching(UIKit.UIApplication! application, Foundation.NSDictionary? launchOptions) -> bool
+virtual Microsoft.Maui.Testing.MauiTestApplicationRunner.Invoke(string![]! args, System.Action<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!, string![]!>! configure) -> System.Threading.Tasks.Task<int>!

--- a/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,0 +1,24 @@
+#nullable enable
+Microsoft.Maui.Testing.MauiTestApp
+Microsoft.Maui.Testing.MauiTestApp.Dispose() -> void
+Microsoft.Maui.Testing.MauiTestApp.MauiApp.get -> Microsoft.Maui.Hosting.MauiApp!
+Microsoft.Maui.Testing.MauiTestApp.Services.get -> System.IServiceProvider!
+Microsoft.Maui.Testing.MauiTestAppBuilder
+Microsoft.Maui.Testing.MauiTestAppBuilder.Build() -> Microsoft.Maui.Testing.MauiTestApp!
+Microsoft.Maui.Testing.MauiTestAppBuilder.ConfigureTestApplication(Microsoft.Maui.Testing.MauiTestApplicationRunner! runner) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+Microsoft.Maui.Testing.MauiTestAppBuilder.ConfigureTestApplication(System.Action<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!>! configure) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+Microsoft.Maui.Testing.MauiTestAppBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Microsoft.Maui.Testing.MauiTestApplicationRunner
+Microsoft.Maui.Testing.MauiTestAppDelegate
+Microsoft.Maui.Testing.MauiTestAppDelegate.MauiTestAppDelegate() -> void
+Microsoft.Maui.Testing.MauiTestAppOptions
+Microsoft.Maui.Testing.MauiTestAppOptions.GenerateTrxReport.get -> bool
+Microsoft.Maui.Testing.MauiTestAppOptions.GenerateTrxReport.init -> void
+Microsoft.Maui.Testing.MauiTestAppOptions.MauiTestAppOptions() -> void
+Microsoft.Maui.Testing.MauiTestAppOptions.ResultsDirectoryName.get -> string!
+Microsoft.Maui.Testing.MauiTestAppOptions.ResultsDirectoryName.init -> void
+static Microsoft.Maui.Testing.MauiTestApp.CreateBuilder() -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+static Microsoft.Maui.Testing.MauiTestApp.CreateBuilder(Microsoft.Maui.Testing.MauiTestAppOptions! options) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+abstract Microsoft.Maui.Testing.MauiTestAppDelegate.CreateMauiTestApp() -> Microsoft.Maui.Testing.MauiTestApp!
+override Microsoft.Maui.Testing.MauiTestAppDelegate.FinishedLaunching(UIKit.UIApplication! application, Foundation.NSDictionary? launchOptions) -> bool
+virtual Microsoft.Maui.Testing.MauiTestApplicationRunner.Invoke(string![]! args, System.Action<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!, string![]!>! configure) -> System.Threading.Tasks.Task<int>!

--- a/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Testing/Microsoft.Maui.Testing/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,20 @@
+#nullable enable
+Microsoft.Maui.Testing.MauiTestApp
+Microsoft.Maui.Testing.MauiTestApp.Dispose() -> void
+Microsoft.Maui.Testing.MauiTestApp.MauiApp.get -> Microsoft.Maui.Hosting.MauiApp!
+Microsoft.Maui.Testing.MauiTestApp.Services.get -> System.IServiceProvider!
+Microsoft.Maui.Testing.MauiTestAppBuilder
+Microsoft.Maui.Testing.MauiTestAppBuilder.Build() -> Microsoft.Maui.Testing.MauiTestApp!
+Microsoft.Maui.Testing.MauiTestAppBuilder.ConfigureTestApplication(Microsoft.Maui.Testing.MauiTestApplicationRunner! runner) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+Microsoft.Maui.Testing.MauiTestAppBuilder.ConfigureTestApplication(System.Action<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!>! configure) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+Microsoft.Maui.Testing.MauiTestAppBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Microsoft.Maui.Testing.MauiTestApplicationRunner
+Microsoft.Maui.Testing.MauiTestAppOptions
+Microsoft.Maui.Testing.MauiTestAppOptions.GenerateTrxReport.get -> bool
+Microsoft.Maui.Testing.MauiTestAppOptions.GenerateTrxReport.init -> void
+Microsoft.Maui.Testing.MauiTestAppOptions.MauiTestAppOptions() -> void
+Microsoft.Maui.Testing.MauiTestAppOptions.ResultsDirectoryName.get -> string!
+Microsoft.Maui.Testing.MauiTestAppOptions.ResultsDirectoryName.init -> void
+static Microsoft.Maui.Testing.MauiTestApp.CreateBuilder() -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+static Microsoft.Maui.Testing.MauiTestApp.CreateBuilder(Microsoft.Maui.Testing.MauiTestAppOptions! options) -> Microsoft.Maui.Testing.MauiTestAppBuilder!
+virtual Microsoft.Maui.Testing.MauiTestApplicationRunner.Invoke(string![]! args, System.Action<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!, string![]!>! configure) -> System.Threading.Tasks.Task<int>!

--- a/src/Testing/Microsoft.Maui.Testing/README.md
+++ b/src/Testing/Microsoft.Maui.Testing/README.md
@@ -1,0 +1,16 @@
+# Microsoft.Maui.Testing
+
+`Microsoft.Maui.Testing` provides a MAUI builder and native test lifecycle for MTP-based tests running on Android, iOS, and Mac Catalyst. The generated project references MAUI Controls, so tests can construct and exercise controls directly.
+
+```console
+dotnet new install Microsoft.Maui.Testing.Templates --prerelease
+dotnet new mauitest -n MyApp.Tests
+cd MyApp.Tests
+dotnet test
+```
+
+The runtime package is referenced automatically by the `mauitest` template. Configure dependencies through `MauiTestApp.CreateBuilder().Services`; MSTest is the template default, and framework adapters are configured in `MauiProgram`.
+
+See the [full documentation](https://github.com/dotnet/maui-labs/tree/main/src/Testing) for Apple commands and framework conversion instructions.
+
+> This package is experimental and requires .NET 11.

--- a/src/Testing/README.md
+++ b/src/Testing/README.md
@@ -1,0 +1,135 @@
+# Microsoft.Maui.Testing
+
+`Microsoft.Maui.Testing` runs Microsoft.Testing.Platform (MTP) tests inside native Android, iOS, and Mac Catalyst applications. It uses the same startup shape as a .NET MAUI app: a shared `MauiProgram.CreateMauiTestApp()` method plus thin platform lifecycle classes.
+
+> [!WARNING]
+> Microsoft.Maui.Testing is experimental. It requires the .NET 11 SDK and the .NET 11 Android, iOS, and Mac Catalyst workloads.
+
+## Requirements
+
+- .NET 11 SDK
+- Android workload for Android tests
+- iOS and Mac Catalyst workloads on macOS for Apple tests
+- An Android device/emulator or Apple simulator/device when executing tests
+
+Install the workloads:
+
+```console
+dotnet workload install maui
+```
+
+## Install the template
+
+```console
+dotnet new install Microsoft.Maui.Testing.Templates --prerelease
+```
+
+## Create a test project
+
+```console
+dotnet new mauitest -n MyApp.Tests
+cd MyApp.Tests
+```
+
+The project targets `net11.0-android`, `net11.0-ios`, and `net11.0-maccatalyst`. MAUI Controls and MSTest are configured by default.
+
+## Run tests
+
+Run the project and select a target framework from the interactive prompt:
+
+```console
+dotnet test
+```
+
+For non-interactive automation, pass a target framework explicitly, such as `dotnet test -f net11.0-android`.
+
+`dotnet test` prompts for the target framework, then builds and launches the native test application through MTP. Android reports live instrumentation status, and Apple platforms report test status to the application log. Each platform writes a TRX file under its application data `TestResults` directory.
+
+For direct Android instrumentation launches, pass MTP arguments as a JSON string array in the `mtp-arguments` extra:
+
+```console
+adb shell am instrument -w -r \
+  -e mtp-arguments '["--filter","FullyQualifiedName~Smoke"]' \
+  com.companyname.myapptests/com.companyname.myapptests.TestInstrumentation
+```
+
+The Android SDK test host can use the same extra when forwarding `dotnet test` request arguments.
+
+`dotnet run -f net11.0-android -- --filter FullyQualifiedName~Smoke` is also supported through the Android host's standard `args` instrumentation extra. The current .NET 11 preview Android `dotnet test` adapter does not yet forward its filter request to the on-device MTP process; use `dotnet run` or the explicit instrumentation extra when an on-device filter is required.
+
+## Configure services
+
+Register services in `MauiProgram.cs`:
+
+```csharp
+public static MauiTestApp CreateMauiTestApp()
+{
+    var builder = MauiTestApp.CreateBuilder();
+
+    builder.Services.AddSingleton<WeatherService>();
+    builder.ConfigureTestApplication(testApplication =>
+        testApplication.AddMSTest(() => [typeof(MauiProgram).Assembly]));
+
+    return builder.Build();
+}
+```
+
+## Switch to NUnit
+
+1. Replace the `MSTest.TestAdapter` and `MSTest.TestFramework` packages and implicit using:
+
+```xml
+<PropertyGroup>
+  <EnableNUnitRunner>true</EnableNUnitRunner>
+</PropertyGroup>
+
+<ItemGroup>
+  <PackageReference Include="Microsoft.Maui.Testing" Version="0.1.0-preview.12" />
+  <PackageReference Include="NUnit" Version="4.4.0" />
+  <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+</ItemGroup>
+
+<ItemGroup>
+  <Using Include="NUnit.Framework" />
+</ItemGroup>
+```
+
+2. Change the registration line in `MauiProgram.cs`:
+
+```csharp
+using NUnit.VisualStudio.TestAdapter.TestingPlatformAdapter;
+
+builder.ConfigureTestApplication(testApplication =>
+    testApplication.AddNUnit(() => [typeof(MauiProgram).Assembly]));
+```
+
+3. Change `[TestClass]`/`[TestMethod]` to NUnit's `[TestFixture]`/`[Test]` attributes and use NUnit assertions.
+
+## xUnit status
+
+The current xUnit v3 MTP package validates desktop app-host properties that mobile SDKs intentionally override. `Microsoft.Maui.Testing` does not patch xUnit's build targets, so xUnit mobile support remains unavailable until that validation supports Android, iOS, and Mac Catalyst.
+
+## Project structure
+
+```text
+MyApp.Tests/
+├── MauiProgram.cs
+├── Test1.cs
+├── Platforms/
+│   ├── Android/TestInstrumentation.cs
+│   ├── iOS/AppDelegate.cs
+│   └── MacCatalyst/AppDelegate.cs
+└── MyApp.Tests.csproj
+```
+
+`MauiTestInstrumentation` owns Android test execution and instrumentation result bundles. `MauiTestAppDelegate` owns the Apple lifecycle and logs test status. The generated platform classes only forward `CreateMauiTestApp()` to `MauiProgram`.
+
+## Build this product
+
+```console
+cd src/Testing
+dotnet build Microsoft.Maui.Testing/Microsoft.Maui.Testing.csproj
+dotnet test Microsoft.Maui.Testing.Tests/Microsoft.Maui.Testing.Tests.csproj
+dotnet pack Microsoft.Maui.Testing/Microsoft.Maui.Testing.csproj
+dotnet pack templates/Microsoft.Maui.Testing.Templates.csproj
+```

--- a/src/Testing/Testing.slnx
+++ b/src/Testing/Testing.slnx
@@ -1,0 +1,9 @@
+<Solution>
+  <Folder Name="/src/Testing/">
+    <Project Path="Microsoft.Maui.Testing/Microsoft.Maui.Testing.csproj" />
+    <Project Path="Microsoft.Maui.Testing.Tests/Microsoft.Maui.Testing.Tests.csproj" />
+  </Folder>
+  <Folder Name="/src/Testing/templates/">
+    <Project Path="templates/Microsoft.Maui.Testing.Templates.csproj" />
+  </Folder>
+</Solution>

--- a/src/Testing/global.json
+++ b/src/Testing/global.json
@@ -1,0 +1,13 @@
+{
+  "sdk": {
+    "version": "11.0.100-preview.7",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26357.114"
+  }
+}

--- a/src/Testing/templates/Microsoft.Maui.Testing.Templates.csproj
+++ b/src/Testing/templates/Microsoft.Maui.Testing.Templates.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <PackageId>Microsoft.Maui.Testing.Templates</PackageId>
+    <Description>Project templates for MTP-based Android, iOS, and Mac Catalyst tests.</Description>
+    <PackageTags>$(PackageTags) dotnet-new templates testing mtp android ios maccatalyst</PackageTags>
+    <TargetFramework>net11.0</TargetFramework>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
+    <PackRepoRootReadme>false</PackRepoRootReadme>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+    <Content Include="mauitest\**\*"
+             Exclude="mauitest\**\bin\**;mauitest\**\obj\**;mauitest\MauiTest1.csproj" />
+    <Content Include="$(IntermediateOutputPath)MauiTest1.csproj"
+             Pack="true"
+             PackagePath="content\mauitest\MauiTest1.csproj" />
+    <Compile Remove="**\*" />
+  </ItemGroup>
+
+  <UsingTask TaskName="StampMauiTestingPackageVersion"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <InputFile ParameterType="System.String" Required="true" />
+      <OutputFile ParameterType="System.String" Required="true" />
+      <PackageVersion ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        var content = File.ReadAllText(InputFile)
+            .Replace("MAUI_TESTING_PACKAGE_VERSION", PackageVersion);
+        Directory.CreateDirectory(Path.GetDirectoryName(OutputFile)!);
+        File.WriteAllText(OutputFile, content);
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="StampMauiTestingTemplatePackageVersion" BeforeTargets="GenerateNuspec">
+    <StampMauiTestingPackageVersion
+        InputFile="$(MSBuildProjectDirectory)\mauitest\MauiTest1.csproj"
+        OutputFile="$(IntermediateOutputPath)MauiTest1.csproj"
+        PackageVersion="$(PackageVersion)" />
+  </Target>
+
+</Project>

--- a/src/Testing/templates/README.md
+++ b/src/Testing/templates/README.md
@@ -1,0 +1,13 @@
+# Microsoft.Maui.Testing.Templates
+
+Install this template pack with the .NET 11 SDK:
+
+```console
+dotnet new install Microsoft.Maui.Testing.Templates
+dotnet new mauitest -n MyApp.Tests
+dotnet test MyApp.Tests
+```
+
+The generated project targets Android, iOS, and Mac Catalyst, references MAUI Controls, and uses MSTest by default. See the [Microsoft.Maui.Testing documentation](https://github.com/dotnet/maui-labs/tree/main/src/Testing) for prerequisites and framework conversion instructions.
+
+> This package is experimental and requires .NET 11.

--- a/src/Testing/templates/mauitest/.template.config/dotnetcli.host.json
+++ b/src/Testing/templates/mauitest/.template.config/dotnetcli.host.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "applicationId": {
+      "longName": "application-id"
+    },
+    "androidMinSdk": {
+      "longName": "android-min-sdk"
+    },
+    "iosMinVersion": {
+      "longName": "ios-min-version"
+    },
+    "maccatalystMinVersion": {
+      "longName": "maccatalyst-min-version"
+    },
+    "skipRestore": {
+      "longName": "no-restore"
+    }
+  }
+}

--- a/src/Testing/templates/mauitest/.template.config/template.json
+++ b/src/Testing/templates/mauitest/.template.config/template.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": ["MAUI", "Testing", "MTP", "Android", "iOS", "Mac Catalyst"],
+  "identity": "Microsoft.Maui.Testing.MauiTest",
+  "groupIdentity": "Microsoft.Maui.Testing",
+  "name": ".NET MAUI Device Test",
+  "shortName": "mauitest",
+  "description": "A single project for running MTP-based tests on Android, iOS, and Mac Catalyst.",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "MauiTest1",
+  "preferNameDirectory": true,
+  "defaultName": "MauiTest1",
+  "primaryOutputs": [
+    {
+      "path": "MauiTest1.csproj"
+    }
+  ],
+  "symbols": {
+    "applicationId": {
+      "type": "parameter",
+      "description": "The application identifier used by Android, iOS, and Mac Catalyst.",
+      "datatype": "string",
+      "defaultValue": "com.companyname.mauitest1",
+      "replaces": "com.companyname.mauitest1"
+    },
+    "androidMinSdk": {
+      "type": "parameter",
+      "description": "The minimum Android API level.",
+      "datatype": "string",
+      "defaultValue": "24.0",
+      "replaces": "ANDROID_MIN_SDK"
+    },
+    "iosMinVersion": {
+      "type": "parameter",
+      "description": "The minimum iOS version.",
+      "datatype": "string",
+      "defaultValue": "13.0",
+      "replaces": "IOS_MIN_VERSION"
+    },
+    "maccatalystMinVersion": {
+      "type": "parameter",
+      "description": "The minimum Mac Catalyst version.",
+      "datatype": "string",
+      "defaultValue": "17.0",
+      "replaces": "MACCATALYST_MIN_VERSION"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Skip restoring the project on creation."
+    }
+  },
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "description": "Create or update 'global.json' for Microsoft.Testing.Platform.",
+      "manualInstructions": [
+        {
+          "text": "Set test.runner to Microsoft.Testing.Platform in the nearest global.json file."
+        }
+      ],
+      "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
+      "id": "configureMicrosoftTestingPlatform",
+      "args": {
+        "allowFileCreation": true,
+        "allowPathCreation": true,
+        "jsonFileName": "global.json",
+        "parentPropertyPath": "test",
+        "newJsonPropertyName": "runner",
+        "newJsonPropertyValue": "Microsoft.Testing.Platform",
+        "detectRepositoryRoot": true,
+        "includeAllDirectoriesInSearch": false,
+        "includeAllParentDirectoriesInSearch": true
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/src/Testing/templates/mauitest/MauiProgram.cs
+++ b/src/Testing/templates/mauitest/MauiProgram.cs
@@ -1,0 +1,16 @@
+using Microsoft.Maui.Testing;
+
+namespace MauiTest1;
+
+public static class MauiProgram
+{
+    public static MauiTestApp CreateMauiTestApp()
+    {
+        var builder = MauiTestApp.CreateBuilder();
+
+        builder.ConfigureTestApplication(testApplication =>
+            testApplication.AddMSTest(() => [typeof(MauiProgram).Assembly]));
+
+        return builder.Build();
+    }
+}

--- a/src/Testing/templates/mauitest/MauiTest1.csproj
+++ b/src/Testing/templates/mauitest/MauiTest1.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net11.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net11.0-ios;net11.0-maccatalyst</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <SingleProject>true</SingleProject>
+    <UseMaui>true</UseMaui>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>MauiTest1</RootNamespace>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <ApplicationTitle>MauiTest1</ApplicationTitle>
+    <ApplicationId>com.companyname.mauitest1</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">ANDROID_MIN_SDK</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">IOS_MIN_VERSION</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">MACCATALYST_MIN_VERSION</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Testing" Version="MAUI_TESTING_PACKAGE_VERSION" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/src/Testing/templates/mauitest/Platforms/Android/AndroidManifest.xml
+++ b/src/Testing/templates/mauitest/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:label="MauiTest1" />
+  <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/src/Testing/templates/mauitest/Platforms/Android/TestInstrumentation.cs
+++ b/src/Testing/templates/mauitest/Platforms/Android/TestInstrumentation.cs
@@ -1,0 +1,16 @@
+using Android.App;
+using Android.Runtime;
+using Microsoft.Maui.Testing;
+
+namespace MauiTest1;
+
+[Instrumentation(Name = "com.companyname.mauitest1.TestInstrumentation")]
+public sealed class TestInstrumentation : MauiTestInstrumentation
+{
+    public TestInstrumentation(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
+
+    protected override MauiTestApp CreateMauiTestApp() => MauiProgram.CreateMauiTestApp();
+}

--- a/src/Testing/templates/mauitest/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/Testing/templates/mauitest/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,0 +1,10 @@
+using Foundation;
+using Microsoft.Maui.Testing;
+
+namespace MauiTest1;
+
+[Register("AppDelegate")]
+public sealed class AppDelegate : MauiTestAppDelegate
+{
+    protected override MauiTestApp CreateMauiTestApp() => MauiProgram.CreateMauiTestApp();
+}

--- a/src/Testing/templates/mauitest/Platforms/MacCatalyst/Info.plist
+++ b/src/Testing/templates/mauitest/Platforms/MacCatalyst/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>6</integer>
+  </array>
+</dict>
+</plist>

--- a/src/Testing/templates/mauitest/Platforms/MacCatalyst/Program.cs
+++ b/src/Testing/templates/mauitest/Platforms/MacCatalyst/Program.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace MauiTest1;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/src/Testing/templates/mauitest/Platforms/iOS/AppDelegate.cs
+++ b/src/Testing/templates/mauitest/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,10 @@
+using Foundation;
+using Microsoft.Maui.Testing;
+
+namespace MauiTest1;
+
+[Register("AppDelegate")]
+public sealed class AppDelegate : MauiTestAppDelegate
+{
+    protected override MauiTestApp CreateMauiTestApp() => MauiProgram.CreateMauiTestApp();
+}

--- a/src/Testing/templates/mauitest/Platforms/iOS/Info.plist
+++ b/src/Testing/templates/mauitest/Platforms/iOS/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>1</integer>
+    <integer>2</integer>
+  </array>
+</dict>
+</plist>

--- a/src/Testing/templates/mauitest/Platforms/iOS/Program.cs
+++ b/src/Testing/templates/mauitest/Platforms/iOS/Program.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace MauiTest1;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/src/Testing/templates/mauitest/Test1.cs
+++ b/src/Testing/templates/mauitest/Test1.cs
@@ -1,0 +1,16 @@
+namespace MauiTest1;
+
+[TestClass]
+public sealed class Test1
+{
+    [TestMethod]
+    public void LabelText_CanBeSetAndRead()
+    {
+        var label = new Label
+        {
+            Text = "Hello, .NET MAUI!",
+        };
+
+        Assert.AreEqual("Hello, .NET MAUI!", label.Text);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the experimental `Microsoft.Maui.Testing` runtime package and `Microsoft.Maui.Testing.Templates` package for running Microsoft.Testing.Platform tests inside native .NET MAUI applications on Android, iOS, and Mac Catalyst.

Customers get a `mauitest` template with the same single-project shape as a MAUI app, a shared builder for dependency injection and test-framework registration, and package-owned Android instrumentation and Apple application lifecycle behavior.

## Customer experience

### Requirements

- .NET 11 SDK
- .NET MAUI workload
- An Android device/emulator or Apple simulator/device when executing tests

```console
dotnet workload install maui
```

### Install the template

```console
dotnet new install Microsoft.Maui.Testing.Templates --prerelease
```

### Create a test project

```console
dotnet new mauitest -n MyApp.Tests
cd MyApp.Tests
```

The generated project targets `net11.0-android`, `net11.0-ios`, and `net11.0-maccatalyst`, enables MAUI Controls, and configures MSTest by default.

Its layout follows normal MAUI single-project conventions:

```text
MyApp.Tests/
├── MauiProgram.cs
├── Test1.cs
├── Platforms/
│   ├── Android/TestInstrumentation.cs
│   ├── iOS/AppDelegate.cs
│   └── MacCatalyst/AppDelegate.cs
└── MyApp.Tests.csproj
```

The platform files are intentionally thin. `MauiTestInstrumentation` owns Android instrumentation execution and result reporting, while `MauiTestAppDelegate` owns the Apple lifecycle. Generated platform classes only forward `CreateMauiTestApp()` to the shared `MauiProgram`.

### Run tests

```console
dotnet test
```

The CLI prompts for a target framework, builds the native test application, installs or launches it through Microsoft.Testing.Platform, and writes a TRX result under the application's `TestResults` directory.

Automation can select a framework explicitly:

```console
dotnet test -f net11.0-android
```

Android instrumentation can also receive MTP arguments directly:

```console
adb shell am instrument -w -r \
  -e mtp-arguments '["--filter","FullyQualifiedName~Smoke"]' \
  com.companyname.myapptests/com.companyname.myapptests.TestInstrumentation
```

### Configure MAUI and dependency injection

The shared startup API mirrors MAUI's builder pattern:

```csharp
public static MauiTestApp CreateMauiTestApp()
{
    var builder = MauiTestApp.CreateBuilder();

    builder.Services.AddSingleton<WeatherService>();
    builder.ConfigureTestApplication(testApplication =>
        testApplication.AddMSTest(() => [typeof(MauiProgram).Assembly]));

    return builder.Build();
}
```

Because the builder wraps `MauiAppBuilder`, customers can configure services, handlers, fonts, and other MAUI application behavior in one shared location.

### Use another test framework

MSTest is the template default, not a runtime requirement. Customers can replace the MSTest packages and change the registration line, for example:

```csharp
builder.ConfigureTestApplication(testApplication =>
    testApplication.AddNUnit(() => [typeof(MauiProgram).Assembly]));
```

NUnit additionally requires `EnableNUnitRunner` and the NUnit adapter packages. xUnit mobile support remains blocked by current xUnit v3 MTP app-host validation.

## Implementation

- Adds `Microsoft.Maui.Testing` with shared builder, MTP runner, argument parsing, result consumption, Android instrumentation, and Apple app delegates.
- Adds per-TFM public API baselines and analyzer enforcement.
- Adds `Microsoft.Maui.Testing.Templates` with package-version stamping so generated projects reference the matching runtime package.
- Adds focused runtime tests and packed-template smoke coverage.
- Adds path-filtered GitHub validation for create, restore, and build of an untouched generated project.
- Adds Arcade official-build integration for signing, package artifact publication, and conditional NuGet.org publishing.
- Documents installation, project structure, execution, DI configuration, and framework conversion.

> [!WARNING]
> `Microsoft.Maui.Testing` is experimental and currently requires .NET 11.