### PR TITLE
Add provider-neutral image classification contract

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,6 +76,7 @@
 
   <!-- EssentialsAI dependencies -->
   <ItemGroup Label="EssentialsAI">
+    <PackageVersion Include="Azure.AI.ContentUnderstanding" Version="$(AzureAIContentUnderstandingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIAbstractionsVersion)" />
     <!-- Sample app: Microsoft Agents AI -->
     <PackageVersion Include="Microsoft.Agents.AI" Version="$(MicrosoftAgentsAIVersion)" />

--- a/MauiLabs.slnx
+++ b/MauiLabs.slnx
@@ -24,6 +24,7 @@
   <Folder Name="/src/" />
   <Folder Name="/src/AI/">
     <Project Path="src/AI/Microsoft.Maui.Essentials.AI/Microsoft.Maui.Essentials.AI.csproj" />
+    <Project Path="src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.csproj" />
   </Folder>
   <Folder Name="/src/AIExtensions/">
     <Project Path="src/AIExtensions/Microsoft.Maui.AI.Attributes/Microsoft.Maui.AI.Attributes.csproj" />
@@ -73,6 +74,7 @@
   <Folder Name="/tests/AI/">
     <Project Path="tests/AI/Microsoft.Maui.Essentials.AI.Benchmarks/Microsoft.Maui.Essentials.AI.Benchmarks.csproj" />
     <Project Path="tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Microsoft.Maui.Essentials.AI.DeviceTests.csproj" />
