### PR TITLE
Keep Sage available across Garden pages

### DIFF
--- a/samples/AIExtensions.Sample.Garden/Pages/CartPage.xaml
+++ b/samples/AIExtensions.Sample.Garden/Pages/CartPage.xaml
@@ -13,6 +13,7 @@
              BackgroundColor="{StaticResource Primary}">
 
     <Grid RowDefinitions="Auto,*"
+          ColumnDefinitions="*,Auto"
           BackgroundColor="{AppThemeBinding Light={StaticResource ModalBackgroundLight}, Dark={StaticResource ModalBackgroundDark}}">
         <!-- Standard header: [back] [icon] [title] ... [mode pill] -->
         <Border Grid.Row="0"
@@ -60,6 +61,8 @@
         <!-- Cart content -->
         <views:CartView Grid.Row="1"
                         BindingContext="{Binding .}" />
+        <views:ChatSidebar Grid.Column="1"
+                           Grid.RowSpan="2" />
     </Grid>
 
 </ContentPage>

--- a/samples/AIExtensions.Sample.Garden/Pages/CatalogPage.xaml
+++ b/samples/AIExtensions.Sample.Garden/Pages/CatalogPage.xaml
@@ -9,6 +9,7 @@
              BackgroundColor="{StaticResource Primary}">
 
     <Grid RowDefinitions="Auto,*"
+          ColumnDefinitions="*,Auto"
           BackgroundColor="{AppThemeBinding Light={StaticResource ModalBackgroundLight}, Dark={StaticResource ModalBackgroundDark}}">
         <!-- Header: [back] [icon] [title] -->
         <Border Grid.Row="0"
@@ -37,6 +38,8 @@
         </Border>
 
         <views:CatalogView Grid.Row="1" />
+        <views:ChatSidebar Grid.Column="1"
+                           Grid.RowSpan="2" />
     </Grid>
 
 </ContentPage>

--- a/samples/AIExtensions.Sample.Garden/Pages/OrderDetailPage.xaml
+++ b/samples/AIExtensions.Sample.Garden/Pages/OrderDetailPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:AIExtensions.Sample.Garden.Views"
              xmlns:vm="clr-namespace:AIExtensions.Sample.Garden.ViewModels"
              x:Class="AIExtensions.Sample.Garden.Pages.OrderDetailPage"
              x:DataType="vm:OrderDetailViewModel"
@@ -10,6 +11,7 @@
              BackgroundColor="{StaticResource Primary}">
 
     <Grid RowDefinitions="Auto,*"
+          ColumnDefinitions="*,Auto"
           BackgroundColor="{AppThemeBinding Light={StaticResource ModalBackgroundLight}, Dark={StaticResource ModalBackgroundDark}}">
         <!-- Header -->
         <Border Grid.Row="0"
@@ -117,6 +119,8 @@
 
             </VerticalStackLayout>
         </ScrollView>
+        <views:ChatSidebar Grid.Column="1"
+                           Grid.RowSpan="2" />
     </Grid>
 
 </ContentPage>

--- a/samples/AIExtensions.Sample.Garden/Pages/OrdersPage.xaml
+++ b/samples/AIExtensions.Sample.Garden/Pages/OrdersPage.xaml
@@ -12,6 +12,7 @@
              BackgroundColor="{StaticResource Primary}">
 
     <Grid RowDefinitions="Auto,*"
+          ColumnDefinitions="*,Auto"
           local:ViewModelBinder.Type="{x:Type vm:OrdersViewModel}"
           BackgroundColor="{AppThemeBinding Light={StaticResource ModalBackgroundLight}, Dark={StaticResource ModalBackgroundDark}}">
         <!-- Header: [back] [icon] [title] ... [clear all] -->
@@ -53,6 +54,8 @@
         </Border>
 
         <views:OrdersView Grid.Row="1" />
+        <views:ChatSidebar Grid.Column="1"
+                           Grid.RowSpan="2" />
     </Grid>
 
 </ContentPage>

--- a/samples/AIExtensions.Sample.Garden/Pages/ProductDetailPage.xaml
+++ b/samples/AIExtensions.Sample.Garden/Pages/ProductDetailPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:AIExtensions.Sample.Garden.Views"
              xmlns:vm="clr-namespace:AIExtensions.Sample.Garden.ViewModels"
              x:Class="AIExtensions.Sample.Garden.Pages.ProductDetailPage"
              x:DataType="vm:ProductDetailViewModel"
