### PR TITLE
Expose dotnet-maui-app in the plugin marketplace

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -8,6 +8,11 @@
       "name": "dotnet-maui",
       "source": "./plugins/dotnet-maui",
       "description": "Skills for .NET MAUI development: DevFlow automation, profiling, accessibility, platform bindings, and diagnostics."
+    },
+    {
+      "name": "dotnet-maui-app",
+      "source": "./plugins/dotnet-maui-app",
+      "description": "Skills for building production .NET MAUI apps: architecture, project structure, UI, accessibility, testing, performance, platform integration, auth, networking, assets, lifecycle, Blazor Hybrid, AI, localization, theming, release notes, and migration."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add the existing `dotnet-maui-app` plugin to the repository marketplace catalog
- point the catalog entry at `./plugins/dotnet-maui-app`

## Validation

- `skill-validator check --plugin plugins/dotnet-maui-app --allowed-external-deps eng/allowed-external-deps.txt`
- parsed `.github/plugin/marketplace.json` and verified the catalog name/source match `plugins/dotnet-maui-app/plugin.json`