### PR TITLE
Add temporary document extraction contract proposal

### DIFF
--- a/MauiLabs.slnx
+++ b/MauiLabs.slnx
@@ -23,6 +23,7 @@
   </Folder>
   <Folder Name="/src/" />
   <Folder Name="/src/AI/">
+    <Project Path="src/AI/DocumentExtraction.ContractProposal/Microsoft.Extensions.DocumentExtraction.Abstractions.csproj" />
     <Project Path="src/AI/Microsoft.Maui.Essentials.AI/Microsoft.Maui.Essentials.AI.csproj" />
   </Folder>
   <Folder Name="/src/AIExtensions/">
@@ -71,6 +72,7 @@
   </Folder>
   <Folder Name="/tests/" />
   <Folder Name="/tests/AI/">
+    <Project Path="tests/AI/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests.csproj" />
     <Project Path="tests/AI/Microsoft.Maui.Essentials.AI.Benchmarks/Microsoft.Maui.Essentials.AI.Benchmarks.csproj" />
     <Project Path="tests/AI/Microsoft.Maui.Essentials.AI.DeviceTests/Microsoft.Maui.Essentials.AI.DeviceTests.csproj" />
     <Project Path="tests/AI/Microsoft.Maui.Essentials.AI.UnitTests/Microsoft.Maui.Essentials.AI.UnitTests.csproj" />