@@ -10,6 +11,7 @@
              BackgroundColor="{StaticResource Primary}">
 
     <Grid RowDefinitions="Auto,*"
+          ColumnDefinitions="*,Auto"
           BackgroundColor="{AppThemeBinding Light={StaticResource ModalBackgroundLight}, Dark={StaticResource ModalBackgroundDark}}">
         <!-- Header -->
         <Border Grid.Row="0"
@@ -128,6 +130,8 @@
 
             </VerticalStackLayout>
         </ScrollView>
+        <views:ChatSidebar Grid.Column="1"
+                           Grid.RowSpan="2" />
     </Grid>
 
 </ContentPage>

--- a/samples/AIExtensions.Sample.Garden/Pages/ProductReviewPage.xaml
+++ b/samples/AIExtensions.Sample.Garden/Pages/ProductReviewPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:AIExtensions.Sample.Garden.Views"
              xmlns:vm="clr-namespace:AIExtensions.Sample.Garden.ViewModels"
              x:Class="AIExtensions.Sample.Garden.Pages.ProductReviewPage"
              x:DataType="vm:ProductReviewViewModel"
@@ -11,6 +12,7 @@
              BackgroundColor="{StaticResource Primary}">
 
     <Grid RowDefinitions="Auto,*"
+          ColumnDefinitions="*,Auto"
           BackgroundColor="{AppThemeBinding Light={StaticResource ModalBackgroundLight}, Dark={StaticResource ModalBackgroundDark}}">
         <!-- Header -->
         <Border Grid.Row="0"
@@ -92,6 +94,8 @@
 
             </VerticalStackLayout>
         </ScrollView>
+        <views:ChatSidebar Grid.Column="1"
+                           Grid.RowSpan="2" />
     </Grid>
 
 </ContentPage>

--- a/samples/AIExtensions.Sample.Garden/README.md
+++ b/samples/AIExtensions.Sample.Garden/README.md
@@ -25,6 +25,17 @@ past purchases using source-generated tools.
 - **Approval flow** — checkout and destructive actions pause the chat and show an
   inline approve/reject banner.
 
+## Persistent chat across pages
+
+`ChatViewModel` is registered as a singleton, so the conversation, approval state,
+and model history survive page navigation. On windows at least 800
+device-independent pixels wide, catalog, cart, order, product, and review pages
+each create a fresh `ChatView` inside a 420-DIP `ChatSidebar`; every instance
+resolves the same singleton through `ViewModelBinder`.
+
+Below 800 DIPs, the sidebar is hidden so each page keeps its full working area.
+Returning home restores the chat-first layout with the same conversation history.
+
 ## Tool sources and lifetimes
 
 `GardenShopTools` composes several very different source types with repeated
@@ -69,6 +80,7 @@ participate in a shared tool context while still writing through to singleton st
 | Accessor-level property tools | `ViewModels/Cart/CartViewModel.cs` → `get_cart_mode` / `set_cart_mode` |
 | Transient tool host | `ViewModels/Catalog/CatalogViewModel.cs` → `recommend_bundle` |
 | Shell modal navigation tools | `ViewModels/MainViewModel.cs` + `AppShell.xaml.cs` |
+| Persistent assistant beside non-home pages | `Views/ChatSidebar.xaml`, backed by singleton `ChatViewModel` |
 | Responsive welcome cards and centered chat layout | `Views/ChatView.xaml` + `Pages/MainPage.xaml` |
 
 ## Approval flow