+    <Project Path="tests/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests.csproj" />
     <Project Path="tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Microsoft.Maui.Essentials.AI.UnitTests.csproj" />
   </Folder>
   <Folder Name="/tests/DevFlow/" />

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ At a glance:
 | [AI Extensions](#ai-extensions) | Source-generated `Microsoft.Extensions.AI` tool bindings for MAUI and .NET apps. |
 | [macOS AppKit Backend](#macos-appkit-backend) | Native AppKit backend for running MAUI apps as macOS apps without Mac Catalyst. |
 | [WPF Backend](#wpf-backend) | WPF-based Windows desktop backend for .NET MAUI apps. |
-| [Essentials.AI](#essentialsai) | On-device AI APIs for chat completion, embeddings, and tool calling in MAUI apps. |
+| [Essentials.AI](#essentialsai) | AI APIs for chat, embeddings, and image classification, with on-device implementations and an optional Azure provider. |
 | [AppProjectReference](#appprojectreference) | MSBuild package for referencing MAUI app projects and consuming their platform artifacts. |
 
 ### Cli
@@ -134,7 +134,7 @@ A WPF-based alternative to the official WinUI backend for .NET MAUI. Run MAUI ap
 
 ### Essentials.AI
 
-On-device AI capabilities for .NET MAUI via `Microsoft.Extensions.AI` abstractions. On Apple platforms, wraps Apple Intelligence (Foundation Models) for chat completion with streaming and tool calling, and Apple NaturalLanguage APIs for on-device embeddings.
+AI capabilities for .NET MAUI via `Microsoft.Extensions.AI` abstractions. On Apple platforms, the core package wraps Apple Intelligence (Foundation Models) for chat completion with streaming and tool calling, and Apple NaturalLanguage APIs for on-device embeddings. An optional Azure Content Understanding package connects the provider-neutral image-classification contract to custom cloud classifier analyzers.
 
 - **`IChatClient`** backed by Apple Intelligence on iOS, macOS, and Mac Catalyst
 - **Streaming infrastructure** — progressive JSON deserialization of LLM responses
@@ -144,6 +144,7 @@ On-device AI capabilities for .NET MAUI via `Microsoft.Extensions.AI` abstractio
 | Package | Description |
 |---------|-------------|
 | [![NuGet: Microsoft.Maui.Essentials.AI](https://img.shields.io/nuget/v/Microsoft.Maui.Essentials.AI.svg?label=Microsoft.Maui.Essentials.AI)](https://www.nuget.org/packages/Microsoft.Maui.Essentials.AI/) | On-device AI APIs for MAUI |
+| [![NuGet: Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding](https://img.shields.io/nuget/v/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.svg?label=Azure%20Content%20Understanding)](https://www.nuget.org/packages/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/) | Azure Content Understanding image-classification provider |
 
 ### AppProjectReference
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,6 +40,7 @@
     <MicrosoftExtensionsAIVersion>10.4.1</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIOpenAIVersion>10.4.1</MicrosoftExtensionsAIOpenAIVersion>
     <AzureAIOpenAIVersion>2.1.0</AzureAIOpenAIVersion>
+    <AzureAIContentUnderstandingVersion>1.1.0</AzureAIContentUnderstandingVersion>
   </PropertyGroup>
   <PropertyGroup Label="Roslyn">
     <MicrosoftCodeAnalysisAnalyzersVersion>3.11.0</MicrosoftCodeAnalysisAnalyzersVersion>

--- a/src/AI/EssentialsAI.slnf
+++ b/src/AI/EssentialsAI.slnf
@@ -4,8 +4,10 @@
     "projects": [
       "samples\\EssentialsAISample\\EssentialsAISample.csproj",
       "src\\AI\\Microsoft.Maui.Essentials.AI\\Microsoft.Maui.Essentials.AI.csproj",
+      "src\\AI\\Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding\\Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.csproj",
       "tests\\AI\\Microsoft.Maui.Essentials.AI.Benchmarks\\Microsoft.Maui.Essentials.AI.Benchmarks.csproj",
       "tests\\AI\\Microsoft.Maui.Essentials.AI.DeviceTests\\Microsoft.Maui.Essentials.AI.DeviceTests.csproj",
+      "tests\\AI\\Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests\\Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests.csproj",
       "tests\\AI\\Microsoft.Maui.Essentials.AI.UnitTests\\Microsoft.Maui.Essentials.AI.UnitTests.csproj"
     ]
   }

--- a/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/AzureContentUnderstandingImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/AzureContentUnderstandingImageClassificationClient.cs
@@ -1,0 +1,197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Http.Headers;
+using Azure;
+using Azure.AI.ContentUnderstanding;
+using Azure.Core;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding;
+
+/// <summary>
+/// Classifies images by invoking a whole-image classifier analyzer in Azure Content Understanding.
+/// </summary>
+/// <remarks>
+/// The supplied credential, injected client, and image streams remain caller-owned. Disposing this adapter
+/// does not dispose them. The analyzer must be configured with <c>EnableSegment=false</c> and produce exactly
+/// one content-level category.
+/// </remarks>
+public sealed class AzureContentUnderstandingImageClassificationClient : IImageClassificationClient
+{
+	private const string ProviderName = "Azure Content Understanding";
+	private const string AnalyzerIdPropertyName = "analyzerId";
+
+	private readonly ContentUnderstandingClient _client;
+	private readonly string _analyzerId;
+	private readonly ImageClassificationClientMetadata _metadata;
+
+	/// <summary>
+	/// Initializes a client for an Azure Content Understanding classifier analyzer.
+	/// </summary>
+	/// <param name="endpoint">The Azure Content Understanding resource endpoint.</param>
+	/// <param name="credential">The caller-owned token credential used to authenticate requests.</param>
+	/// <param name="options">Provider configuration containing the analyzer identifier.</param>
+	public AzureContentUnderstandingImageClassificationClient(
+		Uri endpoint,
+		TokenCredential credential,
+		AzureContentUnderstandingImageClassificationOptions options)
+	{
+		ArgumentNullException.ThrowIfNull(endpoint);
+		ArgumentNullException.ThrowIfNull(credential);
+		ArgumentNullException.ThrowIfNull(options);
+
+		_analyzerId = GetAnalyzerId(options);
+		_client = new ContentUnderstandingClient(endpoint, credential);
+		_metadata = new ImageClassificationClientMetadata(ProviderName, endpoint, _analyzerId);
+	}
+
+	internal AzureContentUnderstandingImageClassificationClient(
+		ContentUnderstandingClient client,
+		AzureContentUnderstandingImageClassificationOptions options,
+		ImageClassificationClientMetadata? metadata = null)
+	{
+		ArgumentNullException.ThrowIfNull(client);
+		ArgumentNullException.ThrowIfNull(options);
+
+		_analyzerId = GetAnalyzerId(options);
+		_client = client;
+		_metadata = metadata ?? new ImageClassificationClientMetadata(ProviderName, defaultModelId: _analyzerId);
+	}
+
+	/// <inheritdoc />
+	public async Task<ImageClassificationResult> ClassifyImageAsync(
+		Stream image,
+		string imageMediaType,
+		ImageClassificationOptions? options = null,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(image);
+		ArgumentException.ThrowIfNullOrWhiteSpace(imageMediaType);
+
+		ImageClassificationOptions optionsSnapshot = options?.Clone() ?? new ImageClassificationOptions();
+
+		if (optionsSnapshot.MinimumConfidence is not null)
+		{
+			throw new NotSupportedException(
+				$"{nameof(ImageClassificationOptions.MinimumConfidence)} is not supported because Azure Content Understanding whole-image classifier categories do not include confidence values.");
+		}
+
+		if (!image.CanRead)
+		{
+			throw new ArgumentException("The image stream must be readable.", nameof(image));
+		}
+
+		if (!MediaTypeHeaderValue.TryParse(imageMediaType, out MediaTypeHeaderValue? parsedMediaType) ||
+			parsedMediaType.MediaType is null ||
+			!parsedMediaType.MediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+		{
+			throw new ArgumentException("The media type must identify image content.", nameof(imageMediaType));
+		}
+
+		if (!IsSupportedImageMediaType(parsedMediaType.MediaType))
+		{
+			throw new NotSupportedException(
+				$"Azure Content Understanding does not support the image media type '{parsedMediaType.MediaType}'. Supported media types are image/jpeg, image/png, image/bmp, image/heif, and image/heic.");
+		}
+
+		byte[] imageBytes = await ImageClassificationInput.ReadBytesAsync(
+			image,
+			optionsSnapshot.MaximumInputBytes,
+			cancellationToken,
+			nameof(image)).ConfigureAwait(false);
+
+		if (imageBytes.Length == 0)
+		{
+			throw new ArgumentException("The image stream must not be empty.", nameof(image));
+		}
+
+		Operation<AnalysisResult> operation = await _client.AnalyzeBinaryAsync(
+			WaitUntil.Completed,
+			_analyzerId,
+			BinaryData.FromBytes(imageBytes),
+			contentRange: null,
+			contentType: imageMediaType,
+			processingLocation: null,
+			cancellationToken: cancellationToken).ConfigureAwait(false);
+
+		AnalysisResult analysisResult = operation.Value;
+		IList<AnalysisContent>? contents = analysisResult.Contents;
+		if (contents is null || contents.Count != 1)
+		{
+			throw new InvalidOperationException(
+				$"Azure Content Understanding analyzer '{_analyzerId}' returned {contents?.Count ?? 0} content results; exactly one is required for whole-image classification.");
+		}
+
+		string? category = contents[0].Category;
+		if (string.IsNullOrWhiteSpace(category))
+		{
+			throw new InvalidOperationException(
+				$"Azure Content Understanding analyzer '{_analyzerId}' did not return a non-empty content-level category.");
+		}
+
+		return new ImageClassificationResult(
+			[new ImageClassificationPrediction(category, confidence: null)])
+		{
+			ModelId = _analyzerId,
+			RawRepresentation = analysisResult,
+			AdditionalProperties = new AdditionalPropertiesDictionary
+			{
+				[AnalyzerIdPropertyName] = _analyzerId,
+			},
+		};
+	}
+
+	/// <inheritdoc />
+	public object? GetService(Type serviceType, object? serviceKey = null)
+	{
+		ArgumentNullException.ThrowIfNull(serviceType);
+
+		if (serviceKey is not null)
+		{
+			return null;
+		}
+
+		if (serviceType.IsInstanceOfType(this))
+		{
+			return this;
+		}
+
+		if (serviceType.IsInstanceOfType(_client))
+		{
+			return _client;
+		}
+
+		if (serviceType.IsInstanceOfType(_metadata))
+		{
+			return _metadata;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Releases adapter resources without disposing the caller-owned credential, injected client, or image streams.
+	/// </summary>
+	public void Dispose()
+	{
+	}
+
+	private static string GetAnalyzerId(AzureContentUnderstandingImageClassificationOptions options)
+	{
+		string? analyzerId = options.AnalyzerId;
+		if (string.IsNullOrWhiteSpace(analyzerId))
+		{
+			throw new ArgumentException("The analyzer identifier must not be empty.", nameof(options));
+		}
+
+		return analyzerId;
+	}
+
+	private static bool IsSupportedImageMediaType(string mediaType) =>
+		mediaType.Equals("image/jpeg", StringComparison.OrdinalIgnoreCase) ||
+		mediaType.Equals("image/png", StringComparison.OrdinalIgnoreCase) ||
+		mediaType.Equals("image/bmp", StringComparison.OrdinalIgnoreCase) ||
+		mediaType.Equals("image/heif", StringComparison.OrdinalIgnoreCase) ||
+		mediaType.Equals("image/heic", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/AzureContentUnderstandingImageClassificationOptions.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/AzureContentUnderstandingImageClassificationOptions.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding;
+
+/// <summary>Configures image classification with Azure Content Understanding.</summary>
+public sealed class AzureContentUnderstandingImageClassificationOptions
+{
+	/// <summary>Gets or sets the identifier of the classifier analyzer to invoke.</summary>
+	public required string AnalyzerId { get; set; }
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.csproj
+++ b/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding</RootNamespace>
+    <AssemblyName>Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding</AssemblyName>
+    <PackageId>Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding</PackageId>
+    <Description>Image classification for .NET MAUI using Azure Content Understanding.</Description>
+    <PackageTags>$(DefaultPackageTags);ai;image-classification;azure;content-understanding</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackRepoRootReadme>false</PackRepoRootReadme>
+    <IsShipping>true</IsShipping>
+    <IsPackable>true</IsPackable>
+    <IsAotCompatible>true</IsAotCompatible>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <MajorVersion>$(EssentialsAIMajorVersion)</MajorVersion>
+    <MinorVersion>$(EssentialsAIMinorVersion)</MinorVersion>
+    <PatchVersion>$(EssentialsAIPatchVersion)</PatchVersion>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <PreReleaseVersionLabel>$(EssentialsAIPreReleaseVersionLabel)</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>$(EssentialsAIPreviewVersionIteration)</PreReleaseVersionIteration>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.ContentUnderstanding" />
+    <ProjectReference Include="..\Microsoft.Maui.Essentials.AI\Microsoft.Maui.Essentials.AI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+</Project>

--- a/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/Properties/AssemblyInfo.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/Properties/AssemblyInfo.cs
@@ -6,6 +6,4 @@ using System.Runtime.CompilerServices;
 using Microsoft.Maui.Essentials.AI;
 
 [assembly: Experimental(DiagnosticIds.Experiments.EssentialsAI)]
-[assembly: InternalsVisibleTo("Microsoft.Maui.Essentials.AI.UnitTests")]
-[assembly: InternalsVisibleTo("Microsoft.Maui.Essentials.AI.DeviceTests")]
-[assembly: InternalsVisibleTo("Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests")]

--- a/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/PublicAPI/net/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,0 +1,10 @@
+#nullable enable
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationClient
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationClient.AzureContentUnderstandingImageClassificationClient(System.Uri! endpoint, Azure.Core.TokenCredential! credential, Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationOptions! options) -> void
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationClient.ClassifyImageAsync(System.IO.Stream! image, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationClient.Dispose() -> void
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationOptions
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationOptions.AnalyzerId.get -> string!
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationOptions.AnalyzerId.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationOptions.AzureContentUnderstandingImageClassificationOptions() -> void

--- a/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/README.md
@@ -34,7 +34,7 @@ using Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding
 
 using IImageClassificationClient classifier =
     new AzureContentUnderstandingImageClassificationClient(
-        new Uri("https://example.cognitiveservices.azure.com/"),
+        new Uri("https://<resource-name>.services.ai.azure.com/"),
         new DefaultAzureCredential(),
         new AzureContentUnderstandingImageClassificationOptions
         {
@@ -62,16 +62,14 @@ The adapter buffers no more than `MaximumInputBytes` from the caller-owned
 stream before invoking Azure. It does not dispose or rewind the stream.
 Disposing the adapter does not dispose the supplied credential.
 
-## Platform support
+## Target and validation
 
-| Platform | Supported |
-|---|---|
-| Android | Yes |
-| iOS | Yes |
-| Mac Catalyst | Yes |
-| macOS | Yes |
-| Windows | Yes |
+The managed provider targets portable .NET 10. This package has been validated
+with a Release `net10.0` build, package creation, local package consumption, and
+an Android Release full-link/AOT compile of the provider dependency graph. These
+checks are compile-time evidence, not Android device validation. This PR does
+not include a live Azure call or runtime validation on iOS, Mac Catalyst, macOS,
+or Windows.
 
-The managed provider targets .NET 10 and is designed for trimming and native
-AOT. Runtime use requires an Azure Content Understanding resource, a configured
+Runtime use requires an Azure Content Understanding resource, a configured
 classifier analyzer, network access, and a credential authorized to invoke it.

--- a/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/README.md
@@ -1,0 +1,77 @@
+# Azure Content Understanding image classification for .NET MAUI
+
+> [!WARNING]
+> This package is experimental and may change without notice.
+
+Use an Azure Content Understanding custom classifier analyzer through the
+provider-neutral image-classification APIs in `Microsoft.Maui.Essentials.AI`.
+
+## Install
+
+```sh
+dotnet add package Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding --prerelease
+dotnet add package Azure.Identity
+```
+
+The package brings the core `Microsoft.Maui.Essentials.AI` contract and
+`Azure.AI.ContentUnderstanding` SDK as transitive dependencies.
+
+## Configure the analyzer
+
+Create an Azure Content Understanding custom classifier analyzer whose
+`ContentCategories` define the possible labels. Configure it with
+`EnableSegment=false` so one content-level category is returned for the whole
+image.
+
+The provider accepts JPEG, PNG, BMP, HEIF, and HEIC image media types.
+
+## Classify an image
+
+```csharp
+using Azure.Identity;
+using Microsoft.Maui.Essentials.AI;
+using Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding;
+
+using IImageClassificationClient classifier =
+    new AzureContentUnderstandingImageClassificationClient(
+        new Uri("https://example.cognitiveservices.azure.com/"),
+        new DefaultAzureCredential(),
+        new AzureContentUnderstandingImageClassificationOptions
+        {
+            AnalyzerId = "my-image-classifier",
+        });
+
+await using Stream image = File.OpenRead("photo.jpg");
+ImageClassificationResult result = await classifier.ClassifyImageAsync(
+    image,
+    "image/jpeg",
+    new ImageClassificationOptions
+    {
+        MaximumPredictions = 1,
+        MaximumInputBytes = 10 * 1024 * 1024,
+    });
+
+Console.WriteLine(result.Predictions[0].Label);
+```
+
+Azure Content Understanding whole-image classifier categories do not include a
+confidence value. Predictions therefore have `Confidence = null`, and setting
+`MinimumConfidence` throws `NotSupportedException`.
+
+The adapter buffers no more than `MaximumInputBytes` from the caller-owned
+stream before invoking Azure. It does not dispose or rewind the stream.
+Disposing the adapter does not dispose the supplied credential.
+
+## Platform support
+
+| Platform | Supported |
+|---|---|
+| Android | Yes |
+| iOS | Yes |
+| Mac Catalyst | Yes |
+| macOS | Yes |
+| Windows | Yes |
+
+The managed provider targets .NET 10 and is designed for trimming and native
+AOT. Runtime use requires an Azure Content Understanding resource, a configured
+classifier analyzer, network access, and a credential authorized to invoke it.

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Maui.Essentials.AI;
 /// </remarks>
 public sealed class ChatClientImageClassificationClient : IImageClassificationClient
 {
+	private const int StreamCopyBufferSize = 81920;
+
 	private readonly IChatClient _chatClient;
 	private readonly string[] _labels;
 	private readonly HashSet<string> _labelSet;
@@ -80,14 +82,14 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 		ArgumentNullException.ThrowIfNull(imageStream);
 		ArgumentNullException.ThrowIfNull(imageMediaType);
 
-		ImageClassificationOptions? optionsSnapshot = options?.Clone();
+		ImageClassificationOptions optionsSnapshot = options?.Clone() ?? new();
 
 		if (!imageStream.CanRead)
 		{
 			throw new ArgumentException("The image stream must be readable.", nameof(imageStream));
 		}
 
-		if (optionsSnapshot?.MinimumConfidence is not null)
+		if (optionsSnapshot.MinimumConfidence is not null)
 		{
 			throw new NotSupportedException(
 				$"{nameof(ChatClientImageClassificationClient)} does not produce confidence values.");
@@ -99,15 +101,17 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 			throw new ArgumentException("The content media type must be an image media type.", nameof(imageMediaType));
 		}
 
-		using var imageBuffer = new MemoryStream();
-		await imageStream.CopyToAsync(imageBuffer, cancellationToken).ConfigureAwait(false);
+		byte[] imageBytes = await ReadImageBytesAsync(
+			imageStream,
+			optionsSnapshot.MaximumInputBytes,
+			cancellationToken).ConfigureAwait(false);
 
-		if (imageBuffer.Length == 0)
+		if (imageBytes.Length == 0)
 		{
 			throw new ArgumentException("The image stream must not be empty.", nameof(imageStream));
 		}
 
-		image = new DataContent(imageBuffer.ToArray(), imageMediaType);
+		image = new DataContent(imageBytes, imageMediaType);
 
 		var messages = new[]
 		{
@@ -159,7 +163,7 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 		}
 
 		IEnumerable<string> selectedLabels = labels;
-		if (optionsSnapshot?.MaximumPredictions is int maximumPredictions)
+		if (optionsSnapshot.MaximumPredictions is int maximumPredictions)
 		{
 			selectedLabels = selectedLabels.Take(maximumPredictions);
 		}
@@ -180,6 +184,57 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 			properties.Current.NameEquals("labels") &&
 			!properties.MoveNext();
 	}
+
+	private static async Task<byte[]> ReadImageBytesAsync(
+		Stream imageStream,
+		long maximumInputBytes,
+		CancellationToken cancellationToken)
+	{
+		if (imageStream.CanSeek)
+		{
+			long length = imageStream.Length;
+			long position = imageStream.Position;
+			long remainingLength = position >= length ? 0 : length - position;
+			if (remainingLength > maximumInputBytes)
+			{
+				throw CreateImageTooLargeException(maximumInputBytes);
+			}
+		}
+
+		using var imageBuffer = new MemoryStream();
+		var buffer = new byte[StreamCopyBufferSize];
+		long totalBytesRead = 0;
+
+		while (true)
+		{
+			long remainingAllowance = maximumInputBytes - totalBytesRead;
+			int requestedBytes = remainingAllowance >= buffer.Length
+				? buffer.Length
+				: (int)remainingAllowance + 1;
+			int bytesRead = await imageStream
+				.ReadAsync(buffer, 0, requestedBytes, cancellationToken)
+				.ConfigureAwait(false);
+
+			if (bytesRead == 0)
+			{
+				return imageBuffer.ToArray();
+			}
+
+			totalBytesRead += bytesRead;
+			if (totalBytesRead > maximumInputBytes)
+			{
+				throw CreateImageTooLargeException(maximumInputBytes);
+			}
+
+			imageBuffer.Write(buffer, 0, bytesRead);
+		}
+	}
+
+	private static ArgumentException CreateImageTooLargeException(long maximumInputBytes) =>
+		new(
+			$"The image stream exceeds the configured maximum of {maximumInputBytes} bytes. " +
+			$"Reduce the image size or increase {nameof(ImageClassificationOptions)}.{nameof(ImageClassificationOptions.MaximumInputBytes)}.",
+			"imageStream");
 
 	/// <inheritdoc />
 	public object? GetService(Type serviceType, object? serviceKey = null)

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Maui.Essentials.AI;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The injected chat client must support image <see cref="DataContent"/> and structured JSON output. The label
+/// The injected chat client must support image <see cref="DataContent"/>. The adapter prefers structured JSON output,
+/// but also accepts a top-level JSON string array when a client ignores the requested response format. The label
 /// allowlist is snapshotted during construction and matched using ordinal comparison.
 /// </para>
 /// <para>
@@ -79,12 +80,14 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 		ArgumentNullException.ThrowIfNull(imageStream);
 		ArgumentNullException.ThrowIfNull(imageMediaType);
 
+		ImageClassificationOptions? optionsSnapshot = options?.Clone();
+
 		if (!imageStream.CanRead)
 		{
 			throw new ArgumentException("The image stream must be readable.", nameof(imageStream));
 		}
 
-		if (options?.MinimumConfidence is not null)
+		if (optionsSnapshot?.MinimumConfidence is not null)
 		{
 			throw new NotSupportedException(
 				$"{nameof(ChatClientImageClassificationClient)} does not produce confidence values.");
@@ -125,25 +128,28 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 			.GetResponseAsync(messages, chatOptions, cancellationToken)
 			.ConfigureAwait(false);
 
-		ChatClientImageClassificationResponse? structuredResponse;
+		string[] labels;
 		try
 		{
-			structuredResponse = JsonSerializer.Deserialize(
-				response.Text,
-				ChatClientImageClassificationJsonContext.Default.ChatClientImageClassificationResponse);
+			using JsonDocument document = JsonDocument.Parse(response.Text);
+			labels = document.RootElement.ValueKind switch
+			{
+				JsonValueKind.Object when HasExactLabelsEnvelope(document.RootElement) => JsonSerializer.Deserialize(
+					response.Text,
+					ChatClientImageClassificationJsonContext.Default.ChatClientImageClassificationResponse)?.Labels,
+				JsonValueKind.Array => JsonSerializer.Deserialize(
+					response.Text,
+					ChatClientImageClassificationJsonContext.Default.StringArray),
+				_ => null
+			} ?? throw new JsonException("The response must be a labels object or a string array.");
 		}
 		catch (JsonException exception)
 		{
 			throw new InvalidOperationException("The chat client returned a malformed image classification response.", exception);
 		}
 
-		if (structuredResponse?.Labels is null)
-		{
-			throw new InvalidOperationException("The chat client returned a malformed image classification response.");
-		}
-
 		var seenLabels = new HashSet<string>(StringComparer.Ordinal);
-		foreach (string? label in structuredResponse.Labels)
+		foreach (string? label in labels)
 		{
 			if (label is null || !_labelSet.Contains(label) || !seenLabels.Add(label))
 			{
@@ -152,8 +158,8 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 			}
 		}
 
-		IEnumerable<string> selectedLabels = structuredResponse.Labels;
-		if (options?.MaximumPredictions is int maximumPredictions)
+		IEnumerable<string> selectedLabels = labels;
+		if (optionsSnapshot?.MaximumPredictions is int maximumPredictions)
 		{
 			selectedLabels = selectedLabels.Take(maximumPredictions);
 		}
@@ -165,6 +171,14 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 			RawRepresentation = response,
 			AdditionalProperties = response.AdditionalProperties
 		};
+	}
+
+	private static bool HasExactLabelsEnvelope(JsonElement root)
+	{
+		JsonElement.ObjectEnumerator properties = root.EnumerateObject();
+		return properties.MoveNext() &&
+			properties.Current.NameEquals("labels") &&
+			!properties.MoveNext();
 	}
 
 	/// <inheritdoc />
@@ -210,8 +224,8 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 	}
 
 	private string CreatePrompt()
-		=> "Classify the attached image. Return labels in descending relevance order. " +
-			"Use each label at most once and use only labels from this allowlist: " +
+		=> "Classify the attached image. Return only a JSON object exactly matching {\"labels\":[...]}, " +
+			"with labels in descending relevance order. Use each label at most once and use only labels from this allowlist: " +
 			JsonSerializer.Serialize(_labels, ChatClientImageClassificationJsonContext.Default.StringArray);
 }
 

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Maui.Essentials.AI;
 /// </remarks>
 public sealed class ChatClientImageClassificationClient : IImageClassificationClient
 {
-	private const int StreamCopyBufferSize = 81920;
-
 	private readonly IChatClient _chatClient;
 	private readonly string[] _labels;
 	private readonly HashSet<string> _labelSet;
@@ -101,10 +99,11 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 			throw new ArgumentException("The content media type must be an image media type.", nameof(imageMediaType));
 		}
 
-		byte[] imageBytes = await ReadImageBytesAsync(
+		byte[] imageBytes = await ImageClassificationInput.ReadBytesAsync(
 			imageStream,
 			optionsSnapshot.MaximumInputBytes,
-			cancellationToken).ConfigureAwait(false);
+			cancellationToken,
+			nameof(imageStream)).ConfigureAwait(false);
 
 		if (imageBytes.Length == 0)
 		{
@@ -183,51 +182,6 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 		return properties.MoveNext() &&
 			properties.Current.NameEquals("labels") &&
 			!properties.MoveNext();
-	}
-
-	private static async Task<byte[]> ReadImageBytesAsync(
-		Stream imageStream,
-		long maximumInputBytes,
-		CancellationToken cancellationToken)
-	{
-		if (imageStream.CanSeek)
-		{
-			long length = imageStream.Length;
-			long position = imageStream.Position;
-			long remainingLength = position >= length ? 0 : length - position;
-			if (remainingLength > maximumInputBytes)
-			{
-				throw ImageClassificationInput.CreateTooLargeException(maximumInputBytes, nameof(imageStream));
-			}
-		}
-
-		using var imageBuffer = new MemoryStream();
-		var buffer = new byte[StreamCopyBufferSize];
-		long totalBytesRead = 0;
-
-		while (true)
-		{
-			long remainingAllowance = maximumInputBytes - totalBytesRead;
-			int requestedBytes = remainingAllowance >= buffer.Length
-				? buffer.Length
-				: (int)remainingAllowance + 1;
-			int bytesRead = await imageStream
-				.ReadAsync(buffer, 0, requestedBytes, cancellationToken)
-				.ConfigureAwait(false);
-
-			if (bytesRead == 0)
-			{
-				return imageBuffer.ToArray();
-			}
-
-			totalBytesRead += bytesRead;
-			if (totalBytesRead > maximumInputBytes)
-			{
-				throw ImageClassificationInput.CreateTooLargeException(maximumInputBytes, nameof(imageStream));
-			}
-
-			imageBuffer.Write(buffer, 0, bytesRead);
-		}
 	}
 
 	/// <inheritdoc />

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
@@ -1,0 +1,230 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Maui.Essentials.AI;
+
+/// <summary>
+/// Adapts a vision-capable <see cref="IChatClient"/> to the <see cref="IImageClassificationClient"/> contract.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The injected chat client must support image <see cref="DataContent"/> and structured JSON output. The label
+/// allowlist is snapshotted during construction and matched using ordinal comparison.
+/// </para>
+/// <para>
+/// Disposing this adapter does not dispose the injected chat client. The caller owns both the chat client and all
+/// input streams.
+/// </para>
+/// </remarks>
+public sealed class ChatClientImageClassificationClient : IImageClassificationClient
+{
+	private readonly IChatClient _chatClient;
+	private readonly string[] _labels;
+	private readonly HashSet<string> _labelSet;
+	private readonly ImageClassificationClientMetadata _metadata;
+
+	/// <summary>Initializes a new instance of the <see cref="ChatClientImageClassificationClient"/> class.</summary>
+	/// <param name="chatClient">The dedicated vision-capable chat client to adapt.</param>
+	/// <param name="labels">The non-empty set of classification labels the model may return.</param>
+	/// <param name="metadata">
+	/// Optional metadata for this adapter. When omitted, metadata is copied from the injected chat client when available.
+	/// </param>
+	/// <exception cref="ArgumentNullException">
+	/// <paramref name="chatClient"/> or <paramref name="labels"/> is <see langword="null"/>.
+	/// </exception>
+	/// <exception cref="ArgumentException">
+	/// <paramref name="labels"/> is empty, contains an empty label, or contains duplicate labels.
+	/// </exception>
+	public ChatClientImageClassificationClient(
+		IChatClient chatClient,
+		IEnumerable<string> labels,
+		ImageClassificationClientMetadata? metadata = null)
+	{
+		ArgumentNullException.ThrowIfNull(chatClient);
+		ArgumentNullException.ThrowIfNull(labels);
+
+		_chatClient = chatClient;
+		_labels = labels.ToArray();
+
+		if (_labels.Length == 0)
+		{
+			throw new ArgumentException("At least one classification label is required.", nameof(labels));
+		}
+
+		if (_labels.Any(string.IsNullOrWhiteSpace))
+		{
+			throw new ArgumentException("Classification labels must not be empty or whitespace.", nameof(labels));
+		}
+
+		_labelSet = new HashSet<string>(_labels, StringComparer.Ordinal);
+		if (_labelSet.Count != _labels.Length)
+		{
+			throw new ArgumentException("Classification labels must be unique.", nameof(labels));
+		}
+
+		_metadata = metadata ?? CreateMetadata(chatClient);
+	}
+
+	/// <inheritdoc />
+	public async Task<ImageClassificationResult> ClassifyImageAsync(
+		Stream imageStream,
+		string imageMediaType,
+		ImageClassificationOptions? options = null,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(imageStream);
+		ArgumentNullException.ThrowIfNull(imageMediaType);
+
+		if (!imageStream.CanRead)
+		{
+			throw new ArgumentException("The image stream must be readable.", nameof(imageStream));
+		}
+
+		if (options?.MinimumConfidence is not null)
+		{
+			throw new NotSupportedException(
+				$"{nameof(ChatClientImageClassificationClient)} does not produce confidence values.");
+		}
+
+		var image = new DataContent(ReadOnlyMemory<byte>.Empty, imageMediaType);
+		if (!image.HasTopLevelMediaType("image"))
+		{
+			throw new ArgumentException("The content media type must be an image media type.", nameof(imageMediaType));
+		}
+
+		using var imageBuffer = new MemoryStream();
+		await imageStream.CopyToAsync(imageBuffer, cancellationToken).ConfigureAwait(false);
+
+		if (imageBuffer.Length == 0)
+		{
+			throw new ArgumentException("The image stream must not be empty.", nameof(imageStream));
+		}
+
+		image = new DataContent(imageBuffer.ToArray(), imageMediaType);
+
+		var messages = new[]
+		{
+			new ChatMessage(
+				ChatRole.User,
+				[
+					new TextContent(CreatePrompt()),
+					image
+				])
+		};
+		var chatOptions = new ChatOptions
+		{
+			ResponseFormat = ChatResponseFormat.ForJsonSchema<ChatClientImageClassificationResponse>(
+				ChatClientImageClassificationJsonContext.Default.Options)
+		};
+
+		ChatResponse response = await _chatClient
+			.GetResponseAsync(messages, chatOptions, cancellationToken)
+			.ConfigureAwait(false);
+
+		ChatClientImageClassificationResponse? structuredResponse;
+		try
+		{
+			structuredResponse = JsonSerializer.Deserialize(
+				response.Text,
+				ChatClientImageClassificationJsonContext.Default.ChatClientImageClassificationResponse);
+		}
+		catch (JsonException exception)
+		{
+			throw new InvalidOperationException("The chat client returned a malformed image classification response.", exception);
+		}
+
+		if (structuredResponse?.Labels is null)
+		{
+			throw new InvalidOperationException("The chat client returned a malformed image classification response.");
+		}
+
+		var seenLabels = new HashSet<string>(StringComparer.Ordinal);
+		foreach (string? label in structuredResponse.Labels)
+		{
+			if (label is null || !_labelSet.Contains(label) || !seenLabels.Add(label))
+			{
+				throw new InvalidOperationException(
+					"The chat client returned a label outside the allowlist or returned a duplicate label.");
+			}
+		}
+
+		IEnumerable<string> selectedLabels = structuredResponse.Labels;
+		if (options?.MaximumPredictions is int maximumPredictions)
+		{
+			selectedLabels = selectedLabels.Take(maximumPredictions);
+		}
+
+		return new ImageClassificationResult(
+			selectedLabels.Select(static label => new ImageClassificationPrediction(label)))
+		{
+			ModelId = response.ModelId ?? _metadata.DefaultModelId,
+			RawRepresentation = response,
+			AdditionalProperties = response.AdditionalProperties
+		};
+	}
+
+	/// <inheritdoc />
+	public object? GetService(Type serviceType, object? serviceKey = null)
+	{
+		ArgumentNullException.ThrowIfNull(serviceType);
+
+		if (serviceKey is null)
+		{
+			if (serviceType == typeof(ImageClassificationClientMetadata))
+			{
+				return _metadata;
+			}
+
+			if (serviceType.IsInstanceOfType(this))
+			{
+				return this;
+			}
+
+			if (serviceType.IsInstanceOfType(_chatClient))
+			{
+				return _chatClient;
+			}
+		}
+
+		return _chatClient.GetService(serviceType, serviceKey);
+	}
+
+	/// <summary>
+	/// Releases this adapter without disposing the injected chat client, which remains owned by the caller.
+	/// </summary>
+	public void Dispose()
+	{
+	}
+
+	private static ImageClassificationClientMetadata CreateMetadata(IChatClient chatClient)
+	{
+		var chatMetadata = chatClient.GetService(typeof(ChatClientMetadata)) as ChatClientMetadata;
+		return new ImageClassificationClientMetadata(
+			chatMetadata?.ProviderName,
+			chatMetadata?.ProviderUri,
+			chatMetadata?.DefaultModelId);
+	}
+
+	private string CreatePrompt()
+		=> "Classify the attached image. Return labels in descending relevance order. " +
+			"Use each label at most once and use only labels from this allowlist: " +
+			JsonSerializer.Serialize(_labels, ChatClientImageClassificationJsonContext.Default.StringArray);
+}
+
+internal sealed class ChatClientImageClassificationResponse
+{
+	public required string[] Labels { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+	PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+	UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow)]
+[JsonSerializable(typeof(ChatClientImageClassificationResponse))]
+[JsonSerializable(typeof(string[]))]
+internal partial class ChatClientImageClassificationJsonContext : JsonSerializerContext
+{
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ChatClientImageClassificationClient.cs
@@ -197,7 +197,7 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 			long remainingLength = position >= length ? 0 : length - position;
 			if (remainingLength > maximumInputBytes)
 			{
-				throw CreateImageTooLargeException(maximumInputBytes);
+				throw ImageClassificationInput.CreateTooLargeException(maximumInputBytes, nameof(imageStream));
 			}
 		}
 
@@ -223,18 +223,12 @@ public sealed class ChatClientImageClassificationClient : IImageClassificationCl
 			totalBytesRead += bytesRead;
 			if (totalBytesRead > maximumInputBytes)
 			{
-				throw CreateImageTooLargeException(maximumInputBytes);
+				throw ImageClassificationInput.CreateTooLargeException(maximumInputBytes, nameof(imageStream));
 			}
 
 			imageBuffer.Write(buffer, 0, bytesRead);
 		}
 	}
-
-	private static ArgumentException CreateImageTooLargeException(long maximumInputBytes) =>
-		new(
-			$"The image stream exceeds the configured maximum of {maximumInputBytes} bytes. " +
-			$"Reduce the image size or increase {nameof(ImageClassificationOptions)}.{nameof(ImageClassificationOptions.MaximumInputBytes)}.",
-			"imageStream");
 
 	/// <inheritdoc />
 	public object? GetService(Type serviceType, object? serviceKey = null)

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/IImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/IImageClassificationClient.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.AI;
+namespace Microsoft.Maui.Essentials.AI;
 
 /// <summary>Represents a client that classifies encoded images.</summary>
 /// <remarks>
@@ -14,9 +14,13 @@ namespace Microsoft.Extensions.AI;
 /// implementations must not dispose the stream or retain it after the returned task completes.
 /// </para>
 /// <para>
-/// The media type supplied to <see cref="ClassifyAsync"/> must identify an image media type, such as <c>image/jpeg</c> or
+/// The media type supplied to <see cref="ClassifyImageAsync"/> must identify an image media type, such as <c>image/jpeg</c> or
 /// <c>image/png</c>. Implementations should throw <see cref="ArgumentException"/> for malformed input and
 /// <see cref="NotSupportedException"/> when the media type is valid but unsupported.
+/// </para>
+/// <para>
+/// Implementations that cannot provide confidence values must throw <see cref="NotSupportedException"/> when
+/// <see cref="ImageClassificationOptions.MinimumConfidence"/> is not <see langword="null"/>.
 /// </para>
 /// </remarks>
 public interface IImageClassificationClient : IDisposable
@@ -41,7 +45,7 @@ public interface IImageClassificationClient : IDisposable
 	/// The image media type is valid but unsupported by the implementation.
 	/// </exception>
 	/// <exception cref="OperationCanceledException">The operation was canceled.</exception>
-	Task<ImageClassificationResult> ClassifyAsync(
+	Task<ImageClassificationResult> ClassifyImageAsync(
 		Stream imageStream,
 		string imageMediaType,
 		ImageClassificationOptions? options = null,

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/IImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/IImageClassificationClient.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents a client that classifies encoded images.</summary>
+/// <remarks>
+/// <para>
+/// Unless otherwise specified, all members are thread-safe for concurrent use. Implementations are expected
+/// to support multiple concurrent requests.
+/// </para>
+/// <para>
+/// The input stream contains one encoded image, beginning at its current position. The caller retains ownership:
+/// implementations must not dispose the stream or retain it after the returned task completes.
+/// </para>
+/// <para>
+/// The media type supplied to <see cref="ClassifyAsync"/> must identify an image media type, such as <c>image/jpeg</c> or
+/// <c>image/png</c>. Implementations should throw <see cref="ArgumentException"/> for malformed input and
+/// <see cref="NotSupportedException"/> when the media type is valid but unsupported.
+/// </para>
+/// </remarks>
+public interface IImageClassificationClient : IDisposable
+{
+	/// <summary>Classifies an encoded image.</summary>
+	/// <param name="imageStream">A readable stream containing one encoded image.</param>
+	/// <param name="imageMediaType">The image media type (also known as MIME type).</param>
+	/// <param name="options">Options that constrain the classification response.</param>
+	/// <param name="cancellationToken">
+	/// The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is
+	/// <see cref="CancellationToken.None"/>.
+	/// </param>
+	/// <returns>The classification result.</returns>
+	/// <exception cref="ArgumentNullException">
+	/// <paramref name="imageStream"/> or <paramref name="imageMediaType"/> is <see langword="null"/>.
+	/// </exception>
+	/// <exception cref="ArgumentException">
+	/// <paramref name="imageStream"/> is unreadable or empty, or <paramref name="imageMediaType"/> is not an
+	/// image media type.
+	/// </exception>
+	/// <exception cref="NotSupportedException">
+	/// The image media type is valid but unsupported by the implementation.
+	/// </exception>
+	/// <exception cref="OperationCanceledException">The operation was canceled.</exception>
+	Task<ImageClassificationResult> ClassifyAsync(
+		Stream imageStream,
+		string imageMediaType,
+		ImageClassificationOptions? options = null,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>Asks the client for an object of the specified type.</summary>
+	/// <param name="serviceType">The type of object being requested.</param>
+	/// <param name="serviceKey">An optional key used to identify the target service.</param>
+	/// <returns>The found object, otherwise <see langword="null"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="serviceType"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// This method enables strongly typed access to services provided or wrapped by the client, including the
+	/// client itself. Provider-specific capabilities belong behind this escape hatch rather than in the common
+	/// classification options.
+	/// </remarks>
+	object? GetService(Type serviceType, object? serviceKey = null);
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/IImageClassificationClient.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/IImageClassificationClient.cs
@@ -39,7 +39,7 @@ public interface IImageClassificationClient : IDisposable
 	/// </exception>
 	/// <exception cref="ArgumentException">
 	/// <paramref name="imageStream"/> is unreadable or empty, or <paramref name="imageMediaType"/> is not an
-	/// image media type.
+	/// image media type, or the remaining image data exceeds <see cref="ImageClassificationOptions.MaximumInputBytes"/>.
 	/// </exception>
 	/// <exception cref="NotSupportedException">
 	/// The image media type is valid but unsupported by the implementation.

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientExtensions.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientExtensions.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides extension methods for <see cref="IImageClassificationClient"/>.</summary>
+public static class ImageClassificationClientExtensions
+{
+	/// <summary>Asks the client for an object of type <typeparamref name="TService"/>.</summary>
+	/// <typeparam name="TService">The type of object to retrieve.</typeparam>
+	/// <param name="client">The image classification client.</param>
+	/// <param name="serviceKey">An optional key used to identify the target service.</param>
+	/// <returns>The found object, otherwise <see langword="null"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="client"/> is <see langword="null"/>.</exception>
+	public static TService? GetService<TService>(
+		this IImageClassificationClient client,
+		object? serviceKey = null)
+	{
+		ArgumentNullException.ThrowIfNull(client);
+
+		return client.GetService(typeof(TService), serviceKey) is TService service ? service : default;
+	}
+
+	/// <summary>Classifies one in-memory image.</summary>
+	/// <param name="client">The image classification client.</param>
+	/// <param name="image">The encoded image and its media type.</param>
+	/// <param name="options">Options that constrain the classification response.</param>
+	/// <param name="cancellationToken">
+	/// The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is
+	/// <see cref="CancellationToken.None"/>.
+	/// </param>
+	/// <returns>The classification result.</returns>
+	/// <exception cref="ArgumentNullException">
+	/// <paramref name="client"/> or <paramref name="image"/> is <see langword="null"/>.
+	/// </exception>
+	/// <exception cref="ArgumentException">
+	/// <paramref name="image"/> is empty or its media type is not an image media type.
+	/// </exception>
+	/// <remarks>
+	/// This overload snapshots the image bytes before invoking the client. The caller retains ownership of
+	/// <paramref name="image"/>; the temporary stream is disposed after the operation completes.
+	/// </remarks>
+	public static async Task<ImageClassificationResult> ClassifyAsync(
+		this IImageClassificationClient client,
+		DataContent image,
+		ImageClassificationOptions? options = null,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(client);
+		ArgumentNullException.ThrowIfNull(image);
+
+		if (!image.HasTopLevelMediaType("image"))
+		{
+			throw new ArgumentException("The content media type must be an image media type.", nameof(image));
+		}
+
+		if (image.Data.IsEmpty)
+		{
+			throw new ArgumentException("The image content must not be empty.", nameof(image));
+		}
+
+		using var imageStream = new MemoryStream(image.Data.ToArray(), writable: false);
+		return await client
+			.ClassifyAsync(imageStream, image.MediaType, options, cancellationToken)
+			.ConfigureAwait(false);
+	}
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientExtensions.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientExtensions.cs
@@ -51,6 +51,8 @@ public static class ImageClassificationClientExtensions
 		ArgumentNullException.ThrowIfNull(client);
 		ArgumentNullException.ThrowIfNull(image);
 
+		ImageClassificationOptions optionsSnapshot = options?.Clone() ?? new();
+
 		if (!image.HasTopLevelMediaType("image"))
 		{
 			throw new ArgumentException("The content media type must be an image media type.", nameof(image));
@@ -61,9 +63,16 @@ public static class ImageClassificationClientExtensions
 			throw new ArgumentException("The image content must not be empty.", nameof(image));
 		}
 
+		if (image.Data.Length > optionsSnapshot.MaximumInputBytes)
+		{
+			throw ImageClassificationInput.CreateTooLargeException(
+				optionsSnapshot.MaximumInputBytes,
+				nameof(image));
+		}
+
 		using var imageStream = new MemoryStream(image.Data.ToArray(), writable: false);
 		return await client
-			.ClassifyImageAsync(imageStream, image.MediaType, options, cancellationToken)
+			.ClassifyImageAsync(imageStream, image.MediaType, optionsSnapshot, cancellationToken)
 			.ConfigureAwait(false);
 	}
 }

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientExtensions.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientExtensions.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Maui.Essentials.AI;
 
 /// <summary>Provides extension methods for <see cref="IImageClassificationClient"/>.</summary>
 public static class ImageClassificationClientExtensions
@@ -40,7 +42,7 @@ public static class ImageClassificationClientExtensions
 	/// This overload snapshots the image bytes before invoking the client. The caller retains ownership of
 	/// <paramref name="image"/>; the temporary stream is disposed after the operation completes.
 	/// </remarks>
-	public static async Task<ImageClassificationResult> ClassifyAsync(
+	public static async Task<ImageClassificationResult> ClassifyImageAsync(
 		this IImageClassificationClient client,
 		DataContent image,
 		ImageClassificationOptions? options = null,
@@ -61,7 +63,7 @@ public static class ImageClassificationClientExtensions
 
 		using var imageStream = new MemoryStream(image.Data.ToArray(), writable: false);
 		return await client
-			.ClassifyAsync(imageStream, image.MediaType, options, cancellationToken)
+			.ClassifyImageAsync(imageStream, image.MediaType, options, cancellationToken)
 			.ConfigureAwait(false);
 	}
 }

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientMetadata.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientMetadata.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides metadata about an <see cref="IImageClassificationClient"/>.</summary>
+public sealed class ImageClassificationClientMetadata
+{
+	/// <summary>Initializes a new instance of the <see cref="ImageClassificationClientMetadata"/> class.</summary>
+	/// <param name="providerName">The provider name, if applicable.</param>
+	/// <param name="providerUri">The URI for accessing the provider, if applicable.</param>
+	/// <param name="defaultModelId">The model identifier used by default, if applicable.</param>
+	public ImageClassificationClientMetadata(
+		string? providerName = null,
+		Uri? providerUri = null,
+		string? defaultModelId = null)
+	{
+		ProviderName = providerName;
+		ProviderUri = providerUri;
+		DefaultModelId = defaultModelId;
+	}
+
+	/// <summary>Gets the provider name.</summary>
+	public string? ProviderName { get; }
+
+	/// <summary>Gets the URI for accessing the provider.</summary>
+	public Uri? ProviderUri { get; }
+
+	/// <summary>Gets the model identifier used by default.</summary>
+	/// <remarks>
+	/// This value can be <see langword="null"/> when the model is unknown or when the client can select among
+	/// multiple models.
+	/// </remarks>
+	public string? DefaultModelId { get; }
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientMetadata.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationClientMetadata.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.AI;
+namespace Microsoft.Maui.Essentials.AI;
 
 /// <summary>Provides metadata about an <see cref="IImageClassificationClient"/>.</summary>
 public sealed class ImageClassificationClientMetadata

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationInput.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationInput.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Maui.Essentials.AI;
+
+internal static class ImageClassificationInput
+{
+	public static ArgumentException CreateTooLargeException(long maximumInputBytes, string parameterName) =>
+		new(
+			$"The image stream exceeds the configured maximum of {maximumInputBytes} bytes. " +
+			$"Reduce the image size or increase {nameof(ImageClassificationOptions)}.{nameof(ImageClassificationOptions.MaximumInputBytes)}.",
+			parameterName);
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationInput.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationInput.cs
@@ -5,9 +5,57 @@ namespace Microsoft.Maui.Essentials.AI;
 
 internal static class ImageClassificationInput
 {
+	private const int StreamCopyBufferSize = 81920;
+
 	public static ArgumentException CreateTooLargeException(long maximumInputBytes, string parameterName) =>
 		new(
 			$"The image stream exceeds the configured maximum of {maximumInputBytes} bytes. " +
 			$"Reduce the image size or increase {nameof(ImageClassificationOptions)}.{nameof(ImageClassificationOptions.MaximumInputBytes)}.",
 			parameterName);
+
+	public static async Task<byte[]> ReadBytesAsync(
+		Stream imageStream,
+		long maximumInputBytes,
+		CancellationToken cancellationToken,
+		string parameterName)
+	{
+		if (imageStream.CanSeek)
+		{
+			long length = imageStream.Length;
+			long position = imageStream.Position;
+			long remainingLength = position >= length ? 0 : length - position;
+			if (remainingLength > maximumInputBytes)
+			{
+				throw CreateTooLargeException(maximumInputBytes, parameterName);
+			}
+		}
+
+		using var imageBuffer = new MemoryStream();
+		var buffer = new byte[StreamCopyBufferSize];
+		long totalBytesRead = 0;
+
+		while (true)
+		{
+			long remainingAllowance = maximumInputBytes - totalBytesRead;
+			int requestedBytes = remainingAllowance >= buffer.Length
+				? buffer.Length
+				: (int)remainingAllowance + 1;
+			int bytesRead = await imageStream
+				.ReadAsync(buffer, 0, requestedBytes, cancellationToken)
+				.ConfigureAwait(false);
+
+			if (bytesRead == 0)
+			{
+				return imageBuffer.ToArray();
+			}
+
+			totalBytesRead += bytesRead;
+			if (totalBytesRead > maximumInputBytes)
+			{
+				throw CreateTooLargeException(maximumInputBytes, parameterName);
+			}
+
+			imageBuffer.Write(buffer, 0, bytesRead);
+		}
+	}
 }

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationOptions.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationOptions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.AI;
+namespace Microsoft.Maui.Essentials.AI;
 
 /// <summary>Represents options that constrain an image classification response.</summary>
 public class ImageClassificationOptions
@@ -30,8 +30,11 @@ public class ImageClassificationOptions
 		MinimumConfidence = other.MinimumConfidence;
 	}
 
-	/// <summary>Gets or sets the maximum number of predictions to return.</summary>
-	/// <value><see langword="null"/> to use the implementation default; otherwise, a value greater than zero.</value>
+	/// <summary>Gets or sets the maximum number of predictions that may be returned.</summary>
+	/// <value>
+	/// <see langword="null"/> to use the implementation default; otherwise, a value greater than zero.
+	/// Implementations may return fewer predictions.
+	/// </value>
 	public int? MaximumPredictions
 	{
 		get => _maximumPredictions;
@@ -48,6 +51,10 @@ public class ImageClassificationOptions
 
 	/// <summary>Gets or sets the minimum confidence required for a prediction.</summary>
 	/// <value><see langword="null"/> to use the implementation default; otherwise, a finite value from 0 through 1.</value>
+	/// <remarks>
+	/// Implementations that cannot provide confidence values must throw <see cref="NotSupportedException"/> when this
+	/// property is not <see langword="null"/>.
+	/// </remarks>
 	public float? MinimumConfidence
 	{
 		get => _minimumConfidence;

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationOptions.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationOptions.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents options that constrain an image classification response.</summary>
+public class ImageClassificationOptions
+{
+	private int? _maximumPredictions;
+	private float? _minimumConfidence;
+
+	/// <summary>Initializes a new instance of the <see cref="ImageClassificationOptions"/> class.</summary>
+	public ImageClassificationOptions()
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ImageClassificationOptions"/> class by copying
+	/// <paramref name="other"/>.
+	/// </summary>
+	/// <param name="other">The options to copy, or <see langword="null"/> to use defaults.</param>
+	protected ImageClassificationOptions(ImageClassificationOptions? other)
+	{
+		if (other is null)
+		{
+			return;
+		}
+
+		MaximumPredictions = other.MaximumPredictions;
+		MinimumConfidence = other.MinimumConfidence;
+	}
+
+	/// <summary>Gets or sets the maximum number of predictions to return.</summary>
+	/// <value><see langword="null"/> to use the implementation default; otherwise, a value greater than zero.</value>
+	public int? MaximumPredictions
+	{
+		get => _maximumPredictions;
+		set
+		{
+			if (value is <= 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), value, "The maximum number of predictions must be greater than zero.");
+			}
+
+			_maximumPredictions = value;
+		}
+	}
+
+	/// <summary>Gets or sets the minimum confidence required for a prediction.</summary>
+	/// <value><see langword="null"/> to use the implementation default; otherwise, a finite value from 0 through 1.</value>
+	public float? MinimumConfidence
+	{
+		get => _minimumConfidence;
+		set
+		{
+			if (value is float confidence &&
+				(!float.IsFinite(confidence) || confidence < 0 || confidence > 1))
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), value, "The minimum confidence must be a finite value from 0 through 1.");
+			}
+
+			_minimumConfidence = value;
+		}
+	}
+
+	/// <summary>Produces a copy of the current options.</summary>
+	/// <returns>A new options instance with the same values.</returns>
+	public virtual ImageClassificationOptions Clone() => new(this);
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationOptions.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationOptions.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Maui.Essentials.AI;
 /// <summary>Represents options that constrain an image classification response.</summary>
 public class ImageClassificationOptions
 {
+	private const long DefaultMaximumInputBytes = 20 * 1024 * 1024;
+
+	private long _maximumInputBytes = DefaultMaximumInputBytes;
 	private int? _maximumPredictions;
 	private float? _minimumConfidence;
 
@@ -26,8 +29,25 @@ public class ImageClassificationOptions
 			return;
 		}
 
+		MaximumInputBytes = other.MaximumInputBytes;
 		MaximumPredictions = other.MaximumPredictions;
 		MinimumConfidence = other.MinimumConfidence;
+	}
+
+	/// <summary>Gets or sets the maximum number of image bytes that may be read from the input stream.</summary>
+	/// <value>The positive input limit in bytes. The default is 20 MiB (20 * 1024 * 1024 bytes).</value>
+	public long MaximumInputBytes
+	{
+		get => _maximumInputBytes;
+		set
+		{
+			if (value <= 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), value, "The maximum input size must be greater than zero.");
+			}
+
+			_maximumInputBytes = value;
+		}
 	}
 
 	/// <summary>Gets or sets the maximum number of predictions that may be returned.</summary>

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationPrediction.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationPrediction.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents one normalized image classification prediction.</summary>
+public sealed class ImageClassificationPrediction
+{
+	/// <summary>Initializes a new instance of the <see cref="ImageClassificationPrediction"/> class.</summary>
+	/// <param name="label">The provider-neutral display label for the predicted class.</param>
+	/// <param name="confidence">The normalized prediction confidence, from 0 through 1.</param>
+	/// <exception cref="ArgumentException"><paramref name="label"/> is empty or whitespace.</exception>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="confidence"/> is not finite or is outside the inclusive range from 0 through 1.
+	/// </exception>
+	public ImageClassificationPrediction(string label, float confidence)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(label);
+
+		if (!float.IsFinite(confidence) || confidence < 0 || confidence > 1)
+		{
+			throw new ArgumentOutOfRangeException(nameof(confidence), confidence, "Confidence must be a finite value from 0 through 1.");
+		}
+
+		Label = label;
+		Confidence = confidence;
+	}
+
+	/// <summary>Gets the predicted class label.</summary>
+	public string Label { get; }
+
+	/// <summary>Gets the normalized prediction confidence, from 0 through 1.</summary>
+	public float Confidence { get; }
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationPrediction.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationPrediction.cs
@@ -1,23 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.AI;
+namespace Microsoft.Maui.Essentials.AI;
 
 /// <summary>Represents one normalized image classification prediction.</summary>
 public sealed class ImageClassificationPrediction
 {
 	/// <summary>Initializes a new instance of the <see cref="ImageClassificationPrediction"/> class.</summary>
 	/// <param name="label">The provider-neutral display label for the predicted class.</param>
-	/// <param name="confidence">The normalized prediction confidence, from 0 through 1.</param>
+	/// <param name="confidence">The normalized prediction confidence, from 0 through 1, or <see langword="null"/> when unavailable.</param>
 	/// <exception cref="ArgumentException"><paramref name="label"/> is empty or whitespace.</exception>
 	/// <exception cref="ArgumentOutOfRangeException">
-	/// <paramref name="confidence"/> is not finite or is outside the inclusive range from 0 through 1.
+	/// <paramref name="confidence"/> is present and is not finite or is outside the inclusive range from 0 through 1.
 	/// </exception>
-	public ImageClassificationPrediction(string label, float confidence)
+	public ImageClassificationPrediction(string label, float? confidence = null)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(label);
 
-		if (!float.IsFinite(confidence) || confidence < 0 || confidence > 1)
+		if (confidence is float value &&
+			(!float.IsFinite(value) || value < 0 || value > 1))
 		{
 			throw new ArgumentOutOfRangeException(nameof(confidence), confidence, "Confidence must be a finite value from 0 through 1.");
 		}
@@ -29,6 +30,6 @@ public sealed class ImageClassificationPrediction
 	/// <summary>Gets the predicted class label.</summary>
 	public string Label { get; }
 
-	/// <summary>Gets the normalized prediction confidence, from 0 through 1.</summary>
-	public float Confidence { get; }
+	/// <summary>Gets the normalized prediction confidence, from 0 through 1, or <see langword="null"/> when unavailable.</summary>
+	public float? Confidence { get; }
 }

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationResult.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationResult.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents a normalized image classification result.</summary>
+public sealed class ImageClassificationResult
+{
+	/// <summary>Initializes a new instance of the <see cref="ImageClassificationResult"/> class.</summary>
+	/// <param name="predictions">The predictions produced by the classification client.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="predictions"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentException"><paramref name="predictions"/> contains a <see langword="null"/> item.</exception>
+	public ImageClassificationResult(IEnumerable<ImageClassificationPrediction> predictions)
+	{
+		ArgumentNullException.ThrowIfNull(predictions);
+
+		ImageClassificationPrediction[] snapshot = predictions.ToArray();
+		if (snapshot.Any(static prediction => prediction is null))
+		{
+			throw new ArgumentException("The predictions collection must not contain null items.", nameof(predictions));
+		}
+
+		Predictions = Array.AsReadOnly(
+			snapshot
+				.OrderByDescending(static prediction => prediction.Confidence)
+				.ToArray());
+	}
+
+	/// <summary>Gets the predictions, ordered from highest to lowest confidence.</summary>
+	public IReadOnlyList<ImageClassificationPrediction> Predictions { get; }
+
+	/// <summary>Gets or initializes the provider that produced this result, when known.</summary>
+	public string? ProviderName { get; init; }
+
+	/// <summary>Gets or initializes the model identifier that produced this result, when known.</summary>
+	public string? ModelId { get; init; }
+}

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationResult.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationResult.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
+
 namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a normalized image classification result.</summary>
@@ -31,4 +33,15 @@ public sealed class ImageClassificationResult
 
 	/// <summary>Gets or initializes the model identifier that produced this result, when known.</summary>
 	public string? ModelId { get; init; }
+
+	/// <summary>Gets or sets the raw representation of the result from the underlying implementation.</summary>
+	/// <remarks>
+	/// This property can preserve the original provider response for debugging or provider-specific access
+	/// without expanding the provider-neutral result contract.
+	/// </remarks>
+	[JsonIgnore]
+	public object? RawRepresentation { get; set; }
+
+	/// <summary>Gets or sets any additional properties associated with the result.</summary>
+	public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
 }

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationResult.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationResult.cs
@@ -29,9 +29,6 @@ public sealed class ImageClassificationResult
 	/// <summary>Gets the predictions, ordered from highest to lowest confidence.</summary>
 	public IReadOnlyList<ImageClassificationPrediction> Predictions { get; }
 
-	/// <summary>Gets or initializes the provider that produced this result, when known.</summary>
-	public string? ProviderName { get; init; }
-
 	/// <summary>Gets or initializes the model identifier that produced this result, when known.</summary>
 	public string? ModelId { get; init; }
 }

--- a/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationResult.cs
+++ b/src/AI/Microsoft.Maui.Essentials.AI/ImageClassification/ImageClassificationResult.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
 
-namespace Microsoft.Extensions.AI;
+namespace Microsoft.Maui.Essentials.AI;
 
 /// <summary>Represents a normalized image classification result.</summary>
 public sealed class ImageClassificationResult
@@ -22,13 +23,10 @@ public sealed class ImageClassificationResult
 			throw new ArgumentException("The predictions collection must not contain null items.", nameof(predictions));
 		}
 
-		Predictions = Array.AsReadOnly(
-			snapshot
-				.OrderByDescending(static prediction => prediction.Confidence)
-				.ToArray());
+		Predictions = Array.AsReadOnly(snapshot);
 	}
 
-	/// <summary>Gets the predictions, ordered from highest to lowest confidence.</summary>
+	/// <summary>Gets the predictions in the order supplied by the implementation.</summary>
 	public IReadOnlyList<ImageClassificationPrediction> Predictions { get; }
 
 	/// <summary>Gets or initializes the model identifier that produced this result, when known.</summary>

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,33 +1,38 @@
 ﻿#nullable enable
-Microsoft.Extensions.AI.IImageClassificationClient
-Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
-Microsoft.Extensions.AI.ImageClassificationClientExtensions
-Microsoft.Extensions.AI.ImageClassificationClientMetadata
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
-Microsoft.Extensions.AI.ImageClassificationOptions
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction
-Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
-Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
-Microsoft.Extensions.AI.ImageClassificationResult
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
-Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
-virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ChatClientImageClassificationClient(Microsoft.Extensions.AI.IChatClient! chatClient, System.Collections.Generic.IEnumerable<string!>! labels, Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata? metadata = null) -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.Dispose() -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.IImageClassificationClient
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Confidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float? confidence = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> void
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,31 @@
 ﻿#nullable enable
+Microsoft.Extensions.AI.IImageClassificationClient
+Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Extensions.AI.ImageClassificationClientExtensions
+Microsoft.Extensions.AI.ImageClassificationClientMetadata
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Extensions.AI.ImageClassificationOptions
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction
+Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
+Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.get -> long
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -24,8 +24,6 @@ Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(Syst
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -20,10 +20,14 @@ Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
 Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
 Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
 Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -36,3 +36,16 @@ Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> 
 static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
 static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!
+Microsoft.Extensions.AI.NLEmbeddingExtensions
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null, System.IServiceProvider? functionInvocationServices = null) -> void
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ChatResponse!>!
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetStreamingResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate!>!
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.Dispose() -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.GenerateAsync(System.Collections.Generic.IEnumerable<string!>! values, Microsoft.Extensions.AI.EmbeddingGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>!>!>!
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator() -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLEmbedding! embedding) -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLLanguage language) -> void
+static Microsoft.Extensions.AI.NLEmbeddingExtensions.AsIEmbeddingGenerator(this NaturalLanguage.NLEmbedding! embedding) -> Microsoft.Extensions.AI.IEmbeddingGenerator<string!, Microsoft.Extensions.AI.Embedding<float>!>!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,46 +1,38 @@
 ﻿#nullable enable
-Microsoft.Extensions.AI.IImageClassificationClient
-Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
-Microsoft.Extensions.AI.ImageClassificationClientExtensions
-Microsoft.Extensions.AI.ImageClassificationClientMetadata
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
-Microsoft.Extensions.AI.ImageClassificationOptions
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction
-Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
-Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
-Microsoft.Extensions.AI.ImageClassificationResult
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
-Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
-virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
-Microsoft.Extensions.AI.NLEmbeddingExtensions
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null, System.IServiceProvider? functionInvocationServices = null) -> void
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ChatResponse!>!
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetStreamingResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate!>!
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.Dispose() -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.GenerateAsync(System.Collections.Generic.IEnumerable<string!>! values, Microsoft.Extensions.AI.EmbeddingGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>!>!>!
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator() -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLEmbedding! embedding) -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLLanguage language) -> void
-static Microsoft.Extensions.AI.NLEmbeddingExtensions.AsIEmbeddingGenerator(this NaturalLanguage.NLEmbedding! embedding) -> Microsoft.Extensions.AI.IEmbeddingGenerator<string!, Microsoft.Extensions.AI.Embedding<float>!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ChatClientImageClassificationClient(Microsoft.Extensions.AI.IChatClient! chatClient, System.Collections.Generic.IEnumerable<string!>! labels, Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata? metadata = null) -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.Dispose() -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.IImageClassificationClient
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Confidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float? confidence = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> void
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.get -> long
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,34 @@
 ﻿#nullable enable
+Microsoft.Extensions.AI.IImageClassificationClient
+Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Extensions.AI.ImageClassificationClientExtensions
+Microsoft.Extensions.AI.ImageClassificationClientMetadata
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Extensions.AI.ImageClassificationOptions
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction
+Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
+Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
 Microsoft.Extensions.AI.NLEmbeddingExtensions
 Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
 Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -24,8 +24,6 @@ Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(Syst
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -20,10 +20,14 @@ Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
 Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
 Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
 Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -36,3 +36,16 @@ Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> 
 static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
 static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!
+Microsoft.Extensions.AI.NLEmbeddingExtensions
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null, System.IServiceProvider? functionInvocationServices = null) -> void
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ChatResponse!>!
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetStreamingResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate!>!
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.Dispose() -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.GenerateAsync(System.Collections.Generic.IEnumerable<string!>! values, Microsoft.Extensions.AI.EmbeddingGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>!>!>!
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator() -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLEmbedding! embedding) -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLLanguage language) -> void
+static Microsoft.Extensions.AI.NLEmbeddingExtensions.AsIEmbeddingGenerator(this NaturalLanguage.NLEmbedding! embedding) -> Microsoft.Extensions.AI.IEmbeddingGenerator<string!, Microsoft.Extensions.AI.Embedding<float>!>!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,46 +1,38 @@
 ﻿#nullable enable
-Microsoft.Extensions.AI.IImageClassificationClient
-Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
-Microsoft.Extensions.AI.ImageClassificationClientExtensions
-Microsoft.Extensions.AI.ImageClassificationClientMetadata
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
-Microsoft.Extensions.AI.ImageClassificationOptions
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction
-Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
-Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
-Microsoft.Extensions.AI.ImageClassificationResult
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
-Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
-virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
-Microsoft.Extensions.AI.NLEmbeddingExtensions
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null, System.IServiceProvider? functionInvocationServices = null) -> void
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ChatResponse!>!
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetStreamingResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate!>!
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.Dispose() -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.GenerateAsync(System.Collections.Generic.IEnumerable<string!>! values, Microsoft.Extensions.AI.EmbeddingGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>!>!>!
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator() -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLEmbedding! embedding) -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLLanguage language) -> void
-static Microsoft.Extensions.AI.NLEmbeddingExtensions.AsIEmbeddingGenerator(this NaturalLanguage.NLEmbedding! embedding) -> Microsoft.Extensions.AI.IEmbeddingGenerator<string!, Microsoft.Extensions.AI.Embedding<float>!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ChatClientImageClassificationClient(Microsoft.Extensions.AI.IChatClient! chatClient, System.Collections.Generic.IEnumerable<string!>! labels, Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata? metadata = null) -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.Dispose() -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.IImageClassificationClient
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Confidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float? confidence = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> void
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.get -> long
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,34 @@
 ﻿#nullable enable
+Microsoft.Extensions.AI.IImageClassificationClient
+Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Extensions.AI.ImageClassificationClientExtensions
+Microsoft.Extensions.AI.ImageClassificationClientMetadata
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Extensions.AI.ImageClassificationOptions
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction
+Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
+Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
 Microsoft.Extensions.AI.NLEmbeddingExtensions
 Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
 Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -24,8 +24,6 @@ Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(Syst
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -20,10 +20,14 @@ Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
 Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
 Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
 Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -36,3 +36,16 @@ Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> 
 static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
 static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!
+Microsoft.Extensions.AI.NLEmbeddingExtensions
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null, System.IServiceProvider? functionInvocationServices = null) -> void
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ChatResponse!>!
+Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetStreamingResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate!>!
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.Dispose() -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.GenerateAsync(System.Collections.Generic.IEnumerable<string!>! values, Microsoft.Extensions.AI.EmbeddingGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>!>!>!
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator() -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLEmbedding! embedding) -> void
+Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLLanguage language) -> void
+static Microsoft.Extensions.AI.NLEmbeddingExtensions.AsIEmbeddingGenerator(this NaturalLanguage.NLEmbedding! embedding) -> Microsoft.Extensions.AI.IEmbeddingGenerator<string!, Microsoft.Extensions.AI.Embedding<float>!>!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -1,46 +1,38 @@
 ﻿#nullable enable
-Microsoft.Extensions.AI.IImageClassificationClient
-Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
-Microsoft.Extensions.AI.ImageClassificationClientExtensions
-Microsoft.Extensions.AI.ImageClassificationClientMetadata
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
-Microsoft.Extensions.AI.ImageClassificationOptions
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction
-Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
-Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
-Microsoft.Extensions.AI.ImageClassificationResult
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
-Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
-virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
-Microsoft.Extensions.AI.NLEmbeddingExtensions
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null, System.IServiceProvider? functionInvocationServices = null) -> void
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ChatResponse!>!
-Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetStreamingResponseAsync(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>! messages, Microsoft.Extensions.AI.ChatOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate!>!
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.Dispose() -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.GenerateAsync(System.Collections.Generic.IEnumerable<string!>! values, Microsoft.Extensions.AI.EmbeddingGenerationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>!>!>!
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator() -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLEmbedding! embedding) -> void
-Microsoft.Maui.Essentials.AI.NLEmbeddingGenerator.NLEmbeddingGenerator(NaturalLanguage.NLLanguage language) -> void
-static Microsoft.Extensions.AI.NLEmbeddingExtensions.AsIEmbeddingGenerator(this NaturalLanguage.NLEmbedding! embedding) -> Microsoft.Extensions.AI.IEmbeddingGenerator<string!, Microsoft.Extensions.AI.Embedding<float>!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ChatClientImageClassificationClient(Microsoft.Extensions.AI.IChatClient! chatClient, System.Collections.Generic.IEnumerable<string!>! labels, Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata? metadata = null) -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.Dispose() -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.IImageClassificationClient
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Confidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float? confidence = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> void
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.get -> long
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -1,4 +1,34 @@
 ﻿#nullable enable
+Microsoft.Extensions.AI.IImageClassificationClient
+Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Extensions.AI.ImageClassificationClientExtensions
+Microsoft.Extensions.AI.ImageClassificationClientMetadata
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Extensions.AI.ImageClassificationOptions
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction
+Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
+Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
 Microsoft.Extensions.AI.NLEmbeddingExtensions
 Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
 Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -24,8 +24,6 @@ Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(Syst
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -20,10 +20,14 @@ Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
 Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
 Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
 Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,33 +1,38 @@
 ﻿#nullable enable
-Microsoft.Extensions.AI.IImageClassificationClient
-Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
-Microsoft.Extensions.AI.ImageClassificationClientExtensions
-Microsoft.Extensions.AI.ImageClassificationClientMetadata
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
-Microsoft.Extensions.AI.ImageClassificationOptions
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction
-Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
-Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
-Microsoft.Extensions.AI.ImageClassificationResult
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
-Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
-virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ChatClientImageClassificationClient(Microsoft.Extensions.AI.IChatClient! chatClient, System.Collections.Generic.IEnumerable<string!>! labels, Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata? metadata = null) -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.Dispose() -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.IImageClassificationClient
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Confidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float? confidence = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> void
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,31 @@
 ﻿#nullable enable
+Microsoft.Extensions.AI.IImageClassificationClient
+Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Extensions.AI.ImageClassificationClientExtensions
+Microsoft.Extensions.AI.ImageClassificationClientMetadata
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Extensions.AI.ImageClassificationOptions
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction
+Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
+Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.get -> long
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -24,8 +24,6 @@ Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(Syst
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -20,10 +20,14 @@ Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
 Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
 Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
 Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,33 +1,38 @@
 ﻿#nullable enable
-Microsoft.Extensions.AI.IImageClassificationClient
-Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
-Microsoft.Extensions.AI.ImageClassificationClientExtensions
-Microsoft.Extensions.AI.ImageClassificationClientMetadata
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
-Microsoft.Extensions.AI.ImageClassificationOptions
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction
-Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
-Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
-Microsoft.Extensions.AI.ImageClassificationResult
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
-Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
-virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ChatClientImageClassificationClient(Microsoft.Extensions.AI.IChatClient! chatClient, System.Collections.Generic.IEnumerable<string!>! labels, Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata? metadata = null) -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.Dispose() -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.IImageClassificationClient
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Confidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float? confidence = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> void
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,31 @@
 ﻿#nullable enable
+Microsoft.Extensions.AI.IImageClassificationClient
+Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Extensions.AI.ImageClassificationClientExtensions
+Microsoft.Extensions.AI.ImageClassificationClientMetadata
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Extensions.AI.ImageClassificationOptions
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction
+Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
+Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.get -> long
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -24,8 +24,6 @@ Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(Syst
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -20,10 +20,14 @@ Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
 Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
 Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
 Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,33 +1,38 @@
 ﻿#nullable enable
-Microsoft.Extensions.AI.IImageClassificationClient
-Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
-Microsoft.Extensions.AI.ImageClassificationClientExtensions
-Microsoft.Extensions.AI.ImageClassificationClientMetadata
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
-Microsoft.Extensions.AI.ImageClassificationOptions
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
-Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
-Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction
-Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
-Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
-Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
-Microsoft.Extensions.AI.ImageClassificationResult
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
-Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
-Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
-Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
-static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
-virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ChatClientImageClassificationClient(Microsoft.Extensions.AI.IChatClient! chatClient, System.Collections.Generic.IEnumerable<string!>! labels, Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata? metadata = null) -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.Dispose() -> void
+Microsoft.Maui.Essentials.AI.ChatClientImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.IImageClassificationClient
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.ClassifyImageAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+Microsoft.Maui.Essentials.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Confidence.get -> float?
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float? confidence = null) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.AdditionalProperties.set -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Essentials.AI.ImageClassificationPrediction!>!
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Maui.Essentials.AI.ImageClassificationResult.RawRepresentation.set -> void
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.ClassifyImageAsync(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult!>!
+static Microsoft.Maui.Essentials.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Maui.Essentials.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Maui.Essentials.AI.ImageClassificationOptions.Clone() -> Microsoft.Maui.Essentials.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,31 @@
 ﻿#nullable enable
+Microsoft.Extensions.AI.IImageClassificationClient
+Microsoft.Extensions.AI.IImageClassificationClient.ClassifyAsync(System.IO.Stream! imageStream, string! imageMediaType, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+Microsoft.Extensions.AI.IImageClassificationClient.GetService(System.Type! serviceType, object? serviceKey = null) -> object?
+Microsoft.Extensions.AI.ImageClassificationClientExtensions
+Microsoft.Extensions.AI.ImageClassificationClientMetadata
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.DefaultModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ImageClassificationClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null) -> void
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationClientMetadata.ProviderUri.get -> System.Uri?
+Microsoft.Extensions.AI.ImageClassificationOptions
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Extensions.AI.ImageClassificationOptions? other) -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
+Microsoft.Extensions.AI.ImageClassificationOptions.MaximumPredictions.set -> void
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.get -> float?
+Microsoft.Extensions.AI.ImageClassificationOptions.MinimumConfidence.set -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction
+Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
+Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
+Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
+Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
+Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
+Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
+static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
+virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -16,6 +16,8 @@ Microsoft.Maui.Essentials.AI.ImageClassificationClientMetadata.ProviderUri.get -
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions() -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.ImageClassificationOptions(Microsoft.Maui.Essentials.AI.ImageClassificationOptions? other) -> void
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.get -> long
+Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumInputBytes.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.get -> int?
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MaximumPredictions.set -> void
 Microsoft.Maui.Essentials.AI.ImageClassificationOptions.MinimumConfidence.get -> float?

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -24,8 +24,6 @@ Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(Syst
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.get -> string?
-Microsoft.Extensions.AI.ImageClassificationResult.ProviderName.init -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/AI/Microsoft.Maui.Essentials.AI/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -20,10 +20,14 @@ Microsoft.Extensions.AI.ImageClassificationPrediction.Confidence.get -> float
 Microsoft.Extensions.AI.ImageClassificationPrediction.ImageClassificationPrediction(string! label, float confidence) -> void
 Microsoft.Extensions.AI.ImageClassificationPrediction.Label.get -> string!
 Microsoft.Extensions.AI.ImageClassificationResult
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.get -> Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
+Microsoft.Extensions.AI.ImageClassificationResult.AdditionalProperties.set -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ImageClassificationResult(System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ImageClassificationPrediction!>! predictions) -> void
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.get -> string?
 Microsoft.Extensions.AI.ImageClassificationResult.ModelId.init -> void
 Microsoft.Extensions.AI.ImageClassificationResult.Predictions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ImageClassificationPrediction!>!
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.get -> object?
+Microsoft.Extensions.AI.ImageClassificationResult.RawRepresentation.set -> void
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.ClassifyAsync(this Microsoft.Extensions.AI.IImageClassificationClient! client, Microsoft.Extensions.AI.DataContent! image, Microsoft.Extensions.AI.ImageClassificationOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.ImageClassificationResult!>!
 static Microsoft.Extensions.AI.ImageClassificationClientExtensions.GetService<TService>(this Microsoft.Extensions.AI.IImageClassificationClient! client, object? serviceKey = null) -> TService?
 virtual Microsoft.Extensions.AI.ImageClassificationOptions.Clone() -> Microsoft.Extensions.AI.ImageClassificationOptions!

--- a/src/AI/Microsoft.Maui.Essentials.AI/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI/README.md
@@ -102,7 +102,7 @@ ImageClassificationResult result =
     await classifier.ClassifyImageAsync(image, "image/jpeg");
 ```
 
-The adapter snapshots the non-empty label allowlist, requests structured output, rejects labels outside the allowlist, and preserves the model's ranking. Its predictions have `null` confidence, and the original `ChatResponse` is available through `RawRepresentation`. Disposing the adapter does not dispose the injected chat client.
+The adapter snapshots the non-empty label allowlist, prefers structured output, rejects malformed responses and labels outside the allowlist, and preserves the model's ranking. If a chat client ignores the requested response format, the adapter also accepts a top-level JSON string array, but never extracts JSON from prose or Markdown fences. Its predictions have `null` confidence, and the original `ChatResponse` is available through `RawRepresentation`. Disposing the adapter does not dispose the injected chat client.
 
 The stream remains owned by the caller. Clients read one encoded image from its current position and must not dispose or retain the stream. A provider should throw `NotSupportedException` for a valid image media type it cannot decode.
 

--- a/src/AI/Microsoft.Maui.Essentials.AI/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI/README.md
@@ -2,15 +2,15 @@
 
 On-device AI for .NET MAUI apps using platform-native models — no cloud required.
 
-This package provides [`Microsoft.Extensions.AI`](https://learn.microsoft.com/dotnet/ai/ai-extensions) abstractions (`IChatClient`, `IEmbeddingGenerator`) backed by on-device AI capabilities:
+This package provides [`Microsoft.Extensions.AI`](https://learn.microsoft.com/dotnet/ai/ai-extensions) abstractions (`IChatClient`, `IEmbeddingGenerator`) backed by on-device AI capabilities, plus an experimental provider-neutral `IImageClassificationClient` contract:
 
-| Platform | Chat (IChatClient) | Embeddings (IEmbeddingGenerator) |
-|----------|-------------------|----------------------------------|
-| iOS 26+ | ✅ Apple Intelligence (Foundation Models) | ✅ NL Embeddings |
-| Mac Catalyst 26+ | ✅ Apple Intelligence | ✅ NL Embeddings |
-| macOS 26+ | ✅ Apple Intelligence | ✅ NL Embeddings |
-| Android | 🔜 Coming soon | 🔜 Coming soon |
-| Windows | 🔜 Coming soon | 🔜 Coming soon |
+| Platform | Chat (IChatClient) | Embeddings (IEmbeddingGenerator) | Image classification contract |
+|----------|-------------------|----------------------------------|-------------------------------|
+| iOS 26+ | ✅ Apple Intelligence (Foundation Models) | ✅ NL Embeddings | ✅ Provider-neutral contract |
+| Mac Catalyst 26+ | ✅ Apple Intelligence | ✅ NL Embeddings | ✅ Provider-neutral contract |
+| macOS 26+ | ✅ Apple Intelligence | ✅ NL Embeddings | ✅ Provider-neutral contract |
+| Android | 🔜 Coming soon | 🔜 Coming soon | ✅ Provider-neutral contract |
+| Windows | 🔜 Coming soon | 🔜 Coming soon | ✅ Provider-neutral contract |
 
 ## Getting Started
 
@@ -65,6 +65,28 @@ await foreach (var update in _chat.GetStreamingResponseAsync("Plan a day trip to
 var generator = new NLEmbeddingGenerator(NLEmbeddingType.Sentence);
 var embeddings = await generator.GenerateAsync(["sunset beach", "mountain hiking"]);
 ```
+
+### Image classification
+
+Applications depend on the contract and receive a provider from dependency injection:
+
+```csharp
+public static async Task<ImageClassificationPrediction?> ClassifyAsync(
+    IImageClassificationClient classifier,
+    Stream image,
+    CancellationToken cancellationToken = default)
+{
+    ImageClassificationResult result = await classifier.ClassifyAsync(
+        image,
+        "image/jpeg",
+        new ImageClassificationOptions { MaximumPredictions = 3 },
+        cancellationToken);
+
+    return result.Predictions.FirstOrDefault();
+}
+```
+
+The stream remains owned by the caller. Clients read one encoded image from its current position and must not dispose or retain the stream. A provider should throw `NotSupportedException` for a valid image media type it cannot decode.
 
 ## Requirements
 

--- a/src/AI/Microsoft.Maui.Essentials.AI/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI/README.md
@@ -88,6 +88,8 @@ public static async Task<ImageClassificationPrediction?> ClassifyAsync(
 
 The stream remains owned by the caller. Clients read one encoded image from its current position and must not dispose or retain the stream. A provider should throw `NotSupportedException` for a valid image media type it cannot decode.
 
+Provider identity is available from `ImageClassificationClientMetadata` through `GetService`. Each result retains its `ModelId` and can preserve provider-native response data through `RawRepresentation` and `AdditionalProperties`.
+
 ## Requirements
 
 - .NET 10

--- a/src/AI/Microsoft.Maui.Essentials.AI/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI/README.md
@@ -71,12 +71,14 @@ var embeddings = await generator.GenerateAsync(["sunset beach", "mountain hiking
 Applications depend on the contract and receive a provider from dependency injection:
 
 ```csharp
+using Microsoft.Maui.Essentials.AI;
+
 public static async Task<ImageClassificationPrediction?> ClassifyAsync(
     IImageClassificationClient classifier,
     Stream image,
     CancellationToken cancellationToken = default)
 {
-    ImageClassificationResult result = await classifier.ClassifyAsync(
+    ImageClassificationResult result = await classifier.ClassifyImageAsync(
         image,
         "image/jpeg",
         new ImageClassificationOptions { MaximumPredictions = 3 },
@@ -85,6 +87,22 @@ public static async Task<ImageClassificationPrediction?> ClassifyAsync(
     return result.Predictions.FirstOrDefault();
 }
 ```
+
+`MaximumPredictions` is an upper bound, so providers may return fewer results. Prediction confidence is optional. Providers that cannot produce confidence values throw `NotSupportedException` when `MinimumConfidence` is set.
+
+To classify against a fixed label set with a dedicated vision-capable `IChatClient`, use the built-in adapter:
+
+```csharp
+IImageClassificationClient classifier =
+    new ChatClientImageClassificationClient(
+        visionChatClient,
+        ["cat", "dog", "bird"]);
+
+ImageClassificationResult result =
+    await classifier.ClassifyImageAsync(image, "image/jpeg");
+```
+
+The adapter snapshots the non-empty label allowlist, requests structured output, rejects labels outside the allowlist, and preserves the model's ranking. Its predictions have `null` confidence, and the original `ChatResponse` is available through `RawRepresentation`. Disposing the adapter does not dispose the injected chat client.
 
 The stream remains owned by the caller. Clients read one encoded image from its current position and must not dispose or retain the stream. A provider should throw `NotSupportedException` for a valid image media type it cannot decode.
 

--- a/src/AI/Microsoft.Maui.Essentials.AI/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI/README.md
@@ -88,7 +88,7 @@ public static async Task<ImageClassificationPrediction?> ClassifyAsync(
 }
 ```
 
-`MaximumPredictions` is an upper bound, so providers may return fewer results. Prediction confidence is optional. Providers that cannot produce confidence values throw `NotSupportedException` when `MinimumConfidence` is set.
+`MaximumPredictions` is an upper bound, so providers may return fewer results. `MaximumInputBytes` limits the image bytes a provider may read and defaults to exactly 20 MiB (`20 * 1024 * 1024` bytes). Prediction confidence is optional. Providers that cannot produce confidence values throw `NotSupportedException` when `MinimumConfidence` is set.
 
 To classify against a fixed label set with a dedicated vision-capable `IChatClient`, use the built-in adapter:
 

--- a/src/AI/Microsoft.Maui.Essentials.AI/README.md
+++ b/src/AI/Microsoft.Maui.Essentials.AI/README.md
@@ -108,6 +108,10 @@ The stream remains owned by the caller. Clients read one encoded image from its 
 
 Provider identity is available from `ImageClassificationClientMetadata` through `GetService`. Each result retains its `ModelId` and can preserve provider-native response data through `RawRepresentation` and `AdditionalProperties`.
 
+For custom cloud classifiers, install
+[`Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding`](https://www.nuget.org/packages/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding/)
+and configure an Azure Content Understanding analyzer with `EnableSegment=false`.
+
 ## Requirements
 
 - .NET 10

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -46,6 +46,8 @@ ImageClassificationResult result =
 ImageClassificationPrediction? best = result.Predictions.FirstOrDefault();
 ```
 
+Provider identity is exposed through `ImageClassificationClientMetadata`; individual results retain model provenance and optional raw or additional response metadata.
+
 ## Packages
 
 | Package | Description |

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -1,6 +1,6 @@
 # Microsoft.Maui.Essentials.AI
 
-On-device AI capabilities for .NET MAUI via [`Microsoft.Extensions.AI`](https://www.nuget.org/packages/Microsoft.Extensions.AI.Abstractions) abstractions.
+AI capabilities for .NET MAUI via [`Microsoft.Extensions.AI`](https://www.nuget.org/packages/Microsoft.Extensions.AI.Abstractions) abstractions, with on-device implementations and an optional Azure image-classification provider.
 
 > **Note:** This is the contributor/repo-browsing README. The NuGet consumer README with install instructions and full usage examples is at [`Microsoft.Maui.Essentials.AI/README.md`](Microsoft.Maui.Essentials.AI/README.md).
 
@@ -8,6 +8,7 @@ On-device AI capabilities for .NET MAUI via [`Microsoft.Extensions.AI`](https://
 
 - **`IChatClient`** — backed by Apple Intelligence (Foundation Models) on iOS, macOS, and Mac Catalyst
 - **`IImageClassificationClient`** — provider-neutral contracts for classifying encoded images
+- **Azure Content Understanding classifier** — optional cloud provider for custom whole-image classifier analyzers
 - **Streaming** — progressive JSON deserialization of LLM responses via `JsonStreamChunker` and `PlainTextStreamChunker`
 - **Tool calling** — function-calling support for on-device models
 - **NL embeddings** — on-device semantic search via Apple's NaturalLanguage framework (`NLEmbeddingGenerator`)
@@ -55,6 +56,7 @@ Provider identity is exposed through `ImageClassificationClientMetadata`; indivi
 | Package | Description |
 |---------|-------------|
 | `Microsoft.Maui.Essentials.AI` | On-device AI APIs for MAUI |
+| `Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding` | Azure Content Understanding image-classification provider |
 
 ## Building
 
@@ -74,6 +76,7 @@ The CI pipeline handles the macOS → Windows artifact flow automatically. See `
 - **Native Swift bindings** (`AppleNative/EssentialsAI/`) compiled via Xcode, producing `.xcframework` bundles
 - **`AppleBindings.targets`** — MSBuild targets for cross-platform native artifact flow
 - **Streaming infrastructure** — `JsonStreamChunker`, `PlainTextStreamChunker`, `StreamingResponseHandler` for progressive deserialization
+- **Azure provider** — independently installable managed adapter over `Azure.AI.ContentUnderstanding`
 
 ## Documentation
 

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -7,19 +7,20 @@ On-device AI capabilities for .NET MAUI via [`Microsoft.Extensions.AI`](https://
 ## Features
 
 - **`IChatClient`** — backed by Apple Intelligence (Foundation Models) on iOS, macOS, and Mac Catalyst
+- **`IImageClassificationClient`** — provider-neutral contracts for classifying encoded images
 - **Streaming** — progressive JSON deserialization of LLM responses via `JsonStreamChunker` and `PlainTextStreamChunker`
 - **Tool calling** — function-calling support for on-device models
 - **NL embeddings** — on-device semantic search via Apple's NaturalLanguage framework (`NLEmbeddingGenerator`)
 
 ### Platform Support
 
-| Platform | Chat (IChatClient) | Embeddings (IEmbeddingGenerator) |
-|----------|-------------------|----------------------------------|
-| iOS 26+ | ✅ Apple Intelligence | ✅ NL Embeddings |
-| Mac Catalyst 26+ | ✅ Apple Intelligence | ✅ NL Embeddings |
-| macOS 26+ | ✅ Apple Intelligence | ✅ NL Embeddings |
-| Android | 🔜 Coming soon | 🔜 Coming soon |
-| Windows | 🔜 Coming soon | 🔜 Coming soon |
+| Platform | Chat (IChatClient) | Embeddings (IEmbeddingGenerator) | Image classification contract |
+|----------|-------------------|----------------------------------|-------------------------------|
+| iOS 26+ | ✅ Apple Intelligence | ✅ NL Embeddings | ✅ Provider-neutral contract |
+| Mac Catalyst 26+ | ✅ Apple Intelligence | ✅ NL Embeddings | ✅ Provider-neutral contract |
+| macOS 26+ | ✅ Apple Intelligence | ✅ NL Embeddings | ✅ Provider-neutral contract |
+| Android | 🔜 Coming soon | 🔜 Coming soon | ✅ Provider-neutral contract |
+| Windows | 🔜 Coming soon | 🔜 Coming soon | ✅ Provider-neutral contract |
 
 ## Quick Start
 
@@ -33,6 +34,16 @@ builder.Services.AddSingleton<IChatClient>(new AppleIntelligenceChatClient());
 // Use via DI
 var client = serviceProvider.GetRequiredService<IChatClient>();
 var response = await client.GetResponseAsync("Plan a weekend trip to Portland");
+```
+
+Image classification providers implement `IImageClassificationClient`; consumer code remains provider-neutral:
+
+```csharp
+await using Stream image = File.OpenRead("photo.jpg");
+ImageClassificationResult result =
+    await classifier.ClassifyAsync(image, "image/jpeg");
+
+ImageClassificationPrediction? best = result.Predictions.FirstOrDefault();
 ```
 
 ## Packages

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -46,7 +46,7 @@ ImageClassificationResult result =
 ImageClassificationPrediction? best = result.Predictions.FirstOrDefault();
 ```
 
-`MaximumPredictions` is an at-most constraint. Confidence is optional, and providers without confidence support reject a non-null `MinimumConfidence`. `ChatClientImageClassificationClient` adapts a dedicated vision-capable `IChatClient` to a snapshotted label allowlist while preserving response ranking and the original `ChatResponse`. It prefers structured output and narrowly falls back to a top-level JSON string array when a client ignores the requested format.
+`MaximumPredictions` is an at-most constraint. `MaximumInputBytes` defaults to exactly 20 MiB (`20 * 1024 * 1024` bytes) and bounds how much image data a provider may read. Confidence is optional, and providers without confidence support reject a non-null `MinimumConfidence`. `ChatClientImageClassificationClient` adapts a dedicated vision-capable `IChatClient` to a snapshotted label allowlist while preserving response ranking and the original `ChatResponse`. It prefers structured output and narrowly falls back to a top-level JSON string array when a client ignores the requested format.
 
 Provider identity is exposed through `ImageClassificationClientMetadata`; individual results retain model provenance and optional raw or additional response metadata. Callers retain ownership of input streams and of any chat client passed to the adapter.
 

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -46,7 +46,7 @@ ImageClassificationResult result =
 ImageClassificationPrediction? best = result.Predictions.FirstOrDefault();
 ```
 
-`MaximumPredictions` is an at-most constraint. Confidence is optional, and providers without confidence support reject a non-null `MinimumConfidence`. `ChatClientImageClassificationClient` adapts a dedicated vision-capable `IChatClient` to a snapshotted label allowlist while preserving response ranking and the original `ChatResponse`.
+`MaximumPredictions` is an at-most constraint. Confidence is optional, and providers without confidence support reject a non-null `MinimumConfidence`. `ChatClientImageClassificationClient` adapts a dedicated vision-capable `IChatClient` to a snapshotted label allowlist while preserving response ranking and the original `ChatResponse`. It prefers structured output and narrowly falls back to a top-level JSON string array when a client ignores the requested format.
 
 Provider identity is exposed through `ImageClassificationClientMetadata`; individual results retain model provenance and optional raw or additional response metadata. Callers retain ownership of input streams and of any chat client passed to the adapter.
 

--- a/src/AI/README.md
+++ b/src/AI/README.md
@@ -41,12 +41,14 @@ Image classification providers implement `IImageClassificationClient`; consumer 
 ```csharp
 await using Stream image = File.OpenRead("photo.jpg");
 ImageClassificationResult result =
-    await classifier.ClassifyAsync(image, "image/jpeg");
+    await classifier.ClassifyImageAsync(image, "image/jpeg");
 
 ImageClassificationPrediction? best = result.Predictions.FirstOrDefault();
 ```
 
-Provider identity is exposed through `ImageClassificationClientMetadata`; individual results retain model provenance and optional raw or additional response metadata.
+`MaximumPredictions` is an at-most constraint. Confidence is optional, and providers without confidence support reject a non-null `MinimumConfidence`. `ChatClientImageClassificationClient` adapts a dedicated vision-capable `IChatClient` to a snapshotted label allowlist while preserving response ranking and the original `ChatResponse`.
+
+Provider identity is exposed through `ImageClassificationClientMetadata`; individual results retain model provenance and optional raw or additional response metadata. Callers retain ownership of input streams and of any chat client passed to the adapter.
 
 ## Packages
 

--- a/tests/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests.csproj
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests</AssemblyName>
+    <RootNamespace>Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);MAUIAI0001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\AI\Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding\Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests/Tests/AzureContentUnderstandingImageClassificationClientTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests/Tests/AzureContentUnderstandingImageClassificationClientTests.cs
@@ -1,0 +1,1317 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Azure;
+using Azure.AI.ContentUnderstanding;
+using Azure.Core;
+using Microsoft.Extensions.AI;
+using Microsoft.Maui.Essentials.AI;
+using Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests;
+
+public class AzureContentUnderstandingImageClassificationClientTests
+{
+	private const string AnalyzerId = "product-classifier-v1";
+	private const long DefaultMaximumInputBytes = 20 * 1024 * 1024;
+
+	[Fact]
+	public void PublicApi_HasExactNamespaceAndSurface()
+	{
+		Type clientType = typeof(AzureContentUnderstandingImageClassificationClient);
+		Type optionsType = typeof(AzureContentUnderstandingImageClassificationOptions);
+		string expectedNamespace = typeof(AzureContentUnderstandingImageClassificationClient).Namespace!;
+
+		Assert.Equal(
+			[
+				"Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationClient",
+				"Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.AzureContentUnderstandingImageClassificationOptions"
+			],
+			clientType.Assembly.GetExportedTypes().OrderBy(type => type.FullName).Select(type => type.FullName));
+		Assert.Equal("Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding", expectedNamespace);
+		Assert.Equal(expectedNamespace, optionsType.Namespace);
+
+		PropertyInfo analyzerProperty = Assert.Single(
+			optionsType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+		Assert.Equal(nameof(AzureContentUnderstandingImageClassificationOptions.AnalyzerId), analyzerProperty.Name);
+		Assert.Equal(typeof(string), analyzerProperty.PropertyType);
+		Assert.NotNull(analyzerProperty.GetCustomAttribute<RequiredMemberAttribute>());
+		Assert.Null(optionsType.GetProperty("ClassificationFieldName"));
+
+		ConstructorInfo[] publicConstructors = clientType.GetConstructors();
+		Assert.DoesNotContain(
+			publicConstructors.SelectMany(constructor => constructor.GetParameters()),
+			parameter => parameter.ParameterType == typeof(string) ||
+				parameter.ParameterType == typeof(AzureKeyCredential));
+	}
+
+	[Fact]
+	public void Constructor_HasExactPublicTokenCredentialShape()
+	{
+		ConstructorInfo constructor = Assert.Single(
+			typeof(AzureContentUnderstandingImageClassificationClient).GetConstructors(
+				BindingFlags.Public | BindingFlags.Instance));
+
+		Assert.Collection(
+			constructor.GetParameters(),
+			parameter =>
+			{
+				Assert.Equal("endpoint", parameter.Name);
+				Assert.Equal(typeof(Uri), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("credential", parameter.Name);
+				Assert.Equal(typeof(TokenCredential), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("options", parameter.Name);
+				Assert.Equal(typeof(AzureContentUnderstandingImageClassificationOptions), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			});
+	}
+
+	[Fact]
+	public void Constructor_HasExpectedInternalInjectionShape()
+	{
+		ConstructorInfo constructor = Assert.Single(
+			typeof(AzureContentUnderstandingImageClassificationClient)
+				.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance),
+			constructor => constructor.IsAssembly);
+
+		Assert.Collection(
+			constructor.GetParameters(),
+			parameter =>
+			{
+				Assert.Equal("client", parameter.Name);
+				Assert.Equal(typeof(ContentUnderstandingClient), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("options", parameter.Name);
+				Assert.Equal(typeof(AzureContentUnderstandingImageClassificationOptions), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("metadata", parameter.Name);
+				Assert.Equal(typeof(ImageClassificationClientMetadata), parameter.ParameterType);
+				Assert.True(parameter.IsOptional);
+			});
+	}
+
+	[Fact]
+	public void Client_ImplementsIImageClassificationClient()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+
+		IImageClassificationClient contract = Assert.IsAssignableFrom<IImageClassificationClient>(client);
+
+		Assert.Same(client, contract);
+		Assert.Same(sdkClient, client.GetService(typeof(ContentUnderstandingClient)));
+	}
+
+	[Theory]
+	[InlineData("endpoint")]
+	[InlineData("credential")]
+	[InlineData("options")]
+	public void Constructor_NullEndpointCredentialOrOptions_Throws(string nullParameter)
+	{
+		var endpoint = new Uri("https://content-understanding.example.test");
+		var credential = new RecordingTokenCredential();
+		AzureContentUnderstandingImageClassificationOptions options = CreateProviderOptions();
+
+		ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+			new AzureContentUnderstandingImageClassificationClient(
+				nullParameter == "endpoint" ? null! : endpoint,
+				nullParameter == "credential" ? null! : credential,
+				nullParameter == "options" ? null! : options));
+
+		Assert.Equal(nullParameter, exception.ParamName);
+		Assert.Equal(0, credential.TokenRequestCount);
+		Assert.False(credential.IsDisposed);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData(" \t")]
+	public void Constructor_NullEmptyOrWhitespaceAnalyzerId_Throws(string? analyzerId)
+	{
+		var credential = new RecordingTokenCredential();
+		var options = new AzureContentUnderstandingImageClassificationOptions
+		{
+			AnalyzerId = analyzerId!
+		};
+
+		ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+			new AzureContentUnderstandingImageClassificationClient(
+				new Uri("https://content-understanding.example.test"),
+				credential,
+				options));
+
+		Assert.Equal("options", exception.ParamName);
+		Assert.Contains("analyzer identifier must not be empty", exception.Message, StringComparison.Ordinal);
+		Assert.Equal(0, credential.TokenRequestCount);
+	}
+
+	[Fact]
+	public async Task Constructor_MutatedOptions_UsesConstructionSnapshot()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		AzureContentUnderstandingImageClassificationOptions providerOptions = CreateProviderOptions();
+		using var client = new AzureContentUnderstandingImageClassificationClient(sdkClient, providerOptions);
+		providerOptions.AnalyzerId = "mutated-analyzer";
+
+		ImageClassificationResult result = await ClassifyAsync(client);
+
+		AnalyzeCall call = Assert.Single(sdkClient.Calls);
+		ImageClassificationClientMetadata metadata = Assert.IsType<ImageClassificationClientMetadata>(
+			client.GetService(typeof(ImageClassificationClientMetadata)));
+		Assert.Equal(AnalyzerId, call.AnalyzerId);
+		Assert.Equal(AnalyzerId, result.ModelId);
+		Assert.Equal(AnalyzerId, metadata.DefaultModelId);
+		Assert.NotEqual(providerOptions.AnalyzerId, call.AnalyzerId);
+	}
+
+	[Fact]
+	public void GetService_ExposesUnderlyingClientMetadataAndSelf()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		var suppliedMetadata = new ImageClassificationClientMetadata(
+			"supplied provider",
+			new Uri("https://injected.example.test"),
+			AnalyzerId);
+		using var injectedClient = new AzureContentUnderstandingImageClassificationClient(
+			sdkClient,
+			CreateProviderOptions(),
+			suppliedMetadata);
+
+		Assert.Same(sdkClient, injectedClient.GetService(typeof(ContentUnderstandingClient)));
+		Assert.Same(suppliedMetadata, injectedClient.GetService(typeof(ImageClassificationClientMetadata)));
+		Assert.Same(injectedClient, injectedClient.GetService(typeof(AzureContentUnderstandingImageClassificationClient)));
+		Assert.Same(injectedClient, injectedClient.GetService(typeof(IImageClassificationClient)));
+
+		var endpoint = new Uri("https://content-understanding.example.test");
+		using var publicClient = new AzureContentUnderstandingImageClassificationClient(
+			endpoint,
+			new RecordingTokenCredential(),
+			CreateProviderOptions());
+		ImageClassificationClientMetadata generatedMetadata = Assert.IsType<ImageClassificationClientMetadata>(
+			publicClient.GetService(typeof(ImageClassificationClientMetadata)));
+		object underlyingClient = Assert.IsType<ContentUnderstandingClient>(
+			publicClient.GetService(typeof(ContentUnderstandingClient)));
+
+		Assert.Same(underlyingClient, publicClient.GetService(typeof(ContentUnderstandingClient)));
+		Assert.Equal("Azure Content Understanding", generatedMetadata.ProviderName);
+		Assert.Equal(endpoint, generatedMetadata.ProviderUri);
+		Assert.Equal(AnalyzerId, generatedMetadata.DefaultModelId);
+	}
+
+	[Fact]
+	public void GetService_KeyedOrUnknown_ReturnsNull()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+
+		Assert.Null(client.GetService(typeof(ContentUnderstandingClient), "key"));
+		Assert.Null(client.GetService(typeof(ImageClassificationClientMetadata), new object()));
+		Assert.Null(client.GetService(typeof(UnknownService)));
+		Assert.Equal(0, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public void Dispose_DoesNotDisposeCredentialOrInjectedClient()
+	{
+		var credential = new RecordingTokenCredential();
+		var publicClient = new AzureContentUnderstandingImageClassificationClient(
+			new Uri("https://content-understanding.example.test"),
+			credential,
+			CreateProviderOptions());
+		var sdkClient = new RecordingContentUnderstandingClient();
+		var injectedClient = CreateClient(sdkClient);
+
+		publicClient.Dispose();
+		publicClient.Dispose();
+		injectedClient.Dispose();
+		injectedClient.Dispose();
+
+		Assert.False(credential.IsDisposed);
+		Assert.False(sdkClient.IsDisposed);
+		Assert.Equal(0, credential.TokenRequestCount);
+		Assert.Equal(0, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_NullOptions_UsesContractDefaults()
+	{
+		byte[] imageBytes = new byte[DefaultMaximumInputBytes];
+		imageBytes[0] = 0x89;
+		imageBytes[^1] = 0x82;
+		var sdkClient = new RecordingContentUnderstandingClient(
+			CreateAnalysisResult("default-category"));
+		using var client = CreateClient(sdkClient);
+		using var image = new TrackingSeekableStream(imageBytes);
+
+		ImageClassificationResult result = await client.ClassifyImageAsync(image, "image/png", options: null);
+
+		AnalyzeCall call = Assert.Single(sdkClient.Calls);
+		Assert.Equal(DefaultMaximumInputBytes, call.Bytes.LongLength);
+		Assert.Equal(0x89, call.Bytes[0]);
+		Assert.Equal(0x82, call.Bytes[^1]);
+		Assert.Equal("default-category", Assert.Single(result.Predictions).Label);
+		Assert.Null(result.Predictions[0].Confidence);
+		Assert.False(image.IsDisposed);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_MutatedPendingOptions_UsesEntrySnapshot()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient(
+			CreateAnalysisResult("snapshot-category"));
+		using var client = CreateClient(sdkClient);
+		var options = new ImageClassificationOptions
+		{
+			MaximumInputBytes = 3,
+			MaximumPredictions = 1,
+			MinimumConfidence = null
+		};
+		using var image = new PendingReadStream([1, 2, 3]);
+
+		Task<ImageClassificationResult> classification =
+			client.ClassifyImageAsync(image, "image/png", options);
+		await image.ReadStarted;
+		Assert.Equal(0, sdkClient.CallCount);
+
+		options.MaximumInputBytes = 1;
+		options.MaximumPredictions = 3;
+		options.MinimumConfidence = 0.5f;
+		image.ReleaseRead();
+
+		ImageClassificationResult result = await classification;
+
+		Assert.Equal([1, 2, 3], Assert.Single(sdkClient.Calls).Bytes);
+		Assert.Equal("snapshot-category", Assert.Single(result.Predictions).Label);
+		Assert.Null(result.Predictions[0].Confidence);
+		Assert.Equal(3, image.BytesRead);
+		Assert.Equal(1, sdkClient.CallCount);
+		Assert.Equal(3, options.MaximumPredictions);
+	}
+
+	[Theory]
+	[InlineData(0f)]
+	[InlineData(0.42f)]
+	[InlineData(1f)]
+	public async Task ClassifyImageAsync_AnyMinimumConfidence_ThrowsBeforeReadOrSdk(float minimumConfidence)
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+		using var image = new TrackingSeekableStream([1, 2, 3], initialPosition: 1);
+		var options = new ImageClassificationOptions { MinimumConfidence = minimumConfidence };
+
+		NotSupportedException exception = await Assert.ThrowsAsync<NotSupportedException>(
+			() => client.ClassifyImageAsync(image, "image/png", options));
+
+		Assert.Equal(
+			"MinimumConfidence is not supported because Azure Content Understanding whole-image classifier categories do not include confidence values.",
+			exception.Message);
+		Assert.Equal(1, image.Position);
+		Assert.Equal(0, image.ReadCalls);
+		Assert.Equal(0, sdkClient.CallCount);
+	}
+
+	[Theory]
+	[InlineData("null")]
+	[InlineData("unreadable")]
+	[InlineData("empty")]
+	public async Task ClassifyImageAsync_NullUnreadableOrEmptyStream_RejectsBeforeSdk(string streamCase)
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+		Stream? image = streamCase switch
+		{
+			"null" => null,
+			"unreadable" => new UnreadableStream(),
+			_ => new TrackingSeekableStream([])
+		};
+
+		ArgumentException exception = await Assert.ThrowsAnyAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(image!, "image/png"));
+
+		if (streamCase == "null")
+		{
+			Assert.IsType<ArgumentNullException>(exception);
+		}
+		else
+		{
+			Assert.IsType<ArgumentException>(exception);
+			Assert.False(((DisposalObservingStream)image!).IsDisposed);
+		}
+
+		Assert.Equal("image", exception.ParamName);
+		Assert.Equal(0, sdkClient.CallCount);
+		if (image is TrackingSeekableStream empty)
+		{
+			Assert.Equal(1, empty.ReadCalls);
+		}
+
+		image?.Dispose();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("not a media type")]
+	[InlineData("text/plain")]
+	public async Task ClassifyImageAsync_NullMalformedOrNonImageMediaType_RejectsBeforeReadOrSdk(
+		string? mediaType)
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+		using var image = new TrackingSeekableStream([1, 2, 3]);
+
+		ArgumentException exception = await Assert.ThrowsAnyAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(image, mediaType!));
+
+		if (mediaType is null)
+		{
+			Assert.IsType<ArgumentNullException>(exception);
+		}
+		else
+		{
+			Assert.IsType<ArgumentException>(exception);
+			Assert.Equal("The media type must identify image content. (Parameter 'imageMediaType')", exception.Message);
+		}
+
+		Assert.Equal("imageMediaType", exception.ParamName);
+		Assert.Equal(0, image.ReadCalls);
+		Assert.Equal(0, sdkClient.CallCount);
+		Assert.False(image.IsDisposed);
+	}
+
+	[Theory]
+	[InlineData("image/gif")]
+	[InlineData("image/svg+xml")]
+	[InlineData("image/webp")]
+	public async Task ClassifyImageAsync_UnsupportedImageMediaType_ThrowsBeforeReadOrSdk(string mediaType)
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+		using var image = new TrackingSeekableStream([1, 2, 3]);
+
+		NotSupportedException exception = await Assert.ThrowsAsync<NotSupportedException>(
+			() => client.ClassifyImageAsync(image, mediaType));
+
+		Assert.Contains(mediaType, exception.Message, StringComparison.Ordinal);
+		Assert.Equal(0, image.ReadCalls);
+		Assert.Equal(0, sdkClient.CallCount);
+		Assert.False(image.IsDisposed);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ExactMaximumInputBytes_Succeeds()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient(
+			CreateAnalysisResult("exact-limit"));
+		using var client = CreateClient(sdkClient);
+		using var image = new TrackingSeekableStream([9, 8, 7, 6, 5], initialPosition: 2);
+		var options = new ImageClassificationOptions { MaximumInputBytes = 3 };
+
+		ImageClassificationResult result =
+			await client.ClassifyImageAsync(image, "image/png", options);
+
+		AnalyzeCall call = Assert.Single(sdkClient.Calls);
+		Assert.Equal([7, 6, 5], call.Bytes);
+		Assert.Equal("image/png", call.ContentType);
+		Assert.Equal("exact-limit", Assert.Single(result.Predictions).Label);
+		Assert.Equal(5, image.Position);
+		Assert.False(image.IsDisposed);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_SeekableOverLimit_RejectsWithoutRead()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+		using var image = new TrackingSeekableStream([9, 8, 7, 6, 5, 4], initialPosition: 2);
+		var options = new ImageClassificationOptions { MaximumInputBytes = 3 };
+
+		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(image, "image/png", options));
+
+		Assert.Equal("image", exception.ParamName);
+		Assert.Contains("configured maximum of 3 bytes", exception.Message, StringComparison.Ordinal);
+		Assert.Contains(nameof(ImageClassificationOptions.MaximumInputBytes), exception.Message, StringComparison.Ordinal);
+		Assert.Equal(0, image.ReadCalls);
+		Assert.Equal(2, image.Position);
+		Assert.False(image.IsDisposed);
+		Assert.Equal(0, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_NonSeekableOverLimit_ReadsAtMostLimitPlusOne()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+		using var image = new ChunkedNonSeekableStream([1, 2, 3, 4, 5, 6], maximumChunkSize: 2);
+		var options = new ImageClassificationOptions { MaximumInputBytes = 3 };
+
+		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(image, "image/png", options));
+
+		Assert.Equal("image", exception.ParamName);
+		Assert.Equal(4, image.BytesRead);
+		Assert.InRange(image.BytesRead, 0, 4);
+		Assert.Equal(2, image.ReadCalls);
+		Assert.False(image.IsDisposed);
+		Assert.Equal(0, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_CancellationDuringRead_StopsBeforeSdk()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+		using var image = new CancellationAwareStream();
+		using var cancellationSource = new CancellationTokenSource();
+
+		Task<ImageClassificationResult> classification = client.ClassifyImageAsync(
+			image,
+			"image/png",
+			new ImageClassificationOptions { MaximumInputBytes = 10 },
+			cancellationSource.Token);
+		await image.SecondReadStarted;
+
+		cancellationSource.Cancel();
+
+		OperationCanceledException exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+			() => classification);
+		Assert.Equal(cancellationSource.Token, exception.CancellationToken);
+		Assert.Equal(2, image.ReadCalls);
+		Assert.Equal(1, image.BytesRead);
+		Assert.False(image.IsDisposed);
+		Assert.Equal(0, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ValidImage_InvokesTypedAnalyzeBinaryAsyncWithExactArguments()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient(
+			CreateAnalysisResult("wildlife"));
+		using var client = CreateClient(sdkClient);
+		using var image = new TrackingSeekableStream([0, 1, 2, 3, 4], initialPosition: 2);
+		using var cancellationSource = new CancellationTokenSource();
+
+		ImageClassificationResult result = await client.ClassifyImageAsync(
+			image,
+			"image/jpeg",
+			cancellationToken: cancellationSource.Token);
+
+		AnalyzeCall call = Assert.Single(sdkClient.Calls);
+		Assert.Equal(WaitUntil.Completed, call.WaitUntil);
+		Assert.Equal(AnalyzerId, call.AnalyzerId);
+		Assert.Equal([2, 3, 4], call.Bytes);
+		Assert.Null(call.ContentRange);
+		Assert.Equal("image/jpeg", call.ContentType);
+		Assert.Null(call.ProcessingLocation);
+		Assert.Equal(cancellationSource.Token, call.CancellationToken);
+		Assert.Equal("wildlife", Assert.Single(result.Predictions).Label);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ExactlyOneContentWithCategory_MapsOneNullConfidencePrediction()
+	{
+		var misleadingFields = new Dictionary<string, ContentField>
+		{
+			["classification"] = ContentUnderstandingModelFactory.ContentStringField(
+				value: "field-category",
+				confidence: 0.99f)
+		};
+		AnalysisContent content = ContentUnderstandingModelFactory.AnalysisContent(
+			kind: "document",
+			mimeType: "image/png",
+			analyzerId: "sdk-analyzer",
+			category: "content-category",
+			fields: misleadingFields);
+		AnalysisResult analysisResult = ContentUnderstandingModelFactory.AnalysisResult(
+			analyzerId: "sdk-analyzer",
+			contents: [content]);
+		var sdkClient = new RecordingContentUnderstandingClient(analysisResult);
+		using var client = CreateClient(sdkClient);
+
+		ImageClassificationResult result = await ClassifyAsync(client);
+
+		ImageClassificationPrediction prediction = Assert.Single(result.Predictions);
+		Assert.Equal("content-category", prediction.Label);
+		Assert.Null(prediction.Confidence);
+		Assert.NotEqual("field-category", prediction.Label);
+		Assert.Same(analysisResult, result.RawRepresentation);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(2)]
+	public async Task ClassifyImageAsync_ZeroOrMultipleContents_Throws(int contentCount)
+	{
+		AnalysisContent[] contents = Enumerable.Range(0, contentCount)
+			.Select(index => CreateAnalysisContent($"category-{index}"))
+			.ToArray();
+		var sdkClient = new RecordingContentUnderstandingClient(
+			ContentUnderstandingModelFactory.AnalysisResult(
+				analyzerId: "sdk-analyzer",
+				contents: contents));
+		using var client = CreateClient(sdkClient);
+
+		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => ClassifyAsync(client));
+
+		Assert.Equal(
+			$"Azure Content Understanding analyzer '{AnalyzerId}' returned {contentCount} content results; exactly one is required for whole-image classification.",
+			exception.Message);
+		Assert.Equal(1, sdkClient.CallCount);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData(" \t")]
+	public async Task ClassifyImageAsync_NullEmptyOrWhitespaceCategory_Throws(string? category)
+	{
+		var sdkClient = new RecordingContentUnderstandingClient(
+			CreateAnalysisResult(category));
+		using var client = CreateClient(sdkClient);
+
+		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => ClassifyAsync(client));
+
+		Assert.Equal(
+			$"Azure Content Understanding analyzer '{AnalyzerId}' did not return a non-empty content-level category.",
+			exception.Message);
+		Assert.Equal(1, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_MaximumPredictionsOne_ReturnsSinglePrediction()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient(
+			CreateAnalysisResult("single-category"));
+		using var client = CreateClient(sdkClient);
+		var options = new ImageClassificationOptions { MaximumPredictions = 1 };
+
+		ImageClassificationResult result = await ClassifyAsync(client, options);
+
+		ImageClassificationPrediction prediction = Assert.Single(result.Predictions);
+		Assert.Equal("single-category", prediction.Label);
+		Assert.Null(prediction.Confidence);
+		Assert.Equal(1, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ResultPreservesRawAnalysisResult()
+	{
+		AnalysisResult analysisResult = CreateAnalysisResult("raw-category");
+		var sdkClient = new RecordingContentUnderstandingClient(analysisResult);
+		using var client = CreateClient(sdkClient);
+
+		ImageClassificationResult result = await ClassifyAsync(client);
+
+		Assert.Same(analysisResult, result.RawRepresentation);
+		Assert.Equal("raw-category", Assert.Single(result.Predictions).Label);
+		Assert.Equal(AnalyzerId, result.ModelId);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ResultUsesConfiguredAnalyzerIdAndSafeAdditionalProperties()
+	{
+		AnalysisResult analysisResult = CreateAnalysisResult("category", sdkAnalyzerId: "different-sdk-analyzer");
+		var sdkClient = new RecordingContentUnderstandingClient(analysisResult);
+		using var client = CreateClient(sdkClient);
+
+		ImageClassificationResult first = await ClassifyAsync(client);
+		ImageClassificationResult second = await ClassifyAsync(client);
+
+		AdditionalPropertiesDictionary firstProperties =
+			Assert.IsType<AdditionalPropertiesDictionary>(first.AdditionalProperties);
+		AdditionalPropertiesDictionary secondProperties =
+			Assert.IsType<AdditionalPropertiesDictionary>(second.AdditionalProperties);
+		KeyValuePair<string, object?> property = Assert.Single(firstProperties);
+		Assert.Equal("analyzerId", property.Key);
+		Assert.IsType<string>(property.Value);
+		Assert.Equal(AnalyzerId, property.Value);
+		Assert.Equal(AnalyzerId, first.ModelId);
+		Assert.Equal(AnalyzerId, second.ModelId);
+		Assert.NotEqual(analysisResult.AnalyzerId, first.ModelId);
+		Assert.NotSame(firstProperties, secondProperties);
+		Assert.Equal(AnalyzerId, secondProperties["analyzerId"]);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_AuthenticationFailure_PropagatesUnchanged()
+	{
+		var failure = new RequestFailedException(
+			status: 401,
+			message: "authentication failed",
+			errorCode: "AuthenticationFailed",
+			innerException: null);
+		var sdkClient = new RecordingContentUnderstandingClient
+		{
+			Handler = _ => Task.FromException<Operation<AnalysisResult>>(failure)
+		};
+		using var client = CreateClient(sdkClient);
+
+		RequestFailedException actual = await Assert.ThrowsAsync<RequestFailedException>(
+			() => ClassifyAsync(client));
+
+		Assert.Same(failure, actual);
+		Assert.Equal(401, actual.Status);
+		Assert.Equal("AuthenticationFailed", actual.ErrorCode);
+		Assert.Equal("authentication failed", actual.Message);
+		Assert.Equal(1, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ServiceFailure_PropagatesUnchanged()
+	{
+		var failure = new RequestFailedException(
+			status: 503,
+			message: "service unavailable",
+			errorCode: "ServiceUnavailable",
+			innerException: null);
+		var sdkClient = new RecordingContentUnderstandingClient
+		{
+			Handler = _ => Task.FromResult<Operation<AnalysisResult>>(new CompletedOperation(failure))
+		};
+		using var client = CreateClient(sdkClient);
+
+		RequestFailedException actual = await Assert.ThrowsAsync<RequestFailedException>(
+			() => ClassifyAsync(client));
+
+		Assert.Same(failure, actual);
+		Assert.Equal(503, actual.Status);
+		Assert.Equal("ServiceUnavailable", actual.ErrorCode);
+		Assert.Equal(1, sdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_SdkCancellation_PropagatesUnchanged()
+	{
+		using var cancellationSource = new CancellationTokenSource();
+		var failure = new OperationCanceledException(
+			"sdk operation canceled",
+			innerException: null,
+			cancellationSource.Token);
+		var sdkClient = new RecordingContentUnderstandingClient
+		{
+			Handler = _ => Task.FromResult<Operation<AnalysisResult>>(new CompletedOperation(failure))
+		};
+		using var client = CreateClient(sdkClient);
+
+		OperationCanceledException actual = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+			() => ClassifyAsync(client, cancellationToken: cancellationSource.Token));
+
+		Assert.Same(failure, actual);
+		Assert.Equal(cancellationSource.Token, actual.CancellationToken);
+		Assert.Equal(cancellationSource.Token, Assert.Single(sdkClient.Calls).CancellationToken);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_SuccessFailureAndCancellation_LeaveInputOpen()
+	{
+		using var successfulStream = new TrackingSeekableStream([1, 2]);
+		var successSdkClient = new RecordingContentUnderstandingClient(CreateAnalysisResult("success"));
+		using var successClient = CreateClient(successSdkClient);
+		ImageClassificationResult success =
+			await successClient.ClassifyImageAsync(successfulStream, "image/png");
+
+		using var oversizedStream = new TrackingSeekableStream([1, 2, 3]);
+		var sizeSdkClient = new RecordingContentUnderstandingClient();
+		using var sizeClient = CreateClient(sizeSdkClient);
+		await Assert.ThrowsAsync<ArgumentException>(() =>
+			sizeClient.ClassifyImageAsync(
+				oversizedStream,
+				"image/png",
+				new ImageClassificationOptions { MaximumInputBytes = 2 }));
+
+		var sdkFailure = new RequestFailedException(500, "sdk failure");
+		using var sdkFailureStream = new TrackingSeekableStream([4, 5]);
+		var failureSdkClient = new RecordingContentUnderstandingClient
+		{
+			Handler = _ => Task.FromException<Operation<AnalysisResult>>(sdkFailure)
+		};
+		using var failureClient = CreateClient(failureSdkClient);
+		RequestFailedException actualFailure = await Assert.ThrowsAsync<RequestFailedException>(
+			() => failureClient.ClassifyImageAsync(sdkFailureStream, "image/jpeg"));
+
+		using var canceledStream = new CancellationAwareStream();
+		var cancellationSdkClient = new RecordingContentUnderstandingClient();
+		using var cancellationClient = CreateClient(cancellationSdkClient);
+		using var cancellationSource = new CancellationTokenSource();
+		Task<ImageClassificationResult> canceledClassification = cancellationClient.ClassifyImageAsync(
+			canceledStream,
+			"image/png",
+			new ImageClassificationOptions { MaximumInputBytes = 10 },
+			cancellationSource.Token);
+		await canceledStream.SecondReadStarted;
+		cancellationSource.Cancel();
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledClassification);
+
+		Assert.Equal("success", Assert.Single(success.Predictions).Label);
+		Assert.Same(sdkFailure, actualFailure);
+		Assert.All(
+			new Stream[] { successfulStream, oversizedStream, sdkFailureStream, canceledStream },
+			stream => Assert.True(stream.CanRead));
+		successfulStream.Position = 0;
+		Assert.Equal(1, successfulStream.ReadByte());
+		Assert.Equal(0, sizeSdkClient.CallCount);
+		Assert.Equal(0, cancellationSdkClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_RepeatedCalls_DoNotLeakState()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient
+		{
+			Handler = call => Task.FromResult<Operation<AnalysisResult>>(
+				new CompletedOperation(CreateAnalysisResult(
+					call.Bytes[0] == 1 ? "first-category" : "second-category",
+					sdkAnalyzerId: call.Bytes[0] == 1 ? "sdk-one" : "sdk-two")))
+		};
+		using var client = CreateClient(sdkClient);
+		using var firstTokenSource = new CancellationTokenSource();
+		using var secondTokenSource = new CancellationTokenSource();
+		using var firstStream = new TrackingSeekableStream([0, 1, 2], initialPosition: 1);
+		using var secondStream = new TrackingSeekableStream([9, 8, 7, 6], initialPosition: 1);
+
+		ImageClassificationResult first = await client.ClassifyImageAsync(
+			firstStream,
+			"image/png",
+			new ImageClassificationOptions { MaximumInputBytes = 2, MaximumPredictions = 1 },
+			firstTokenSource.Token);
+		ImageClassificationResult second = await client.ClassifyImageAsync(
+			secondStream,
+			"image/jpeg",
+			new ImageClassificationOptions { MaximumInputBytes = 3 },
+			secondTokenSource.Token);
+
+		Assert.Collection(
+			sdkClient.Calls,
+			call =>
+			{
+				Assert.Equal([1, 2], call.Bytes);
+				Assert.Equal("image/png", call.ContentType);
+				Assert.Equal(firstTokenSource.Token, call.CancellationToken);
+			},
+			call =>
+			{
+				Assert.Equal([8, 7, 6], call.Bytes);
+				Assert.Equal("image/jpeg", call.ContentType);
+				Assert.Equal(secondTokenSource.Token, call.CancellationToken);
+			});
+		Assert.Equal("first-category", Assert.Single(first.Predictions).Label);
+		Assert.Equal("second-category", Assert.Single(second.Predictions).Label);
+		Assert.NotSame(first.RawRepresentation, second.RawRepresentation);
+		Assert.Equal(AnalyzerId, first.ModelId);
+		Assert.Equal(AnalyzerId, second.ModelId);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ConcurrentCalls_KeepBytesOptionsResultsAndTokensIsolated()
+	{
+		var firstCompletion = new TaskCompletionSource<Operation<AnalysisResult>>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		var secondCompletion = new TaskCompletionSource<Operation<AnalysisResult>>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		var sdkClient = new RecordingContentUnderstandingClient
+		{
+			Handler = call => call.Bytes[0] == 1 ? firstCompletion.Task : secondCompletion.Task
+		};
+		using var client = CreateClient(sdkClient);
+		using var firstTokenSource = new CancellationTokenSource();
+		using var secondTokenSource = new CancellationTokenSource();
+		using var firstStream = new TrackingSeekableStream([1, 2]);
+		using var secondStream = new TrackingSeekableStream([9, 8, 7]);
+
+		Task<ImageClassificationResult> firstTask = client.ClassifyImageAsync(
+			firstStream,
+			"image/png",
+			new ImageClassificationOptions { MaximumInputBytes = 2, MaximumPredictions = 1 },
+			firstTokenSource.Token);
+		Task<ImageClassificationResult> secondTask = client.ClassifyImageAsync(
+			secondStream,
+			"image/bmp",
+			new ImageClassificationOptions { MaximumInputBytes = 3 },
+			secondTokenSource.Token);
+		await sdkClient.TwoCallsRecorded;
+
+		AnalysisResult secondAnalysisResult = CreateAnalysisResult("second-category", "sdk-second");
+		AnalysisResult firstAnalysisResult = CreateAnalysisResult("first-category", "sdk-first");
+		secondCompletion.SetResult(new CompletedOperation(secondAnalysisResult));
+		ImageClassificationResult second = await secondTask;
+		Assert.False(firstTask.IsCompleted);
+		firstCompletion.SetResult(new CompletedOperation(firstAnalysisResult));
+		ImageClassificationResult first = await firstTask;
+
+		Dictionary<byte, AnalyzeCall> calls = sdkClient.Calls.ToDictionary(call => call.Bytes[0]);
+		Assert.Equal([1, 2], calls[1].Bytes);
+		Assert.Equal("image/png", calls[1].ContentType);
+		Assert.Equal(firstTokenSource.Token, calls[1].CancellationToken);
+		Assert.Equal([9, 8, 7], calls[9].Bytes);
+		Assert.Equal("image/bmp", calls[9].ContentType);
+		Assert.Equal(secondTokenSource.Token, calls[9].CancellationToken);
+		Assert.Equal("first-category", Assert.Single(first.Predictions).Label);
+		Assert.Equal("second-category", Assert.Single(second.Predictions).Label);
+		Assert.Same(firstAnalysisResult, first.RawRepresentation);
+		Assert.Same(secondAnalysisResult, second.RawRepresentation);
+		Assert.False(firstStream.IsDisposed);
+		Assert.False(secondStream.IsDisposed);
+	}
+
+	[Theory]
+	[InlineData("client")]
+	[InlineData("options")]
+	public void Constructor_InternalNullClientOrOptions_ThrowsExactParameter(string nullParameter)
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		AzureContentUnderstandingImageClassificationOptions options = CreateProviderOptions();
+
+		ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+			new AzureContentUnderstandingImageClassificationClient(
+				nullParameter == "client" ? null! : sdkClient,
+				nullParameter == "options" ? null! : options));
+
+		Assert.Equal(nullParameter, exception.ParamName);
+		Assert.Equal(0, sdkClient.CallCount);
+		Assert.False(sdkClient.IsDisposed);
+	}
+
+	[Fact]
+	public void GetService_NullServiceType_ThrowsBeforeKeyHandling()
+	{
+		var sdkClient = new RecordingContentUnderstandingClient();
+		using var client = CreateClient(sdkClient);
+
+		ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+			() => client.GetService(null!, new object()));
+
+		Assert.Equal("serviceType", exception.ParamName);
+		Assert.Equal(0, sdkClient.CallCount);
+		Assert.False(sdkClient.IsDisposed);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_UppercaseImageMediaType_IsAcceptedAndPreserved()
+	{
+		AnalysisResult analysisResult = CreateAnalysisResult("case-insensitive-category");
+		var sdkClient = new RecordingContentUnderstandingClient(analysisResult);
+		using var client = CreateClient(sdkClient);
+		using var image = new TrackingSeekableStream([0x00, 0x10, 0x20, 0x30], initialPosition: 1);
+
+		ImageClassificationResult result = await client.ClassifyImageAsync(image, "IMAGE/PNG");
+
+		AnalyzeCall call = Assert.Single(sdkClient.Calls);
+		Assert.Equal([0x10, 0x20, 0x30], call.Bytes);
+		Assert.Equal("IMAGE/PNG", call.ContentType);
+		Assert.Equal("case-insensitive-category", Assert.Single(result.Predictions).Label);
+		Assert.Same(analysisResult, result.RawRepresentation);
+		Assert.Equal(4, image.Position);
+		Assert.False(image.IsDisposed);
+	}
+
+	private static AzureContentUnderstandingImageClassificationClient CreateClient(
+		ContentUnderstandingClient sdkClient) =>
+		new(sdkClient, CreateProviderOptions());
+
+	private static AzureContentUnderstandingImageClassificationOptions CreateProviderOptions() =>
+		new() { AnalyzerId = AnalyzerId };
+
+	private static async Task<ImageClassificationResult> ClassifyAsync(
+		AzureContentUnderstandingImageClassificationClient client,
+		ImageClassificationOptions? options = null,
+		CancellationToken cancellationToken = default)
+	{
+		using var image = new MemoryStream([1, 2, 3]);
+		return await client.ClassifyImageAsync(image, "image/png", options, cancellationToken);
+	}
+
+	private static AnalysisContent CreateAnalysisContent(string? category) =>
+		ContentUnderstandingModelFactory.AnalysisContent(
+			kind: "document",
+			mimeType: "image/png",
+			analyzerId: "sdk-analyzer",
+			category: category);
+
+	private static AnalysisResult CreateAnalysisResult(
+		string? category = "category",
+		string? sdkAnalyzerId = "sdk-analyzer") =>
+		ContentUnderstandingModelFactory.AnalysisResult(
+			analyzerId: sdkAnalyzerId,
+			apiVersion: "2025-05-01-preview",
+			createdAt: new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero),
+			stringEncoding: "utf16",
+			contents: [CreateAnalysisContent(category)]);
+
+	private sealed record AnalyzeCall(
+		WaitUntil WaitUntil,
+		string AnalyzerId,
+		byte[] Bytes,
+		ContentRange? ContentRange,
+		string? ContentType,
+		ProcessingLocation? ProcessingLocation,
+		CancellationToken CancellationToken);
+
+	private sealed class RecordingContentUnderstandingClient : ContentUnderstandingClient, IDisposable
+	{
+		private readonly ConcurrentQueue<AnalyzeCall> _calls = new();
+		private readonly TaskCompletionSource _twoCallsRecorded =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private int _callCount;
+
+		public RecordingContentUnderstandingClient(AnalysisResult? result = null)
+		{
+			AnalysisResult configuredResult = result ?? CreateAnalysisResult();
+			Handler = _ => Task.FromResult<Operation<AnalysisResult>>(
+				new CompletedOperation(configuredResult));
+		}
+
+		public Func<AnalyzeCall, Task<Operation<AnalysisResult>>> Handler { get; init; }
+
+		public IReadOnlyList<AnalyzeCall> Calls => _calls.ToArray();
+
+		public int CallCount => Volatile.Read(ref _callCount);
+
+		public Task TwoCallsRecorded => _twoCallsRecorded.Task;
+
+		public bool IsDisposed { get; private set; }
+
+		public override Task<Operation<AnalysisResult>> AnalyzeBinaryAsync(
+			WaitUntil waitUntil,
+			string analyzerId,
+			BinaryData binaryInput,
+			ContentRange? contentRange = null,
+			string? contentType = null,
+			ProcessingLocation? processingLocation = null,
+			CancellationToken cancellationToken = default)
+		{
+			var call = new AnalyzeCall(
+				waitUntil,
+				analyzerId,
+				binaryInput.ToArray(),
+				contentRange,
+				contentType,
+				processingLocation,
+				cancellationToken);
+			_calls.Enqueue(call);
+			if (Interlocked.Increment(ref _callCount) >= 2)
+			{
+				_twoCallsRecorded.TrySetResult();
+			}
+
+			return Handler(call);
+		}
+
+		public void Dispose() => IsDisposed = true;
+	}
+
+	private sealed class CompletedOperation : Operation<AnalysisResult>
+	{
+		private readonly AnalysisResult? _value;
+		private readonly Exception? _failure;
+		private readonly Response _response = new TestResponse();
+
+		public CompletedOperation(AnalysisResult value)
+		{
+			_value = value;
+		}
+
+		public CompletedOperation(Exception failure)
+		{
+			_failure = failure;
+		}
+
+		public override string Id => "completed-test-operation";
+
+		public override AnalysisResult Value => _failure is null ? _value! : throw _failure;
+
+		public override bool HasCompleted => true;
+
+		public override bool HasValue => _failure is null;
+
+		public override Response GetRawResponse() => _response;
+
+		public override Response UpdateStatus(CancellationToken cancellationToken = default) => _response;
+
+		public override ValueTask<Response> UpdateStatusAsync(
+			CancellationToken cancellationToken = default) =>
+			ValueTask.FromResult(_response);
+	}
+
+	private sealed class TestResponse : Response
+	{
+		public override int Status => 200;
+
+		public override string ReasonPhrase => "OK";
+
+		public override Stream? ContentStream { get; set; }
+
+		public override string ClientRequestId { get; set; } = "test-request";
+
+		public override void Dispose()
+		{
+		}
+
+		protected override bool ContainsHeader(string name) => false;
+
+		protected override IEnumerable<HttpHeader> EnumerateHeaders() => [];
+
+		protected override bool TryGetHeader(string name, out string value)
+		{
+			value = string.Empty;
+			return false;
+		}
+
+		protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+		{
+			values = [];
+			return false;
+		}
+	}
+
+	private sealed class RecordingTokenCredential : TokenCredential, IDisposable
+	{
+		private int _tokenRequestCount;
+
+		public int TokenRequestCount => Volatile.Read(ref _tokenRequestCount);
+
+		public bool IsDisposed { get; private set; }
+
+		public override AccessToken GetToken(
+			TokenRequestContext requestContext,
+			CancellationToken cancellationToken)
+		{
+			Interlocked.Increment(ref _tokenRequestCount);
+			return new AccessToken("test-token", new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+		}
+
+		public override ValueTask<AccessToken> GetTokenAsync(
+			TokenRequestContext requestContext,
+			CancellationToken cancellationToken) =>
+			ValueTask.FromResult(GetToken(requestContext, cancellationToken));
+
+		public void Dispose() => IsDisposed = true;
+	}
+
+	private abstract class DisposalObservingStream : Stream
+	{
+		public bool IsDisposed { get; private set; }
+
+		protected override void Dispose(bool disposing)
+		{
+			IsDisposed = true;
+			base.Dispose(disposing);
+		}
+
+		public override void Flush() => throw new NotSupportedException();
+
+		public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+		public override void SetLength(long value) => throw new NotSupportedException();
+
+		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+		public override bool CanWrite => false;
+	}
+
+	private sealed class TrackingSeekableStream : DisposalObservingStream
+	{
+		private readonly MemoryStream _inner;
+
+		public TrackingSeekableStream(byte[] bytes, int initialPosition = 0)
+		{
+			_inner = new MemoryStream(bytes, writable: false);
+			_inner.Position = initialPosition;
+		}
+
+		public int ReadCalls { get; private set; }
+
+		public override bool CanRead => !IsDisposed;
+
+		public override bool CanSeek => !IsDisposed;
+
+		public override long Length => _inner.Length;
+
+		public override long Position
+		{
+			get => _inner.Position;
+			set => _inner.Position = value;
+		}
+
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			ReadCalls++;
+			return _inner.Read(buffer, offset, count);
+		}
+
+		public override Task<int> ReadAsync(
+			byte[] buffer,
+			int offset,
+			int count,
+			CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			return Task.FromResult(Read(buffer, offset, count));
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				_inner.Dispose();
+			}
+
+			base.Dispose(disposing);
+		}
+	}
+
+	private sealed class UnreadableStream : DisposalObservingStream
+	{
+		public override bool CanRead => false;
+
+		public override bool CanSeek => false;
+
+		public override long Length => throw new NotSupportedException();
+
+		public override long Position
+		{
+			get => throw new NotSupportedException();
+			set => throw new NotSupportedException();
+		}
+
+		public override int Read(byte[] buffer, int offset, int count) =>
+			throw new NotSupportedException();
+	}
+
+	private class ChunkedNonSeekableStream(byte[] bytes, int maximumChunkSize = int.MaxValue)
+		: DisposalObservingStream
+	{
+		private int _position;
+
+		public int BytesRead { get; private set; }
+
+		public int ReadCalls { get; private set; }
+
+		public override bool CanRead => !IsDisposed;
+
+		public override bool CanSeek => false;
+
+		public override long Length => throw new NotSupportedException();
+
+		public override long Position
+		{
+			get => throw new NotSupportedException();
+			set => throw new NotSupportedException();
+		}
+
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			ReadCalls++;
+			int bytesRead = Math.Min(Math.Min(count, maximumChunkSize), bytes.Length - _position);
+			bytes.AsSpan(_position, bytesRead).CopyTo(buffer.AsSpan(offset, bytesRead));
+			_position += bytesRead;
+			BytesRead += bytesRead;
+			return bytesRead;
+		}
+
+		public override Task<int> ReadAsync(
+			byte[] buffer,
+			int offset,
+			int count,
+			CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			return Task.FromResult(Read(buffer, offset, count));
+		}
+	}
+
+	private sealed class PendingReadStream(byte[] bytes) : ChunkedNonSeekableStream(bytes)
+	{
+		private readonly TaskCompletionSource _readStarted =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private readonly TaskCompletionSource _releaseRead =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public Task ReadStarted => _readStarted.Task;
+
+		public void ReleaseRead() => _releaseRead.TrySetResult();
+
+		public override async Task<int> ReadAsync(
+			byte[] buffer,
+			int offset,
+			int count,
+			CancellationToken cancellationToken)
+		{
+			_readStarted.TrySetResult();
+			await _releaseRead.Task.WaitAsync(cancellationToken);
+			return await base.ReadAsync(buffer, offset, count, cancellationToken);
+		}
+	}
+
+	private sealed class CancellationAwareStream : DisposalObservingStream
+	{
+		private readonly TaskCompletionSource _secondReadStarted =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private readonly TaskCompletionSource _neverCompletes =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public int BytesRead { get; private set; }
+
+		public int ReadCalls { get; private set; }
+
+		public Task SecondReadStarted => _secondReadStarted.Task;
+
+		public override bool CanRead => !IsDisposed;
+
+		public override bool CanSeek => false;
+
+		public override long Length => throw new NotSupportedException();
+
+		public override long Position
+		{
+			get => throw new NotSupportedException();
+			set => throw new NotSupportedException();
+		}
+
+		public override int Read(byte[] buffer, int offset, int count) =>
+			throw new NotSupportedException();
+
+		public override async Task<int> ReadAsync(
+			byte[] buffer,
+			int offset,
+			int count,
+			CancellationToken cancellationToken)
+		{
+			ReadCalls++;
+			if (ReadCalls == 1)
+			{
+				buffer[offset] = 0x42;
+				BytesRead = 1;
+				return 1;
+			}
+
+			_secondReadStarted.TrySetResult();
+			await _neverCompletes.Task.WaitAsync(cancellationToken);
+			return 0;
+		}
+	}
+
+	private sealed class UnknownService
+	{
+	}
+}

--- a/tests/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests/Tests/AzureContentUnderstandingImageClassificationOptionsTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests/Tests/AzureContentUnderstandingImageClassificationOptionsTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding.Tests;
+
+public class AzureContentUnderstandingImageClassificationOptionsTests
+{
+	[Fact]
+	public void AnalyzerId_SetAndGet_RoundTripsValue()
+	{
+		var options = new AzureContentUnderstandingImageClassificationOptions
+		{
+			AnalyzerId = "product-classifier-v1"
+		};
+
+		Assert.Equal("product-classifier-v1", options.AnalyzerId);
+
+		options.AnalyzerId = "wildlife-classifier-v2";
+
+		Assert.Equal("wildlife-classifier-v2", options.AnalyzerId);
+	}
+
+	[Fact]
+	public void AnalyzerId_PropertyHasRequiredPublicWritableStringContract()
+	{
+		Type optionsType = typeof(AzureContentUnderstandingImageClassificationOptions);
+		System.Reflection.PropertyInfo property = Assert.Single(
+			optionsType.GetProperties(
+				System.Reflection.BindingFlags.Public |
+				System.Reflection.BindingFlags.Instance |
+				System.Reflection.BindingFlags.DeclaredOnly));
+
+		Assert.Equal(nameof(AzureContentUnderstandingImageClassificationOptions.AnalyzerId), property.Name);
+		Assert.Equal(typeof(string), property.PropertyType);
+		Assert.True(property.GetMethod?.IsPublic);
+		Assert.True(property.SetMethod?.IsPublic);
+		Assert.NotNull(property.GetCustomAttributes(
+			typeof(System.Runtime.CompilerServices.RequiredMemberAttribute),
+			inherit: false).SingleOrDefault());
+	}
+}

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ChatClientImageClassificationClientTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ChatClientImageClassificationClientTests.cs
@@ -331,34 +331,112 @@ public class ChatClientImageClassificationClientTests
 	[Fact]
 	public async Task ClassifyImageAsync_OptionsMutatedDuringPendingRequest_UsesEntrySnapshot()
 	{
-		var responseSource = new TaskCompletionSource<ChatResponse>(
-			TaskCreationOptions.RunContinuationsAsynchronously);
-		var chatClient = new RecordingChatClient
-		{
-			ResponseTask = responseSource.Task
-		};
+		var chatClient = new RecordingChatClient(
+			CreateResponse("""{"labels":["dog","cat","bird"]}"""));
 		using var client = new ChatClientImageClassificationClient(
 			chatClient,
 			["cat", "dog", "bird"]);
 		var options = new ImageClassificationOptions
 		{
+			MaximumInputBytes = 3,
 			MaximumPredictions = 1,
 			MinimumConfidence = null
 		};
-		using var imageStream = new MemoryStream([1, 2, 3]);
+		using var imageStream = new PendingReadStream([1, 2, 3]);
 
 		Task<ImageClassificationResult> classificationTask =
 			client.ClassifyImageAsync(imageStream, "image/png", options);
-		Assert.Equal(1, chatClient.CallCount);
+		await imageStream.ReadStarted;
+		Assert.Equal(0, chatClient.CallCount);
 
+		options.MaximumInputBytes = 1;
 		options.MaximumPredictions = 3;
 		options.MinimumConfidence = 0.5f;
-		responseSource.SetResult(CreateResponse("""{"labels":["dog","cat","bird"]}"""));
+		imageStream.ReleaseRead();
 
 		ImageClassificationResult result = await classificationTask;
 
 		Assert.Equal("dog", Assert.Single(result.Predictions).Label);
 		Assert.Null(result.Predictions[0].Confidence);
+		Assert.Equal(3, imageStream.BytesRead);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ExactMaximumInputBytes_Succeeds()
+	{
+		byte[] imageBytes = [1, 2, 3];
+		var chatClient = new RecordingChatClient(CreateResponse("""{"labels":["cat"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var imageStream = new MemoryStream(imageBytes);
+		var options = new ImageClassificationOptions { MaximumInputBytes = imageBytes.Length };
+
+		ImageClassificationResult result =
+			await client.ClassifyImageAsync(imageStream, "image/png", options);
+
+		DataContent image = Assert.IsType<DataContent>(
+			Assert.Single(chatClient.Messages).Contents[1]);
+		Assert.Equal(imageBytes, image.Data.ToArray());
+		Assert.Equal("cat", Assert.Single(result.Predictions).Label);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_SeekableInputExceedsMaximum_RejectsBeforeReading()
+	{
+		var chatClient = new RecordingChatClient();
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var imageStream = new MemoryStream([1, 2, 3, 4]);
+		var options = new ImageClassificationOptions { MaximumInputBytes = 3 };
+
+		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(imageStream, "image/png", options));
+
+		Assert.Equal("imageStream", exception.ParamName);
+		Assert.Contains("configured maximum of 3 bytes", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("MaximumInputBytes", exception.Message, StringComparison.Ordinal);
+		Assert.Equal(0, imageStream.Position);
+		Assert.Equal(0, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_NonSeekableInputExceedsMaximum_ReadsAtMostLimitPlusOne()
+	{
+		var chatClient = new RecordingChatClient();
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var imageStream = new NonSeekableReadStream([1, 2, 3, 4, 5]);
+		var options = new ImageClassificationOptions { MaximumInputBytes = 3 };
+
+		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(imageStream, "image/png", options));
+
+		Assert.Equal("imageStream", exception.ParamName);
+		Assert.Equal(4, imageStream.BytesRead);
+		Assert.False(imageStream.IsDisposed);
+		Assert.Equal(0, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_CancellationDuringChunkedRead_StopsWithoutCallingClient()
+	{
+		var chatClient = new RecordingChatClient();
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var imageStream = new CancellableChunkedStream();
+		using var cancellationSource = new CancellationTokenSource();
+
+		Task<ImageClassificationResult> classificationTask = client.ClassifyImageAsync(
+			imageStream,
+			"image/png",
+			new ImageClassificationOptions { MaximumInputBytes = 10 },
+			cancellationSource.Token);
+		await imageStream.FirstReadCompleted;
+
+		cancellationSource.Cancel();
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => classificationTask);
+		Assert.Equal(1, imageStream.BytesRead);
+		Assert.False(imageStream.IsDisposed);
+		Assert.Equal(0, chatClient.CallCount);
 	}
 
 	[Fact]
@@ -701,5 +779,116 @@ public class ChatClientImageClassificationClientTests
 
 		public override void Write(byte[] buffer, int offset, int count) =>
 			throw new NotSupportedException();
+	}
+
+	private class NonSeekableReadStream(byte[] bytes) : Stream
+	{
+		private int _position;
+
+		public int BytesRead { get; private set; }
+
+		public bool IsDisposed { get; private set; }
+
+		public override bool CanRead => !IsDisposed;
+
+		public override bool CanSeek => false;
+
+		public override bool CanWrite => false;
+
+		public override long Length => throw new NotSupportedException();
+
+		public override long Position
+		{
+			get => throw new NotSupportedException();
+			set => throw new NotSupportedException();
+		}
+
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			int bytesRead = Math.Min(count, bytes.Length - _position);
+			bytes.AsSpan(_position, bytesRead).CopyTo(buffer.AsSpan(offset, bytesRead));
+			_position += bytesRead;
+			BytesRead += bytesRead;
+			return bytesRead;
+		}
+
+		public override Task<int> ReadAsync(
+			byte[] buffer,
+			int offset,
+			int count,
+			CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			return Task.FromResult(Read(buffer, offset, count));
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			IsDisposed = true;
+			base.Dispose(disposing);
+		}
+
+		public override void Flush() => throw new NotSupportedException();
+
+		public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+		public override void SetLength(long value) => throw new NotSupportedException();
+
+		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+	}
+
+	private sealed class CancellableChunkedStream : NonSeekableReadStream
+	{
+		private int _readCount;
+
+		public CancellableChunkedStream()
+			: base([1])
+		{
+		}
+
+		public Task FirstReadCompleted => _firstReadCompleted.Task;
+
+		private readonly TaskCompletionSource _firstReadCompleted =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public override async Task<int> ReadAsync(
+			byte[] buffer,
+			int offset,
+			int count,
+			CancellationToken cancellationToken)
+		{
+			if (_readCount++ == 0)
+			{
+				int bytesRead = await base.ReadAsync(buffer, offset, Math.Min(count, 1), cancellationToken);
+				_firstReadCompleted.SetResult();
+				return bytesRead;
+			}
+
+			await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+			return 0;
+		}
+	}
+
+	private sealed class PendingReadStream(byte[] bytes) : NonSeekableReadStream(bytes)
+	{
+		private readonly TaskCompletionSource _readStarted =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private readonly TaskCompletionSource _releaseRead =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public Task ReadStarted => _readStarted.Task;
+
+		public void ReleaseRead() => _releaseRead.TrySetResult();
+
+		public override async Task<int> ReadAsync(
+			byte[] buffer,
+			int offset,
+			int count,
+			CancellationToken cancellationToken)
+		{
+			_readStarted.TrySetResult();
+			await _releaseRead.Task.WaitAsync(cancellationToken);
+			return await base.ReadAsync(buffer, offset, count, cancellationToken);
+		}
 	}
 }

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ChatClientImageClassificationClientTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ChatClientImageClassificationClientTests.cs
@@ -92,7 +92,7 @@ public class ChatClientImageClassificationClientTests
 		TextContent prompt = Assert.IsType<TextContent>(
 			Assert.Single(chatClient.Messages).Contents[0]);
 		Assert.Equal(
-			"Classify the attached image. Return labels in descending relevance order. Use each label at most once and use only labels from this allowlist: [\"cat\",\"dog\"]",
+			"Classify the attached image. Return only a JSON object exactly matching {\"labels\":[...]}, with labels in descending relevance order. Use each label at most once and use only labels from this allowlist: [\"cat\",\"dog\"]",
 			prompt.Text);
 		Assert.DoesNotContain("fox", prompt.Text, StringComparison.Ordinal);
 	}
@@ -141,7 +141,7 @@ public class ChatClientImageClassificationClientTests
 			{
 				TextContent text = Assert.IsType<TextContent>(content);
 				Assert.Equal(
-					"Classify the attached image. Return labels in descending relevance order. Use each label at most once and use only labels from this allowlist: [\"cat\",\"dog\"]",
+					"Classify the attached image. Return only a JSON object exactly matching {\"labels\":[...]}, with labels in descending relevance order. Use each label at most once and use only labels from this allowlist: [\"cat\",\"dog\"]",
 					text.Text);
 			},
 			content =>
@@ -172,16 +172,32 @@ public class ChatClientImageClassificationClientTests
 	}
 
 	[Fact]
-	public async Task ClassifyImageAsync_MalformedJson_IsRejected()
+	public async Task ClassifyImageAsync_IgnoredResponseFormatTopLevelArray_PreservesRanking()
 	{
-		var chatClient = new RecordingChatClient(CreateResponse("{not-json"));
+		var chatClient = new RecordingChatClient(CreateResponse("""["dog","cat"]"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat", "dog"]);
+
+		ImageClassificationResult result = await ClassifyAsync(client);
+
+		Assert.Equal(["dog", "cat"], result.Predictions.Select(prediction => prediction.Label));
+		Assert.All(result.Predictions, prediction => Assert.Null(prediction.Confidence));
+		Assert.IsType<ChatResponseFormatJson>(Assert.IsType<ChatOptions>(chatClient.Options).ResponseFormat);
+	}
+
+	[Theory]
+	[InlineData("{not-json")]
+	[InlineData("The labels are [\"cat\"].")]
+	[InlineData("```json\n{\"labels\":[\"cat\"]}\n```")]
+	public async Task ClassifyImageAsync_MalformedProseOrFencedJson_IsRejected(string responseText)
+	{
+		var chatClient = new RecordingChatClient(CreateResponse(responseText));
 		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
 
 		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
 			() => ClassifyAsync(client));
 
 		Assert.Equal("The chat client returned a malformed image classification response.", exception.Message);
-		Assert.IsType<JsonException>(exception.InnerException);
+		Assert.IsAssignableFrom<JsonException>(exception.InnerException);
 		Assert.Equal(1, chatClient.CallCount);
 	}
 
@@ -215,9 +231,26 @@ public class ChatClientImageClassificationClientTests
 	}
 
 	[Fact]
-	public async Task ClassifyImageAsync_UnknownLabel_IsRejected()
+	public async Task ClassifyImageAsync_DuplicateLabelsProperty_IsRejected()
 	{
-		var chatClient = new RecordingChatClient(CreateResponse("""{"labels":["lynx"]}"""));
+		var chatClient = new RecordingChatClient(
+			CreateResponse("""{"labels":["lynx"],"labels":["cat"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => ClassifyAsync(client));
+
+		Assert.Equal("The chat client returned a malformed image classification response.", exception.Message);
+		Assert.IsType<JsonException>(exception.InnerException);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Theory]
+	[InlineData("""{"labels":["lynx"]}""")]
+	[InlineData("""["lynx"]""")]
+	public async Task ClassifyImageAsync_UnknownLabel_IsRejected(string responseText)
+	{
+		var chatClient = new RecordingChatClient(CreateResponse(responseText));
 		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
 
 		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -293,6 +326,39 @@ public class ChatClientImageClassificationClientTests
 		Assert.Equal(["dog", "cat"], result.Predictions.Select(prediction => prediction.Label));
 		Assert.All(result.Predictions, prediction => Assert.Null(prediction.Confidence));
 		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_OptionsMutatedDuringPendingRequest_UsesEntrySnapshot()
+	{
+		var responseSource = new TaskCompletionSource<ChatResponse>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		var chatClient = new RecordingChatClient
+		{
+			ResponseTask = responseSource.Task
+		};
+		using var client = new ChatClientImageClassificationClient(
+			chatClient,
+			["cat", "dog", "bird"]);
+		var options = new ImageClassificationOptions
+		{
+			MaximumPredictions = 1,
+			MinimumConfidence = null
+		};
+		using var imageStream = new MemoryStream([1, 2, 3]);
+
+		Task<ImageClassificationResult> classificationTask =
+			client.ClassifyImageAsync(imageStream, "image/png", options);
+		Assert.Equal(1, chatClient.CallCount);
+
+		options.MaximumPredictions = 3;
+		options.MinimumConfidence = 0.5f;
+		responseSource.SetResult(CreateResponse("""{"labels":["dog","cat","bird"]}"""));
+
+		ImageClassificationResult result = await classificationTask;
+
+		Assert.Equal("dog", Assert.Single(result.Predictions).Label);
+		Assert.Null(result.Predictions[0].Confidence);
 	}
 
 	[Fact]
@@ -549,6 +615,8 @@ public class ChatClientImageClassificationClientTests
 
 		public ChatResponse Response { get; set; }
 
+		public Task<ChatResponse>? ResponseTask { get; init; }
+
 		public ChatClientMetadata? Metadata { get; }
 
 		public int CallCount { get; private set; }
@@ -579,7 +647,7 @@ public class ChatClientImageClassificationClientTests
 			Messages = messages.ToArray();
 			Options = options;
 			CancellationToken = cancellationToken;
-			return Task.FromResult(Response);
+			return ResponseTask ?? Task.FromResult(Response);
 		}
 
 		public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ChatClientImageClassificationClientTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ChatClientImageClassificationClientTests.cs
@@ -1,0 +1,637 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Maui.Essentials.AI;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.AI.UnitTests;
+
+public class ChatClientImageClassificationClientTests
+{
+	[Fact]
+	public void Constructor_HasExpectedPublicShape()
+	{
+		var constructor = Assert.Single(typeof(ChatClientImageClassificationClient).GetConstructors());
+
+		Assert.Collection(
+			constructor.GetParameters(),
+			parameter =>
+			{
+				Assert.Equal("chatClient", parameter.Name);
+				Assert.Equal(typeof(IChatClient), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("labels", parameter.Name);
+				Assert.Equal(typeof(IEnumerable<string>), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("metadata", parameter.Name);
+				Assert.Equal(typeof(ImageClassificationClientMetadata), parameter.ParameterType);
+				Assert.True(parameter.IsOptional);
+				Assert.Null(parameter.DefaultValue);
+			});
+	}
+
+	[Fact]
+	public void Constructor_NullOrEmptyInputs_ThrowDocumentedExceptions()
+	{
+		var chatClient = new RecordingChatClient();
+
+		ArgumentNullException nullClient = Assert.Throws<ArgumentNullException>(
+			() => new ChatClientImageClassificationClient(null!, ["cat"]));
+		ArgumentNullException nullLabels = Assert.Throws<ArgumentNullException>(
+			() => new ChatClientImageClassificationClient(chatClient, null!));
+		ArgumentException emptyLabels = Assert.Throws<ArgumentException>(
+			() => new ChatClientImageClassificationClient(chatClient, []));
+
+		Assert.Equal("chatClient", nullClient.ParamName);
+		Assert.Equal("labels", nullLabels.ParamName);
+		Assert.Equal("labels", emptyLabels.ParamName);
+	}
+
+	[Fact]
+	public void Constructor_NullEmptyWhitespaceOrDuplicateLabel_Throws()
+	{
+		var chatClient = new RecordingChatClient();
+		IEnumerable<string>[] invalidAllowlists =
+		[
+			new string[] { null! },
+			[""],
+			[" \t"],
+			["cat", "cat"]
+		];
+
+		foreach (IEnumerable<string> labels in invalidAllowlists)
+		{
+			ArgumentException exception = Assert.Throws<ArgumentException>(
+				() => new ChatClientImageClassificationClient(chatClient, labels));
+
+			Assert.Equal("labels", exception.ParamName);
+		}
+	}
+
+	[Fact]
+	public async Task Constructor_SnapshotsLabelAllowlist()
+	{
+		var labels = new List<string> { "cat", "dog" };
+		var chatClient = new RecordingChatClient(CreateResponse("""{"labels":["cat"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, labels);
+		labels.Clear();
+		labels.Add("fox");
+
+		ImageClassificationResult result = await ClassifyAsync(client);
+
+		Assert.Equal("cat", Assert.Single(result.Predictions).Label);
+		TextContent prompt = Assert.IsType<TextContent>(
+			Assert.Single(chatClient.Messages).Contents[0]);
+		Assert.Equal(
+			"Classify the attached image. Return labels in descending relevance order. Use each label at most once and use only labels from this allowlist: [\"cat\",\"dog\"]",
+			prompt.Text);
+		Assert.DoesNotContain("fox", prompt.Text, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void Constructor_DefaultMetadata_CopiesChatClientMetadata()
+	{
+		var providerUri = new Uri("https://provider.example.test");
+		var chatMetadata = new ChatClientMetadata("provider", providerUri, "default-model");
+		var chatClient = new RecordingChatClient(metadata: chatMetadata);
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		ImageClassificationClientMetadata metadata =
+			Assert.IsType<ImageClassificationClientMetadata>(
+				client.GetService(typeof(ImageClassificationClientMetadata)));
+
+		Assert.Equal("provider", metadata.ProviderName);
+		Assert.Equal(providerUri, metadata.ProviderUri);
+		Assert.Equal("default-model", metadata.DefaultModelId);
+		Assert.Collection(
+			chatClient.ServiceRequests,
+			request =>
+			{
+				Assert.Equal(typeof(ChatClientMetadata), request.ServiceType);
+				Assert.Null(request.ServiceKey);
+			});
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ValidRequest_UsesStrictJsonSchemaAndExactImageContent()
+	{
+		byte[] imageBytes = [0x89, 0x50, 0x4E, 0x47];
+		var chatClient = new RecordingChatClient(CreateResponse("""{"labels":["cat"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat", "dog"]);
+		using var imageStream = new MemoryStream(imageBytes);
+
+		ImageClassificationResult result =
+			await client.ClassifyImageAsync(imageStream, "image/png");
+
+		Assert.Equal(1, chatClient.CallCount);
+		ChatMessage message = Assert.Single(chatClient.Messages);
+		Assert.Equal(ChatRole.User, message.Role);
+		Assert.Collection(
+			message.Contents,
+			content =>
+			{
+				TextContent text = Assert.IsType<TextContent>(content);
+				Assert.Equal(
+					"Classify the attached image. Return labels in descending relevance order. Use each label at most once and use only labels from this allowlist: [\"cat\",\"dog\"]",
+					text.Text);
+			},
+			content =>
+			{
+				DataContent image = Assert.IsType<DataContent>(content);
+				Assert.Equal(imageBytes, image.Data.ToArray());
+				Assert.Equal("image/png", image.MediaType);
+			});
+
+		ChatResponseFormatJson responseFormat = Assert.IsType<ChatResponseFormatJson>(
+			Assert.IsType<ChatOptions>(chatClient.Options).ResponseFormat);
+		Assert.True(responseFormat.Schema.HasValue);
+		JsonElement schema = responseFormat.Schema.GetValueOrDefault();
+		Assert.Equal("object", schema.GetProperty("type").GetString());
+		Assert.Collection(
+			schema.GetProperty("properties").EnumerateObject(),
+			property =>
+			{
+				Assert.Equal("labels", property.Name);
+				Assert.Equal("array", property.Value.GetProperty("type").GetString());
+				Assert.Equal("string", property.Value.GetProperty("items").GetProperty("type").GetString());
+			});
+		Assert.Equal(
+			["labels"],
+			schema.GetProperty("required").EnumerateArray().Select(item => item.GetString()));
+		Assert.False(schema.GetProperty("additionalProperties").GetBoolean());
+		Assert.Equal("cat", Assert.Single(result.Predictions).Label);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_MalformedJson_IsRejected()
+	{
+		var chatClient = new RecordingChatClient(CreateResponse("{not-json"));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => ClassifyAsync(client));
+
+		Assert.Equal("The chat client returned a malformed image classification response.", exception.Message);
+		Assert.IsType<JsonException>(exception.InnerException);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_MissingLabels_IsRejected()
+	{
+		var chatClient = new RecordingChatClient(CreateResponse("{}"));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => ClassifyAsync(client));
+
+		Assert.Equal("The chat client returned a malformed image classification response.", exception.Message);
+		Assert.IsType<JsonException>(exception.InnerException);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ExtraTopLevelProperty_IsRejected()
+	{
+		var chatClient = new RecordingChatClient(
+			CreateResponse("""{"labels":["cat"],"extra":true}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => ClassifyAsync(client));
+
+		Assert.Equal("The chat client returned a malformed image classification response.", exception.Message);
+		Assert.IsType<JsonException>(exception.InnerException);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_UnknownLabel_IsRejected()
+	{
+		var chatClient = new RecordingChatClient(CreateResponse("""{"labels":["lynx"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => ClassifyAsync(client));
+
+		Assert.Equal(
+			"The chat client returned a label outside the allowlist or returned a duplicate label.",
+			exception.Message);
+		Assert.Null(exception.InnerException);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_DuplicateLabel_IsRejected()
+	{
+		var chatClient = new RecordingChatClient(
+			CreateResponse("""{"labels":["cat","cat"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => ClassifyAsync(client));
+
+		Assert.Equal(
+			"The chat client returned a label outside the allowlist or returned a duplicate label.",
+			exception.Message);
+		Assert.Null(exception.InnerException);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_LabelsMapInProviderOrderWithNullConfidence()
+	{
+		var chatClient = new RecordingChatClient(
+			CreateResponse("""{"labels":["dog","cat","bird"]}"""));
+		using var client = new ChatClientImageClassificationClient(
+			chatClient,
+			["cat", "dog", "bird"]);
+
+		ImageClassificationResult result = await ClassifyAsync(client);
+
+		Assert.Collection(
+			result.Predictions,
+			prediction =>
+			{
+				Assert.Equal("dog", prediction.Label);
+				Assert.Null(prediction.Confidence);
+			},
+			prediction =>
+			{
+				Assert.Equal("cat", prediction.Label);
+				Assert.Null(prediction.Confidence);
+			},
+			prediction =>
+			{
+				Assert.Equal("bird", prediction.Label);
+				Assert.Null(prediction.Confidence);
+			});
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_MaximumPredictions_TruncatesWithoutReordering()
+	{
+		var chatClient = new RecordingChatClient(
+			CreateResponse("""{"labels":["dog","cat","bird"]}"""));
+		using var client = new ChatClientImageClassificationClient(
+			chatClient,
+			["cat", "dog", "bird"]);
+		var options = new ImageClassificationOptions { MaximumPredictions = 2 };
+
+		ImageClassificationResult result = await ClassifyAsync(client, options);
+
+		Assert.Equal(["dog", "cat"], result.Predictions.Select(prediction => prediction.Label));
+		Assert.All(result.Predictions, prediction => Assert.Null(prediction.Confidence));
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_NonNullMinimumConfidence_ThrowsBeforeInnerCall()
+	{
+		var chatClient = new RecordingChatClient(CreateResponse("""{"labels":["cat"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var imageStream = new MemoryStream([1, 2, 3]);
+		var options = new ImageClassificationOptions { MinimumConfidence = 0f };
+
+		NotSupportedException exception = await Assert.ThrowsAsync<NotSupportedException>(
+			() => client.ClassifyImageAsync(imageStream, "image/png", options));
+
+		Assert.Equal(
+			"ChatClientImageClassificationClient does not produce confidence values.",
+			exception.Message);
+		Assert.Equal(0, chatClient.CallCount);
+		Assert.Equal(0, imageStream.Position);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ResultCopiesExactProviderResponseData()
+	{
+		var additionalProperties = new AdditionalPropertiesDictionary
+		{
+			["requestId"] = "request-42"
+		};
+		ChatResponse response = CreateResponse(
+			"""{"labels":["cat"]}""",
+			modelId: "provider-model",
+			additionalProperties: additionalProperties);
+		var chatClient = new RecordingChatClient(response);
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		ImageClassificationResult result = await ClassifyAsync(client);
+
+		AdditionalPropertiesDictionary actualProperties =
+			Assert.IsType<AdditionalPropertiesDictionary>(result.AdditionalProperties);
+		Assert.Same(response, result.RawRepresentation);
+		Assert.Equal("provider-model", result.ModelId);
+		Assert.Same(additionalProperties, actualProperties);
+		Assert.Equal("request-42", actualProperties["requestId"]);
+		Assert.Equal("cat", Assert.Single(result.Predictions).Label);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_ForwardsExactCancellationToken()
+	{
+		var chatClient = new RecordingChatClient(CreateResponse("""{"labels":["cat"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var cancellationSource = new CancellationTokenSource();
+
+		ImageClassificationResult result = await ClassifyAsync(
+			client,
+			cancellationToken: cancellationSource.Token);
+
+		Assert.Equal(cancellationSource.Token, chatClient.CancellationToken);
+		Assert.Equal(1, chatClient.CallCount);
+		Assert.Equal("cat", Assert.Single(result.Predictions).Label);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_NullUnreadableOrEmptyStream_RejectsBeforeInnerCall()
+	{
+		var chatClient = new RecordingChatClient();
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var unreadableStream = new UnreadableStream();
+		using var emptyStream = new MemoryStream();
+
+		ArgumentNullException nullException = await Assert.ThrowsAsync<ArgumentNullException>(
+			() => client.ClassifyImageAsync(null!, "image/png"));
+		ArgumentException unreadableException = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(unreadableStream, "image/png"));
+		ArgumentException emptyException = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(emptyStream, "image/png"));
+
+		Assert.Equal("imageStream", nullException.ParamName);
+		Assert.Equal("imageStream", unreadableException.ParamName);
+		Assert.Equal("imageStream", emptyException.ParamName);
+		Assert.Equal(0, chatClient.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_NullMalformedOrNonImageMediaType_RejectsBeforeInnerCall()
+	{
+		var chatClient = new RecordingChatClient();
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var nullMediaStream = new MemoryStream([1]);
+		using var malformedMediaStream = new MemoryStream([1]);
+		using var nonImageMediaStream = new MemoryStream([1]);
+
+		ArgumentNullException nullException = await Assert.ThrowsAsync<ArgumentNullException>(
+			() => client.ClassifyImageAsync(nullMediaStream, null!));
+		ArgumentException malformedException = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(malformedMediaStream, "not a media type"));
+		ArgumentException nonImageException = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(nonImageMediaStream, "text/plain"));
+
+		Assert.Equal("imageMediaType", nullException.ParamName);
+		Assert.Equal("mediaType", malformedException.ParamName);
+		Assert.Equal("imageMediaType", nonImageException.ParamName);
+		Assert.Equal(0, chatClient.CallCount);
+		Assert.Equal(0, malformedMediaStream.Position);
+		Assert.Equal(0, nonImageMediaStream.Position);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_DirectCallerStreamRemainsOpen()
+	{
+		var chatClient = new RecordingChatClient(CreateResponse("""{"labels":["cat"]}"""));
+		using var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+		using var imageStream = new MemoryStream([1, 2, 3]);
+
+		ImageClassificationResult result =
+			await client.ClassifyImageAsync(imageStream, "image/webp");
+
+		Assert.True(imageStream.CanRead);
+		Assert.Equal(3, imageStream.Position);
+		imageStream.Position = 0;
+		Assert.Equal(1, imageStream.ReadByte());
+		Assert.Equal("cat", Assert.Single(result.Predictions).Label);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	[Fact]
+	public void GetService_TypedAndUntypedExposeAdapterSuppliedMetadataAndInnerClient()
+	{
+		var metadata = new ImageClassificationClientMetadata(
+			"provider",
+			new Uri("https://provider.example.test"),
+			"model");
+		var chatClient = new RecordingChatClient();
+		using var client = new ChatClientImageClassificationClient(
+			chatClient,
+			["cat"],
+			metadata);
+
+		Assert.Same(client, client.GetService<ChatClientImageClassificationClient>());
+		Assert.Same(client, client.GetService<IImageClassificationClient>());
+		Assert.Same(client, client.GetService(typeof(ChatClientImageClassificationClient)));
+		Assert.Same(client, client.GetService(typeof(IImageClassificationClient)));
+		Assert.Same(metadata, client.GetService<ImageClassificationClientMetadata>());
+		Assert.Same(metadata, client.GetService(typeof(ImageClassificationClientMetadata)));
+		Assert.Same(chatClient, client.GetService<IChatClient>());
+		Assert.Same(chatClient, client.GetService(typeof(IChatClient)));
+		Assert.Same(chatClient, client.GetService(typeof(RecordingChatClient)));
+		Assert.Empty(chatClient.ServiceRequests);
+	}
+
+	[Fact]
+	public void GetService_UnknownAndKeyedRequestsDelegateExactlyToInnerClient()
+	{
+		var unknownService = new DelegatedService();
+		var keyedMetadata = new ImageClassificationClientMetadata("keyed-provider");
+		var serviceKey = new object();
+		var chatClient = new RecordingChatClient
+		{
+			ServiceFactory = (serviceType, key) =>
+				serviceType == typeof(DelegatedService) && key is null
+					? unknownService
+					: serviceType == typeof(ImageClassificationClientMetadata) &&
+						ReferenceEquals(key, serviceKey)
+						? keyedMetadata
+						: null
+		};
+		using var client = new ChatClientImageClassificationClient(
+			chatClient,
+			["cat"],
+			new ImageClassificationClientMetadata("supplied-provider"));
+
+		DelegatedService? actualUnknown = client.GetService<DelegatedService>();
+		object? actualUnknownUntyped = client.GetService(typeof(DelegatedService));
+		ImageClassificationClientMetadata? actualKeyedTyped =
+			client.GetService<ImageClassificationClientMetadata>(serviceKey);
+		object? actualKeyed = client.GetService(
+			typeof(ImageClassificationClientMetadata),
+			serviceKey);
+
+		Assert.Same(unknownService, actualUnknown);
+		Assert.Same(unknownService, actualUnknownUntyped);
+		Assert.Same(keyedMetadata, actualKeyedTyped);
+		Assert.Same(keyedMetadata, actualKeyed);
+		Assert.Collection(
+			chatClient.ServiceRequests,
+			request =>
+			{
+				Assert.Equal(typeof(DelegatedService), request.ServiceType);
+				Assert.Null(request.ServiceKey);
+			},
+			request =>
+			{
+				Assert.Equal(typeof(DelegatedService), request.ServiceType);
+				Assert.Null(request.ServiceKey);
+			},
+			request =>
+			{
+				Assert.Equal(typeof(ImageClassificationClientMetadata), request.ServiceType);
+				Assert.Same(serviceKey, request.ServiceKey);
+			},
+			request =>
+			{
+				Assert.Equal(typeof(ImageClassificationClientMetadata), request.ServiceType);
+				Assert.Same(serviceKey, request.ServiceKey);
+			});
+	}
+
+	[Fact]
+	public async Task Dispose_DoesNotDisposeInnerClientAndInnerRemainsCallable()
+	{
+		ChatResponse response = CreateResponse("""{"labels":["cat"]}""");
+		var chatClient = new RecordingChatClient(response);
+		var client = new ChatClientImageClassificationClient(chatClient, ["cat"]);
+
+		client.Dispose();
+		ChatResponse actualResponse = await chatClient.GetResponseAsync([]);
+
+		Assert.False(chatClient.IsDisposed);
+		Assert.Same(response, actualResponse);
+		Assert.Equal(1, chatClient.CallCount);
+	}
+
+	private static async Task<ImageClassificationResult> ClassifyAsync(
+		ChatClientImageClassificationClient client,
+		ImageClassificationOptions? options = null,
+		CancellationToken cancellationToken = default)
+	{
+		using var imageStream = new MemoryStream([1, 2, 3]);
+		return await client.ClassifyImageAsync(
+			imageStream,
+			"image/png",
+			options,
+			cancellationToken);
+	}
+
+	private static ChatResponse CreateResponse(
+		string json,
+		string? modelId = null,
+		AdditionalPropertiesDictionary? additionalProperties = null) =>
+		new(new ChatMessage(ChatRole.Assistant, json))
+		{
+			ModelId = modelId,
+			AdditionalProperties = additionalProperties
+		};
+
+	private sealed class RecordingChatClient : IChatClient
+	{
+		public RecordingChatClient(
+			ChatResponse? response = null,
+			ChatClientMetadata? metadata = null)
+		{
+			Response = response ?? CreateResponse("""{"labels":[]}""");
+			Metadata = metadata;
+		}
+
+		public ChatResponse Response { get; set; }
+
+		public ChatClientMetadata? Metadata { get; }
+
+		public int CallCount { get; private set; }
+
+		public IReadOnlyList<ChatMessage> Messages { get; private set; } = [];
+
+		public ChatOptions? Options { get; private set; }
+
+		public CancellationToken CancellationToken { get; private set; }
+
+		public bool IsDisposed { get; private set; }
+
+		public Func<Type, object?, object?>? ServiceFactory { get; init; }
+
+		public List<(Type ServiceType, object? ServiceKey)> ServiceRequests { get; } = [];
+
+		public Task<ChatResponse> GetResponseAsync(
+			IEnumerable<ChatMessage> messages,
+			ChatOptions? options = null,
+			CancellationToken cancellationToken = default)
+		{
+			if (IsDisposed)
+			{
+				throw new ObjectDisposedException(nameof(RecordingChatClient));
+			}
+
+			CallCount++;
+			Messages = messages.ToArray();
+			Options = options;
+			CancellationToken = cancellationToken;
+			return Task.FromResult(Response);
+		}
+
+		public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+			IEnumerable<ChatMessage> messages,
+			ChatOptions? options = null,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			await Task.CompletedTask;
+			yield break;
+		}
+
+		public object? GetService(Type serviceType, object? serviceKey = null)
+		{
+			ServiceRequests.Add((serviceType, serviceKey));
+			return ServiceFactory?.Invoke(serviceType, serviceKey) ??
+				(serviceKey is null && serviceType == typeof(ChatClientMetadata) ? Metadata : null);
+		}
+
+		public void Dispose() => IsDisposed = true;
+	}
+
+	private sealed class DelegatedService
+	{
+	}
+
+	private sealed class UnreadableStream : Stream
+	{
+		public override bool CanRead => false;
+
+		public override bool CanSeek => false;
+
+		public override bool CanWrite => false;
+
+		public override long Length => throw new NotSupportedException();
+
+		public override long Position
+		{
+			get => throw new NotSupportedException();
+			set => throw new NotSupportedException();
+		}
+
+		public override void Flush() => throw new NotSupportedException();
+
+		public override int Read(byte[] buffer, int offset, int count) =>
+			throw new NotSupportedException();
+
+		public override long Seek(long offset, SeekOrigin origin) =>
+			throw new NotSupportedException();
+
+		public override void SetLength(long value) => throw new NotSupportedException();
+
+		public override void Write(byte[] buffer, int offset, int count) =>
+			throw new NotSupportedException();
+	}
+}

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
@@ -1,0 +1,231 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.AI.UnitTests;
+
+public class ImageClassificationContractTests
+{
+	[Fact]
+	public async Task ClassifyAsync_DataContent_ForwardsSnapshotMediaTypeOptionsAndCancellation()
+	{
+		byte[] imageBytes = [1, 2, 3, 4];
+		var image = new DataContent(imageBytes, "image/png");
+		var options = new ImageClassificationOptions
+		{
+			MaximumPredictions = 2,
+			MinimumConfidence = 0.25f
+		};
+		using var cancellationSource = new CancellationTokenSource();
+		var client = new RecordingClient();
+
+		ImageClassificationResult result = await client.ClassifyAsync(
+			image,
+			options,
+			cancellationSource.Token);
+
+		imageBytes[0] = 99;
+
+		Assert.Same(client.Result, result);
+		Assert.Equal([1, 2, 3, 4], client.ImageBytes);
+		Assert.Equal("image/png", client.MediaType);
+		Assert.Same(options, client.Options);
+		Assert.Equal(cancellationSource.Token, client.CancellationToken);
+		Assert.NotNull(client.InputStream);
+		Assert.False(client.InputStream.CanRead);
+	}
+
+	[Theory]
+	[InlineData("application/octet-stream")]
+	[InlineData("text/plain")]
+	public async Task ClassifyAsync_NonImageData_ThrowsBeforeInvokingClient(string mediaType)
+	{
+		var client = new RecordingClient();
+		var image = new DataContent(new byte[] { 1 }, mediaType);
+
+		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyAsync(image));
+
+		Assert.Equal("image", exception.ParamName);
+		Assert.Equal(0, client.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyAsync_EmptyData_ThrowsBeforeInvokingClient()
+	{
+		var client = new RecordingClient();
+		var image = new DataContent(ReadOnlyMemory<byte>.Empty, "image/png");
+
+		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyAsync(image));
+
+		Assert.Equal("image", exception.ParamName);
+		Assert.Equal(0, client.CallCount);
+	}
+
+	[Fact]
+	public void Options_InvalidValues_Throw()
+	{
+		var options = new ImageClassificationOptions();
+
+		Assert.Throws<ArgumentOutOfRangeException>(() => options.MaximumPredictions = 0);
+		Assert.Throws<ArgumentOutOfRangeException>(() => options.MaximumPredictions = -1);
+		Assert.Throws<ArgumentOutOfRangeException>(() => options.MinimumConfidence = -0.01f);
+		Assert.Throws<ArgumentOutOfRangeException>(() => options.MinimumConfidence = 1.01f);
+		Assert.Throws<ArgumentOutOfRangeException>(() => options.MinimumConfidence = float.NaN);
+		Assert.Throws<ArgumentOutOfRangeException>(() => options.MinimumConfidence = float.PositiveInfinity);
+	}
+
+	[Fact]
+	public void Options_Clone_CopiesNormalizedConstraints()
+	{
+		var options = new ImageClassificationOptions
+		{
+			MaximumPredictions = 3,
+			MinimumConfidence = 0.5f
+		};
+
+		ImageClassificationOptions clone = options.Clone();
+
+		Assert.NotSame(options, clone);
+		Assert.Equal(3, clone.MaximumPredictions);
+		Assert.Equal(0.5f, clone.MinimumConfidence);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData(" ")]
+	public void Prediction_EmptyLabel_Throws(string label)
+	{
+		Assert.Throws<ArgumentException>(() => new ImageClassificationPrediction(label, 0.5f));
+	}
+
+	[Theory]
+	[InlineData(-0.01f)]
+	[InlineData(1.01f)]
+	[InlineData(float.NaN)]
+	[InlineData(float.PositiveInfinity)]
+	public void Prediction_InvalidConfidence_Throws(float confidence)
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(
+			() => new ImageClassificationPrediction("cat", confidence));
+	}
+
+	[Fact]
+	public void Result_SnapshotsAndOrdersPredictions_WithProvenance()
+	{
+		var predictions = new List<ImageClassificationPrediction>
+		{
+			new("cat", 0.25f),
+			new("dog", 0.9f)
+		};
+
+		var result = new ImageClassificationResult(predictions)
+		{
+			ProviderName = "fixture",
+			ModelId = "animals-v1"
+		};
+		predictions.Clear();
+
+		Assert.Collection(
+			result.Predictions,
+			prediction =>
+			{
+				Assert.Equal("dog", prediction.Label);
+				Assert.Equal(0.9f, prediction.Confidence);
+			},
+			prediction =>
+			{
+				Assert.Equal("cat", prediction.Label);
+				Assert.Equal(0.25f, prediction.Confidence);
+			});
+		Assert.Equal("fixture", result.ProviderName);
+		Assert.Equal("animals-v1", result.ModelId);
+	}
+
+	[Fact]
+	public void Metadata_ExposesProviderAndDefaultModel()
+	{
+		var providerUri = new Uri("https://example.test");
+		var metadata = new ImageClassificationClientMetadata(
+			providerName: "fixture",
+			providerUri: providerUri,
+			defaultModelId: "animals-v1");
+
+		Assert.Equal("fixture", metadata.ProviderName);
+		Assert.Equal(providerUri, metadata.ProviderUri);
+		Assert.Equal("animals-v1", metadata.DefaultModelId);
+	}
+
+	[Fact]
+	public void GetService_ProvidesTypedEscapeHatch()
+	{
+		var metadata = new ImageClassificationClientMetadata("fixture");
+		using var client = new RecordingClient(metadata);
+
+		Assert.Same(metadata, client.GetService<ImageClassificationClientMetadata>());
+		Assert.Null(client.GetService<string>());
+		Assert.Null(client.GetService<ImageClassificationClientMetadata>("unknown"));
+	}
+
+	private sealed class RecordingClient(ImageClassificationClientMetadata? metadata = null)
+		: IImageClassificationClient
+	{
+		public ImageClassificationResult Result { get; } = new(
+			[new ImageClassificationPrediction("fixture", 1)]);
+
+		public int CallCount { get; private set; }
+
+		public byte[]? ImageBytes { get; private set; }
+
+		public string? MediaType { get; private set; }
+
+		public ImageClassificationOptions? Options { get; private set; }
+
+		public CancellationToken CancellationToken { get; private set; }
+
+		public Stream? InputStream { get; private set; }
+
+		public async Task<ImageClassificationResult> ClassifyAsync(
+			Stream imageStream,
+			string imageMediaType,
+			ImageClassificationOptions? options = null,
+			CancellationToken cancellationToken = default)
+		{
+			CallCount++;
+			InputStream = imageStream;
+			MediaType = imageMediaType;
+			Options = options;
+			CancellationToken = cancellationToken;
+
+			using var copy = new MemoryStream();
+			await imageStream.CopyToAsync(copy, cancellationToken);
+			ImageBytes = copy.ToArray();
+
+			return Result;
+		}
+
+		public object? GetService(Type serviceType, object? serviceKey = null)
+		{
+			ArgumentNullException.ThrowIfNull(serviceType);
+
+			if (serviceKey is not null)
+			{
+				return null;
+			}
+
+			if (serviceType == typeof(ImageClassificationClientMetadata))
+			{
+				return metadata;
+			}
+
+			return serviceType.IsInstanceOfType(this) ? this : null;
+		}
+
+		public void Dispose()
+		{
+		}
+	}
+}

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
@@ -121,10 +121,17 @@ public class ImageClassificationContractTests
 			new("cat", 0.25f),
 			new("dog", 0.9f)
 		};
+		var rawRepresentation = new object();
+		var additionalProperties = new AdditionalPropertiesDictionary
+		{
+			["taxonomy"] = "animals"
+		};
 
 		var result = new ImageClassificationResult(predictions)
 		{
-			ModelId = "animals-v1"
+			ModelId = "animals-v1",
+			RawRepresentation = rawRepresentation,
+			AdditionalProperties = additionalProperties
 		};
 		predictions.Clear();
 
@@ -141,6 +148,8 @@ public class ImageClassificationContractTests
 				Assert.Equal(0.25f, prediction.Confidence);
 			});
 		Assert.Equal("animals-v1", result.ModelId);
+		Assert.Same(rawRepresentation, result.RawRepresentation);
+		Assert.Same(additionalProperties, result.AdditionalProperties);
 	}
 
 	[Fact]

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.AI;
+using Microsoft.Maui.Essentials.AI;
 using Xunit;
 
 namespace Microsoft.Maui.Essentials.AI.UnitTests;
@@ -9,7 +10,7 @@ namespace Microsoft.Maui.Essentials.AI.UnitTests;
 public class ImageClassificationContractTests
 {
 	[Fact]
-	public async Task ClassifyAsync_DataContent_ForwardsSnapshotMediaTypeOptionsAndCancellation()
+	public async Task ClassifyImageAsync_DataContent_ForwardsSnapshotMediaTypeOptionsAndCancellation()
 	{
 		byte[] imageBytes = [1, 2, 3, 4];
 		var image = new DataContent(imageBytes, "image/png");
@@ -21,7 +22,7 @@ public class ImageClassificationContractTests
 		using var cancellationSource = new CancellationTokenSource();
 		var client = new RecordingClient();
 
-		ImageClassificationResult result = await client.ClassifyAsync(
+		ImageClassificationResult result = await client.ClassifyImageAsync(
 			image,
 			options,
 			cancellationSource.Token);
@@ -29,6 +30,7 @@ public class ImageClassificationContractTests
 		imageBytes[0] = 99;
 
 		Assert.Same(client.Result, result);
+		Assert.Equal(1, client.CallCount);
 		Assert.Equal([1, 2, 3, 4], client.ImageBytes);
 		Assert.Equal("image/png", client.MediaType);
 		Assert.Same(options, client.Options);
@@ -38,48 +40,39 @@ public class ImageClassificationContractTests
 	}
 
 	[Theory]
-	[InlineData("application/octet-stream")]
-	[InlineData("text/plain")]
-	public async Task ClassifyAsync_NonImageData_ThrowsBeforeInvokingClient(string mediaType)
+	[InlineData(true, "image/png")]
+	[InlineData(false, "application/octet-stream")]
+	[InlineData(false, "text/plain")]
+	public async Task ClassifyImageAsync_EmptyOrNonImageData_RejectsBeforeClientCall(
+		bool empty,
+		string mediaType)
 	{
 		var client = new RecordingClient();
-		var image = new DataContent(new byte[] { 1 }, mediaType);
+		var image = new DataContent(empty ? ReadOnlyMemory<byte>.Empty : new byte[] { 1 }, mediaType);
 
 		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
-			() => client.ClassifyAsync(image));
+			() => client.ClassifyImageAsync(image));
 
 		Assert.Equal("image", exception.ParamName);
 		Assert.Equal(0, client.CallCount);
 	}
 
-	[Fact]
-	public async Task ClassifyAsync_EmptyData_ThrowsBeforeInvokingClient()
-	{
-		var client = new RecordingClient();
-		var image = new DataContent(ReadOnlyMemory<byte>.Empty, "image/png");
-
-		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
-			() => client.ClassifyAsync(image));
-
-		Assert.Equal("image", exception.ParamName);
-		Assert.Equal(0, client.CallCount);
-	}
-
-	[Fact]
-	public void Options_InvalidValues_Throw()
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Options_MaximumPredictions_RejectsNonPositiveValues(int maximumPredictions)
 	{
 		var options = new ImageClassificationOptions();
 
-		Assert.Throws<ArgumentOutOfRangeException>(() => options.MaximumPredictions = 0);
-		Assert.Throws<ArgumentOutOfRangeException>(() => options.MaximumPredictions = -1);
-		Assert.Throws<ArgumentOutOfRangeException>(() => options.MinimumConfidence = -0.01f);
-		Assert.Throws<ArgumentOutOfRangeException>(() => options.MinimumConfidence = 1.01f);
-		Assert.Throws<ArgumentOutOfRangeException>(() => options.MinimumConfidence = float.NaN);
-		Assert.Throws<ArgumentOutOfRangeException>(() => options.MinimumConfidence = float.PositiveInfinity);
+		ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
+			() => options.MaximumPredictions = maximumPredictions);
+
+		Assert.Equal("value", exception.ParamName);
+		Assert.Equal(maximumPredictions, Assert.IsType<int>(exception.ActualValue));
 	}
 
 	[Fact]
-	public void Options_Clone_CopiesNormalizedConstraints()
+	public void Options_Clone_PreservesValuesAndIndependence()
 	{
 		var options = new ImageClassificationOptions
 		{
@@ -88,33 +81,45 @@ public class ImageClassificationContractTests
 		};
 
 		ImageClassificationOptions clone = options.Clone();
+		options.MaximumPredictions = 5;
+		options.MinimumConfidence = 0.75f;
 
 		Assert.NotSame(options, clone);
 		Assert.Equal(3, clone.MaximumPredictions);
 		Assert.Equal(0.5f, clone.MinimumConfidence);
+		Assert.Equal(5, options.MaximumPredictions);
+		Assert.Equal(0.75f, options.MinimumConfidence);
 	}
 
 	[Theory]
+	[InlineData(null)]
 	[InlineData("")]
 	[InlineData(" ")]
-	public void Prediction_EmptyLabel_Throws(string label)
+	public void Prediction_NullOrEmptyLabel_Throws(string? label)
 	{
-		Assert.Throws<ArgumentException>(() => new ImageClassificationPrediction(label, 0.5f));
+		ArgumentException exception = Assert.ThrowsAny<ArgumentException>(
+			() => new ImageClassificationPrediction(label!, 0.5f));
+
+		Assert.Equal("label", exception.ParamName);
 	}
 
 	[Theory]
 	[InlineData(-0.01f)]
 	[InlineData(1.01f)]
-	[InlineData(float.NaN)]
+	[InlineData(float.NegativeInfinity)]
 	[InlineData(float.PositiveInfinity)]
-	public void Prediction_InvalidConfidence_Throws(float confidence)
+	[InlineData(float.NaN)]
+	public void Prediction_PresentConfidence_RejectsNonFiniteOrOutOfRange(float confidence)
 	{
-		Assert.Throws<ArgumentOutOfRangeException>(
+		ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
 			() => new ImageClassificationPrediction("cat", confidence));
+
+		Assert.Equal("confidence", exception.ParamName);
+		Assert.Equal(confidence, Assert.IsType<float>(exception.ActualValue));
 	}
 
 	[Fact]
-	public void Result_SnapshotsAndOrdersPredictions_WithModelProvenance()
+	public void Result_SnapshotsAndPreservesPredictionOrder_WithModelProvenance()
 	{
 		var predictions = new List<ImageClassificationPrediction>
 		{
@@ -139,13 +144,13 @@ public class ImageClassificationContractTests
 			result.Predictions,
 			prediction =>
 			{
-				Assert.Equal("dog", prediction.Label);
-				Assert.Equal(0.9f, prediction.Confidence);
+				Assert.Equal("cat", prediction.Label);
+				Assert.Equal(0.25f, prediction.Confidence);
 			},
 			prediction =>
 			{
-				Assert.Equal("cat", prediction.Label);
-				Assert.Equal(0.25f, prediction.Confidence);
+				Assert.Equal("dog", prediction.Label);
+				Assert.Equal(0.9f, prediction.Confidence);
 			});
 		Assert.Equal("animals-v1", result.ModelId);
 		Assert.Same(rawRepresentation, result.RawRepresentation);
@@ -153,7 +158,7 @@ public class ImageClassificationContractTests
 	}
 
 	[Fact]
-	public void Metadata_ExposesProviderAndDefaultModel()
+	public void Metadata_ExposesConfiguredValues()
 	{
 		var providerUri = new Uri("https://example.test");
 		var metadata = new ImageClassificationClientMetadata(
@@ -177,6 +182,309 @@ public class ImageClassificationContractTests
 		Assert.Null(client.GetService<ImageClassificationClientMetadata>("unknown"));
 	}
 
+	[Fact]
+	public void PublicImageClassificationTypes_AreInMicrosoftMauiEssentialsAINamespace()
+	{
+		Type[] publicContractTypes =
+		[
+			typeof(IImageClassificationClient),
+			typeof(ImageClassificationClientExtensions),
+			typeof(ImageClassificationClientMetadata),
+			typeof(ImageClassificationOptions),
+			typeof(ImageClassificationPrediction),
+			typeof(ImageClassificationResult)
+		];
+
+		Assert.All(
+			publicContractTypes,
+			type =>
+			{
+				Assert.True(type.IsPublic);
+				Assert.Equal("Microsoft.Maui.Essentials.AI", type.Namespace);
+			});
+	}
+
+	[Fact]
+	public void Prediction_DefaultConfidence_IsNull()
+	{
+		var prediction = new ImageClassificationPrediction("snow leopard");
+
+		Assert.Equal(
+			typeof(float?),
+			typeof(ImageClassificationPrediction).GetProperty(nameof(ImageClassificationPrediction.Confidence))!.PropertyType);
+		Assert.Equal("snow leopard", prediction.Label);
+		Assert.Null(prediction.Confidence);
+	}
+
+	[Theory]
+	[InlineData(0f)]
+	[InlineData(0.375f)]
+	[InlineData(1f)]
+	public void Prediction_PresentConfidence_AcceptsInclusiveFiniteBounds(float confidence)
+	{
+		var prediction = new ImageClassificationPrediction("snow leopard", confidence);
+
+		Assert.Equal("snow leopard", prediction.Label);
+		Assert.Equal(confidence, prediction.Confidence);
+	}
+
+	[Fact]
+	public void Options_DefaultsAreNull()
+	{
+		var options = new ImageClassificationOptions();
+
+		Assert.Null(options.MaximumPredictions);
+		Assert.Null(options.MinimumConfidence);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData(0f)]
+	[InlineData(0.375f)]
+	[InlineData(1f)]
+	public void Options_MinimumConfidence_AcceptsNullAndInclusiveFiniteBounds(float? minimumConfidence)
+	{
+		var options = new ImageClassificationOptions
+		{
+			MinimumConfidence = minimumConfidence
+		};
+
+		Assert.Equal(minimumConfidence, options.MinimumConfidence);
+		Assert.Null(options.MaximumPredictions);
+	}
+
+	[Theory]
+	[InlineData(-0.01f)]
+	[InlineData(1.01f)]
+	[InlineData(float.NegativeInfinity)]
+	[InlineData(float.PositiveInfinity)]
+	[InlineData(float.NaN)]
+	public void Options_MinimumConfidence_RejectsNonFiniteOrOutOfRange(float minimumConfidence)
+	{
+		var options = new ImageClassificationOptions();
+
+		ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
+			() => options.MinimumConfidence = minimumConfidence);
+
+		Assert.Equal("value", exception.ParamName);
+		Assert.Equal(minimumConfidence, Assert.IsType<float>(exception.ActualValue));
+		Assert.Null(options.MinimumConfidence);
+	}
+
+	[Fact]
+	public void Metadata_DefaultsToNull()
+	{
+		var metadata = new ImageClassificationClientMetadata();
+
+		Assert.Null(metadata.ProviderName);
+		Assert.Null(metadata.ProviderUri);
+		Assert.Null(metadata.DefaultModelId);
+	}
+
+	[Fact]
+	public void Result_PreservesProviderPredictionOrder()
+	{
+		var first = new ImageClassificationPrediction("lynx", 0.2f);
+		var second = new ImageClassificationPrediction("bobcat", 0.95f);
+		var third = new ImageClassificationPrediction("cougar");
+		var predictions = new List<ImageClassificationPrediction> { first, second, third };
+
+		var result = new ImageClassificationResult(predictions);
+		predictions.Clear();
+
+		Assert.Collection(
+			result.Predictions,
+			prediction => Assert.Same(first, prediction),
+			prediction => Assert.Same(second, prediction),
+			prediction => Assert.Same(third, prediction));
+		Assert.Equal(["lynx", "bobcat", "cougar"], result.Predictions.Select(prediction => prediction.Label));
+	}
+
+	[Fact]
+	public void Result_RetainsModelIdRawRepresentationAndAdditionalProperties()
+	{
+		var prediction = new ImageClassificationPrediction("harbor seal", 0.8f);
+		var rawRepresentation = new object();
+		var additionalProperties = new AdditionalPropertiesDictionary
+		{
+			["providerRequestId"] = "request-42"
+		};
+
+		var result = new ImageClassificationResult([prediction])
+		{
+			ModelId = "wildlife-v2",
+			RawRepresentation = rawRepresentation,
+			AdditionalProperties = additionalProperties
+		};
+
+		Assert.Equal("wildlife-v2", result.ModelId);
+		Assert.Same(rawRepresentation, result.RawRepresentation);
+		Assert.Same(additionalProperties, result.AdditionalProperties);
+		Assert.Same(prediction, Assert.Single(result.Predictions));
+	}
+
+	[Fact]
+	public void Result_NullSequenceOrNullItem_Throws()
+	{
+		ArgumentNullException nullSequenceException = Assert.Throws<ArgumentNullException>(
+			() => new ImageClassificationResult(null!));
+		ArgumentException nullItemException = Assert.Throws<ArgumentException>(
+			() => new ImageClassificationResult([new ImageClassificationPrediction("otter"), null!]));
+
+		Assert.Equal("predictions", nullSequenceException.ParamName);
+		Assert.Equal("predictions", nullItemException.ParamName);
+	}
+
+	[Fact]
+	public void IImageClassificationClient_ClassifyImageAsync_HasExpectedTaskShape()
+	{
+		var method = Assert.Single(
+			typeof(IImageClassificationClient).GetMethods(),
+			method => method.Name == nameof(IImageClassificationClient.ClassifyImageAsync));
+
+		Assert.Equal(typeof(Task<ImageClassificationResult>), method.ReturnType);
+		Assert.Collection(
+			method.GetParameters(),
+			parameter =>
+			{
+				Assert.Equal("imageStream", parameter.Name);
+				Assert.Equal(typeof(Stream), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("imageMediaType", parameter.Name);
+				Assert.Equal(typeof(string), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("options", parameter.Name);
+				Assert.Equal(typeof(ImageClassificationOptions), parameter.ParameterType);
+				Assert.True(parameter.IsOptional);
+				Assert.Null(parameter.DefaultValue);
+			},
+			parameter =>
+			{
+				Assert.Equal("cancellationToken", parameter.Name);
+				Assert.Equal(typeof(CancellationToken), parameter.ParameterType);
+				Assert.True(parameter.IsOptional);
+				Assert.Null(parameter.DefaultValue);
+			});
+	}
+
+	[Fact]
+	public void ImageClassificationClientExtensions_ClassifyImageAsync_HasDataContentOverload()
+	{
+		var method = Assert.Single(
+			typeof(ImageClassificationClientExtensions).GetMethods(),
+			method => method.Name == nameof(ImageClassificationClientExtensions.ClassifyImageAsync));
+
+		Assert.True(method.IsPublic);
+		Assert.True(method.IsStatic);
+		Assert.False(method.IsGenericMethod);
+		Assert.True(method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), inherit: false));
+		Assert.Equal(typeof(Task<ImageClassificationResult>), method.ReturnType);
+		Assert.Collection(
+			method.GetParameters(),
+			parameter =>
+			{
+				Assert.Equal("client", parameter.Name);
+				Assert.Equal(typeof(IImageClassificationClient), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("image", parameter.Name);
+				Assert.Equal(typeof(DataContent), parameter.ParameterType);
+				Assert.False(parameter.IsOptional);
+			},
+			parameter =>
+			{
+				Assert.Equal("options", parameter.Name);
+				Assert.Equal(typeof(ImageClassificationOptions), parameter.ParameterType);
+				Assert.True(parameter.IsOptional);
+				Assert.Null(parameter.DefaultValue);
+			},
+			parameter =>
+			{
+				Assert.Equal("cancellationToken", parameter.Name);
+				Assert.Equal(typeof(CancellationToken), parameter.ParameterType);
+				Assert.True(parameter.IsOptional);
+				Assert.Null(parameter.DefaultValue);
+			});
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_NullClientOrImage_Throws()
+	{
+		IImageClassificationClient nullClient = null!;
+		var client = new RecordingClient();
+		var image = new DataContent(new byte[] { 1 }, "image/png");
+
+		ArgumentNullException clientException = await Assert.ThrowsAsync<ArgumentNullException>(
+			() => nullClient.ClassifyImageAsync(image));
+		ArgumentNullException imageException = await Assert.ThrowsAsync<ArgumentNullException>(
+			() => client.ClassifyImageAsync(null!));
+
+		Assert.Equal("client", clientException.ParamName);
+		Assert.Equal("image", imageException.ParamName);
+		Assert.Equal(0, client.CallCount);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_Stream_CallerRetainsOwnership()
+	{
+		byte[] imageBytes = [8, 6, 7, 5, 3, 0, 9];
+		using var imageStream = new MemoryStream(imageBytes);
+		var options = new ImageClassificationOptions { MaximumPredictions = 3 };
+		using var cancellationSource = new CancellationTokenSource();
+		var client = new RecordingClient();
+
+		ImageClassificationResult result = await client.ClassifyImageAsync(
+			imageStream,
+			"image/webp",
+			options,
+			cancellationSource.Token);
+
+		Assert.Same(client.Result, result);
+		Assert.Equal(1, client.CallCount);
+		Assert.Same(imageStream, client.InputStream);
+		Assert.Equal(imageBytes, client.ImageBytes);
+		Assert.Equal("image/webp", client.MediaType);
+		Assert.Same(options, client.Options);
+		Assert.Equal(cancellationSource.Token, client.CancellationToken);
+		Assert.True(imageStream.CanRead);
+		imageStream.Position = 0;
+		Assert.Equal(8, imageStream.ReadByte());
+	}
+
+	[Fact]
+	public void GetService_TypedAndUntyped_ExposeSelfAndMetadata()
+	{
+		var metadata = new ImageClassificationClientMetadata(
+			providerName: "fixture",
+			defaultModelId: "wildlife-v2");
+		using var client = new RecordingClient(metadata);
+
+		Assert.Same(client, client.GetService<IImageClassificationClient>());
+		Assert.Same(client, client.GetService(typeof(IImageClassificationClient)));
+		Assert.Same(metadata, client.GetService<ImageClassificationClientMetadata>());
+		Assert.Same(metadata, client.GetService(typeof(ImageClassificationClientMetadata)));
+	}
+
+	[Fact]
+	public void GetService_KeyedOrUnknown_ReturnsNull()
+	{
+		using var client = new RecordingClient(new ImageClassificationClientMetadata("fixture"));
+		var serviceKey = new object();
+
+		Assert.Null(client.GetService<string>());
+		Assert.Null(client.GetService(typeof(string)));
+		Assert.Null(client.GetService<IImageClassificationClient>(serviceKey));
+		Assert.Null(client.GetService(typeof(IImageClassificationClient), serviceKey));
+	}
+
 	private sealed class RecordingClient(ImageClassificationClientMetadata? metadata = null)
 		: IImageClassificationClient
 	{
@@ -195,7 +503,7 @@ public class ImageClassificationContractTests
 
 		public Stream? InputStream { get; private set; }
 
-		public async Task<ImageClassificationResult> ClassifyAsync(
+		public async Task<ImageClassificationResult> ClassifyImageAsync(
 			Stream imageStream,
 			string imageMediaType,
 			ImageClassificationOptions? options = null,

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
@@ -10,33 +10,65 @@ namespace Microsoft.Maui.Essentials.AI.UnitTests;
 public class ImageClassificationContractTests
 {
 	[Fact]
-	public async Task ClassifyImageAsync_DataContent_ForwardsSnapshotMediaTypeOptionsAndCancellation()
+	public async Task ClassifyImageAsync_DataContent_AcceptedPathUsesEntrySnapshot()
 	{
 		byte[] imageBytes = [1, 2, 3, 4];
 		var image = new DataContent(imageBytes, "image/png");
 		var options = new ImageClassificationOptions
 		{
+			MaximumInputBytes = 4,
 			MaximumPredictions = 2,
 			MinimumConfidence = 0.25f
 		};
 		using var cancellationSource = new CancellationTokenSource();
-		var client = new RecordingClient();
+		var responseSource = new TaskCompletionSource(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		var client = new RecordingClient { ResponseTask = responseSource.Task };
 
-		ImageClassificationResult result = await client.ClassifyImageAsync(
+		Task<ImageClassificationResult> classificationTask = client.ClassifyImageAsync(
 			image,
 			options,
 			cancellationSource.Token);
+		Assert.Equal(1, client.CallCount);
 
 		imageBytes[0] = 99;
+		options.MaximumInputBytes = 1;
+		options.MaximumPredictions = 1;
+		options.MinimumConfidence = null;
+		responseSource.SetResult();
+
+		ImageClassificationResult result = await classificationTask;
 
 		Assert.Same(client.Result, result);
-		Assert.Equal(1, client.CallCount);
 		Assert.Equal([1, 2, 3, 4], client.ImageBytes);
 		Assert.Equal("image/png", client.MediaType);
-		Assert.Same(options, client.Options);
+		ImageClassificationOptions forwardedOptions =
+			Assert.IsType<ImageClassificationOptions>(client.Options);
+		Assert.NotSame(options, forwardedOptions);
+		Assert.Equal(4, forwardedOptions.MaximumInputBytes);
+		Assert.Equal(2, forwardedOptions.MaximumPredictions);
+		Assert.Equal(0.25f, forwardedOptions.MinimumConfidence);
 		Assert.Equal(cancellationSource.Token, client.CancellationToken);
 		Assert.NotNull(client.InputStream);
 		Assert.False(client.InputStream.CanRead);
+	}
+
+	[Fact]
+	public async Task ClassifyImageAsync_DataContentOverMaximum_RejectsBeforeClientInvocation()
+	{
+		var image = new DataContent(new byte[] { 1, 2, 3, 4 }, "image/png");
+		var options = new ImageClassificationOptions { MaximumInputBytes = 3 };
+		var client = new RecordingClient();
+
+		ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
+			() => client.ClassifyImageAsync(image, options));
+
+		Assert.Equal("image", exception.ParamName);
+		Assert.Contains("configured maximum of 3 bytes", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("MaximumInputBytes", exception.Message, StringComparison.Ordinal);
+		Assert.Equal(0, client.CallCount);
+		Assert.Null(client.InputStream);
+		Assert.Null(client.ImageBytes);
 	}
 
 	[Theory]
@@ -535,6 +567,8 @@ public class ImageClassificationContractTests
 
 		public Stream? InputStream { get; private set; }
 
+		public Task? ResponseTask { get; init; }
+
 		public async Task<ImageClassificationResult> ClassifyImageAsync(
 			Stream imageStream,
 			string imageMediaType,
@@ -550,6 +584,11 @@ public class ImageClassificationContractTests
 			using var copy = new MemoryStream();
 			await imageStream.CopyToAsync(copy, cancellationToken);
 			ImageBytes = copy.ToArray();
+
+			if (ResponseTask is not null)
+			{
+				await ResponseTask.WaitAsync(cancellationToken);
+			}
 
 			return Result;
 		}

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
@@ -114,7 +114,7 @@ public class ImageClassificationContractTests
 	}
 
 	[Fact]
-	public void Result_SnapshotsAndOrdersPredictions_WithProvenance()
+	public void Result_SnapshotsAndOrdersPredictions_WithModelProvenance()
 	{
 		var predictions = new List<ImageClassificationPrediction>
 		{
@@ -124,7 +124,6 @@ public class ImageClassificationContractTests
 
 		var result = new ImageClassificationResult(predictions)
 		{
-			ProviderName = "fixture",
 			ModelId = "animals-v1"
 		};
 		predictions.Clear();
@@ -141,7 +140,6 @@ public class ImageClassificationContractTests
 				Assert.Equal("cat", prediction.Label);
 				Assert.Equal(0.25f, prediction.Confidence);
 			});
-		Assert.Equal("fixture", result.ProviderName);
 		Assert.Equal("animals-v1", result.ModelId);
 	}
 

--- a/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
+++ b/tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Tests/ImageClassificationContractTests.cs
@@ -76,19 +76,50 @@ public class ImageClassificationContractTests
 	{
 		var options = new ImageClassificationOptions
 		{
+			MaximumInputBytes = 1024,
 			MaximumPredictions = 3,
 			MinimumConfidence = 0.5f
 		};
 
 		ImageClassificationOptions clone = options.Clone();
+		options.MaximumInputBytes = 2048;
 		options.MaximumPredictions = 5;
 		options.MinimumConfidence = 0.75f;
 
 		Assert.NotSame(options, clone);
+		Assert.Equal(1024, clone.MaximumInputBytes);
 		Assert.Equal(3, clone.MaximumPredictions);
 		Assert.Equal(0.5f, clone.MinimumConfidence);
+		Assert.Equal(2048, options.MaximumInputBytes);
 		Assert.Equal(5, options.MaximumPredictions);
 		Assert.Equal(0.75f, options.MinimumConfidence);
+	}
+
+	[Fact]
+	public void Options_MaximumInputBytes_DefaultsToExactlyTwentyMiBAndAcceptsExplicitValue()
+	{
+		var options = new ImageClassificationOptions();
+
+		Assert.Equal(20L * 1024 * 1024, options.MaximumInputBytes);
+
+		options.MaximumInputBytes = 1234;
+
+		Assert.Equal(1234, options.MaximumInputBytes);
+	}
+
+	[Theory]
+	[InlineData(0L)]
+	[InlineData(-1L)]
+	public void Options_MaximumInputBytes_RejectsNonPositiveValues(long maximumInputBytes)
+	{
+		var options = new ImageClassificationOptions();
+
+		ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
+			() => options.MaximumInputBytes = maximumInputBytes);
+
+		Assert.Equal("value", exception.ParamName);
+		Assert.Equal(maximumInputBytes, Assert.IsType<long>(exception.ActualValue));
+		Assert.Equal(20L * 1024 * 1024, options.MaximumInputBytes);
 	}
 
 	[Theory]
@@ -233,6 +264,7 @@ public class ImageClassificationContractTests
 	{
 		var options = new ImageClassificationOptions();
 
+		Assert.Equal(20L * 1024 * 1024, options.MaximumInputBytes);
 		Assert.Null(options.MaximumPredictions);
 		Assert.Null(options.MinimumConfidence);
 	}


### PR DESCRIPTION
> Working proposal for current head `47c3ca0c54b017018fde6df364be49cc39ca932b`. Keep this PR
> in draft until every exit gate below has reproducible evidence.

## Background and motivation

.NET MAUI applications increasingly need focused AI tasks such as image classification without
requiring every consumer to understand tensors, model preprocessing, prompts, or a provider SDK.
`IChatClient` is useful for generative and multimodal chat, but it is not the task contract: a
classic ONNX classifier and a managed classification service should not need to pretend to be chat
clients.

This proposal adds a narrow experimental image-classification waist owned by MAUI Labs:

- one encoded image enters;
- provider-ranked labels and optional measured confidence leave;
- provider-specific capabilities remain available through `GetService`;
- local ONNX, vision `IChatClient`, and Azure Content Understanding implementations are the planned
  proof that the contract is portable rather than designed around one runtime.

The experiment is deliberately under `Microsoft.Maui.Essentials.AI`, not
`Microsoft.Extensions.AI`. MAUI Labs is the incubation and evidence-gathering venue, not a claim
that image-classification semantics are intrinsically MAUI-specific. A later cross-.NET proposal
requires its own multi-ecosystem evidence and review. The package's existing `MAUIAI0001`
experimental diagnostic applies.

The validation target is one MAUI workbench running on Windows and Android. It must switch all
three providers behind the same `IImageClassificationClient` without provider branches in the
ViewModel.

## API Proposal

```csharp
namespace Microsoft.Maui.Essentials.AI;

public interface IImageClassificationClient : IDisposable
{
    Task<ImageClassificationResult> ClassifyImageAsync(
        Stream imageStream,
        string imageMediaType,
        ImageClassificationOptions? options = null,
        CancellationToken cancellationToken = default);

    object? GetService(Type serviceType, object? serviceKey = null);
}

public class ImageClassificationOptions
{
    public ImageClassificationOptions();
    protected ImageClassificationOptions(ImageClassificationOptions? other);

    public long MaximumInputBytes { get; set; }
    public int? MaximumPredictions { get; set; }
    public float? MinimumConfidence { get; set; }

    public virtual ImageClassificationOptions Clone();
}

public sealed class ImageClassificationPrediction
{
    public ImageClassificationPrediction(string label, float? confidence = null);

    public string Label { get; }
    public float? Confidence { get; }
}

public sealed class ImageClassificationResult
{
    public ImageClassificationResult(
        IEnumerable<ImageClassificationPrediction> predictions);

    public IReadOnlyList<ImageClassificationPrediction> Predictions { get; }
    public string? ModelId { get; init; }
    public object? RawRepresentation { get; set; }
    public Microsoft.Extensions.AI.AdditionalPropertiesDictionary?
        AdditionalProperties { get; set; }
}

public sealed class ImageClassificationClientMetadata
{
    public ImageClassificationClientMetadata(
        string? providerName = null,
        Uri? providerUri = null,
        string? defaultModelId = null);

    public string? ProviderName { get; }
    public Uri? ProviderUri { get; }
    public string? DefaultModelId { get; }
}

public static class ImageClassificationClientExtensions
{
    public static Task<ImageClassificationResult> ClassifyImageAsync(
        this IImageClassificationClient client,
        Microsoft.Extensions.AI.DataContent image,
        ImageClassificationOptions? options = null,
        CancellationToken cancellationToken = default);

    public static TService? GetService<TService>(
        this IImageClassificationClient client,
        object? serviceKey = null);
}

public sealed class ChatClientImageClassificationClient :
    IImageClassificationClient
{
    public ChatClientImageClassificationClient(
        Microsoft.Extensions.AI.IChatClient chatClient,
        IEnumerable<string> labels,
        ImageClassificationClientMetadata? metadata = null);

    public Task<ImageClassificationResult> ClassifyImageAsync(
        Stream imageStream,
        string imageMediaType,
        ImageClassificationOptions? options = null,
        CancellationToken cancellationToken = default);

    public object? GetService(Type serviceType, object? serviceKey = null);
    public void Dispose();
}
```

Validation-provider packages use separate namespaces and packages. The Azure surface below is
implemented. No ONNX provider declaration is proposed in this revision: its public ML.NET Android
prerequisite is blocked, so presenting a speculative API here would get ahead of implementation
evidence.

```csharp
namespace Microsoft.Maui.Essentials.AI.ImageClassification.AzureContentUnderstanding;

public sealed class AzureContentUnderstandingImageClassificationOptions
{
    public required string AnalyzerId { get; set; }
}

public sealed class AzureContentUnderstandingImageClassificationClient :
    Microsoft.Maui.Essentials.AI.IImageClassificationClient
{
    public AzureContentUnderstandingImageClassificationClient(
        Uri endpoint,
        Azure.Core.TokenCredential credential,
        AzureContentUnderstandingImageClassificationOptions options);

    public Task<Microsoft.Maui.Essentials.AI.ImageClassificationResult>
        ClassifyImageAsync(
            Stream image,
            string imageMediaType,
            Microsoft.Maui.Essentials.AI.ImageClassificationOptions? options = null,
            CancellationToken cancellationToken = default);

    public object? GetService(Type serviceType, object? serviceKey = null);
    public void Dispose();
}
```

These declarations are transcribed from the checked-in PublicAPI baselines at the current head.

## API Usage

The consumer depends on the task contract, not a provider:

```csharp
public sealed class ClassifyPhotoViewModel(
    IImageClassificationClient classifier)
{
    public async Task<IReadOnlyList<ImageClassificationPrediction>> ClassifyPhotoAsync(
        Stream encodedImage,
        CancellationToken cancellationToken)
    {
        ImageClassificationResult result =
            await classifier.ClassifyImageAsync(
                encodedImage,
                "image/jpeg",
                new ImageClassificationOptions
                {
                    MaximumPredictions = 5,
                },
                cancellationToken);

        return result.Predictions;
    }
}
```

The intended local MobileNetV2 usage, after its prerequisite packages and provider API exist, is:

```csharp
IImageClassificationClient classifier =
    await OnnxImageClassificationClient.CreateMobileNetV2Async(
        cancellationToken: cancellationToken);
```

Adapt a caller-owned vision-capable chat client to a fixed task taxonomy:

```csharp
IImageClassificationClient classifier =
    new ChatClientImageClassificationClient(
        visionChatClient,
        ["animal", "food", "vehicle", "other"]);
```

The injected chat client remains caller-owned; disposing the adapter does not dispose it. The
adapter requests structured output, preserves returned order, validates every label against the
constructor allowlist, and returns null confidence. Compatibility fallback accepts only the exact
JSON object envelope or a top-level JSON string array. It does not recover labels from prose or
Markdown fences.

Use a token-authenticated Content Understanding analyzer:

```csharp
IImageClassificationClient classifier =
    new AzureContentUnderstandingImageClassificationClient(
        new Uri(endpoint),
        new DefaultAzureCredential(),
        new AzureContentUnderstandingImageClassificationOptions
        {
            AnalyzerId = "maui-image-classifier-v1",
        });
```

`DefaultAzureCredential` is the Windows developer composition. Android supplies an MSAL-backed
`TokenCredential` whose token methods honor `TokenRequestContext.Scopes` and use silent acquisition
only. Interactive UI belongs to an explicit workbench sign-in command, not to the provider call.

Provision that analyzer from `prebuilt-image` with service-native `ContentCategories`
(`animal`, `food`, `vehicle`, and `other`), `EnableSegment = false`,
`ShouldReturnDetails = true`, and one supported completion model. The zero-shot classifier does not
define a synthetic result field or require an embedding deployment. The provider maps the returned
content-level `AnalysisContent.Category` to one null-confidence prediction; segmentation remains
disabled for the one-image request.

Advanced consumers can inspect metadata or a provider SDK without adding those concepts to the
common request:

```csharp
ImageClassificationClientMetadata? metadata =
    classifier.GetService<ImageClassificationClientMetadata>();
```

## Alternative Designs

### Put the contract in `Microsoft.Extensions.AI`

Rejected for this experiment. The current evidence is MAUI-specific and does not establish a
cross-.NET abstraction. A later promotion can be proposed independently if multiple ecosystems
converge on the same semantics.

### Name the operation `ClassifyAsync`

Rejected because the task is ambiguous at the call site. `ClassifyImageAsync` states both the job
and input domain and leaves room for text, audio, or document classification contracts.

### Use only `IChatClient`

Rejected because local ONNX classification is not chat, managed task services need not expose chat,
and model-generated "confidence" is not a calibrated classifier score. The chat implementation is
an adapter into this task contract, not the contract itself.

### Require confidence on every prediction

Rejected because some valid providers rank labels without a measured normalized score.
`Confidence` is nullable. Providers must not fabricate it. A provider that cannot produce
confidence throws `NotSupportedException` when `MinimumConfidence` is requested. The current
vision-chat and GA Content Understanding image providers both return null confidence; the planned
MobileNetV2 ONNX provider would supply normalized probabilities.

### Sort all results by confidence

Rejected because sorting destroys provider ranking when confidence is absent. The result snapshots
predictions in provider order.

### Ship one package containing every provider

Rejected because it would force local-only applications to restore cloud SDKs and cloud-only
applications to restore ONNX native assets. Each provider package is independently installable.

### Standardize one taxonomy

Rejected because MobileNetV2, a chat allowlist, and a Content Understanding analyzer own different
vocabularies. This proposal standardizes transport and result semantics, not label equivalence.

### Model Content Understanding classification as an extracted `Category` field

Rejected because the GA SDK exposes a service-native classifier contract:
`ContentAnalyzerConfig.ContentCategories` on a `prebuilt-image` analyzer and a content-level
`AnalysisContent.Category` result when segmentation is disabled. A synthetic classify field would
misrepresent the service, add a field-name option to the provider, and couple mapping code to the
wrong result shape.

### Use Azure Custom Vision or Azure AI Vision Image Analysis

Rejected for a new experiment because both services are scheduled to retire on September 25,
2028. Content Understanding is the current managed task-service proof. A deterministic custom
classifier can use Azure Machine Learning if later evidence justifies the extra training and
hosting lifecycle.

### Vendor the ONNX transform or model source into MAUI Labs

Rejected because it would duplicate the user's independently versioned ML.NET transform and Model
Garden packages, blur provenance, and hide whether an ordinary consumer can restore the provider.
The integration gate is an immutable public package. The known Android SkiaSharp alignment blocker
must remain visible; this PR will not bypass it with copied direct-ORT preprocessing.

## Risks

- This is experimental API. Device and provider evidence can still require source-compatible or
  breaking revisions before review.
- Provider outputs are substitutable as task results, not semantically identical. Labels and
  confidence calibration differ.
- Local ONNX increases package and application size and must prove Android native loading,
  trimming, AOT, concurrency, cancellation, and disposal.
- Encoded images must be buffered by some providers. Every buffering implementation needs an
  explicit byte limit and cancellation. The common options default that bound to 20 MiB; the ONNX
  provider must also reject unreasonable decoded dimensions before allocating a full pixel buffer.
- Direct mobile calls to Azure require public network access and a delegated user identity;
  establishing that identity can require an explicit interactive sign-in. This is acceptable only
  for the experiment. Production guidance is a managed-identity service boundary with private
  networking.
- Content Understanding analyzer schemas, supported model versions, quota, and regional capacity
  can change independently from this API. The exact `prebuilt-image` classifier configuration and
  content-level category response therefore remain live-service gates even though the 1.1.0 SDK
  surface and classifier sample support them.
- GA `prebuilt-image` analyzers do not document field-confidence estimation. The Content
  Understanding provider rejects `MinimumConfidence` before a paid request and returns null
  confidence.
- A vision chat adapter can return syntactically valid but disallowed labels. The adapter must
  validate all output against its constructor allowlist and fail explicitly.
- The three-provider workbench can imply parity that does not exist. It must display active
  provider, model/analyzer, execution location, taxonomy, and whether confidence is available.

## Behavioral contract

- The caller owns the stream and its lifetime.
- The stream contains one encoded image matching `imageMediaType`.
- `MaximumPredictions` means "at most," not "exactly."
- `MaximumPredictions = null` selects the provider's documented sensible default; it does not
  require a provider to return its full vocabulary. Portable consumers set an explicit value when
  cardinality matters.
- `MaximumInputBytes` defaults to 20 MiB, must be positive, is cloned with the request, and bounds
  seekable and non-seekable encoded streams before buffering or decoding.
- `MinimumConfidence` is valid only when the selected provider exposes normalized confidence.
- Prediction order is immutable provider ranking.
- Confidence is `null` or a finite value from 0 through 1.
- Empty results are valid when no label satisfies the request or the provider abstains.
- `ModelId` identifies a model or analyzer, not a provider.
- `RawRepresentation` and `AdditionalProperties` are escape hatches, not portable contract data.
- `RawRepresentation` is a detached managed response/snapshot, never a disposed native inference
  value that transfers lifetime responsibility to the result consumer.
- Cancellation must flow through stream reads, model acquisition, inference, HTTP calls, and
  long-running-operation polling.

## Architecture

```mermaid
flowchart TD
    VM[Provider-neutral MAUI ViewModel] --> API[IImageClassificationClient]
    API --> ONNX[MobileNetV2 ONNX provider]
    API --> CHAT[Vision IChatClient adapter]
    API --> CU[Content Understanding provider]
    ONNX --> MODEL[Immutable MobileNetV2 model package]
    MODEL --> RUNTIME[ML.NET ONNX transform and ONNX Runtime]
    CHAT --> FOUNDRY[Vision chat deployment]
    CU --> ANALYZER[Versioned ContentCategories analyzer]
    FOUNDRY --> RESOURCE[Microsoft Foundry resource]
    ANALYZER --> RESOURCE
```

The contract knows images, request constraints, ranked labels, optional confidence, model
provenance, cancellation, metadata, and escape hatches. It does not know tensor names,
preprocessing constants, prompts, credentials, analyzer schemas, model download paths, or platform
UI. The workbench registers a provider-neutral descriptor beside each client for readiness,
execution location, taxonomy, and confidence/threshold capabilities. The ViewModel reads that
descriptor and never branches on concrete provider types.

| Package/layer | Owns | Deliberately excludes |
| --- | --- | --- |
| `Microsoft.Maui.Essentials.AI` | Contract, normalized shapes, `DataContent` convenience, vision-chat adapter | ONNX, model download, Azure SDK, credentials |
| `.ImageClassification.Onnx` | ML.NET transformer invocation, task-option mapping, normalized result, runtime lifetime | Cloud fallback, model-cache policy, copied preprocessing |
| `MLNet.ImageInference.Onnx` | Image decode, MobileNet preprocessing, ONNX inference | MAUI UI, model acquisition, common task contract |
| MobileNetV2 Model Garden package | Immutable model/label manifest, verified acquisition, transformer factory | MAUI UI, provider-neutral API |
| `.ImageClassification.AzureContentUnderstanding` | Typed SDK call, analyzer-category mapping, token-auth boundary | Provisioning, interactive sign-in, resource lifecycle |
| Workbench | Provider selection, readiness, input, diagnostics, observable evidence | Concrete-provider branches in the ViewModel |

## Validation evidence

Before requesting review, replace remaining open items with exact commands, commits, package
versions, hashes, device names, and run results.

- [x] Corrected contract and deterministic chat-adapter validation at `892daf8c`: 79 focused tests,
      412 full Essentials AI tests, clean Release product build, and all seven PublicAPI baselines.
- [ ] One real vision call whose category depends on the image.
- [x] ModelPackages hardening candidate on draft PR #58 at `4abda8c0`: 156 tests, two independently
      compiled deterministic packs, isolated package consumption, Windows NativeAOT execution,
      Android Release trim/AOT compilation, and green live CI run `33797716054`. The candidate
      nupkg SHA-256 is
      `E9D121E3330C48EBC558D5ACE1C33026656FEC0FB15BBF424AD09F0ACB976593`.
- [ ] Public immutable ModelPackages prerelease with clean-install proof.
      The candidate remains deliberately unpublished and has no Android device-runtime evidence.
- [ ] Public immutable ML.NET ONNX prerelease with clean-install proof.
      Current public `Microsoft.ML.ImageAnalytics` packages still depend on a 4 KB-aligned
      SkiaSharp Android native asset; publication remains blocked pending an official package with
      the merged SkiaSharp 3 adaptation or a separately approved architecture change.
- [ ] Pinned MobileNetV2 model package with source revision, size, SHA-256, labels, preprocessing,
      offline cache reuse, and fixed predictions.
- [ ] ONNX provider Windows and Android Release execution.
- [x] `Azure.AI.ContentUnderstanding` 1.1.0 restore, compile, trim, and Android AOT/link probe.
- [x] Content Understanding provider at `8b76cb7`: 54 deterministic typed-SDK tests, package
      pack/local restore, exact-SHA core regression tests, and Android full-link/AOT compilation
      with no provider or Content Understanding SDK-attributed trim warning.
- [x] `Azure.AI.ContentUnderstanding` 1.1.0 mirrored into the repository's curated
      `dotnet-public` feed by authorized dnceng pipeline 931 run `3065808` using
      `New or non-Microsoft`, including transitive dependencies. An anonymous isolated net10
      consumer restored and built from `dotnet-public` alone with zero warnings and errors.
- [ ] Upstream EssentialsAI validation after the mirror. The PR author cannot rerun the failed
      workflow without repository-admin permission, so this proposal-body update triggers the
      fresh validation run. Do not add NuGet.org or a personal feed.
- [ ] Clean unrelated CI rerun. Run `33788207652` reports 26 CLI unit failures because bundled
      DevFlow skill resources were missing at runtime; this PR changes no `src/Cli` path.
- [ ] Token-authenticated live Content Understanding analyzer calls on Windows and Android.
- [ ] One provider-neutral workbench executing all three providers on Windows and Android.
- [x] Three public-domain fixture bytes pinned with source records, credits, dimensions, and
      SHA-256 values.
- [ ] Fixture matrix recording outputs, confidence presence, identity, taxonomy, and latency
      without claiming score parity.

## Review decisions requested

1. Is MAUI Labs the right incubation venue while the evidence is limited to MAUI applications,
   without claiming that the eventual abstraction must remain MAUI-specific?
2. Is `ClassifyImageAsync(Stream, string, ...)` the right primitive, with `DataContent` as a
   convenience overload?
3. Are nullable confidence and preserved provider order the honest common semantics?
4. Should `MinimumConfidence` remain a common request option when scoreless providers reject it,
   or should scored-result filtering stay entirely with the caller?
5. Should the task-specific chat adapter live in the core package or in a separate provider
   package? The core already depends on MEAI abstractions for `DataContent` and
   `AdditionalPropertiesDictionary`, so this is a cohesion/discoverability decision rather than a
   dependency-weight decision.
6. Should the injected `IChatClient` remain caller-owned, as implemented, or should disposing the
   adapter dispose the injected client?
7. Are `RawRepresentation`, `AdditionalProperties`, and `GetService` sufficient escape hatches?
8. Is it right to defer a delegating base, builder/middleware pipeline, and DI helpers until this
   experiment exercises a concrete cross-cutting scenario for them?

## Deferred work

- Cross-.NET promotion into `Microsoft.Extensions.AI`.
- A delegating client base, builder/middleware pipeline, and DI registration helpers.
- Standard readiness, execution-location, taxonomy, and capability descriptors.
- Streaming or batched image classification.
- Detection, segmentation, embedding, OCR, and document extraction contracts.
- Production mobile-to-service gateway architecture.
- Provider score calibration or taxonomy mapping.

## Draft exit criteria

Keep this PR in draft until:

1. Every proposed declaration matches source and PublicAPI baselines.
2. Every external dependency is an immutable public package restorable without local feeds or
   credentials.
3. All three providers execute through the same ViewModel on Windows and Android.
4. Local model acquisition proves progress, cancellation, hash/size verification, atomic cache,
   and offline reuse.
5. Azure provisioning, least-privilege RBAC, MSAL sign-in, token-only calls, analyzer deployment,
   and cleanup are reproduced without committed credentials.
6. Focused, complete, trimming/AOT, package, and device evidence is recorded here.
7. Named API and MAUI reviewers agree that the proposal is ready for review.

If direct Android delegated-token access to Content Understanding cannot pass, this PR stays draft
or is parked. A managed-identity gateway is the production-style follow-up, not a substitute result
for this direct-provider experiment.

## Stack preflight

This remains an ordinary fork-based PR targeting `main`. Direct push to `dotnet/maui-labs`
returns HTTP 403, so same-repository native GitHub stack metadata is unavailable. Draft branches
and pushed commits are work in progress, not landed work.