--- a/src/AI/DocumentExtraction.ContractProposal/.gitattributes
+++ b/src/AI/DocumentExtraction.ContractProposal/.gitattributes
@@ -1,0 +1,2 @@
+# Keep the imported upstream subtree byte-for-byte stable on every platform.
+Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/** -text

--- a/src/AI/DocumentExtraction.ContractProposal/Compatibility/DiagnosticIds.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Compatibility/DiagnosticIds.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.Shared.DiagnosticIds;
+
+internal static class DiagnosticIds
+{
+    internal const string UrlFormat = "https://aka.ms/dotnet-extensions-warnings/{0}";
+
+    internal static class Experiments
+    {
+        internal const string DocumentExtraction = "MEDE0001";
+    }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Compatibility/Throw.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Compatibility/Throw.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Shared.Diagnostics;
+
+internal static class Throw
+{
+    [return: NotNull]
+    public static T IfNull<T>(
+        [NotNull] T argument,
+        [CallerArgumentExpression(nameof(argument))] string paramName = "")
+    {
+        if (argument is null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        return argument;
+    }
+
+    [return: NotNull]
+    public static string IfNullOrWhitespace(
+        [NotNull] string? argument,
+        [CallerArgumentExpression(nameof(argument))] string paramName = "")
+    {
+        if (argument is null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        if (string.IsNullOrWhiteSpace(argument))
+        {
+            throw new ArgumentException("Argument is whitespace", paramName);
+        }
+
+        return argument;
+    }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Microsoft.Extensions.DocumentExtraction.Abstractions.csproj
+++ b/src/AI/DocumentExtraction.ContractProposal/Microsoft.Extensions.DocumentExtraction.Abstractions.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Microsoft.Extensions.DocumentExtraction</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsShipping>false</IsShipping>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnablePackageValidation>false</EnablePackageValidation>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Compatibility\*.cs" />
+    <Compile Include="Upstream\dotnet-extensions\src\Libraries\Microsoft.Extensions.DocumentExtraction.Abstractions\*.cs"
+             Link="Upstream\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/AI/DocumentExtraction.ContractProposal/README.md
+++ b/src/AI/DocumentExtraction.ContractProposal/README.md
@@ -1,0 +1,20 @@
+# Document extraction contract proposal
+
+This directory temporarily compiles the proposed
+`Microsoft.Extensions.DocumentExtraction` abstractions from
+[dotnet/extensions#7588](https://github.com/dotnet/extensions/pull/7588) so MAUI Labs
+experiments can reference the exact contract while it is under upstream review.
+
+The project targets only `net10.0`, is non-shipping, and is not packable. The imported
+source remains byte-for-byte unchanged under
+`Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions`.
+MAUI Labs compatibility shims stay in `Compatibility`.
+
+Run the provenance check from the repository root:
+
+```powershell
+pwsh -File src/AI/DocumentExtraction.ContractProposal/Verify-Upstream.ps1
+```
+
+Use `-Offline` to verify the local files against the recorded hashes without downloading
+the pinned upstream revision.

--- a/src/AI/DocumentExtraction.ContractProposal/UPSTREAM.json
+++ b/src/AI/DocumentExtraction.ContractProposal/UPSTREAM.json
@@ -1,0 +1,143 @@
+{
+  "upstreamRepository": "https://github.com/dotnet/extensions",
+  "sourceRepository": "https://github.com/luisquintanilla/extensions",
+  "pullRequest": "https://github.com/dotnet/extensions/pull/7588",
+  "commit": "a215825ae2c96723e922e068c226ff77122c7c94",
+  "sourcePath": "src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions",
+  "importRoot": "Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions",
+  "importDate": "2026-08-26",
+  "license": {
+    "name": "MIT",
+    "url": "https://github.com/luisquintanilla/extensions/blob/a215825ae2c96723e922e068c226ff77122c7c94/LICENSE"
+  },
+  "verificationCommand": "pwsh -File src/AI/DocumentExtraction.ContractProposal/Verify-Upstream.ps1",
+  "sourceFileCount": 23,
+  "provenanceArtifactCount": 2,
+  "files": [
+    {
+      "path": "DelegatingDocumentExtractionClient.cs",
+      "role": "source",
+      "sha256": "bf67bb1d7f99a9f0060a7646cae26385ac2ee656bbd76c7d59124b289a752240"
+    },
+    {
+      "path": "DocumentBlock.cs",
+      "role": "source",
+      "sha256": "276702e3082d24164e32ca80469389618ebacbb2c286baf60b2e594429d5e5ca"
+    },
+    {
+      "path": "DocumentBlockKind.cs",
+      "role": "source",
+      "sha256": "892bcc4cea94d1fd7822f8364ff0237fd1aa6b65da56b2aabbec4ef81c4ab4bc"
+    },
+    {
+      "path": "DocumentBoundingBox.cs",
+      "role": "source",
+      "sha256": "3e6d93dda590c2ecbefaeb671946e65540097a0d9906a5f4e386db812084d059"
+    },
+    {
+      "path": "DocumentBoundingRegion.cs",
+      "role": "source",
+      "sha256": "71eb18909324e3cffe5006ecb7d8ee31341f54707e6ca75c68b107bc1f3c25e4"
+    },
+    {
+      "path": "DocumentCoordinateOrigin.cs",
+      "role": "source",
+      "sha256": "21c20449aa89e9bc339a02cd985e92ccf8ac89d7685e74f38117b9d51ac85f97"
+    },
+    {
+      "path": "DocumentCoordinateUnit.cs",
+      "role": "source",
+      "sha256": "b6e2c24a0fd36cad8abbd21bc19cf815c61f475ece01c7073f7fc19405dfb8c9"
+    },
+    {
+      "path": "DocumentElement.cs",
+      "role": "source",
+      "sha256": "ef3c16d65cb27254612165bfce99cdda1402dd4c3be09463d8afe6771b4a6cf0"
+    },
+    {
+      "path": "DocumentExtractionClientExtensions.cs",
+      "role": "source",
+      "sha256": "dd8983d02ecbb000b6eb0c0f7d57f95578e82c8a0bae84b6b5efe76948e9c843"
+    },
+    {
+      "path": "DocumentExtractionClientMetadata.cs",
+      "role": "source",
+      "sha256": "996ddffcea4cd1addf200dd26d3ab726c99b1a75a2f26afbdae8a23b6e4d23dc"
+    },
+    {
+      "path": "DocumentExtractionOptions.cs",
+      "role": "source",
+      "sha256": "c73f3f4350deff3f42f783db824b072bde07e2a56bdaacd6af889e9e794c681a"
+    },
+    {
+      "path": "DocumentExtractionPageResult.cs",
+      "role": "source",
+      "sha256": "2dcf2353a10f75ad9e6aad00015c37058ef61b4af0bca03b80664817e78038f0"
+    },
+    {
+      "path": "DocumentExtractionPageResultExtensions.cs",
+      "role": "source",
+      "sha256": "4f58a8b7d82dfa118f202dc9f620b0515fd4c164a8c71bc98a5031615f1641f0"
+    },
+    {
+      "path": "DocumentExtractionResult.cs",
+      "role": "source",
+      "sha256": "440bf34f38b53de7c24a937d062d6518aa2966493cf91c926e4377e261fcae90"
+    },
+    {
+      "path": "DocumentExtractionUsage.cs",
+      "role": "source",
+      "sha256": "9cceccc31ff0a4e01fd23a273db34064da7ab7b6cc17399269dd262d35be1566"
+    },
+    {
+      "path": "DocumentImage.cs",
+      "role": "source",
+      "sha256": "b1d9fe44683a81d8d855d4c9c16bb32e6f4ce255ca8ee88f053b940208b33e04"
+    },
+    {
+      "path": "DocumentPage.cs",
+      "role": "source",
+      "sha256": "310abbd2277acc8b56136e7d53be7719bf6864d55791b2136ca7d07d8cb1e612"
+    },
+    {
+      "path": "DocumentPageDimensions.cs",
+      "role": "source",
+      "sha256": "94e330d6c6098e9d9ead74fc270d802fa9629f91262adc7a8ee38089020ee593"
+    },
+    {
+      "path": "DocumentPoint.cs",
+      "role": "source",
+      "sha256": "9d6a3ba3d2ce69b046819078afdc171105050801e13586a2fce03de17ba9cff8"
+    },
+    {
+      "path": "DocumentTable.cs",
+      "role": "source",
+      "sha256": "ca01c38b4c3093ddb78439738ddc8a583942b8e074dca8055942654e783046dc"
+    },
+    {
+      "path": "DocumentTableCell.cs",
+      "role": "source",
+      "sha256": "882ed6c6f2ce2be265474869d680cc469bd1d2aa48679fde89c95ce94faf57d5"
+    },
+    {
+      "path": "DocumentTableCellKind.cs",
+      "role": "source",
+      "sha256": "eced8ee1f969c88e638402f026b29607f5fa221fd14058c37715168a6a23996b"
+    },
+    {
+      "path": "IDocumentExtractionClient.cs",
+      "role": "source",
+      "sha256": "4997015d5ff6121b9272f38d4e384831c01b3662108dcd5626355614abbff98d"
+    },
+    {
+      "path": "Microsoft.Extensions.DocumentExtraction.Abstractions.json",
+      "role": "api-baseline-provenance",
+      "sha256": "9c77489ef06d78ba8b19be22dc2e08d51f5d02c3bd6efc936b774776bda98784"
+    },
+    {
+      "path": "README.md",
+      "role": "readme-provenance",
+      "sha256": "a8d6c2611fc81e13e6f792d0b6c7fea39c247ff1fc1994a51bdb5925f70aa053"
+    }
+  ]
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DelegatingDocumentExtractionClient.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DelegatingDocumentExtractionClient.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Provides an optional base class for an <see cref="IDocumentExtractionClient"/> that passes through calls to another instance.</summary>
+/// <remarks>
+/// This is recommended as a base type when building clients that can be chained in any order around an
+/// underlying <see cref="IDocumentExtractionClient"/>. The default implementation simply passes each call to the inner
+/// client instance.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DelegatingDocumentExtractionClient : IDocumentExtractionClient
+{
+    /// <summary>Initializes a new instance of the <see cref="DelegatingDocumentExtractionClient"/> class.</summary>
+    /// <param name="innerClient">The wrapped client instance.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="innerClient"/> is <see langword="null"/>.</exception>
+    protected DelegatingDocumentExtractionClient(IDocumentExtractionClient innerClient)
+    {
+        InnerClient = Throw.IfNull(innerClient);
+    }
+
+    /// <summary>Gets the inner <see cref="IDocumentExtractionClient"/>.</summary>
+    protected IDocumentExtractionClient InnerClient { get; }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc />
+    public virtual Task<DocumentExtractionResult> ExtractAsync(
+        Stream document,
+        string mediaType,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return InnerClient.ExtractAsync(document, mediaType, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual IAsyncEnumerable<DocumentExtractionPageResult> ExtractPagesAsync(
+        Stream document,
+        string mediaType,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return InnerClient.ExtractPagesAsync(document, mediaType, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        _ = Throw.IfNull(serviceType);
+
+        // If the key is non-null, we don't know what it means so pass through to the inner service.
+        return
+            serviceKey is null && serviceType.IsInstanceOfType(this) ? this :
+            InnerClient.GetService(serviceType, serviceKey);
+    }
+
+    /// <summary>Provides a mechanism for releasing unmanaged resources.</summary>
+    /// <param name="disposing"><see langword="true"/> if being called from <see cref="Dispose()"/>; otherwise, <see langword="false"/>.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            InnerClient.Dispose();
+        }
+    }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentBlock.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentBlock.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents a positioned layout block, such as a paragraph, heading, or figure.</summary>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentBlock : DocumentElement
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentBlock"/> class.</summary>
+    /// <param name="text">The text content of the block.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
+    public DocumentBlock(string text)
+    {
+        Text = Throw.IfNull(text);
+    }
+
+    /// <summary>Gets the text content of the block.</summary>
+    public string Text { get; }
+
+    /// <summary>Gets or sets the kind of block, for example <see cref="DocumentBlockKind.Paragraph"/>, <see cref="DocumentBlockKind.Title"/>, or <see cref="DocumentBlockKind.Figure"/>.</summary>
+    public DocumentBlockKind? Kind { get; set; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentBlockKind.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentBlockKind.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Describes the kind of an <see cref="DocumentBlock"/>, such as a paragraph, title, or figure.</summary>
+/// <remarks>
+/// This is a small open set modeled on <see cref="Microsoft.Extensions.AI.ChatRole"/>: the well-known values cover the common
+/// layout categories, and a provider may introduce its own value when an engine reports a kind that is
+/// not represented here.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct DocumentBlockKind : IEquatable<DocumentBlockKind>
+{
+    /// <summary>Gets the kind representing a paragraph of body text.</summary>
+    public static DocumentBlockKind Paragraph { get; } = new("paragraph");
+
+    /// <summary>Gets the kind representing a title or heading.</summary>
+    public static DocumentBlockKind Title { get; } = new("title");
+
+    /// <summary>Gets the kind representing a figure or image region.</summary>
+    public static DocumentBlockKind Figure { get; } = new("figure");
+
+    /// <summary>Gets the value associated with this <see cref="DocumentBlockKind"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="DocumentBlockKind"/> struct with the provided value.</summary>
+    /// <param name="value">The value to associate with this <see cref="DocumentBlockKind"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is empty or composed entirely of whitespace.</exception>
+    [JsonConstructor]
+    public DocumentBlockKind(string value)
+    {
+        Value = Throw.IfNullOrWhitespace(value);
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="DocumentBlockKind"/> instances are equivalent, using a case-insensitive comparison.</summary>
+    /// <param name="left">The first <see cref="DocumentBlockKind"/> instance to compare.</param>
+    /// <param name="right">The second <see cref="DocumentBlockKind"/> instance to compare.</param>
+    /// <returns><see langword="true"/> if left and right have equivalent values; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(DocumentBlockKind left, DocumentBlockKind right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="DocumentBlockKind"/> instances are not equivalent, using a case-insensitive comparison.</summary>
+    /// <param name="left">The first <see cref="DocumentBlockKind"/> instance to compare.</param>
+    /// <param name="right">The second <see cref="DocumentBlockKind"/> instance to compare.</param>
+    /// <returns><see langword="true"/> if left and right have different values; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(DocumentBlockKind left, DocumentBlockKind right)
+    {
+        return !(left == right);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is DocumentBlockKind otherKind && Equals(otherKind);
+
+    /// <inheritdoc/>
+    public bool Equals(DocumentBlockKind other)
+        => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+        => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc/>
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{DocumentBlockKind}"/> for serializing <see cref="DocumentBlockKind"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<DocumentBlockKind>
+    {
+        /// <inheritdoc/>
+        public override DocumentBlockKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            new(reader.GetString()!);
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, DocumentBlockKind value, JsonSerializerOptions options) =>
+            Throw.IfNull(writer).WriteStringValue(value.Value);
+    }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentBoundingBox.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentBoundingBox.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents the axis-aligned bounds of a bounding polygon, in the coordinate space defined by the OCR engine.</summary>
+/// <param name="Left">The minimum horizontal coordinate.</param>
+/// <param name="Top">The minimum vertical coordinate.</param>
+/// <param name="Right">The maximum horizontal coordinate.</param>
+/// <param name="Bottom">The maximum vertical coordinate.</param>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public readonly record struct DocumentBoundingBox(float Left, float Top, float Right, float Bottom);

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentBoundingRegion.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentBoundingRegion.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents a positioned region on a page.</summary>
+/// <remarks>
+/// The region is a polygon (a clockwise sequence of <see cref="DocumentPoint"/> vertices) so it can
+/// faithfully carry a possibly rotation-skewed quadrilateral, such as Azure Document Intelligence's
+/// <c>BoundingRegion.Polygon</c>, without loss. Engines that emit only an axis-aligned rectangle
+/// (such as Mistral OCR) can convert via <see cref="FromRectangle"/>. The same type is reused for
+/// layout-block geometry and for field grounding, providing one region primitive across providers.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentBoundingRegion
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentBoundingRegion"/> class.</summary>
+    /// <param name="pageNumber">The one-based page number the region is on.</param>
+    /// <param name="polygon">The clockwise polygon vertices.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="polygon"/> is <see langword="null"/>.</exception>
+    public DocumentBoundingRegion(int pageNumber, IReadOnlyList<DocumentPoint> polygon)
+    {
+        PageNumber = pageNumber;
+        Polygon = Throw.IfNull(polygon);
+    }
+
+    /// <summary>Gets the one-based page number the region is on.</summary>
+    /// <remarks>A region can reference a different page than its parent element.</remarks>
+    public int PageNumber { get; }
+
+    /// <summary>Gets the polygon vertices, in clockwise order.</summary>
+    /// <remarks>An Azure Document Intelligence quadrilateral is four points.</remarks>
+    public IReadOnlyList<DocumentPoint> Polygon { get; }
+
+    /// <summary>Builds a clockwise quadrilateral region from an axis-aligned rectangle.</summary>
+    /// <param name="pageNumber">The one-based page number the region is on.</param>
+    /// <param name="left">The left coordinate.</param>
+    /// <param name="top">The top coordinate.</param>
+    /// <param name="right">The right coordinate.</param>
+    /// <param name="bottom">The bottom coordinate.</param>
+    /// <returns>A region whose polygon is the four corners of the rectangle.</returns>
+    public static DocumentBoundingRegion FromRectangle(int pageNumber, float left, float top, float right, float bottom)
+        => new(pageNumber,
+        [
+            new DocumentPoint(left, top),
+            new DocumentPoint(right, top),
+            new DocumentPoint(right, bottom),
+            new DocumentPoint(left, bottom),
+        ]);
+
+    /// <summary>Computes the axis-aligned bounds of the polygon.</summary>
+    /// <returns>The axis-aligned bounds, or <see langword="null"/> when the polygon has no vertices.</returns>
+    /// <remarks>
+    /// Returning <see langword="null"/> for an empty polygon avoids conflating "no geometry" with a real
+    /// zero-size box located at the origin.
+    /// </remarks>
+    public DocumentBoundingBox? GetBounds()
+    {
+        if (Polygon.Count == 0)
+        {
+            return null;
+        }
+
+        float minX = float.MaxValue, minY = float.MaxValue, maxX = float.MinValue, maxY = float.MinValue;
+        foreach (DocumentPoint point in Polygon)
+        {
+            minX = Math.Min(minX, point.X);
+            maxX = Math.Max(maxX, point.X);
+            minY = Math.Min(minY, point.Y);
+            maxY = Math.Max(maxY, point.Y);
+        }
+
+        return new DocumentBoundingBox(minX, minY, maxX, maxY);
+    }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentCoordinateOrigin.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentCoordinateOrigin.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>
+/// Describes the origin corner and vertical axis direction of an OCR coordinate space.
+/// </summary>
+/// <remarks>
+/// Engines disagree on where a page's coordinate origin sits and which way the y axis grows: rasterized
+/// page images place the origin at the top-left with y increasing downward, whereas PDF-native
+/// (point) coordinates place it at the bottom-left with y increasing upward. The origin is reported per
+/// page on <see cref="DocumentPage.CoordinateOrigin"/>, alongside <see cref="DocumentCoordinateUnit"/>, so bounding
+/// regions from different engines can be compared and normalized without guessing the convention.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public enum DocumentCoordinateOrigin
+{
+    /// <summary>The origin sits at the top-left corner, with the y axis increasing downward. The convention for rasterized page images.</summary>
+    TopLeft,
+
+    /// <summary>The origin sits at the bottom-left corner, with the y axis increasing upward. The convention for PDF-native point coordinates.</summary>
+    BottomLeft,
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentCoordinateUnit.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentCoordinateUnit.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>
+/// Describes the unit in which OCR geometry coordinates (<see cref="DocumentPoint"/> and
+/// <see cref="DocumentBoundingBox"/>) are expressed.
+/// </summary>
+/// <remarks>
+/// Coordinate conventions differ across OCR engines: some report pixels of the rendered page image,
+/// some report a physical unit such as points or inches, and some normalize to the page. The unit is
+/// reported per page on <see cref="DocumentPage.CoordinateUnit"/>, paired with an
+/// <see cref="DocumentCoordinateOrigin"/> and the page dimensions (<see cref="DocumentPageDimensions"/>), so a
+/// consumer can interpret or normalize regions with engine-agnostic code. It is per page because engines
+/// can emit different units for different pages of one document (for example, a batch mixing image and
+/// PDF inputs). Unlike the taxonomy kinds (<see cref="DocumentBlockKind"/>, <see cref="DocumentTableCellKind"/>),
+/// the set of coordinate units is physically bounded, so it is modeled as a closed enumeration.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public enum DocumentCoordinateUnit
+{
+    /// <summary>Coordinates expressed in pixels of the rendered page image.</summary>
+    Pixel,
+
+    /// <summary>Coordinates expressed in points (1/72 inch), the native unit of PDF content.</summary>
+    Point,
+
+    /// <summary>Coordinates expressed in inches.</summary>
+    Inch,
+
+    /// <summary>Coordinates normalized to the range [0, 1] relative to the page width and height.</summary>
+    Normalized,
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentElement.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentElement.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents a single positioned element within an <see cref="DocumentPage"/>, such as a block, table, or image.</summary>
+/// <remarks>
+/// Elements appear in <see cref="DocumentPage.Elements"/> in reading order, so a consumer can walk a page as one
+/// heterogeneous stream and project the kinds it cares about with
+/// <see cref="System.Linq.Enumerable.OfType{TResult}(System.Collections.IEnumerable)"/> (for example
+/// <c>page.Elements.OfType&lt;DocumentTable&gt;()</c>). The full page text is available directly on
+/// <see cref="DocumentPage.Text"/>. The base is shaped to be promotable to a future shared document-element type.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+[JsonDerivedType(typeof(DocumentBlock), typeDiscriminator: "block")]
+[JsonDerivedType(typeof(DocumentTable), typeDiscriminator: "table")]
+[JsonDerivedType(typeof(DocumentImage), typeDiscriminator: "image")]
+public abstract class DocumentElement
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentElement"/> class.</summary>
+    protected DocumentElement()
+    {
+    }
+
+    /// <summary>Gets or sets the region of the page the element occupies, when the engine provides geometry.</summary>
+    public DocumentBoundingRegion? BoundingRegion { get; set; }
+
+    /// <summary>Gets or sets the confidence for the element in the range [0, 1], when available.</summary>
+    public double? Confidence { get; set; }
+
+    /// <summary>Gets or sets the provider-native object underlying this element.</summary>
+    /// <remarks>
+    /// If an <see cref="DocumentElement"/> is created to represent an underlying object from another object model,
+    /// this property can store that original object. This can be useful for debugging or for enabling a
+    /// consumer to access the underlying object model if needed.
+    /// </remarks>
+    [JsonIgnore]
+    public object? RawRepresentation { get; set; }
+
+    /// <summary>Gets or sets any additional properties associated with the element.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionClientExtensions.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionClientExtensions.cs
@@ -1,0 +1,224 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Provides extension methods for <see cref="IDocumentExtractionClient"/>.</summary>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public static class DocumentExtractionClientExtensions
+{
+    /// <summary>Asks the <see cref="IDocumentExtractionClient"/> for an object of type <typeparamref name="TService"/>.</summary>
+    /// <typeparam name="TService">The type of the object to be retrieved.</typeparam>
+    /// <param name="client">The client.</param>
+    /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
+    /// <returns>The found object, otherwise <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// The purpose of this method is to allow for the retrieval of strongly typed services that might be
+    /// provided by the <see cref="IDocumentExtractionClient"/>, including itself or any services it might be wrapping.
+    /// </remarks>
+    public static TService? GetService<TService>(this IDocumentExtractionClient client, object? serviceKey = null)
+    {
+        _ = Throw.IfNull(client);
+
+        return (TService?)client.GetService(typeof(TService), serviceKey);
+    }
+
+    /// <summary>Runs OCR over a single document provided as a <see cref="DataContent"/>.</summary>
+    /// <param name="client">The client.</param>
+    /// <param name="document">The document content to parse.</param>
+    /// <param name="options">The OCR options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The structured OCR result.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> or <paramref name="document"/> is <see langword="null"/>.</exception>
+    public static Task<DocumentExtractionResult> ExtractAsync(
+        this IDocumentExtractionClient client,
+        DataContent document,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(client);
+        _ = Throw.IfNull(document);
+
+        var documentStream = MemoryMarshal.TryGetArray(document.Data, out var array) ?
+            new MemoryStream(array.Array!, array.Offset, array.Count) :
+            new MemoryStream(document.Data.ToArray());
+
+        return client.ExtractAsync(documentStream, document.MediaType, options, cancellationToken);
+    }
+
+    /// <summary>Runs OCR over a single document referenced by a <see cref="UriContent"/>.</summary>
+    /// <param name="client">The client.</param>
+    /// <param name="document">The document reference to parse.</param>
+    /// <param name="options">The OCR options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The structured OCR result.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> or <paramref name="document"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">The <paramref name="document"/> references a remote URI, which this overload does not fetch.</exception>
+    /// <remarks>
+    /// This overload handles self-contained <c>data:</c> URIs by delegating to the
+    /// <see cref="DataContent"/> overload. It intentionally does no file or network IO: for
+    /// <c>file:</c> and remote (<c>http</c>/<c>https</c>) URIs it throws, because whether to read/download
+    /// the bytes or hand the URL to the engine natively (for example Mistral <c>document_url</c> or Azure
+    /// Document Intelligence <c>uriSource</c>) is an open design question the abstraction does not decide.
+    /// To download a remote document explicitly, use
+    /// <see cref="ExtractFromUriAsync(IDocumentExtractionClient, UriContent, HttpClient, DocumentExtractionOptions?, CancellationToken)"/>
+    /// with a caller-supplied <see cref="HttpClient"/>; or read the bytes yourself and pass a
+    /// <see cref="Stream"/> or <see cref="DataContent"/>; or use an engine that accepts a URL directly.
+    /// </remarks>
+    public static Task<DocumentExtractionResult> ExtractAsync(
+        this IDocumentExtractionClient client,
+        UriContent document,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(client);
+        _ = Throw.IfNull(document);
+
+        Uri uri = document.Uri;
+        if (uri.IsAbsoluteUri && string.Equals(uri.Scheme, "data", StringComparison.OrdinalIgnoreCase))
+        {
+            // Reuse DataContent's data: URI parsing, then defer to the DataContent overload.
+            return client.ExtractAsync(new DataContent(uri), options, cancellationToken);
+        }
+
+        throw new NotSupportedException(
+            "This overload handles only self-contained data: URIs. For file or remote URIs, read the bytes " +
+            "and pass a stream or DataContent, or use an engine that accepts a URL natively.");
+    }
+
+    /// <summary>
+    /// Runs OCR over a single document referenced by a <see cref="UriContent"/>, explicitly downloading the
+    /// bytes with a caller-supplied <see cref="HttpClient"/> when the reference is remote.
+    /// </summary>
+    /// <param name="client">The client.</param>
+    /// <param name="document">The document reference to download and parse.</param>
+    /// <param name="httpClient">The <see cref="HttpClient"/> used to download remote (<c>http</c>/<c>https</c>) documents.</param>
+    /// <param name="options">The OCR options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The structured OCR result.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/>, <paramref name="document"/>, or <paramref name="httpClient"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">The <paramref name="document"/> uses a scheme other than <c>data:</c>, <c>http</c>, or <c>https</c>.</exception>
+    /// <remarks>
+    /// This is the explicit, opt-in counterpart to
+    /// <see cref="ExtractAsync(IDocumentExtractionClient, UriContent, DocumentExtractionOptions?, CancellationToken)"/>,
+    /// which never touches the network. Self-contained <c>data:</c> URIs are handled inline (no download);
+    /// <c>http</c>/<c>https</c> URIs are fetched with the supplied <paramref name="httpClient"/> and passed
+    /// to the stream-based extraction path. The abstraction performs no ambient network IO: the caller owns
+    /// the <see cref="HttpClient"/> and therefore its handlers, authentication, timeouts, and lifetime.
+    /// Engines that accept a URL natively (for example Azure Document Intelligence <c>uriSource</c>) should
+    /// expose that on the concrete client instead; this extension serves the bytes-only majority.
+    /// </remarks>
+    public static async Task<DocumentExtractionResult> ExtractFromUriAsync(
+        this IDocumentExtractionClient client,
+        UriContent document,
+        HttpClient httpClient,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(client);
+        _ = Throw.IfNull(document);
+        _ = Throw.IfNull(httpClient);
+
+        Uri uri = document.Uri;
+
+        // Self-contained data: URIs carry their own bytes - no download needed.
+        if (uri.IsAbsoluteUri && string.Equals(uri.Scheme, "data", StringComparison.OrdinalIgnoreCase))
+        {
+            return await client.ExtractAsync(document, options, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!uri.IsAbsoluteUri ||
+            (!string.Equals(uri.Scheme, "http", StringComparison.OrdinalIgnoreCase) &&
+             !string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new NotSupportedException(
+                "ExtractFromUriAsync downloads only http/https URIs (and inlines data: URIs). For other " +
+                "schemes, read the bytes and pass a stream or DataContent.");
+        }
+
+        using HttpResponseMessage response = await httpClient
+            .GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        _ = response.EnsureSuccessStatusCode();
+
+        string mediaType = response.Content.Headers.ContentType?.MediaType ?? document.MediaType;
+
+#if NET
+        using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#else
+        using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#endif
+        return await client.ExtractAsync(contentStream, mediaType, options, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Runs streaming OCR over a single document provided as a <see cref="DataContent"/>.</summary>
+    /// <param name="client">The client.</param>
+    /// <param name="document">The document content to parse.</param>
+    /// <param name="options">The OCR options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The structured OCR updates representing the streamed output.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> or <paramref name="document"/> is <see langword="null"/>.</exception>
+    public static IAsyncEnumerable<DocumentExtractionPageResult> ExtractPagesAsync(
+        this IDocumentExtractionClient client,
+        DataContent document,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(client);
+        _ = Throw.IfNull(document);
+
+        var documentStream = MemoryMarshal.TryGetArray(document.Data, out var array) ?
+            new MemoryStream(array.Array!, array.Offset, array.Count) :
+            new MemoryStream(document.Data.ToArray());
+
+        return client.ExtractPagesAsync(documentStream, document.MediaType, options, cancellationToken);
+    }
+
+    /// <summary>Runs streaming OCR over a single document referenced by a <see cref="UriContent"/>.</summary>
+    /// <param name="client">The client.</param>
+    /// <param name="document">The document reference to parse.</param>
+    /// <param name="options">The OCR options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The structured OCR updates representing the streamed output.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> or <paramref name="document"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">The <paramref name="document"/> references a remote URI, which this overload does not fetch.</exception>
+    /// <remarks>
+    /// This is the streaming counterpart to
+    /// <see cref="ExtractAsync(IDocumentExtractionClient, UriContent, DocumentExtractionOptions?, CancellationToken)"/>; it handles only
+    /// self-contained <c>data:</c> URIs and does no file or network IO. For <c>file:</c> and remote URIs it
+    /// throws, for the same reasons documented on the unary overload.
+    /// </remarks>
+    public static IAsyncEnumerable<DocumentExtractionPageResult> ExtractPagesAsync(
+        this IDocumentExtractionClient client,
+        UriContent document,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(client);
+        _ = Throw.IfNull(document);
+
+        Uri uri = document.Uri;
+        if (uri.IsAbsoluteUri && string.Equals(uri.Scheme, "data", StringComparison.OrdinalIgnoreCase))
+        {
+            // Reuse DataContent's data: URI parsing, then defer to the DataContent overload.
+            return client.ExtractPagesAsync(new DataContent(uri), options, cancellationToken);
+        }
+
+        throw new NotSupportedException(
+            "This overload handles only self-contained data: URIs. For file or remote URIs, read the bytes " +
+            "and pass a stream or DataContent, or use an engine that accepts a URL natively.");
+    }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionClientMetadata.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionClientMetadata.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Provides metadata about an <see cref="IDocumentExtractionClient"/>.</summary>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentExtractionClientMetadata
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentExtractionClientMetadata"/> class.</summary>
+    /// <param name="providerName">The name of the OCR provider, if applicable.</param>
+    /// <param name="providerUri">The URL for accessing the OCR provider, if applicable.</param>
+    /// <param name="defaultModelId">The identifier of the model used by default, if applicable.</param>
+    public DocumentExtractionClientMetadata(string? providerName = null, Uri? providerUri = null, string? defaultModelId = null)
+    {
+        DefaultModelId = defaultModelId;
+        ProviderName = providerName;
+        ProviderUri = providerUri;
+    }
+
+    /// <summary>Gets the name of the OCR provider.</summary>
+    public string? ProviderName { get; }
+
+    /// <summary>Gets the URL for accessing the OCR provider.</summary>
+    public Uri? ProviderUri { get; }
+
+    /// <summary>Gets the identifier of the default model used by this OCR client.</summary>
+    /// <remarks>
+    /// This value can be <see langword="null"/> if the name is unknown or if there are multiple possible
+    /// models associated with this instance. An individual request can override this value via
+    /// <see cref="DocumentExtractionOptions.ModelId"/>.
+    /// </remarks>
+    public string? DefaultModelId { get; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionOptions.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionOptions.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents the options to configure an OCR request.</summary>
+/// <remarks>
+/// Normalized options common to engines, plus an <see cref="AdditionalProperties"/> bag for
+/// provider-specific settings, mirroring <c>ChatOptions</c>.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentExtractionOptions
+{
+    /// <summary>Gets or sets the model or deployment identifier to use for this request.</summary>
+    public string? ModelId { get; set; }
+
+    /// <summary>Gets or sets any additional provider-specific request settings.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+
+    /// <summary>Produces a clone of the current <see cref="DocumentExtractionOptions"/> instance.</summary>
+    /// <returns>A shallow clone of the options instance.</returns>
+    public DocumentExtractionOptions Clone() =>
+        new()
+        {
+            ModelId = ModelId,
+            AdditionalProperties = AdditionalProperties?.Clone(),
+        };
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionPageResult.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionPageResult.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents a single streaming update from an <see cref="IDocumentExtractionClient"/>.</summary>
+/// <remarks>
+/// <para>
+/// An <see cref="IDocumentExtractionClient.ExtractPagesAsync"/> request produces a sequence of
+/// <see cref="DocumentExtractionPageResult"/> instances, one per page as that page finishes (carrying the completed
+/// <see cref="Page"/>). Progress rides along on each result via <see cref="PagesProcessed"/> and
+/// <see cref="TotalPages"/> for long-running operations such as Azure Document Intelligence. Completion is
+/// signaled by the end of the sequence.
+/// </para>
+/// <para>
+/// The relationship between <see cref="DocumentExtractionResult"/> and <see cref="DocumentExtractionPageResult"/> is codified in
+/// <see cref="DocumentExtractionPageResultExtensions.ToDocumentExtractionResultAsync"/>, which reassembles a stream of updates into a
+/// single <see cref="DocumentExtractionResult"/>. The conversion can be slightly lossy: for example, only one
+/// <see cref="RawRepresentation"/> slot is available on the assembled <see cref="DocumentExtractionResult"/>.
+/// </para>
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentExtractionPageResult
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentExtractionPageResult"/> class with the page completed in this update.</summary>
+    /// <param name="page">The page produced in this update.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="page"/> is <see langword="null"/>.</exception>
+    [JsonConstructor]
+    public DocumentExtractionPageResult(DocumentPage page)
+    {
+        Page = Throw.IfNull(page);
+    }
+
+    /// <summary>Gets the page produced in this update.</summary>
+    public DocumentPage Page { get; }
+
+    /// <summary>Gets or sets the number of pages processed so far, when known.</summary>
+    public int? PagesProcessed { get; set; }
+
+    /// <summary>Gets or sets the total number of pages, when known.</summary>
+    public int? TotalPages { get; set; }
+
+    /// <summary>Gets or sets usage details associated with the request, when reported.</summary>
+    /// <remarks>Usage is typically carried on a terminal update once the full document has been processed.</remarks>
+    public DocumentExtractionUsage? Usage { get; set; }
+
+    /// <summary>Gets or sets the provider-native object underlying this update.</summary>
+    /// <remarks>
+    /// If an <see cref="DocumentExtractionPageResult"/> is created to represent an underlying object from another object
+    /// model, this property can store that original object. This can be useful for debugging or for enabling
+    /// a consumer to access the underlying object model if needed.
+    /// </remarks>
+    [JsonIgnore]
+    public object? RawRepresentation { get; set; }
+
+    /// <summary>Gets or sets any additional properties associated with the update.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionPageResultExtensions.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionPageResultExtensions.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Provides extension methods for working with <see cref="DocumentExtractionPageResult"/> instances.</summary>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public static class DocumentExtractionPageResultExtensions
+{
+    /// <summary>Combines <see cref="DocumentExtractionPageResult"/> instances into a single <see cref="DocumentExtractionResult"/>.</summary>
+    /// <param name="updates">The updates to be combined.</param>
+    /// <returns>The combined <see cref="DocumentExtractionResult"/>.</returns>
+    /// <exception cref="System.ArgumentNullException"><paramref name="updates"/> is <see langword="null"/>.</exception>
+    public static DocumentExtractionResult ToDocumentExtractionResult(this IEnumerable<DocumentExtractionPageResult> updates)
+    {
+        _ = Throw.IfNull(updates);
+
+        List<DocumentPage> pages = [];
+        DocumentExtractionResult result = new(pages);
+
+        foreach (var update in updates)
+        {
+            ProcessUpdate(update, pages, result);
+        }
+
+        return result;
+    }
+
+    /// <summary>Combines <see cref="DocumentExtractionPageResult"/> instances into a single <see cref="DocumentExtractionResult"/>.</summary>
+    /// <param name="updates">The updates to be combined.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The combined <see cref="DocumentExtractionResult"/>.</returns>
+    /// <exception cref="System.ArgumentNullException"><paramref name="updates"/> is <see langword="null"/>.</exception>
+    public static Task<DocumentExtractionResult> ToDocumentExtractionResultAsync(
+        this IAsyncEnumerable<DocumentExtractionPageResult> updates, CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(updates);
+
+        return ToResultAsync(updates, cancellationToken);
+
+        static async Task<DocumentExtractionResult> ToResultAsync(
+            IAsyncEnumerable<DocumentExtractionPageResult> updates, CancellationToken cancellationToken)
+        {
+            List<DocumentPage> pages = [];
+            DocumentExtractionResult result = new(pages);
+
+            await foreach (var update in updates.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                ProcessUpdate(update, pages, result);
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>Incorporates one <see cref="DocumentExtractionPageResult"/> into the assembled <see cref="DocumentExtractionResult"/>.</summary>
+    /// <param name="update">The update to process.</param>
+    /// <param name="pages">The accumulating list of pages backing <see cref="DocumentExtractionResult.Pages"/>.</param>
+    /// <param name="result">The <see cref="DocumentExtractionResult"/> being assembled.</param>
+    private static void ProcessUpdate(DocumentExtractionPageResult update, List<DocumentPage> pages, DocumentExtractionResult result)
+    {
+        pages.Add(update.Page);
+
+        if (update.Usage is not null)
+        {
+            result.Usage = update.Usage;
+        }
+
+        if (update.AdditionalProperties is not null)
+        {
+            if (result.AdditionalProperties is null)
+            {
+                result.AdditionalProperties = new(update.AdditionalProperties);
+            }
+            else
+            {
+                foreach (var entry in update.AdditionalProperties)
+                {
+                    result.AdditionalProperties[entry.Key] = entry.Value;
+                }
+            }
+        }
+    }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionResult.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionResult.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents the structured result of an OCR / document-parsing request.</summary>
+/// <remarks>
+/// The result normalizes the content common to every engine (text, pages, tables, bounding
+/// regions) while preserving everything provider-specific via
+/// <see cref="RawRepresentation"/> and <see cref="AdditionalProperties"/>, mirroring how
+/// <c>ChatResponse</c> normalizes the common surface and preserves the raw.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentExtractionResult
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentExtractionResult"/> class.</summary>
+    /// <param name="pages">The per-page structured content.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="pages"/> is <see langword="null"/>.</exception>
+    public DocumentExtractionResult(IReadOnlyList<DocumentPage> pages)
+    {
+        Pages = Throw.IfNull(pages);
+    }
+
+    /// <summary>Gets the per-page structured content (text, tables, blocks).</summary>
+    public IReadOnlyList<DocumentPage> Pages { get; }
+
+    /// <summary>Gets the full-document text, formed by joining the per-page text.</summary>
+    public string Text => string.Join("\n\n", Pages.Select(p => p.Text));
+
+    /// <summary>Gets or sets usage details associated with the request.</summary>
+    public DocumentExtractionUsage? Usage { get; set; }
+
+    /// <summary>Gets or sets the provider-native object underlying this result.</summary>
+    /// <remarks>
+    /// The escape hatch for provider richness that does not map onto the normalized surface, mirroring
+    /// <c>ChatResponse.RawRepresentation</c>. Nothing is lost.
+    /// </remarks>
+    public object? RawRepresentation { get; set; }
+
+    /// <summary>Gets or sets any additional properties associated with the result.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionUsage.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentExtractionUsage.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents usage details associated with an OCR request.</summary>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentExtractionUsage
+{
+    /// <summary>Gets or sets the number of pages processed by the request, when known.</summary>
+    public int? PagesProcessed { get; set; }
+
+    /// <summary>Gets or sets the number of input tokens consumed, when the engine reports token usage.</summary>
+    /// <remarks>Typically reported only by vision-LLM OCR paths; classic OCR engines usually leave this <see langword="null"/>.</remarks>
+    public int? InputTokenCount { get; set; }
+
+    /// <summary>Gets or sets the number of output tokens produced, when the engine reports token usage.</summary>
+    public int? OutputTokenCount { get; set; }
+
+    /// <summary>Gets or sets the total number of tokens (input plus output), when the engine reports token usage.</summary>
+    public int? TotalTokenCount { get; set; }
+
+    /// <summary>Gets or sets any additional provider-specific usage details.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentImage.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentImage.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents an image or figure extracted from a page during OCR.</summary>
+/// <remarks>
+/// Populated when the engine supports it and images are present. Every
+/// member is optional so each implementer fills what it can provide: document-native engines (for
+/// example Mistral OCR inline images, or Azure Document Intelligence figures) populate <see cref="Content"/>
+/// with the rendered image bytes, whereas a vision-LLM transcriber that cannot emit bytes may instead
+/// populate only <see cref="Caption"/>. This lets one shape serve both provider archetypes.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentImage : DocumentElement
+{
+    /// <summary>Gets or sets the rendered image bytes, when the engine returns them.</summary>
+    public DataContent? Content { get; set; }
+
+    /// <summary>Gets or sets a caption or description of the image, when available.</summary>
+    public string? Caption { get; set; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentPage.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentPage.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents one page of structured OCR output.</summary>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentPage
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentPage"/> class.</summary>
+    /// <param name="pageNumber">The one-based page number.</param>
+    /// <param name="text">The structured text for this page.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
+    public DocumentPage(int pageNumber, string text)
+    {
+        PageNumber = pageNumber;
+        Text = Throw.IfNull(text);
+    }
+
+    /// <summary>Gets the one-based page number.</summary>
+    public int PageNumber { get; }
+
+    /// <summary>Gets the structured text for this page, with headings, tables, and reading order preserved.</summary>
+    public string Text { get; }
+
+    /// <summary>Gets or sets the elements extracted from this page, in reading order.</summary>
+    /// <remarks>
+    /// A single heterogeneous stream of blocks, tables, and images in the order a human would read them.
+    /// Project a specific kind with <see cref="System.Linq.Enumerable.OfType{TResult}(System.Collections.IEnumerable)"/>,
+    /// for example <c>Elements.OfType&lt;DocumentTable&gt;()</c>. The full page text is available directly on
+    /// <see cref="Text"/>, so reading-order consumers do not need geometry math.
+    /// </remarks>
+    public IReadOnlyList<DocumentElement> Elements { get; set; } = [];
+
+    /// <summary>Gets or sets the page dimensions (width and height), expressed in <see cref="CoordinateUnit"/>, when the engine provides them.</summary>
+    /// <remarks>
+    /// Together with <see cref="CoordinateUnit"/> and <see cref="CoordinateOrigin"/>, the dimensions let a consumer
+    /// interpret or normalize the geometry (<see cref="DocumentBoundingBox"/> / <see cref="DocumentPoint"/>) on this page with
+    /// engine-agnostic code. For example, dividing a coordinate by the corresponding dimension yields a page-relative
+    /// [0, 1] value regardless of the native unit.
+    /// </remarks>
+    public DocumentPageDimensions? Dimensions { get; set; }
+
+    /// <summary>Gets or sets the unit in which this page's geometry coordinates are expressed, when known.</summary>
+    /// <remarks>
+    /// Reported per page: engines can emit different units for different pages of one document (for example, a batch
+    /// mixing image and PDF inputs). Applies to every <see cref="DocumentBoundingRegion"/> on the page and to
+    /// <see cref="Dimensions"/>. When <see langword="null"/>, the geometry should be treated as an opaque,
+    /// provider-specific coordinate space.
+    /// </remarks>
+    public DocumentCoordinateUnit? CoordinateUnit { get; set; }
+
+    /// <summary>Gets or sets the origin corner and axis direction of this page's geometry coordinates, when known.</summary>
+    public DocumentCoordinateOrigin? CoordinateOrigin { get; set; }
+
+    /// <summary>Gets or sets the provider-native object underlying this page.</summary>
+    /// <remarks>
+    /// If an <see cref="DocumentPage"/> is created to represent an underlying object from another object model, this
+    /// property can store that original object. This can be useful for debugging or for enabling a consumer to
+    /// access the underlying object model if needed. Because the page node rides through
+    /// <see cref="DocumentExtractionPageResultExtensions.ToDocumentExtractionResult"/> reduction, provider-native page data set here survives
+    /// into <see cref="DocumentExtractionResult.Pages"/>.
+    /// </remarks>
+    [JsonIgnore]
+    public object? RawRepresentation { get; set; }
+
+    /// <summary>Gets or sets any additional properties associated with the page.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentPageDimensions.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentPageDimensions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents the width and height of an <see cref="DocumentPage"/>, expressed in the page's <see cref="DocumentPage.CoordinateUnit"/>.</summary>
+/// <param name="Width">The page width.</param>
+/// <param name="Height">The page height.</param>
+/// <remarks>
+/// Together with the page's <see cref="DocumentPage.CoordinateUnit"/> and <see cref="DocumentPage.CoordinateOrigin"/>, the
+/// dimensions let a consumer interpret or normalize the geometry (<see cref="DocumentBoundingBox"/> / <see cref="DocumentPoint"/>)
+/// on the page with engine-agnostic code. For example, dividing a coordinate by the corresponding dimension yields a
+/// page-relative [0, 1] value regardless of the native unit.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public readonly record struct DocumentPageDimensions(float Width, float Height);

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentPoint.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentPoint.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents a single vertex of a bounding polygon, in the coordinate space defined by the OCR engine.</summary>
+/// <param name="X">The horizontal coordinate.</param>
+/// <param name="Y">The vertical coordinate.</param>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public readonly record struct DocumentPoint(float X, float Y);

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentTable.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentTable.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents a table extracted from a document.</summary>
+/// <remarks>
+/// Cells are the primary, structured representation (row and column indices with spans, the Azure
+/// Document Intelligence shape) and are authoritative when non-<see langword="null"/>.
+/// <see cref="MarkdownRepresentation"/> is the fallback for engines that only emit markdown or HTML
+/// (such as Mistral OCR). Consumers prefer <see cref="Cells"/> when present and fall back to
+/// <see cref="MarkdownRepresentation"/> otherwise. On the markdown-only path <see cref="RowCount"/> and
+/// <see cref="ColumnCount"/> may be 0 because the structure was not enumerated.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentTable : DocumentElement
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentTable"/> class.</summary>
+    /// <param name="rowCount">The number of rows in the table.</param>
+    /// <param name="columnCount">The number of columns in the table.</param>
+    /// <param name="cells">The structured cells, or <see langword="null"/> when only markdown is available.</param>
+    /// <param name="markdownRepresentation">The markdown or HTML representation, or <see langword="null"/> when cells are available.</param>
+    public DocumentTable(
+        int rowCount,
+        int columnCount,
+        IReadOnlyList<DocumentTableCell>? cells = null,
+        string? markdownRepresentation = null)
+    {
+        RowCount = rowCount;
+        ColumnCount = columnCount;
+        Cells = cells;
+        MarkdownRepresentation = markdownRepresentation;
+    }
+
+    /// <summary>Gets the number of rows in the table.</summary>
+    public int RowCount { get; }
+
+    /// <summary>Gets the number of columns in the table.</summary>
+    public int ColumnCount { get; }
+
+    /// <summary>Gets the structured cells, or <see langword="null"/> when the engine only returned markdown.</summary>
+    public IReadOnlyList<DocumentTableCell>? Cells { get; }
+
+    /// <summary>Gets the markdown or HTML table text, or <see langword="null"/> when only cells were returned.</summary>
+    public string? MarkdownRepresentation { get; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentTableCell.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentTableCell.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents a single cell within an <see cref="DocumentTable"/>.</summary>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public class DocumentTableCell
+{
+    /// <summary>Initializes a new instance of the <see cref="DocumentTableCell"/> class.</summary>
+    /// <param name="rowIndex">The zero-based row index of the cell.</param>
+    /// <param name="columnIndex">The zero-based column index of the cell.</param>
+    /// <param name="content">The text content of the cell.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="content"/> is <see langword="null"/>.</exception>
+    public DocumentTableCell(int rowIndex, int columnIndex, string content)
+    {
+        RowIndex = rowIndex;
+        ColumnIndex = columnIndex;
+        Content = Throw.IfNull(content);
+    }
+
+    /// <summary>Gets or sets the role of the cell, for example <see cref="DocumentTableCellKind.ColumnHeader"/> or <see cref="DocumentTableCellKind.Content"/>.</summary>
+    public DocumentTableCellKind? Kind { get; set; }
+
+    /// <summary>Gets the zero-based row index of the cell.</summary>
+    public int RowIndex { get; }
+
+    /// <summary>Gets the zero-based column index of the cell.</summary>
+    public int ColumnIndex { get; }
+
+    /// <summary>Gets or sets the number of rows the cell spans. The default is 1.</summary>
+    public int RowSpan { get; set; } = 1;
+
+    /// <summary>Gets or sets the number of columns the cell spans. The default is 1.</summary>
+    public int ColumnSpan { get; set; } = 1;
+
+    /// <summary>Gets the text content of the cell.</summary>
+    public string Content { get; }
+
+    /// <summary>Gets or sets the nested content of the cell, in reading order, when the engine provides structured cell content.</summary>
+    /// <remarks>
+    /// When <see langword="null"/>, the cell is text-only and <see cref="Content"/> carries its text. When present,
+    /// the cell holds richer structured content (for example nested blocks or tables), and <see cref="Content"/>
+    /// remains a flat-text convenience. This mirrors the nested-content model used by engines such as Docling and
+    /// Google Document AI.
+    /// </remarks>
+    public IReadOnlyList<DocumentElement>? Elements { get; set; }
+
+    /// <summary>Gets or sets the region of the page the cell occupies, when the engine provides geometry.</summary>
+    /// <remarks>
+    /// A cell can carry its own rectangle even when it is empty or padded, so this is not always derivable from
+    /// the geometry of its nested <see cref="Elements"/>. These members mirror <see cref="DocumentElement"/> so a cell
+    /// can be promoted to a shared positioned-node type later without a reshape.
+    /// </remarks>
+    public DocumentBoundingRegion? BoundingRegion { get; set; }
+
+    /// <summary>Gets or sets the confidence for the cell in the range [0, 1], when available.</summary>
+    public double? Confidence { get; set; }
+
+    /// <summary>Gets or sets the provider-native object underlying this cell.</summary>
+    /// <remarks>
+    /// If an <see cref="DocumentTableCell"/> is created to represent an underlying object from another object model,
+    /// this property can store that original object. This can be useful for debugging or for enabling a
+    /// consumer to access the underlying object model if needed.
+    /// </remarks>
+    [JsonIgnore]
+    public object? RawRepresentation { get; set; }
+
+    /// <summary>Gets or sets any additional properties associated with the cell.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentTableCellKind.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/DocumentTableCellKind.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Describes the role of an <see cref="DocumentTableCell"/>, such as a column header or a content cell.</summary>
+/// <remarks>
+/// This is a small open set modeled on <see cref="Microsoft.Extensions.AI.ChatRole"/>: the well-known values cover the common
+/// table cell roles, and a provider may introduce its own value when an engine reports a role that is
+/// not represented here.
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct DocumentTableCellKind : IEquatable<DocumentTableCellKind>
+{
+    /// <summary>Gets the kind representing a column header cell.</summary>
+    public static DocumentTableCellKind ColumnHeader { get; } = new("columnHeader");
+
+    /// <summary>Gets the kind representing a regular content cell.</summary>
+    public static DocumentTableCellKind Content { get; } = new("content");
+
+    /// <summary>Gets the kind representing a row header cell (a header that labels the row it sits in).</summary>
+    public static DocumentTableCellKind RowHeader { get; } = new("rowHeader");
+
+    /// <summary>Gets the kind representing a cell that introduces a labeled section spanning subsequent rows.</summary>
+    public static DocumentTableCellKind RowSection { get; } = new("rowSection");
+
+    /// <summary>Gets the value associated with this <see cref="DocumentTableCellKind"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="DocumentTableCellKind"/> struct with the provided value.</summary>
+    /// <param name="value">The value to associate with this <see cref="DocumentTableCellKind"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is empty or composed entirely of whitespace.</exception>
+    [JsonConstructor]
+    public DocumentTableCellKind(string value)
+    {
+        Value = Throw.IfNullOrWhitespace(value);
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="DocumentTableCellKind"/> instances are equivalent, using a case-insensitive comparison.</summary>
+    /// <param name="left">The first <see cref="DocumentTableCellKind"/> instance to compare.</param>
+    /// <param name="right">The second <see cref="DocumentTableCellKind"/> instance to compare.</param>
+    /// <returns><see langword="true"/> if left and right have equivalent values; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(DocumentTableCellKind left, DocumentTableCellKind right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="DocumentTableCellKind"/> instances are not equivalent, using a case-insensitive comparison.</summary>
+    /// <param name="left">The first <see cref="DocumentTableCellKind"/> instance to compare.</param>
+    /// <param name="right">The second <see cref="DocumentTableCellKind"/> instance to compare.</param>
+    /// <returns><see langword="true"/> if left and right have different values; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(DocumentTableCellKind left, DocumentTableCellKind right)
+    {
+        return !(left == right);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is DocumentTableCellKind otherKind && Equals(otherKind);
+
+    /// <inheritdoc/>
+    public bool Equals(DocumentTableCellKind other)
+        => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+        => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc/>
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{DocumentTableCellKind}"/> for serializing <see cref="DocumentTableCellKind"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<DocumentTableCellKind>
+    {
+        /// <inheritdoc/>
+        public override DocumentTableCellKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            new(reader.GetString()!);
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, DocumentTableCellKind value, JsonSerializerOptions options) =>
+            Throw.IfNull(writer).WriteStringValue(value.Value);
+    }
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/IDocumentExtractionClient.cs
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/IDocumentExtractionClient.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Extensions.DocumentExtraction;
+
+/// <summary>Represents an optical character recognition (OCR) / document-parsing client.</summary>
+/// <remarks>
+/// <para>
+/// An <see cref="IDocumentExtractionClient"/> transcribes a document or image into structured output: text,
+/// per-page content, tables, layout blocks with bounding regions, and confidence. It is the
+/// capability sibling to <see cref="Microsoft.Extensions.AI.IChatClient"/>, <c>IEmbeddingGenerator</c>, and
+/// <c>ISpeechToTextClient</c> for the document-extraction problem.
+/// </para>
+/// <para>
+/// The contract is independent of <see cref="Microsoft.Extensions.AI.IChatClient"/>. Most OCR / document-AI engines are not
+/// chat models: they emit structured output (tables, bounding regions, confidence, reading order)
+/// that does not map onto a chat response. An implementation may wrap a vision-capable
+/// <see cref="Microsoft.Extensions.AI.IChatClient"/> as the lowest-fidelity, transcription-only path, but the interface does
+/// not require one.
+/// </para>
+/// <para>
+/// Unless otherwise specified, all members of <see cref="IDocumentExtractionClient"/> are thread-safe for concurrent
+/// use. Implementations might mutate the <see cref="DocumentExtractionOptions"/> supplied to <see cref="ExtractAsync"/>
+/// and <see cref="ExtractPagesAsync"/>; consumers should avoid sharing a single options instance across
+/// concurrent invocations when that is a concern. The document stream passed to these methods is not
+/// disposed by the implementation.
+/// </para>
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.DocumentExtraction, UrlFormat = DiagnosticIds.UrlFormat)]
+public interface IDocumentExtractionClient : IDisposable
+{
+    /// <summary>Runs OCR / document parsing over a document stream and returns structured output.</summary>
+    /// <param name="document">The document or image content to parse.</param>
+    /// <param name="mediaType">The media type of <paramref name="document"/>, for example <c>application/pdf</c> or <c>image/png</c>.</param>
+    /// <param name="options">The OCR options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The structured OCR result.</returns>
+    Task<DocumentExtractionResult> ExtractAsync(
+        Stream document,
+        string mediaType,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Runs OCR / document parsing over a document stream and streams back structured output as it is produced.</summary>
+    /// <param name="document">The document or image content to parse.</param>
+    /// <param name="mediaType">The media type of <paramref name="document"/>, for example <c>application/pdf</c> or <c>image/png</c>.</param>
+    /// <param name="options">The OCR options to configure the request.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The structured OCR updates representing the streamed output.</returns>
+    /// <remarks>
+    /// Engines that produce pages incrementally (for example, while polling a long-running operation such as
+    /// Azure Document Intelligence) can yield each page as it completes, letting a consumer begin processing
+    /// early pages before later pages finish. Synchronous engines may yield a single terminal update. Use
+    /// <see cref="DocumentExtractionPageResultExtensions.ToDocumentExtractionResultAsync"/> to reassemble the stream into an
+    /// <see cref="DocumentExtractionResult"/>.
+    /// </remarks>
+    IAsyncEnumerable<DocumentExtractionPageResult> ExtractPagesAsync(
+        Stream document,
+        string mediaType,
+        DocumentExtractionOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Asks the <see cref="IDocumentExtractionClient"/> for an object of the specified type <paramref name="serviceType"/>.</summary>
+    /// <param name="serviceType">The type of object being requested.</param>
+    /// <param name="serviceKey">An optional key that can be used to help identify the target service.</param>
+    /// <returns>The found object, otherwise <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="serviceType"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// The purpose of this method is to allow for the retrieval of strongly typed services that might be
+    /// provided by the <see cref="IDocumentExtractionClient"/>, including itself or any services it might be wrapping.
+    /// </remarks>
+    object? GetService(Type serviceType, object? serviceKey = null);
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/Microsoft.Extensions.DocumentExtraction.Abstractions.json
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/Microsoft.Extensions.DocumentExtraction.Abstractions.json
@@ -1,0 +1,845 @@
+{
+  "Name": "Microsoft.Extensions.DocumentExtraction.Abstractions, Version=10.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DelegatingDocumentExtractionClient : Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient, System.IDisposable",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DelegatingDocumentExtractionClient.DelegatingDocumentExtractionClient(Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient innerClient);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.DocumentExtraction.DelegatingDocumentExtractionClient.Dispose();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual void Microsoft.Extensions.DocumentExtraction.DelegatingDocumentExtractionClient.Dispose(bool disposing);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.Task<Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult> Microsoft.Extensions.DocumentExtraction.DelegatingDocumentExtractionClient.ExtractAsync(System.IO.Stream document, string mediaType, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult> Microsoft.Extensions.DocumentExtraction.DelegatingDocumentExtractionClient.ExtractPagesAsync(System.IO.Stream document, string mediaType, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual object? Microsoft.Extensions.DocumentExtraction.DelegatingDocumentExtractionClient.GetService(System.Type serviceType, object? serviceKey = null);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient Microsoft.Extensions.DocumentExtraction.DelegatingDocumentExtractionClient.InnerClient { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentBlock : Microsoft.Extensions.DocumentExtraction.DocumentElement",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBlock.DocumentBlock(string text);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBlockKind? Microsoft.Extensions.DocumentExtraction.DocumentBlock.Kind { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.DocumentExtraction.DocumentBlock.Text { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.DocumentExtraction.DocumentBlockKind : System.IEquatable<Microsoft.Extensions.DocumentExtraction.DocumentBlockKind>",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.DocumentBlockKind(string value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.DocumentBlockKind();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Equals(object? obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Equals(Microsoft.Extensions.DocumentExtraction.DocumentBlockKind other);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.GetHashCode();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.operator ==(Microsoft.Extensions.DocumentExtraction.DocumentBlockKind left, Microsoft.Extensions.DocumentExtraction.DocumentBlockKind right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.operator !=(Microsoft.Extensions.DocumentExtraction.DocumentBlockKind left, Microsoft.Extensions.DocumentExtraction.DocumentBlockKind right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.ToString();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentBlockKind Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Figure { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentBlockKind Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Paragraph { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentBlockKind Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Title { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Value { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Converter",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Converter.Converter();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override Microsoft.Extensions.DocumentExtraction.DocumentBlockKind Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Converter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override void Microsoft.Extensions.DocumentExtraction.DocumentBlockKind.Converter.Write(System.Text.Json.Utf8JsonWriter writer, Microsoft.Extensions.DocumentExtraction.DocumentBlockKind value, System.Text.Json.JsonSerializerOptions options);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly class Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox(float Left, float Top, float Right, float Bottom)",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.DocumentBoundingBox(float Left, float Top, float Right, float Bottom);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.DocumentBoundingBox();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.Deconstruct(out float Left, out float Top, out float Right, out float Bottom);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.Equals(object obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.Equals(Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox other);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.GetHashCode();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.operator ==(Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox left, Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.operator !=(Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox left, Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.ToString();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "float Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.Bottom { get; init; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "float Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.Left { get; init; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "float Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.Right { get; init; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "float Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox.Top { get; init; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion.DocumentBoundingRegion(int pageNumber, System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.DocumentExtraction.DocumentPoint> polygon);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion.FromRectangle(int pageNumber, float left, float top, float right, float bottom);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBoundingBox? Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion.GetBounds();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion.PageNumber { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.DocumentExtraction.DocumentPoint> Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion.Polygon { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.DocumentExtraction.DocumentCoordinateOrigin",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentCoordinateOrigin.DocumentCoordinateOrigin();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.DocumentExtraction.DocumentCoordinateOrigin Microsoft.Extensions.DocumentExtraction.DocumentCoordinateOrigin.BottomLeft",
+          "Stage": "Experimental",
+          "Value": "1"
+        },
+        {
+          "Member": "const Microsoft.Extensions.DocumentExtraction.DocumentCoordinateOrigin Microsoft.Extensions.DocumentExtraction.DocumentCoordinateOrigin.TopLeft",
+          "Stage": "Experimental",
+          "Value": "0"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit.DocumentCoordinateUnit();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit.Inch",
+          "Stage": "Experimental",
+          "Value": "2"
+        },
+        {
+          "Member": "const Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit.Normalized",
+          "Stage": "Experimental",
+          "Value": "3"
+        },
+        {
+          "Member": "const Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit.Pixel",
+          "Stage": "Experimental",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit.Point",
+          "Stage": "Experimental",
+          "Value": "1"
+        }
+      ]
+    },
+    {
+      "Type": "abstract class Microsoft.Extensions.DocumentExtraction.DocumentElement",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentElement.DocumentElement();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.DocumentExtraction.DocumentElement.AdditionalProperties { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion? Microsoft.Extensions.DocumentExtraction.DocumentElement.BoundingRegion { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "double? Microsoft.Extensions.DocumentExtraction.DocumentElement.Confidence { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.DocumentExtraction.DocumentElement.RawRepresentation { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult> Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientExtensions.ExtractAsync(this Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient client, Microsoft.Extensions.AI.DataContent document, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult> Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientExtensions.ExtractAsync(this Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient client, Microsoft.Extensions.AI.UriContent document, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult> Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientExtensions.ExtractFromUriAsync(this Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient client, Microsoft.Extensions.AI.UriContent document, System.Net.Http.HttpClient httpClient, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult> Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientExtensions.ExtractPagesAsync(this Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient client, Microsoft.Extensions.AI.DataContent document, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult> Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientExtensions.ExtractPagesAsync(this Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient client, Microsoft.Extensions.AI.UriContent document, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static TService? Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientExtensions.GetService<TService>(this Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient client, object? serviceKey = null);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientMetadata",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientMetadata.DocumentExtractionClientMetadata(string? providerName = null, System.Uri? providerUri = null, string? defaultModelId = null);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientMetadata.DefaultModelId { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientMetadata.ProviderName { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Uri? Microsoft.Extensions.DocumentExtraction.DocumentExtractionClientMetadata.ProviderUri { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions.DocumentExtractionOptions();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions.Clone();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions.AdditionalProperties { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions.ModelId { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult.DocumentExtractionPageResult(Microsoft.Extensions.DocumentExtraction.DocumentPage page);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult.AdditionalProperties { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentPage Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult.Page { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult.PagesProcessed { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult.RawRepresentation { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult.TotalPages { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage? Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult.Usage { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResultExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResultExtensions.ToDocumentExtractionResult(this System.Collections.Generic.IEnumerable<Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult> updates);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult> Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResultExtensions.ToDocumentExtractionResultAsync(this System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult> updates, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult.DocumentExtractionResult(System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.DocumentExtraction.DocumentPage> pages);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult.AdditionalProperties { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.DocumentExtraction.DocumentPage> Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult.Pages { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult.RawRepresentation { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult.Text { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage? Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult.Usage { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage.DocumentExtractionUsage();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage.AdditionalProperties { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage.InputTokenCount { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage.OutputTokenCount { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage.PagesProcessed { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.DocumentExtraction.DocumentExtractionUsage.TotalTokenCount { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentImage : Microsoft.Extensions.DocumentExtraction.DocumentElement",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentImage.DocumentImage();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.DocumentExtraction.DocumentImage.Caption { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.AI.DataContent? Microsoft.Extensions.DocumentExtraction.DocumentImage.Content { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentPage",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentPage.DocumentPage(int pageNumber, string text);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.DocumentExtraction.DocumentPage.AdditionalProperties { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentCoordinateOrigin? Microsoft.Extensions.DocumentExtraction.DocumentPage.CoordinateOrigin { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentCoordinateUnit? Microsoft.Extensions.DocumentExtraction.DocumentPage.CoordinateUnit { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions? Microsoft.Extensions.DocumentExtraction.DocumentPage.Dimensions { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.DocumentExtraction.DocumentElement> Microsoft.Extensions.DocumentExtraction.DocumentPage.Elements { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.DocumentExtraction.DocumentPage.PageNumber { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.DocumentExtraction.DocumentPage.RawRepresentation { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.DocumentExtraction.DocumentPage.Text { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly class Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions(float Width, float Height)",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.DocumentPageDimensions(float Width, float Height);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.DocumentPageDimensions();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.Deconstruct(out float Width, out float Height);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.Equals(object obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.Equals(Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions other);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.GetHashCode();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.operator ==(Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions left, Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.operator !=(Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions left, Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.ToString();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "float Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.Height { get; init; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "float Microsoft.Extensions.DocumentExtraction.DocumentPageDimensions.Width { get; init; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly class Microsoft.Extensions.DocumentExtraction.DocumentPoint(float X, float Y)",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentPoint.DocumentPoint(float X, float Y);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentPoint.DocumentPoint();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.DocumentExtraction.DocumentPoint.Deconstruct(out float X, out float Y);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.DocumentExtraction.DocumentPoint.Equals(object obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.DocumentExtraction.DocumentPoint.Equals(Microsoft.Extensions.DocumentExtraction.DocumentPoint other);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.DocumentExtraction.DocumentPoint.GetHashCode();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentPoint.operator ==(Microsoft.Extensions.DocumentExtraction.DocumentPoint left, Microsoft.Extensions.DocumentExtraction.DocumentPoint right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentPoint.operator !=(Microsoft.Extensions.DocumentExtraction.DocumentPoint left, Microsoft.Extensions.DocumentExtraction.DocumentPoint right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.DocumentExtraction.DocumentPoint.ToString();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "float Microsoft.Extensions.DocumentExtraction.DocumentPoint.X { get; init; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "float Microsoft.Extensions.DocumentExtraction.DocumentPoint.Y { get; init; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentTable : Microsoft.Extensions.DocumentExtraction.DocumentElement",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentTable.DocumentTable(int rowCount, int columnCount, System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.DocumentExtraction.DocumentTableCell>? cells = null, string? markdownRepresentation = null);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.DocumentExtraction.DocumentTableCell>? Microsoft.Extensions.DocumentExtraction.DocumentTable.Cells { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.DocumentExtraction.DocumentTable.ColumnCount { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.DocumentExtraction.DocumentTable.MarkdownRepresentation { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.DocumentExtraction.DocumentTable.RowCount { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.DocumentExtraction.DocumentTableCell",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentTableCell.DocumentTableCell(int rowIndex, int columnIndex, string content);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.AI.AdditionalPropertiesDictionary? Microsoft.Extensions.DocumentExtraction.DocumentTableCell.AdditionalProperties { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentBoundingRegion? Microsoft.Extensions.DocumentExtraction.DocumentTableCell.BoundingRegion { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.DocumentExtraction.DocumentTableCell.ColumnIndex { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.DocumentExtraction.DocumentTableCell.ColumnSpan { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "double? Microsoft.Extensions.DocumentExtraction.DocumentTableCell.Confidence { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.DocumentExtraction.DocumentTableCell.Content { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.DocumentExtraction.DocumentElement>? Microsoft.Extensions.DocumentExtraction.DocumentTableCell.Elements { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind? Microsoft.Extensions.DocumentExtraction.DocumentTableCell.Kind { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.DocumentExtraction.DocumentTableCell.RawRepresentation { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.DocumentExtraction.DocumentTableCell.RowIndex { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.DocumentExtraction.DocumentTableCell.RowSpan { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind : System.IEquatable<Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind>",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.DocumentTableCellKind(string value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.DocumentTableCellKind();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.Equals(object? obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.Equals(Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind other);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.GetHashCode();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.operator ==(Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind left, Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.operator !=(Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind left, Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.ToString();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.ColumnHeader { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.Content { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.RowHeader { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.RowSection { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.Value { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.Converter",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.Converter.Converter();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.Converter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override void Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind.Converter.Write(System.Text.Json.Utf8JsonWriter writer, Microsoft.Extensions.DocumentExtraction.DocumentTableCellKind value, System.Text.Json.JsonSerializerOptions options);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient : System.IDisposable",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.Task<Microsoft.Extensions.DocumentExtraction.DocumentExtractionResult> Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient.ExtractAsync(System.IO.Stream document, string mediaType, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IAsyncEnumerable<Microsoft.Extensions.DocumentExtraction.DocumentExtractionPageResult> Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient.ExtractPagesAsync(System.IO.Stream document, string mediaType, Microsoft.Extensions.DocumentExtraction.DocumentExtractionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.DocumentExtraction.IDocumentExtractionClient.GetService(System.Type serviceType, object? serviceKey = null);",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/README.md
+++ b/src/AI/DocumentExtraction.ContractProposal/Upstream/dotnet-extensions/src/Libraries/Microsoft.Extensions.DocumentExtraction.Abstractions/README.md
@@ -1,0 +1,39 @@
+# Microsoft.Extensions.DocumentExtraction.Abstractions
+
+.NET developers need to turn documents such as scanned images and PDFs into structured, AI-ready content, recovering text along with layout, tables, figures, and coordinates in a provider-neutral way. The `Microsoft.Extensions.DocumentExtraction` libraries provide a unified approach for representing document-extraction components, complementing `Microsoft.Extensions.DataIngestion` (extraction pulls content out of documents; ingestion feeds that content into a retrieval pipeline).
+
+## The packages
+
+The [Microsoft.Extensions.DocumentExtraction.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.DocumentExtraction.Abstractions) package provides the core exchange types, including [`IDocumentExtractionClient`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.documentextraction.idocumentextractionclient), [`DocumentExtractionResult`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.documentextraction.documentextractionresult), [`DocumentPage`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.documentextraction.documentpage), and the reading-order [`DocumentElement`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.documentextraction.documentelement) model (blocks, tables, and images with bounding regions and confidence). Any .NET library that provides a document-extraction engine can implement these abstractions to enable seamless integration with consuming code.
+
+The [Microsoft.Extensions.DocumentExtraction](https://www.nuget.org/packages/Microsoft.Extensions.DocumentExtraction) package has an implicit dependency on the `Microsoft.Extensions.DocumentExtraction.Abstractions` package. This package enables you to easily integrate components such as logging, telemetry, and options configuration into your applications using familiar dependency injection and builder patterns.
+
+## Which package to reference
+
+Libraries that provide implementations of the abstractions typically reference only `Microsoft.Extensions.DocumentExtraction.Abstractions`.
+
+To also have access to higher-level utilities for working with document-extraction clients, reference the `Microsoft.Extensions.DocumentExtraction` package instead (which itself references `Microsoft.Extensions.DocumentExtraction.Abstractions`). Most consuming applications and services should reference the `Microsoft.Extensions.DocumentExtraction` package along with a library that provides a concrete implementation of the abstractions.
+
+## Install the package
+
+From the command-line:
+
+```console
+dotnet add package Microsoft.Extensions.DocumentExtraction.Abstractions --prerelease
+```
+
+Or directly in the C# project file:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Extensions.DocumentExtraction.Abstractions" Version="[CURRENTVERSION]" />
+</ItemGroup>
+```
+
+## Documentation
+
+Refer to the [Microsoft.Extensions.DocumentExtraction libraries documentation](https://learn.microsoft.com/dotnet/api/microsoft.extensions.documentextraction) for more information and API usage examples.
+
+## Feedback & Contributing
+
+We welcome feedback and contributions in [our GitHub repo](https://github.com/dotnet/extensions).

--- a/src/AI/DocumentExtraction.ContractProposal/Verify-Upstream.ps1
+++ b/src/AI/DocumentExtraction.ContractProposal/Verify-Upstream.ps1
@@ -1,0 +1,71 @@
+[CmdletBinding()]
+param(
+    [switch]$Offline
+)
+
+$ErrorActionPreference = 'Stop'
+$manifestPath = Join-Path $PSScriptRoot 'UPSTREAM.json'
+$manifest = Get-Content -Raw -Path $manifestPath | ConvertFrom-Json
+$importRoot = Join-Path $PSScriptRoot $manifest.importRoot
+
+function Get-Sha256FromBytes {
+    param([byte[]]$Bytes)
+
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        return ([System.BitConverter]::ToString($sha256.ComputeHash($Bytes))).Replace('-', '').ToLowerInvariant()
+    }
+    finally {
+        $sha256.Dispose()
+    }
+}
+
+$actualFiles = @(Get-ChildItem -Path $importRoot -File)
+$sourceFiles = @($manifest.files | Where-Object role -eq 'source')
+
+if ($sourceFiles.Count -ne $manifest.sourceFileCount) {
+    throw "Manifest expected $($manifest.sourceFileCount) source files but records $($sourceFiles.Count)."
+}
+
+if (@($actualFiles | Where-Object Extension -eq '.cs').Count -ne $manifest.sourceFileCount) {
+    throw "Import must contain exactly $($manifest.sourceFileCount) C# source files."
+}
+
+if ($actualFiles.Count -ne $manifest.files.Count) {
+    throw "Import contains $($actualFiles.Count) files but the manifest records $($manifest.files.Count)."
+}
+
+$httpClient = if ($Offline) { $null } else { [System.Net.Http.HttpClient]::new() }
+
+try {
+    foreach ($file in $manifest.files) {
+        $localPath = Join-Path $importRoot $file.path
+        if (-not (Test-Path -LiteralPath $localPath -PathType Leaf)) {
+            throw "Missing imported file: $($file.path)"
+        }
+
+        $localHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $localPath).Hash.ToLowerInvariant()
+        if ($localHash -ne $file.sha256) {
+            throw "Local hash mismatch for $($file.path): expected $($file.sha256), got $localHash."
+        }
+
+        if (-not $Offline) {
+            $relativePath = "$($manifest.sourcePath)/$($file.path)"
+            $uri = "$($manifest.sourceRepository)/raw/$($manifest.commit)/$relativePath"
+            $upstreamBytes = $httpClient.GetByteArrayAsync($uri).GetAwaiter().GetResult()
+            $upstreamHash = Get-Sha256FromBytes -Bytes $upstreamBytes
+
+            if ($upstreamHash -ne $file.sha256) {
+                throw "Upstream hash mismatch for $($file.path): expected $($file.sha256), got $upstreamHash."
+            }
+        }
+    }
+}
+finally {
+    if ($null -ne $httpClient) {
+        $httpClient.Dispose()
+    }
+}
+
+$mode = if ($Offline) { 'manifest hashes' } else { "upstream commit $($manifest.commit)" }
+Write-Host "Verified $($manifest.files.Count) files, including $($manifest.sourceFileCount) C# sources, against $mode."

--- a/src/AI/EssentialsAI.slnf
+++ b/src/AI/EssentialsAI.slnf
@@ -3,7 +3,9 @@
     "path": "../../MauiLabs.slnx",
     "projects": [
       "samples\\EssentialsAISample\\EssentialsAISample.csproj",
+      "src\\AI\\DocumentExtraction.ContractProposal\\Microsoft.Extensions.DocumentExtraction.Abstractions.csproj",
       "src\\AI\\Microsoft.Maui.Essentials.AI\\Microsoft.Maui.Essentials.AI.csproj",
+      "tests\\AI\\Microsoft.Maui.DocumentExtraction.ContractProposal.Tests\\Microsoft.Maui.DocumentExtraction.ContractProposal.Tests.csproj",
       "tests\\AI\\Microsoft.Maui.Essentials.AI.Benchmarks\\Microsoft.Maui.Essentials.AI.Benchmarks.csproj",
       "tests\\AI\\Microsoft.Maui.Essentials.AI.DeviceTests\\Microsoft.Maui.Essentials.AI.DeviceTests.csproj",
       "tests\\AI\\Microsoft.Maui.Essentials.AI.UnitTests\\Microsoft.Maui.Essentials.AI.UnitTests.csproj"

--- a/tests/AI/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests/CompatibilityShimTests.cs
+++ b/tests/AI/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests/CompatibilityShimTests.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Extensions.DocumentExtraction;
+using Xunit;
+
+namespace Microsoft.Maui.DocumentExtraction.ContractProposal.Tests;
+
+public class CompatibilityShimTests
+{
+    [Fact]
+    public void ContractTypes_ExperimentalMetadata_UsesUpstreamDiagnosticValues()
+    {
+        ExperimentalAttribute attribute = Assert.IsType<ExperimentalAttribute>(
+            typeof(IDocumentExtractionClient).GetCustomAttribute<ExperimentalAttribute>());
+
+        Assert.Equal("MEDE0001", attribute.DiagnosticId);
+        Assert.Equal("https://aka.ms/dotnet-extensions-warnings/{0}", attribute.UrlFormat);
+    }
+
+    [Fact]
+    public void DocumentBlock_NullText_UsesIfNullCompatibilityShim()
+    {
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+            () => new DocumentBlock(null!));
+
+        Assert.Equal("text", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t\r\n")]
+    public void DocumentBlockKind_WhitespaceValue_UsesIfNullOrWhitespaceCompatibilityShim(string value)
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => new DocumentBlockKind(value));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void DocumentBlockKind_NullValue_UsesIfNullOrWhitespaceCompatibilityShim()
+    {
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+            () => new DocumentBlockKind(null!));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+}

--- a/tests/AI/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests.csproj
+++ b/tests/AI/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <IsShipping>false</IsShipping>
+    <NoWarn>$(NoWarn);MEDE0001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\AI\DocumentExtraction.ContractProposal\Microsoft.Extensions.DocumentExtraction.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- import the 23 `Microsoft.Extensions.DocumentExtraction.Abstractions` C# files byte-for-byte from dotnet/extensions#7588 head `a215825ae2c96723e922e068c226ff77122c7c94`
- compile them in an isolated `net10.0`, non-shipping, non-packable MAUI Labs project with only the permitted internal diagnostic and guard compatibility shims
- record per-file SHA-256 provenance, retain the upstream README/API baseline as inert provenance artifacts, and add online/offline verification
- wire the proposal and focused compatibility tests into `MauiLabs.slnx` and `src/AI/EssentialsAI.slnf`, reusing existing `src/AI/**` and `tests/AI/**` CI coverage

This is a temporary contract proposal only. It does not add middleware/DI, providers, scenarios, samples, package shipping metadata, or a local contract redesign.

## Validation

- `pwsh -NoProfile -File src/AI/DocumentExtraction.ContractProposal/Verify-Upstream.ps1`
  - verified 25 imported files, including all 23 C# sources, against the pinned commit
- `dotnet build src/AI/DocumentExtraction.ContractProposal/Microsoft.Extensions.DocumentExtraction.Abstractions.csproj --configuration Release --no-restore --warnaserror --verbosity minimal`
  - 0 warnings, 0 errors
- `dotnet test tests/AI/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests/Microsoft.Maui.DocumentExtraction.ContractProposal.Tests.csproj --configuration Release --verbosity minimal`
  - 6 passed, 0 failed
- final preflight confirmed dotnet/extensions#7588 remained open at `a215825ae2c96723e922e068c226ff77122c7c94`