--- a/samples/AIExtensions.Sample.Garden/ViewModels/MainViewModel.cs
+++ b/samples/AIExtensions.Sample.Garden/ViewModels/MainViewModel.cs
@@ -40,7 +40,7 @@ public sealed partial class MainViewModel(CurrentCart currentCart) : ObservableO
     // ─── Navigation AI tools ────────────────────────────────────────
 
     [ExportAIFunction("navigate_to_page",
-        Description = "Navigate to a page in the app. Use 'catalog' to browse products, 'orders' to see past orders, 'cart' to view the shopping cart. Pages open as modal overlays.")]
+        Description = "Navigate to a page in the app. Use 'catalog' to browse products, 'orders' to see past orders, or 'cart' to view the shopping cart. The persistent chat remains available beside non-home pages on wide windows.")]
     public async Task<string> NavigateToPageAsync(
         [System.ComponentModel.Description("The page to navigate to: 'catalog', 'orders', or 'cart'")] string page)
     {
@@ -71,7 +71,7 @@ public sealed partial class MainViewModel(CurrentCart currentCart) : ObservableO
     }
 
     [ExportAIFunction("dismiss_page",
-        Description = "Close the current modal page (catalog or orders) and return to the main shop view.")]
+        Description = "Close the current page or modal and return toward the main shop view without resetting the chat.")]
     public async Task<string> DismissPageAsync()
     {
         var tcs = new TaskCompletionSource();

--- a/samples/AIExtensions.Sample.Garden/Views/ChatSidebar.xaml
+++ b/samples/AIExtensions.Sample.Garden/Views/ChatSidebar.xaml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:AIExtensions.Sample.Garden.Views"
+             x:Class="AIExtensions.Sample.Garden.Views.ChatSidebar"
+             AutomationId="ChatSidebar"
+             WidthRequest="420"
+             HorizontalOptions="End"
+             VerticalOptions="Fill"
+             SafeAreaEdges="Container">
+
+    <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup>
+            <VisualState x:Name="Wide">
+                <VisualState.StateTriggers>
+                    <AdaptiveTrigger MinWindowWidth="800" />
+                </VisualState.StateTriggers>
+                <VisualState.Setters>
+                    <Setter Property="IsVisible" Value="True" />
+                </VisualState.Setters>
+            </VisualState>
+            <VisualState x:Name="Narrow">
+                <VisualState.StateTriggers>
+                    <AdaptiveTrigger MinWindowWidth="0" />
+                </VisualState.StateTriggers>
+                <VisualState.Setters>
+                    <Setter Property="IsVisible" Value="False" />
+                </VisualState.Setters>
+            </VisualState>
+        </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
+
+    <Border Margin="12"
+            Padding="0"
+            BackgroundColor="{AppThemeBinding Light={StaticResource InputBackgroundLight}, Dark={StaticResource InputBackgroundDark}}"
+            Stroke="{AppThemeBinding Light={StaticResource CardStrokeLight}, Dark={StaticResource CardStrokeDark}}"
+            StrokeThickness="1"
+            StrokeShape="RoundRectangle 16">
+        <Border.Shadow>
+            <Shadow Brush="Black" Offset="0,2" Radius="8" Opacity="0.12" />
+        </Border.Shadow>
+
+        <Grid RowDefinitions="Auto,*">
+            <Border BackgroundColor="{StaticResource Primary}"
+                    StrokeThickness="0"
+                    Padding="14,10">
+                <HorizontalStackLayout Spacing="8">
+                    <Label Text="&#xE76C;"
+                           FontFamily="FluentFilled"
+                           FontSize="{StaticResource FontSizeSubtitle}"
+                           TextColor="{StaticResource White}"
+                           VerticalOptions="Center"
+                           SemanticProperties.Description="Sage app icon" />
+                    <Label Text="Ask Sage"
+                           FontSize="{StaticResource FontSizeSubtitle}"
+                           FontAttributes="Bold"
+                           TextColor="{StaticResource White}"
+                           VerticalOptions="Center" />
+                </HorizontalStackLayout>
+            </Border>
+
+            <views:ChatView Grid.Row="1" />
+        </Grid>
+    </Border>
+
+</ContentView>

--- a/samples/AIExtensions.Sample.Garden/Views/ChatSidebar.xaml.cs
+++ b/samples/AIExtensions.Sample.Garden/Views/ChatSidebar.xaml.cs
@@ -1,0 +1,9 @@
+namespace AIExtensions.Sample.Garden.Views;
+
+public partial class ChatSidebar : ContentView
+{
+    public ChatSidebar()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable 420-DIP `ChatSidebar` to Garden's catalog, cart, orders, order detail, product detail, and product review pages
- show the sidebar at widths of 800 DIPs and above while preserving each page's existing primary content
- reuse the singleton `ChatViewModel` so Sage conversation history survives navigation
- document the persistent-chat behavior in the Garden README

## Validation
- `./eng/common/dotnet.sh build samples/AIExtensions.Sample.Garden/AIExtensions.Sample.Garden.csproj -f net10.0-maccatalyst -c Debug --nologo`
- live Mac Catalyst DevFlow check: conversation persisted home → catalog → product → review
- responsive check: sidebar hidden at 799 DIPs and visible at 800 DIPs