### PR TITLE
Enable NativeAOT for MAUI CLI

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -129,6 +129,7 @@ jobs:
           -prepareMachine
           -projects %CD%\${{ inputs.project-path }}
           /p:VersionSuffix=%CI_PACKAGE_VERSION_SUFFIX%
+          ${{ inputs.project-name == 'cli' && '/p:SkipMauiCliPack=true' || '' }}
         shell: cmd
 
       - name: Build and Test (macOS)
@@ -141,6 +142,7 @@ jobs:
           --prepareMachine
           --projects $(pwd)/${{ inputs.project-path }}
           /p:VersionSuffix=$CI_PACKAGE_VERSION_SUFFIX
+          ${{ inputs.project-name == 'cli' && '/p:SkipMauiCliPack=true' || '' }}
 
       - name: Build and Test (Linux)
         if: startsWith(matrix.os, 'ubuntu')
@@ -152,6 +154,7 @@ jobs:
           --prepareMachine
           --projects $(pwd)/${{ inputs.project-path }}
           /p:VersionSuffix=$CI_PACKAGE_VERSION_SUFFIX
+          ${{ inputs.project-name == 'cli' && '/p:SkipMauiCliPack=true' || '' }}
 
       - name: Pack NativeAOT CLI
         if: inputs.pack && inputs.project-name == 'cli'
@@ -177,6 +180,11 @@ jobs:
               -p:PublishAot=false `
               -p:PublishTrimmed=false `
               -p:SelfContained=false `
+              -p:VersionSuffix=$env:CI_PACKAGE_VERSION_SUFFIX
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+            dotnet pack src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj `
+              --configuration Release `
               -p:VersionSuffix=$env:CI_PACKAGE_VERSION_SUFFIX
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
@@ -218,9 +226,13 @@ jobs:
           "$cli_path" devflow list --json > "$agents_json"
           "$cli_path" devflow broker stop >/dev/null 2>&1 || true
 
-          python - "$commands_json" "$agents_json" <<'PY'
+          python - "$commands_json" "$agents_json" "$cli_path" <<'PY'
           import json
+          import queue
+          import subprocess
           import sys
+          import threading
+          import time
 
           with open(sys.argv[1], "r", encoding="utf-8") as fp:
               commands = json.load(fp)
@@ -231,6 +243,62 @@ jobs:
           assert commands, "Expected at least one command description"
           assert all("command" in item and "description" in item for item in commands), "Command entries must include command and description"
           assert isinstance(agents, list), "Expected list --json output to be a JSON array"
+
+          mcp = subprocess.Popen(
+              [sys.argv[3], "devflow", "mcp"],
+              stdin=subprocess.PIPE,
+              stdout=subprocess.PIPE,
+              stderr=subprocess.PIPE,
+              text=True,
+              bufsize=1,
+          )
+          requests = [
+              {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "method": "initialize",
+                  "params": {
+                      "protocolVersion": "2024-11-05",
+                      "capabilities": {},
+                      "clientInfo": {"name": "nativeaot-smoke", "version": "1.0"},
+                  },
+              },
+              {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+              {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+          ]
+          try:
+              for request in requests:
+                  mcp.stdin.write(json.dumps(request) + "\n")
+              mcp.stdin.flush()
+
+              responses = queue.Queue()
+              def read_responses():
+                  for line in mcp.stdout:
+                      responses.put(json.loads(line))
+
+              threading.Thread(target=read_responses, daemon=True).start()
+              deadline = time.monotonic() + 20
+              tools_response = None
+              while time.monotonic() < deadline and tools_response is None:
+                  if mcp.poll() is not None:
+                      raise RuntimeError(f"MCP server exited early: {mcp.stderr.read()}")
+                  try:
+                      response = responses.get(timeout=1)
+                  except queue.Empty:
+                      continue
+                  if response.get("id") == 2:
+                      tools_response = response
+
+              assert tools_response is not None, "Timed out waiting for MCP tools/list response"
+              tools = tools_response.get("result", {}).get("tools")
+              assert isinstance(tools, list) and tools, "Expected MCP tools/list to return a non-empty tool catalog"
+          finally:
+              mcp.terminate()
+              try:
+                  mcp.wait(timeout=5)
+              except subprocess.TimeoutExpired:
+                  mcp.kill()
+                  mcp.wait()
           PY
 
           rm -f "$commands_json" "$agents_json"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -91,6 +91,10 @@ jobs:
         if: inputs.native-deps != ''
         run: ${{ inputs.native-deps }}
 
+      - name: Install NativeAOT dependencies
+        if: inputs.project-name == 'cli' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
       # Use Arcade's dotnet wrapper for workload-related setup so SDK resolution
       # matches the later cibuild invocation.
       - name: Install workloads (Windows)
@@ -148,6 +152,34 @@ jobs:
           --prepareMachine
           --projects $(pwd)/${{ inputs.project-path }}
           /p:VersionSuffix=$CI_PACKAGE_VERSION_SUFFIX
+
+      - name: Pack NativeAOT CLI
+        if: inputs.pack && inputs.project-name == 'cli'
+        shell: pwsh
+        run: |
+          $rid = switch ('${{ runner.os }}') {
+            'Windows' { 'win-x64' }
+            'Linux' { 'linux-x64' }
+            'macOS' { 'osx-arm64' }
+            default { throw "Unsupported NativeAOT build OS: ${{ runner.os }}" }
+          }
+
+          dotnet pack src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj `
+            --configuration Release `
+            --runtime $rid `
+            -p:VersionSuffix=$env:CI_PACKAGE_VERSION_SUFFIX
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          if ('${{ runner.os }}' -eq 'Windows') {
+            dotnet pack src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj `
+              --configuration Release `
+              --runtime any `
+              -p:PublishAot=false `
+              -p:PublishTrimmed=false `
+              -p:SelfContained=false `
+              -p:VersionSuffix=$env:CI_PACKAGE_VERSION_SUFFIX
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
       - name: NativeAOT publish smoke test (macOS)
         if: matrix.os == 'macos-latest' && inputs.project-name == 'cli'

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -40,3 +40,4 @@ jobs:
       run-tests: true
       pack: true
       install-workloads: false
+      os: '["macos-latest", "windows-latest", "ubuntu-24.04"]'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ A command-line tool for .NET MAUI development environment setup, device manageme
 |---------|-------------|
 | [![NuGet: Microsoft.Maui.Cli](https://img.shields.io/nuget/v/Microsoft.Maui.Cli.svg?label=Microsoft.Maui.Cli)](https://www.nuget.org/packages/Microsoft.Maui.Cli/) | CLI global tool (`maui`) |
 
+The .NET 10 SDK is required to install the tool. It automatically selects a NativeAOT package on `win-x64`, `linux-x64`, and `osx-arm64`, with a framework-dependent fallback for other platforms.
+
 ```bash
 # Microsoft.Maui.Cli is currently released as a pre-release, so make sure to use the --prerelease flag
 dotnet tool install -g Microsoft.Maui.Cli --prerelease

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -87,6 +87,7 @@ extends:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           enableMicrobuild: true
+          enableMicrobuildForMacAndLinux: true
           enablePublishBuildAssets: true
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
@@ -150,7 +151,114 @@ extends:
                 -prepareMachine
                 -projects $(Build.SourcesDirectory)\src\Cli\Cli.slnf
                 $(_OfficialBuildArgs)
-              displayName: Build and Test Cli
+              displayName: Build, Test, Sign and Publish Cli
+            - pwsh: |
+                $artifactsDir = '$(Build.ArtifactStagingDirectory)/CliRidArtifacts'
+                $commonArguments = @(
+                  'pack'
+                  'src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj'
+                  '--configuration'
+                  '$(_BuildConfig)'
+                  "/p:ArtifactsDir=$artifactsDir"
+                  '/p:OfficialBuildId=$(BUILD.BUILDNUMBER)'
+                  '/p:TeamName=$(_TeamName)'
+                  '/p:DotNetSignType=$(_SignType)'
+                )
+
+                & eng/common/dotnet.ps1 @commonArguments --runtime win-x64
+                if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+                & eng/common/dotnet.ps1 @commonArguments --runtime any /p:PublishAot=false /p:PublishTrimmed=false /p:SelfContained=false
+                if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+                & eng/common/build.ps1 `
+                  -configuration '$(_BuildConfig)' `
+                  -restore `
+                  -sign `
+                  -publish `
+                  -ci `
+                  -prepareMachine `
+                  -projects '$(Build.SourcesDirectory)/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj' `
+                  "/p:ArtifactsDir=$artifactsDir" `
+                  '/p:OfficialBuildId=$(BUILD.BUILDNUMBER)' `
+                  '/p:TeamName=$(_TeamName)' `
+                  '/p:DotNetSignType=$(_SignType)'
+                if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              displayName: Pack and sign Cli RID packages
+
+          - job: Cli_macOS
+            displayName: Cli NativeAOT - macOS
+            pool:
+              name: Azure Pipelines
+              vmImage: macos-latest-internal
+              os: macOS
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+                  _OfficialBuildArgs: /p:DotNetSignType=$(_SignType)
+                    /p:TeamName=$(_TeamName)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            steps:
+            - template: /eng/pipelines/install-dotnet-sdk.yml@self
+            - script: |
+                dotnet pack src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj \
+                  --configuration $(_BuildConfig) \
+                  --runtime osx-arm64 \
+                  /p:ArtifactsDir='$(Build.ArtifactStagingDirectory)/CliRidArtifacts' \
+                  $(_OfficialBuildArgs)
+              displayName: Pack Cli NativeAOT for macOS
+            - script: |
+                ./eng/common/build.sh \
+                  --restore \
+                  --sign \
+                  --publish \
+                  --ci \
+                  --prepareMachine \
+                  --configuration $(_BuildConfig) \
+                  --projects $(Build.SourcesDirectory)/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj \
+                  /p:ArtifactsDir='$(Build.ArtifactStagingDirectory)/CliRidArtifacts' \
+                  $(_OfficialBuildArgs)
+              displayName: Sign and publish Cli macOS package
+
+          - job: Cli_Linux
+            displayName: Cli NativeAOT - Linux
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals build.ubuntu.2204.amd64
+              os: linux
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+                  _OfficialBuildArgs: /p:DotNetSignType=$(_SignType)
+                    /p:TeamName=$(_TeamName)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            steps:
+            - template: /eng/pipelines/install-dotnet-sdk.yml@self
+            - script: |
+                sudo apt-get update
+                sudo apt-get install -y clang zlib1g-dev
+              displayName: Install NativeAOT dependencies
+            - script: |
+                dotnet pack src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj \
+                  --configuration $(_BuildConfig) \
+                  --runtime linux-x64 \
+                  /p:ArtifactsDir='$(Build.ArtifactStagingDirectory)/CliRidArtifacts' \
+                  $(_OfficialBuildArgs)
+              displayName: Pack Cli NativeAOT for Linux
+            - script: |
+                ./eng/common/build.sh \
+                  --restore \
+                  --sign \
+                  --publish \
+                  --ci \
+                  --prepareMachine \
+                  --configuration $(_BuildConfig) \
+                  --projects $(Build.SourcesDirectory)/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj \
+                  /p:ArtifactsDir='$(Build.ArtifactStagingDirectory)/CliRidArtifacts' \
+                  $(_OfficialBuildArgs)
+              displayName: Sign and publish Cli Linux package
 
           - job: AI
             displayName: AI Extensions - Windows
@@ -488,9 +596,61 @@ extends:
             artifact: PackageArtifacts
             displayName: Download PackageArtifacts
           - powershell: |
-              New-Item -ItemType Directory -Force -Path '$(Pipeline.Workspace)/CliPackages'
-              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Cli.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose
-              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.ProfilingHelper.*.nupkg' '$(Pipeline.Workspace)/CliPackages/' -Verbose -ErrorAction Stop
+              $ridSpecificPath = '$(Pipeline.Workspace)/CliPackages/RidSpecific'
+              $topLevelPath = '$(Pipeline.Workspace)/CliPackages/TopLevel'
+              New-Item -ItemType Directory -Force -Path $ridSpecificPath, $topLevelPath
+
+              Add-Type -AssemblyName System.IO.Compression.FileSystem
+              $cliPackages = Get-ChildItem '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.Cli.*.nupkg' |
+                ForEach-Object {
+                  $archive = [System.IO.Compression.ZipFile]::OpenRead($_.FullName)
+                  try {
+                    $nuspecEntry = $archive.Entries | Where-Object { $_.FullName -like '*.nuspec' } | Select-Object -First 1
+                    $reader = [System.IO.StreamReader]::new($nuspecEntry.Open())
+                    try {
+                      [xml] $nuspec = $reader.ReadToEnd()
+                    } finally {
+                      $reader.Dispose()
+                    }
+
+                    [pscustomobject]@{
+                      File = $_
+                      Id = [string] $nuspec.package.metadata.id
+                      Version = [string] $nuspec.package.metadata.version
+                    }
+                  } finally {
+                    $archive.Dispose()
+                  }
+                }
+
+              $ridPackageIds = @(
+                'Microsoft.Maui.Cli.win-x64'
+                'Microsoft.Maui.Cli.linux-x64'
+                'Microsoft.Maui.Cli.osx-arm64'
+                'Microsoft.Maui.Cli.any'
+              )
+              $expectedPackageIds = @('Microsoft.Maui.Cli') + $ridPackageIds
+              if ($cliPackages.Count -ne $expectedPackageIds.Count) {
+                throw "Expected exactly $($expectedPackageIds.Count) CLI packages, but found $($cliPackages.Count)."
+              }
+
+              foreach ($packageId in $expectedPackageIds) {
+                if ($packageId -notin $cliPackages.Id) {
+                  throw "Expected CLI package '$packageId' was not produced."
+                }
+              }
+
+              $versions = @($cliPackages.Version | Sort-Object -Unique)
+              if ($versions.Count -ne 1) {
+                throw "CLI pointer and RID package versions must match. Found: $($versions -join ', ')"
+              }
+
+              foreach ($package in $cliPackages) {
+                $destination = if ($package.Id -in $ridPackageIds) { $ridSpecificPath } else { $topLevelPath }
+                Copy-Item $package.File.FullName $destination -Verbose
+              }
+
+              Copy-Item '$(Pipeline.Workspace)/PackageArtifacts/Microsoft.Maui.ProfilingHelper.*.nupkg' $topLevelPath -Verbose -ErrorAction Stop
             displayName: Filter Cli packages
 
         - job: PublishNuGet
@@ -510,11 +670,19 @@ extends:
               targetPath: '$(Pipeline.Workspace)/CliPackages'
           steps:
           - task: 1ES.PublishNuget@1
-            displayName: 'Push Cli to NuGet.org'
+            displayName: 'Push Cli RID packages to NuGet.org'
             inputs:
               useDotNetTask: false
-              packagesToPush: '$(Pipeline.Workspace)/CliPackages/*.nupkg'
-              packageParentPath: '$(Pipeline.Workspace)/CliPackages'
+              packagesToPush: '$(Pipeline.Workspace)/CliPackages/RidSpecific/*.nupkg'
+              packageParentPath: '$(Pipeline.Workspace)/CliPackages/RidSpecific'
+              nuGetFeedType: external
+              publishFeedCredentials: 'nuget.org (dotnetframework)'
+          - task: 1ES.PublishNuget@1
+            displayName: 'Push Cli top-level packages to NuGet.org'
+            inputs:
+              useDotNetTask: false
+              packagesToPush: '$(Pipeline.Workspace)/CliPackages/TopLevel/*.nupkg'
+              packageParentPath: '$(Pipeline.Workspace)/CliPackages/TopLevel'
               nuGetFeedType: external
               publishFeedCredentials: 'nuget.org (dotnetframework)'
 

--- a/eng/pipelines/devflow-official.yml
+++ b/eng/pipelines/devflow-official.yml
@@ -151,6 +151,7 @@ extends:
                 -prepareMachine
                 -projects $(Build.SourcesDirectory)\src\Cli\Cli.slnf
                 $(_OfficialBuildArgs)
+                /p:SkipMauiCliPack=true
               displayName: Build, Test, Sign and Publish Cli
             - pwsh: |
                 $artifactsDir = '$(Build.ArtifactStagingDirectory)/CliRidArtifacts'
@@ -169,6 +170,9 @@ extends:
                 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
                 & eng/common/dotnet.ps1 @commonArguments --runtime any /p:PublishAot=false /p:PublishTrimmed=false /p:SelfContained=false
+                if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+                & eng/common/dotnet.ps1 @commonArguments
                 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
                 & eng/common/build.ps1 `

--- a/src/Cli/Microsoft.Maui.Cli/Commands/GoCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/Commands/GoCommands.cs
@@ -3,6 +3,8 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Maui.Cli.Commands;
 
@@ -93,7 +95,7 @@ public static class GoCommands
 				return 1;
 			}
 #if NET10_0_OR_GREATER
-			return await Microsoft.Maui.Go.Server.GoDevServer.RunSingleFileAsync(filePath, port, showQr, ct);
+			return await RunGoServerAsync(filePath, port, showQr, ct);
 #else
 			Console.Error.WriteLine("Error: 'maui go' dev server requires the .NET 10 build of the CLI.");
 			return 1;
@@ -121,14 +123,73 @@ public static class GoCommands
 		// Single .cs file → single-file mode
 		if (csFiles.Length == 1)
 		{
-			return await Microsoft.Maui.Go.Server.GoDevServer.RunSingleFileAsync(csFiles[0], port, showQr, ct);
+			return await RunGoServerAsync(csFiles[0], port, showQr, ct);
 		}
 
 		// Multiple .cs files → project mode (look for .csproj)
 		var csproj = Directory.GetFiles(cwd, "*.csproj").FirstOrDefault();
 		if (csproj is not null)
 		{
-			return await Microsoft.Maui.Go.Server.GoDevServer.RunAsync(cwd, port, showQr, ct);
+			return await RunGoServerAsync(cwd, port, showQr, ct);
+		}
+
+		static async Task<int> RunGoServerAsync(string target, int port, bool showQr, CancellationToken ct)
+		{
+			if (RuntimeFeature.IsDynamicCodeSupported)
+			{
+				return target.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+					? await Microsoft.Maui.Go.Server.GoDevServer.RunSingleFileAsync(target, port, showQr, ct)
+					: await Microsoft.Maui.Go.Server.GoDevServer.RunAsync(target, port, showQr, ct);
+			}
+
+			var serverPath = Path.Combine(
+				AppContext.BaseDirectory,
+				"go-server",
+				"Microsoft.Maui.Go.Server.dll");
+			if (!File.Exists(serverPath))
+			{
+				Console.Error.WriteLine($"Error: MAUI Go server was not found at '{serverPath}'.");
+				return 1;
+			}
+
+			var startInfo = new ProcessStartInfo("dotnet")
+			{
+				UseShellExecute = false,
+				WorkingDirectory = Directory.GetCurrentDirectory(),
+			};
+			startInfo.ArgumentList.Add(serverPath);
+			startInfo.ArgumentList.Add(target);
+			startInfo.ArgumentList.Add("--port");
+			startInfo.ArgumentList.Add(port.ToString(System.Globalization.CultureInfo.InvariantCulture));
+			if (!showQr)
+				startInfo.ArgumentList.Add("--no-qr");
+
+			using var process = Process.Start(startInfo);
+			if (process is null)
+			{
+				Console.Error.WriteLine("Error: Failed to start the MAUI Go server.");
+				return 1;
+			}
+
+			try
+			{
+				await process.WaitForExitAsync(ct);
+			}
+			catch (OperationCanceledException) when (ct.IsCancellationRequested)
+			{
+				try
+				{
+					if (!process.HasExited)
+						process.Kill(entireProcessTree: true);
+				}
+				catch (InvalidOperationException) when (process.HasExited)
+				{
+				}
+
+				await process.WaitForExitAsync(CancellationToken.None);
+				throw;
+			}
+			return process.ExitCode;
 		}
 
 		// Multiple .cs files but no .csproj — ask the author to disambiguate.

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerFlowCoordinator.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerFlowCoordinator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text.Json.Serialization;
 using Microsoft.Maui.Cli.DevFlow.Flows;
 
 namespace Microsoft.Maui.Cli.DevFlow.Broker;
@@ -254,36 +255,36 @@ internal sealed class BrokerFlowCoordinator
 
 internal sealed class FlowObservation
 {
-    public string Action { get; set; } = "";
-    public string? AutomationId { get; set; }
-    public string? Text { get; set; }
-    public string? Type { get; set; }
-    public int? Index { get; set; }
-    public string? Id { get; set; }
-    public string? Value { get; set; }
-    public string? Name { get; set; }
-    public double? Dx { get; set; }
-    public double? Dy { get; set; }
-    public int? ItemIndex { get; set; }
-    public string? Position { get; set; }
-    public string? Page { get; set; }
-    public bool Navigated { get; set; }
-    public string? AssertsJson { get; set; }
+    [JsonPropertyName("action")] public string Action { get; set; } = "";
+    [JsonPropertyName("automationId")] public string? AutomationId { get; set; }
+    [JsonPropertyName("text")] public string? Text { get; set; }
+    [JsonPropertyName("type")] public string? Type { get; set; }
+    [JsonPropertyName("index")] public int? Index { get; set; }
+    [JsonPropertyName("id")] public string? Id { get; set; }
+    [JsonPropertyName("value")] public string? Value { get; set; }
+    [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("dx")] public double? Dx { get; set; }
+    [JsonPropertyName("dy")] public double? Dy { get; set; }
+    [JsonPropertyName("itemIndex")] public int? ItemIndex { get; set; }
+    [JsonPropertyName("position")] public string? Position { get; set; }
+    [JsonPropertyName("page")] public string? Page { get; set; }
+    [JsonPropertyName("navigated")] public bool Navigated { get; set; }
+    [JsonPropertyName("assertsJson")] public string? AssertsJson { get; set; }
 }
 
 internal sealed class BrokerFlowResult
 {
-    public bool Ok { get; set; }
-    public bool Recording { get; set; }
-    public string? RecordingId { get; set; }
-    public string? Name { get; set; }
-    public int Steps { get; set; }
-    public int? Seq { get; set; }
-    public bool Fragile { get; set; }
-    public bool Empty { get; set; }
-    public string? Markdown { get; set; }
-    public string[]? Warnings { get; set; }
-    public string? Error { get; set; }
+    [JsonPropertyName("ok")] public bool Ok { get; set; }
+    [JsonPropertyName("recording")] public bool Recording { get; set; }
+    [JsonPropertyName("recordingId")] public string? RecordingId { get; set; }
+    [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("steps")] public int Steps { get; set; }
+    [JsonPropertyName("seq")] public int? Seq { get; set; }
+    [JsonPropertyName("fragile")] public bool Fragile { get; set; }
+    [JsonPropertyName("empty")] public bool Empty { get; set; }
+    [JsonPropertyName("markdown")] public string? Markdown { get; set; }
+    [JsonPropertyName("warnings")] public string[]? Warnings { get; set; }
+    [JsonPropertyName("error")] public string? Error { get; set; }
 
     public static BrokerFlowResult Failure(string error) => new()
     {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Broker/BrokerServer.cs
@@ -762,8 +762,7 @@ public class BrokerServer : IDisposable
                     break;
                 case "observe":
                     var observationNode = body["observation"];
-                    var observation = observationNode?.Deserialize<FlowObservation>(
-                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    var observation = observationNode?.Deserialize(DevFlowCliJsonContext.Default.FlowObservation);
                     result = observation is null
                         ? BrokerFlowResult.Failure("observation is required")
                         : _flows.Observe(agentId, observation, recordingId);
@@ -787,11 +786,7 @@ public class BrokerServer : IDisposable
             stateGate.Release();
         }
 
-        var resultNode = JsonSerializer.SerializeToNode(result, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-        })?.AsObject() ?? new JsonObject();
+        var resultNode = JsonSerializer.SerializeToNode(result, DevFlowCliJsonContext.Default.BrokerFlowResult)?.AsObject() ?? new JsonObject();
         await WriteJsonResponseAsync(context, result.Ok ? 200 : 400, resultNode);
     }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCliJsonContext.cs
@@ -1,13 +1,16 @@
 using System.Text.Json.Serialization;
 using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Maui.Cli.DevFlow.Broker;
+using Microsoft.Maui.Cli.DevFlow.Flows;
 using Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
 using Microsoft.Maui.Cli.DevFlow.Inspector;
 using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.Cli.DevFlow;
 
-[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNameCaseInsensitive = true)]
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(bool))]
 [JsonSerializable(typeof(int))]
@@ -22,6 +25,7 @@ namespace Microsoft.Maui.Cli.DevFlow;
 [JsonSerializable(typeof(List<NetworkRequest>))]
 [JsonSerializable(typeof(ThemeResult))]
 [JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(AgentRegistration))]
 [JsonSerializable(typeof(List<AgentRegistration>))]
 [JsonSerializable(typeof(AgentRegistration[]))]
@@ -40,4 +44,26 @@ namespace Microsoft.Maui.Cli.DevFlow;
 [JsonSerializable(typeof(LayoutDiagnosticsPolicy))]
 [JsonSerializable(typeof(LayoutDiagnosticsDelta))]
 [JsonSerializable(typeof(InspectorServer.InspectorDiagnosticRequest))]
+[JsonSerializable(typeof(FlowObservation))]
+[JsonSerializable(typeof(BrokerFlowResult))]
+[JsonSerializable(typeof(MutationRecordingStatus))]
+[JsonSerializable(typeof(MauiFlow))]
+[JsonSerializable(typeof(FlowReplayReport))]
+[JsonSerializable(typeof(List<FlowAssert>))]
+[JsonSerializable(typeof(FlowTools.FlowFileSummary))]
+[JsonSerializable(typeof(List<FlowTools.FlowFileSummary>))]
+[JsonSerializable(typeof(FlowRecordTools.ActiveRecordingSummary))]
+[JsonSerializable(typeof(List<FlowRecordTools.ActiveRecordingSummary>))]
+[JsonSerializable(typeof(InspectorAlertResult))]
+[JsonSerializable(typeof(AlertInfo))]
 internal sealed partial class DevFlowCliJsonContext : JsonSerializerContext;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(MauiFlow))]
+[JsonSerializable(typeof(FlowReplayReport))]
+[JsonSerializable(typeof(InspectorAlertResult))]
+[JsonSerializable(typeof(NetworkRequest))]
+[JsonSerializable(typeof(List<NetworkRequest>))]
+internal sealed partial class DevFlowCliJsonPreserveNullContext : JsonSerializerContext;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -1890,7 +1890,7 @@ public class DevFlowCommands
         try
         {
             using var doc = JsonDocument.Parse(value);
-            return JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
+            return CliJson.PrettyPrint(doc.RootElement);
         }
         catch (JsonException)
         {
@@ -5373,7 +5373,7 @@ public class DevFlowCommands
         // Scan for devflow-enabled projects
         var projects = ScanForDevFlowProjects();
         foreach (var project in projects)
-            projectsJson.Add(project);
+            projectsJson.Add((JsonNode?)JsonValue.Create(project));
         
         if (json)
         {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Flows/FlowMarkdown.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Flows/FlowMarkdown.cs
@@ -29,16 +29,6 @@ public static class FlowMarkdown
         "```json maui-test\\s*\\r?\\n(.*?)\\r?\\n```",
         RegexOptions.Singleline | RegexOptions.Compiled);
 
-    private static readonly JsonSerializerOptions ReadOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
-    private static readonly JsonSerializerOptions WriteOptions = new()
-    {
-        WriteIndented = true,
-    };
-
     /// <summary>Extract and deserialize the authoritative flow payload from a <c>.md</c> document.</summary>
     public static FlowParseResult Parse(string markdown, string? file = null)
     {
@@ -58,7 +48,7 @@ public static class FlowMarkdown
         MauiFlow? flow;
         try
         {
-            flow = JsonSerializer.Deserialize<MauiFlow>(jsonText, ReadOptions);
+            flow = JsonSerializer.Deserialize(jsonText, DevFlowCliJsonContext.Default.MauiFlow);
         }
         catch (JsonException ex)
         {
@@ -78,7 +68,7 @@ public static class FlowMarkdown
     /// <summary>Render a flow as a dual-layer <c>.md</c> (human prose + authoritative json block).</summary>
     public static string Serialize(MauiFlow flow)
     {
-        var json = JsonSerializer.Serialize(flow, WriteOptions);
+        var json = CliJson.PrettyPrint(JsonSerializer.Serialize(flow, DevFlowCliJsonPreserveNullContext.Default.MauiFlow));
         var sb = new StringBuilder();
         sb.Append("# Scenario: ").Append(NoFence(flow.Name)).Append('\n').Append('\n');
         sb.Append("<!-- Recorded by MAUI DevFlow. The fenced ```json maui-test block below is the source of\n");

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Flows/FlowRecordTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Flows/FlowRecordTools.cs
@@ -1,8 +1,10 @@
 using System.ComponentModel;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
+using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.Cli.DevFlow.Flows;
 
@@ -87,13 +89,13 @@ public sealed class FlowRecordTools
                 return Error(status.Error ?? "No shared recording is active.");
             if (!string.Equals(recordingId, status.RecordingId, StringComparison.Ordinal))
                 return Error($"Unknown recordingId '{recordingId}'.");
-            return Json(new
+            return Json(new JsonObject
             {
-                ok = true,
-                recordingId = status.RecordingId,
-                stepCount = status.Steps,
-                automaticallyRecorded = true,
-                message = "The mutation was observed automatically; no duplicate step was appended."
+                ["ok"] = true,
+                ["recordingId"] = status.RecordingId,
+                ["stepCount"] = status.Steps,
+                ["automaticallyRecorded"] = true,
+                ["message"] = "The mutation was observed automatically; no duplicate step was appended."
             });
         }
         catch (Exception ex)
@@ -251,7 +253,15 @@ public sealed class FlowRecordTools
             using var fs = new FileStream(resolved!, mode, FileAccess.Write, FileShare.None);
             using var writer = new StreamWriter(fs);
             await writer.WriteAsync(result.Markdown);
-            return Json(new { ok = true, file = resolved, steps = result.Steps, warnings = result.Warnings });
+            var stopNode = new JsonObject
+            {
+                ["ok"] = true,
+                ["file"] = resolved,
+                ["steps"] = result.Steps,
+            };
+            if (result.Warnings is not null)
+                stopNode["warnings"] = JsonSerializer.SerializeToNode(result.Warnings, DevFlowCliJsonContext.Default.StringArray);
+            return Json(stopNode);
         }
         catch (IOException) when (!overwrite && File.Exists(resolved))
         {
@@ -341,7 +351,20 @@ public sealed class FlowRecordTools
         var id = FlowRecordingStore.Instance.Start(name, app, platform, preconditions);
         return id is null
             ? Error($"Too many active recordings (max {FlowRecordingStore.MaxActive}). Stop or cancel one first.")
-            : Json(new { ok = true, recordingId = id, name = string.IsNullOrWhiteSpace(name) ? "scenario" : name.Trim(), app, platform });
+            : Json(BuildStartLocalNode(id, name, app, platform));
+    }
+
+    private static JsonObject BuildStartLocalNode(string id, string name, string? app, string? platform)
+    {
+        var node = new JsonObject
+        {
+            ["ok"] = true,
+            ["recordingId"] = id,
+            ["name"] = string.IsNullOrWhiteSpace(name) ? "scenario" : name.Trim(),
+        };
+        if (app is not null) node["app"] = app;
+        if (platform is not null) node["platform"] = platform;
+        return node;
     }
 
     private static string StepLocal(
@@ -369,7 +392,7 @@ public sealed class FlowRecordTools
             recorder, action, automationId, text, type, index, id, value, name,
             dx, dy, itemIndex, position, page, navigated, assertsJson);
         return added.ok
-            ? Json(new { ok = true, seq = added.seq, stepCount = added.stepCount, fragile = added.fragile })
+            ? Json(new JsonObject { ["ok"] = true, ["seq"] = added.seq, ["stepCount"] = added.stepCount, ["fragile"] = added.fragile })
             : Error(added.error!);
     }
 
@@ -383,12 +406,12 @@ public sealed class FlowRecordTools
             return Error("Recording has no steps. Add steps or cancel it.");
         if (!validation.valid)
         {
-            return Json(new
+            return Json(new JsonObject
             {
-                ok = false,
-                error = "Recording has validation errors; fix the offending steps or cancel. Not written.",
-                errors = validation.errors,
-                warnings = validation.warnings,
+                ["ok"] = false,
+                ["error"] = "Recording has validation errors; fix the offending steps or cancel. Not written.",
+                ["errors"] = JsonSerializer.SerializeToNode(validation.errors, DevFlowCliJsonContext.Default.StringArray),
+                ["warnings"] = JsonSerializer.SerializeToNode(validation.warnings, DevFlowCliJsonContext.Default.StringArray),
             });
         }
 
@@ -418,12 +441,12 @@ public sealed class FlowRecordTools
         }
 
         FlowRecordingStore.Instance.Remove(recordingId);
-        return Json(new
+        return Json(new JsonObject
         {
-            ok = true,
-            file = resolved,
-            steps = finished.flow!.Steps.Count,
-            warnings = validation.warnings
+            ["ok"] = true,
+            ["file"] = resolved,
+            ["steps"] = finished.flow!.Steps.Count,
+            ["warnings"] = JsonSerializer.SerializeToNode(validation.warnings, DevFlowCliJsonContext.Default.StringArray)
         });
     }
 
@@ -433,21 +456,31 @@ public sealed class FlowRecordTools
         {
             if (!FlowRecordingStore.Instance.TryGet(recordingId!, out var recorder))
                 return Error($"Unknown recordingId '{recordingId}'.");
-            return Json(new { ok = true, recordingId, name = recorder.Name, steps = recorder.StepCount });
+            return Json(new JsonObject { ["ok"] = true, ["recordingId"] = recordingId, ["name"] = recorder.Name, ["steps"] = recorder.StepCount });
         }
 
         var active = FlowRecordingStore.Instance.List()
-            .Select(r => new { name = r.Name, steps = r.Steps })
+            .Select(r => new ActiveRecordingSummary(r.Name, r.Steps))
             .ToList();
-        return Json(new { ok = true, count = active.Count, active });
+        return Json(new JsonObject
+        {
+            ["ok"] = true,
+            ["count"] = active.Count,
+            ["active"] = JsonSerializer.SerializeToNode(active, DevFlowCliJsonContext.Default.ListActiveRecordingSummary)
+        });
     }
+
+    /// <summary>A single active recording entry returned by <see cref="RecordStatus"/>.</summary>
+    internal sealed record ActiveRecordingSummary(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("steps")] int Steps);
 
     private static string CancelLocal(string recordingId)
     {
         var removed = FlowRecordingStore.Instance.Remove(recordingId);
         return removed is null
             ? Error($"Unknown recordingId '{recordingId}'.")
-            : Json(new { ok = true, cancelled = recordingId });
+            : Json(new JsonObject { ["ok"] = true, ["cancelled"] = recordingId });
     }
 
     /// <summary>Builds a canonical selector keeping ONLY the highest-precedence form provided
@@ -472,7 +505,7 @@ public sealed class FlowRecordTools
         if (assertsJson.Length > MaxAssertsJson)
             throw new InvalidOperationException("assertsJson is too large.");
 
-        var parsed = JsonSerializer.Deserialize<List<FlowAssert>>(assertsJson, ReadOptions);
+        var parsed = JsonSerializer.Deserialize(assertsJson, DevFlowCliJsonContext.Default.ListFlowAssert);
         if (parsed is not { Count: > 0 })
             return null;
         if (parsed.Any(a => a is null))
@@ -578,15 +611,13 @@ public sealed class FlowRecordTools
     /// <summary>Trims an identifier-like field and treats whitespace-only as missing (null).</summary>
     private static string? Clean(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
 
-    private static readonly JsonSerializerOptions ReadOptions = new() { PropertyNameCaseInsensitive = true };
-
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    private static string Json(object value) => JsonSerializer.Serialize(value, JsonOpts);
-    private static string Error(string error) => JsonSerializer.Serialize(new { ok = false, error }, JsonOpts);
+    private static string Json(JsonNode? value) => value?.ToJsonString(JsonOpts) ?? "null";
+    private static string Json(MutationRecordingStatus value) =>
+        Json(JsonSerializer.SerializeToNode(value, DevFlowCliJsonContext.Default.MutationRecordingStatus));
+    private static string Error(string error) => Json(new JsonObject { ["ok"] = false, ["error"] = error });
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Flows/FlowReplayer.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Flows/FlowReplayer.cs
@@ -1,38 +1,39 @@
 using Microsoft.Maui.DevFlow.Driver;
 using System.Globalization;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Maui.Cli.DevFlow.Flows;
 
 public sealed class FlowAssertResult
 {
-    public string Kind { get; set; } = "";
+    [JsonPropertyName("kind")] public string Kind { get; set; } = "";
     /// <summary>true = passed, false = failed, null = not evaluated (report-only or skipped).</summary>
-    public bool? Ok { get; set; }
-    public bool Skipped { get; set; }
-    public string? Name { get; set; }
-    public string? Expected { get; set; }
-    public string? Actual { get; set; }
+    [JsonPropertyName("ok")] public bool? Ok { get; set; }
+    [JsonPropertyName("skipped")] public bool Skipped { get; set; }
+    [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("expected")] public string? Expected { get; set; }
+    [JsonPropertyName("actual")] public string? Actual { get; set; }
 }
 
 public sealed class FlowStepResult
 {
-    public int Seq { get; set; }
-    public string Action { get; set; } = "";
-    public string Label { get; set; } = "";
-    public bool Ok { get; set; }
-    public string? Error { get; set; }
-    public List<FlowAssertResult> Asserts { get; set; } = new();
+    [JsonPropertyName("seq")] public int Seq { get; set; }
+    [JsonPropertyName("action")] public string Action { get; set; } = "";
+    [JsonPropertyName("label")] public string Label { get; set; } = "";
+    [JsonPropertyName("ok")] public bool Ok { get; set; }
+    [JsonPropertyName("error")] public string? Error { get; set; }
+    [JsonPropertyName("asserts")] public List<FlowAssertResult> Asserts { get; set; } = new();
 }
 
 public sealed class FlowReplayReport
 {
-    public bool Ok { get; set; }
-    public string Name { get; set; } = "scenario";
-    public string? File { get; set; }
-    public int Total { get; set; }
-    public int Passed { get; set; }
-    public int Failed { get; set; }
-    public List<FlowStepResult> Results { get; set; } = new();
+    [JsonPropertyName("ok")] public bool Ok { get; set; }
+    [JsonPropertyName("name")] public string Name { get; set; } = "scenario";
+    [JsonPropertyName("file")] public string? File { get; set; }
+    [JsonPropertyName("total")] public int Total { get; set; }
+    [JsonPropertyName("passed")] public int Passed { get; set; }
+    [JsonPropertyName("failed")] public int Failed { get; set; }
+    [JsonPropertyName("results")] public List<FlowStepResult> Results { get; set; } = new();
 }
 
 /// <summary>

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Flows/FlowTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Flows/FlowTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using ModelContextProtocol.Server;
 using Microsoft.Maui.Cli.DevFlow.Mcp;
@@ -38,7 +39,7 @@ public sealed class FlowTools
         using var agent = await session.GetAgentClientAsync(agentPort);
         var replayer = new FlowReplayer(agent);
         var report = await replayer.ReplayAsync(parsed.Flow!, read.Path);
-        return Json(report);
+        return Json(JsonSerializer.SerializeToNode(report, DevFlowCliJsonContext.Default.FlowReplayReport));
     }
 
     [McpServerTool(Name = "maui_flow_validate"),
@@ -54,13 +55,13 @@ public sealed class FlowTools
         if (!parsed.Ok) return Task.FromResult(Error(parsed.Error!));
 
         var v = FlowValidator.Validate(parsed.Flow!);
-        return Task.FromResult(Json(new
+        return Task.FromResult(Json(new JsonObject
         {
-            ok = v.Ok,
-            name = parsed.Flow!.Name,
-            steps = parsed.Flow!.Steps.Count,
-            errors = v.Errors,
-            warnings = v.Warnings,
+            ["ok"] = v.Ok,
+            ["name"] = parsed.Flow!.Name,
+            ["steps"] = parsed.Flow!.Steps.Count,
+            ["errors"] = JsonSerializer.SerializeToNode(v.Errors, DevFlowCliJsonContext.Default.ListString),
+            ["warnings"] = JsonSerializer.SerializeToNode(v.Warnings, DevFlowCliJsonContext.Default.ListString),
         }));
     }
 
@@ -83,21 +84,36 @@ public sealed class FlowTools
         }
 
         if (!Directory.Exists(dir))
-            return Task.FromResult(Json(new { ok = true, directory = dir, tests = Array.Empty<object>() }));
+            return Task.FromResult(Json(new JsonObject
+            {
+                ["ok"] = true,
+                ["directory"] = dir,
+                ["tests"] = new JsonArray()
+            }));
 
         try
         {
             var tests = Directory.EnumerateFiles(dir, "*.md", SearchOption.TopDirectoryOnly)
                 .Take(MaxListResults)
-                .Select(f => new { name = Path.GetFileNameWithoutExtension(f), file = f })
+                .Select(f => new FlowFileSummary(Path.GetFileNameWithoutExtension(f), f))
                 .ToList();
-            return Task.FromResult(Json(new { ok = true, directory = dir, tests }));
+            return Task.FromResult(Json(new JsonObject
+            {
+                ["ok"] = true,
+                ["directory"] = dir,
+                ["tests"] = JsonSerializer.SerializeToNode(tests, DevFlowCliJsonContext.Default.ListFlowFileSummary)
+            }));
         }
         catch (Exception ex)
         {
             return Task.FromResult(Error($"Could not list tests: {ex.Message}"));
         }
     }
+
+    /// <summary>A single .md flow test entry returned by <see cref="List"/>.</summary>
+    internal sealed record FlowFileSummary(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("file")] string File);
 
     // ── File reading with validation (defence: .md only, existing regular file, size cap) ──
     private static (string? Path, string? Text, string? Error) ReadFlowFile(string file)
@@ -135,11 +151,9 @@ public sealed class FlowTools
 
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    private static string Json(object value) => JsonSerializer.Serialize(value, JsonOpts);
-    private static string Error(string error) => JsonSerializer.Serialize(new { ok = false, error }, JsonOpts);
+    private static string Json(JsonNode? value) => value?.ToJsonString(JsonOpts) ?? "null";
+    private static string Error(string error) => Json(new JsonObject { ["ok"] = false, ["error"] = error });
 }

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/InspectorAlertController.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/InspectorAlertController.cs
@@ -1,14 +1,15 @@
+using System.Text.Json.Serialization;
 using Microsoft.Maui.Cli.DevFlow.Android;
 using Microsoft.Maui.DevFlow.Driver;
 
 namespace Microsoft.Maui.Cli.DevFlow.Inspector;
 
 internal sealed record InspectorAlertResult(
-    bool Ok,
-    bool Supported,
-    AlertInfo? Alert = null,
-    string? Error = null,
-    bool Dismissed = false);
+    [property: JsonPropertyName("ok")] bool Ok,
+    [property: JsonPropertyName("supported")] bool Supported,
+    [property: JsonPropertyName("alert")] AlertInfo? Alert = null,
+    [property: JsonPropertyName("error")] string? Error = null,
+    [property: JsonPropertyName("dismissed")] bool Dismissed = false);
 
 internal sealed class InspectorAlertController
 {

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/InspectorServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/InspectorServer.cs
@@ -338,7 +338,7 @@ public sealed class InspectorServer : IDisposable
     }
 
     private static (int, string, byte[]) CaptureMetadataError(string error)
-        => (400, "application/json", JsonSerializer.SerializeToUtf8Bytes(new { error }));
+        => (400, "application/json", Encoding.UTF8.GetBytes(new JsonObject { ["error"] = error }.ToJsonString()));
 
     private static (int, string, byte[]) ActionOutcomeResponse(ActionResult outcome)
     {
@@ -351,12 +351,12 @@ public sealed class InspectorServer : IDisposable
         return (
             statusCode,
             "application/json",
-            JsonSerializer.SerializeToUtf8Bytes(new
+            Encoding.UTF8.GetBytes(new JsonObject
             {
-                ok = false,
-                reason = outcome.Reason,
-                retryable = outcome.Retryable
-            }));
+                ["ok"] = false,
+                ["reason"] = outcome.Reason,
+                ["retryable"] = outcome.Retryable
+            }.ToJsonString()));
     }
 
     private static (int, string, byte[]) UiReadOutcomeResponse(UiReadResult outcome)
@@ -367,12 +367,12 @@ public sealed class InspectorServer : IDisposable
         return (
             statusCode,
             "application/json",
-            JsonSerializer.SerializeToUtf8Bytes(new
+            Encoding.UTF8.GetBytes(new JsonObject
             {
-                ok = false,
-                reason = outcome.Reason,
-                retryable = outcome.Retryable
-            }));
+                ["ok"] = false,
+                ["reason"] = outcome.Reason,
+                ["retryable"] = outcome.Retryable
+            }.ToJsonString()));
     }
 
     private async Task<bool> RequiresCaptureEpochAsync()
@@ -927,16 +927,16 @@ public sealed class InspectorServer : IDisposable
                     holderLabel);
                 if (!status.YouHold)
                 {
-                    var payload = JsonSerializer.Serialize(new
+                    var payload = new JsonObject
                     {
-                        ok = false,
-                        reason = "writer",
-                        error = "Another session is driving this app.",
-                        holderKind = status.HolderKind,
-                        label = status.Label,
-                        expiresInMs = status.ExpiresInMs,
-                        authority = status.Authority
-                    }, CamelCase);
+                        ["ok"] = false,
+                        ["reason"] = "writer",
+                        ["error"] = "Another session is driving this app.",
+                        ["holderKind"] = status.HolderKind,
+                        ["label"] = status.Label,
+                        ["expiresInMs"] = status.ExpiresInMs,
+                        ["authority"] = status.Authority
+                    }.ToJsonString();
                     return (409, "application/json", Encoding.UTF8.GetBytes(payload));
                 }
             }
@@ -1081,12 +1081,12 @@ public sealed class InspectorServer : IDisposable
             return (
                 503,
                 "application/json",
-                JsonSerializer.SerializeToUtf8Bytes(new
+                Encoding.UTF8.GetBytes(new JsonObject
                 {
-                    ok = false,
-                    error = "The DevFlow agent is unavailable.",
-                    retryable = true
-                }));
+                    ["ok"] = false,
+                    ["error"] = "The DevFlow agent is unavailable.",
+                    ["retryable"] = true
+                }.ToJsonString()));
         }
 
         if (frame.Png.Length == 0)
@@ -1094,30 +1094,33 @@ public sealed class InspectorServer : IDisposable
             return (
                 503,
                 "application/json",
-                JsonSerializer.SerializeToUtf8Bytes(new
+                Encoding.UTF8.GetBytes(new JsonObject
                 {
-                    ok = false,
-                    error = "Unable to capture the current app state.",
-                    retryable = true
-                }));
+                    ["ok"] = false,
+                    ["error"] = "Unable to capture the current app state.",
+                    ["retryable"] = true
+                }.ToJsonString()));
         }
 
-        var json = JsonSerializer.Serialize(new
+        var diagnostics = wantsDiagnostics
+            ? await ResolveFrameDiagnosticsAsync(frame.TreeRevision)
+            : null;
+        var json = new JsonObject
         {
-            frameId = frame.Id,
-            screenshotUrl = $"screenshot.png?frame={Uri.EscapeDataString(frame.Id)}",
-            elements = frame.ElementsHtml,
-            viewportWidth = frame.Width,
-            viewportHeight = frame.Height,
-            rootOffsetX = frame.RootOffsetX,
-            rootOffsetY = frame.RootOffsetY,
-            diagnostics = wantsDiagnostics
-                ? await ResolveFrameDiagnosticsAsync(frame.TreeRevision)
-                : null,
-            captureEpoch = frame.CaptureEpoch,
-            registryGeneration = frame.RegistryGeneration,
-            windowId = frame.WindowId
-        });
+            ["frameId"] = frame.Id,
+            ["screenshotUrl"] = $"screenshot.png?frame={Uri.EscapeDataString(frame.Id)}",
+            ["elements"] = frame.ElementsHtml,
+            ["viewportWidth"] = frame.Width,
+            ["viewportHeight"] = frame.Height,
+            ["rootOffsetX"] = frame.RootOffsetX,
+            ["rootOffsetY"] = frame.RootOffsetY,
+            ["diagnostics"] = diagnostics is null
+                ? null
+                : JsonSerializer.SerializeToNode(diagnostics, DevFlowCliJsonContext.Default.LayoutInspectionResult),
+            ["captureEpoch"] = frame.CaptureEpoch,
+            ["registryGeneration"] = frame.RegistryGeneration,
+            ["windowId"] = frame.WindowId
+        }.ToJsonString();
 
         return (200, "application/json", Encoding.UTF8.GetBytes(json));
     }
@@ -1125,7 +1128,8 @@ public sealed class InspectorServer : IDisposable
     private async Task<(int, string, byte[])> HandleEventSupportAsync()
     {
         var capabilities = await _client.GetCapabilitiesAsync();
-        return Ok(JsonSerializer.Serialize(new { supported = SupportsUiEvents(capabilities) }, CamelCase));
+        var supported = SupportsUiEvents(capabilities);
+        return Ok(new JsonObject { ["supported"] = supported }.ToJsonString());
     }
 
     internal static bool? SupportsUiEvents(JsonElement capabilities)
@@ -1405,14 +1409,14 @@ public sealed class InspectorServer : IDisposable
             {
                 return JsonResponse(
                     409,
-                    new
+                    new JsonObject
                     {
-                        success = false,
-                        findingId = request.FindingId,
-                        suppressed = true,
-                        projectRemovable = false,
-                        provenance = ex.Provenance,
-                        message = ex.Provenance.Count == 0
+                        ["success"] = false,
+                        ["findingId"] = request.FindingId,
+                        ["suppressed"] = true,
+                        ["projectRemovable"] = false,
+                        ["provenance"] = JsonSerializer.SerializeToNode(ex.Provenance.ToArray(), DevFlowCliJsonContext.Default.StringArray),
+                        ["message"] = ex.Provenance.Count == 0
                             ? "No project-owned exact suppression exists for this finding."
                             : "This finding is also suppressed by a user or broad project policy. Edit that policy to unsuppress it."
                     });
@@ -1455,13 +1459,15 @@ public sealed class InspectorServer : IDisposable
 
         return JsonResponse(
             200,
-            new
+            new JsonObject
             {
-                success = true,
-                findingId = request.FindingId,
-                suppressed = !remove,
-                projectRemovable = !remove,
-                provenance = remove ? Array.Empty<string>() : ["project-exact"]
+                ["success"] = true,
+                ["findingId"] = request.FindingId,
+                ["suppressed"] = !remove,
+                ["projectRemovable"] = !remove,
+                ["provenance"] = JsonSerializer.SerializeToNode(
+                    remove ? Array.Empty<string>() : ["project-exact"],
+                    DevFlowCliJsonContext.Default.StringArray)
             });
     }
 
@@ -1834,7 +1840,7 @@ public sealed class InspectorServer : IDisposable
 
         using (hitDocument)
         {
-            var candidates = new List<Dictionary<string, string?>>(Math.Min(12, elements.GetArrayLength()));
+            var candidates = new JsonArray();
             for (var index = 0; index < elements.GetArrayLength() && candidates.Count < 12; index++)
             {
                 var element = elements[index];
@@ -1843,7 +1849,7 @@ public sealed class InspectorServer : IDisposable
                 var id = idProperty.GetString();
                 if (string.IsNullOrEmpty(id)) continue;
 
-                candidates.Add(new Dictionary<string, string?>
+                candidates.Add((JsonNode?)new JsonObject
                 {
                     ["id"] = id,
                     ["type"] = ReadOptionalString(element, "type"),
@@ -1852,12 +1858,13 @@ public sealed class InspectorServer : IDisposable
                 });
             }
 
-            var payload = JsonSerializer.Serialize(new
+            var elementId = candidates.Count > 0 ? (string?)candidates[0]!["id"] : null;
+            var payload = new JsonObject
             {
-                ok = true,
-                elementId = candidates.FirstOrDefault()?["id"],
-                candidates
-            }, CamelCase);
+                ["ok"] = true,
+                ["elementId"] = elementId,
+                ["candidates"] = candidates
+            }.ToJsonString();
             return Ok(payload);
         }
     }
@@ -2226,7 +2233,7 @@ public sealed class InspectorServer : IDisposable
             return (400, "application/json", Encoding.UTF8.GetBytes("{\"error\":\"elementId and name required\"}"));
 
         var value = await _client.GetPropertyAsync(elementId!, name!);
-        var payload = JsonSerializer.Serialize(new { ok = true, value });
+        var payload = new JsonObject { ["ok"] = true, ["value"] = value }.ToJsonString();
         return (200, "application/json", Encoding.UTF8.GetBytes(payload));
     }
 
@@ -2244,15 +2251,16 @@ public sealed class InspectorServer : IDisposable
             return Ok("{\"ok\":false,\"supported\":false}");
         }
 
-        var descriptors = properties.EnumerateArray().Select(property =>
+        var descriptors = new JsonArray();
+        foreach (var property in properties.EnumerateArray())
         {
             var node = JsonNode.Parse(property.GetRawText())!.AsObject();
             var name = property.TryGetProperty("name", out var nameElement) ? nameElement.GetString() : null;
             node["persistable"] = !string.IsNullOrWhiteSpace(name) &&
                 XamlSourcePropertyEditor.IsSupportedPropertyName(name);
-            return node;
-        }).ToArray();
-        return Ok(JsonSerializer.Serialize(new { ok = true, supported = true, properties = descriptors }, CamelCase));
+            descriptors.Add((JsonNode?)node);
+        }
+        return Ok(new JsonObject { ["ok"] = true, ["supported"] = true, ["properties"] = descriptors }.ToJsonString());
     }
 
     // Live-edits a single property value on an element, proxied to the agent, then invalidates the
@@ -2415,15 +2423,15 @@ public sealed class InspectorServer : IDisposable
             XamlSourceEditStatus.SourceUnavailable or XamlSourceEditStatus.Unsupported => 422,
             _ => 500,
         };
-        var payload = JsonSerializer.Serialize(new
+        var payload = new JsonObject
         {
-            ok = result.Success,
-            error = result.Error,
-            file = result.File,
-            line = result.Line,
-            column = result.Column,
-            sourceHash = result.SourceHash
-        }, CamelCase);
+            ["ok"] = result.Success,
+            ["error"] = result.Error,
+            ["file"] = result.File,
+            ["line"] = result.Line,
+            ["column"] = result.Column,
+            ["sourceHash"] = result.SourceHash
+        }.ToJsonString();
         return (statusCode, "application/json", Encoding.UTF8.GetBytes(payload));
     }
 
@@ -2492,15 +2500,15 @@ public sealed class InspectorServer : IDisposable
             catch { /* best-effort — a recording can start without agent metadata */ }
 
             var result = await _client.ControlMutationRecordingAsync("start", name, app, platform, preconditions);
-            var payload = JsonSerializer.Serialize(new
+            var payload = new JsonObject
             {
-                ok = result.Ok,
-                recordingId = result.RecordingId,
-                name = result.Name ?? name,
-                steps = result.Steps,
-                route,
-                error = result.Error
-            }, CamelCase);
+                ["ok"] = result.Ok,
+                ["recordingId"] = result.RecordingId,
+                ["name"] = result.Name ?? name,
+                ["steps"] = result.Steps,
+                ["route"] = route,
+                ["error"] = result.Error
+            }.ToJsonString();
             return (result.Ok ? 200 : 400, "application/json", Encoding.UTF8.GetBytes(payload));
         }
         finally
@@ -2547,14 +2555,14 @@ public sealed class InspectorServer : IDisposable
                 AssertsJson = assertsJson
             }, recordingId)
             : await _client.ControlMutationRecordingAsync("status");
-        var payload = JsonSerializer.Serialize(new
+        var payload = new JsonObject
         {
-            ok = result.Ok,
-            seq = result.Seq ?? result.Steps,
-            stepCount = result.Steps,
-            fragile = result.Fragile,
-            error = result.Error
-        }, CamelCase);
+            ["ok"] = result.Ok,
+            ["seq"] = result.Seq ?? result.Steps,
+            ["stepCount"] = result.Steps,
+            ["fragile"] = result.Fragile,
+            ["error"] = result.Error
+        }.ToJsonString();
         return (result.Ok ? 200 : 400, "application/json", Encoding.UTF8.GetBytes(payload));
     }
 
@@ -2565,40 +2573,40 @@ public sealed class InspectorServer : IDisposable
         if (!result.Ok && result.Empty)
         {
             var cancelled = await _client.ControlMutationRecordingAsync("cancel-if-empty", null, null, null, null, recordingId);
-            var emptyPayload = JsonSerializer.Serialize(new
+            var emptyPayload = new JsonObject
             {
-                ok = cancelled.Ok && cancelled.Empty,
-                empty = cancelled.Empty,
-                steps = 0,
-                error = cancelled.Ok ? null : cancelled.Error ?? result.Error
-            }, CamelCase);
+                ["ok"] = cancelled.Ok && cancelled.Empty,
+                ["empty"] = cancelled.Empty,
+                ["steps"] = 0,
+                ["error"] = cancelled.Ok ? null : cancelled.Error ?? result.Error
+            }.ToJsonString();
             return (cancelled.Ok && cancelled.Empty ? 200 : 409, "application/json", Encoding.UTF8.GetBytes(emptyPayload));
         }
 
-        var payload = JsonSerializer.Serialize(new
+        var payload = new JsonObject
         {
-            ok = result.Ok,
-            markdown = result.Markdown,
-            name = result.Name,
-            steps = result.Steps,
-            warnings = result.Warnings,
-            error = result.Error
-        }, CamelCase);
+            ["ok"] = result.Ok,
+            ["markdown"] = result.Markdown,
+            ["name"] = result.Name,
+            ["steps"] = result.Steps,
+            ["warnings"] = result.Warnings is null ? null : JsonSerializer.SerializeToNode(result.Warnings, DevFlowCliJsonContext.Default.StringArray),
+            ["error"] = result.Error
+        }.ToJsonString();
         return (result.Ok ? 200 : 400, "application/json", Encoding.UTF8.GetBytes(payload));
     }
 
     private async Task<(int, string, byte[])> HandleFlowRecordStatusAsync(string? body)
     {
         var result = await _client.ControlMutationRecordingAsync("status");
-        var payload = JsonSerializer.Serialize(new
+        var payload = new JsonObject
         {
-            ok = result.Ok,
-            recording = result.Recording,
-            recordingId = result.RecordingId,
-            name = result.Name,
-            steps = result.Steps,
-            error = result.Error
-        }, CamelCase);
+            ["ok"] = result.Ok,
+            ["recording"] = result.Recording,
+            ["recordingId"] = result.RecordingId,
+            ["name"] = result.Name,
+            ["steps"] = result.Steps,
+            ["error"] = result.Error
+        }.ToJsonString();
         return (result.Ok ? 200 : 400, "application/json", Encoding.UTF8.GetBytes(payload));
     }
 
@@ -2611,13 +2619,13 @@ public sealed class InspectorServer : IDisposable
             null,
             null,
             ReadStringField(body, "recordingId"));
-        var payload = JsonSerializer.Serialize(new
+        var payload = new JsonObject
         {
-            ok = result.Ok,
-            recording = result.Recording,
-            recordingId = result.RecordingId,
-            error = result.Error
-        }, CamelCase);
+            ["ok"] = result.Ok,
+            ["recording"] = result.Recording,
+            ["recordingId"] = result.RecordingId,
+            ["error"] = result.Error
+        }.ToJsonString();
         return (result.Ok ? 200 : 400, "application/json", Encoding.UTF8.GetBytes(payload));
     }
 
@@ -2625,31 +2633,31 @@ public sealed class InspectorServer : IDisposable
     // the same engine as maui_flow_replay — and returns a per-step pass/fail report. This RE-DRIVES
     // the app (destructive by nature); the UI gates it behind an explicit button and blocks it while
     // a recording is active.
-    private static readonly JsonSerializerOptions CamelCase = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     private async Task<(int, string, byte[])> HandleFlowFilesListAsync()
     {
         var root = await ResolveWorkflowRootAsync();
         if (root is null)
         {
-            return JsonResponse(200, new
+            return JsonResponse(200, new JsonObject
             {
-                ok = true,
-                supported = false,
-                tests = Array.Empty<object>(),
-                error = "The registered app project could not be resolved. Use Choose file instead."
+                ["ok"] = true,
+                ["supported"] = false,
+                ["tests"] = new JsonArray(),
+                ["error"] = "The registered app project could not be resolved. Use Choose file instead."
             });
         }
 
         if (!Directory.Exists(root))
-            return JsonResponse(200, new { ok = true, supported = true, tests = Array.Empty<object>() });
+            return JsonResponse(200, new JsonObject { ["ok"] = true, ["supported"] = true, ["tests"] = new JsonArray() });
 
         try
         {
             if ((File.GetAttributes(root) & FileAttributes.ReparsePoint) != 0)
-                return JsonResponse(403, new { ok = false, error = "The project workflow directory cannot be a symbolic link or reparse point." });
+                return JsonError(403, "The project workflow directory cannot be a symbolic link or reparse point.");
 
-            var tests = Directory.EnumerateFiles(root, "*", SearchOption.TopDirectoryOnly)
+            var tests = new JsonArray();
+            foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.TopDirectoryOnly)
                 .Where(path => string.Equals(Path.GetExtension(path), ".md", StringComparison.OrdinalIgnoreCase))
                 .Select(path => new FileInfo(path))
                 .Where(file =>
@@ -2657,30 +2665,31 @@ public sealed class InspectorServer : IDisposable
                     file.Length <= MaxWorkflowFileBytes)
                 .OrderByDescending(file => file.LastWriteTimeUtc)
                 .ThenBy(file => file.Name, StringComparer.OrdinalIgnoreCase)
-                .Take(MaxWorkflowFiles)
-                .Select(file => new
+                .Take(MaxWorkflowFiles))
+            {
+                tests.Add((JsonNode?)new JsonObject
                 {
-                    name = file.Name,
-                    size = file.Length,
-                    modifiedAt = file.LastWriteTimeUtc
-                })
-                .ToArray();
-            return JsonResponse(200, new { ok = true, supported = true, tests });
+                    ["name"] = file.Name,
+                    ["size"] = file.Length,
+                    ["modifiedAt"] = file.LastWriteTimeUtc
+                });
+            }
+            return JsonResponse(200, new JsonObject { ["ok"] = true, ["supported"] = true, ["tests"] = tests });
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            return JsonResponse(500, new { ok = false, error = "Could not list project workflow tests." });
+            return JsonError(500, "Could not list project workflow tests.");
         }
     }
 
     private async Task<(int, string, byte[])> HandleFlowFileLoadAsync(string? body)
     {
         if (!TryReadWorkflowFileName(body, out var name, out var requestError))
-            return JsonResponse(400, new { ok = false, error = requestError });
+            return JsonError(400, requestError!);
 
         var root = await ResolveWorkflowRootAsync();
         if (root is null)
-            return JsonResponse(400, new { ok = false, error = "The registered app project could not be resolved. Use Choose file instead." });
+            return JsonError(400, "The registered app project could not be resolved. Use Choose file instead.");
 
         string path;
         try
@@ -2689,59 +2698,59 @@ public sealed class InspectorServer : IDisposable
         }
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
         {
-            return JsonResponse(400, new { ok = false, error = "The workflow filename is invalid." });
+            return JsonError(400, "The workflow filename is invalid.");
         }
 
         if (!XamlSourcePropertyEditor.IsUnderRoot(path, root) ||
             !string.Equals(Path.GetFileName(path), name, StringComparison.Ordinal) ||
             !string.Equals(Path.GetExtension(path), ".md", StringComparison.OrdinalIgnoreCase))
         {
-            return JsonResponse(403, new { ok = false, error = "Only top-level Markdown files in the project maui-tests directory can be loaded." });
+            return JsonError(403, "Only top-level Markdown files in the project maui-tests directory can be loaded.");
         }
 
         try
         {
             if (!File.Exists(path))
-                return JsonResponse(404, new { ok = false, error = "The selected workflow test no longer exists." });
+                return JsonError(404, "The selected workflow test no longer exists.");
             var info = new FileInfo(path);
             if ((info.Attributes & FileAttributes.ReparsePoint) != 0 ||
                 XamlSourcePropertyEditor.PathContainsReparsePoint(root, path))
             {
-                return JsonResponse(403, new { ok = false, error = "Workflow tests reached through symbolic links or reparse points cannot be loaded." });
+                return JsonError(403, "Workflow tests reached through symbolic links or reparse points cannot be loaded.");
             }
             if (info.Length > MaxWorkflowFileBytes)
-                return JsonResponse(413, new { ok = false, error = "Workflow test files larger than 1 MB cannot be loaded." });
+                return JsonError(413, "Workflow test files larger than 1 MB cannot be loaded.");
 
             var markdown = await File.ReadAllTextAsync(path, _lifetimeCts.Token);
             var parsed = Flows.FlowMarkdown.Parse(markdown, path);
             if (!parsed.Ok || parsed.Flow is null)
-                return JsonResponse(400, new { ok = false, error = parsed.Error ?? "Could not parse the workflow test." });
+                return JsonError(400, parsed.Error ?? "Could not parse the workflow test.");
             if (parsed.Flow.Steps.Count > MaxReplaySteps)
-                return JsonResponse(400, new { ok = false, error = $"Flow too large (max {MaxReplaySteps} steps)." });
+                return JsonError(400, $"Flow too large (max {MaxReplaySteps} steps).");
             var validation = Flows.FlowValidator.Validate(parsed.Flow);
             if (!validation.Ok)
             {
-                return JsonResponse(400, new
+                return JsonResponse(400, new JsonObject
                 {
-                    ok = false,
-                    error = "Flow failed validation.",
-                    errors = validation.Errors,
-                    warnings = validation.Warnings
+                    ["ok"] = false,
+                    ["error"] = "Flow failed validation.",
+                    ["errors"] = JsonSerializer.SerializeToNode(validation.Errors, DevFlowCliJsonContext.Default.ListString),
+                    ["warnings"] = JsonSerializer.SerializeToNode(validation.Warnings, DevFlowCliJsonContext.Default.ListString)
                 });
             }
 
-            return JsonResponse(200, new
+            return JsonResponse(200, new JsonObject
             {
-                ok = true,
-                name,
-                markdown,
-                steps = parsed.Flow.Steps.Count,
-                warnings = validation.Warnings
+                ["ok"] = true,
+                ["name"] = name,
+                ["markdown"] = markdown,
+                ["steps"] = parsed.Flow.Steps.Count,
+                ["warnings"] = JsonSerializer.SerializeToNode(validation.Warnings, DevFlowCliJsonContext.Default.ListString)
             });
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DecoderFallbackException)
         {
-            return JsonResponse(500, new { ok = false, error = "Could not read the selected workflow test." });
+            return JsonError(500, "Could not read the selected workflow test.");
         }
     }
 
@@ -2829,8 +2838,11 @@ public sealed class InspectorServer : IDisposable
         return true;
     }
 
-    private static (int, string, byte[]) JsonResponse(int status, object value)
-        => (status, "application/json", Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value, CamelCase)));
+    private static (int, string, byte[]) JsonResponse(int status, JsonNode value)
+        => (status, "application/json", Encoding.UTF8.GetBytes(value.ToJsonString()));
+
+    private static (int, string, byte[]) JsonError(int status, string error)
+        => JsonResponse(status, new JsonObject { ["ok"] = false, ["error"] = error });
 
     private async Task<(int, string, byte[])> HandleFlowReplayAsync(string? body)
     {
@@ -2859,20 +2871,20 @@ public sealed class InspectorServer : IDisposable
 
         var parsed = Flows.FlowMarkdown.Parse(markdown);
         if (!parsed.Ok || parsed.Flow is null)
-            return (400, "application/json", Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { ok = false, error = parsed.Error ?? "Could not parse the flow." })));
+            return (400, "application/json", Encoding.UTF8.GetBytes(new JsonObject { ["ok"] = false, ["error"] = parsed.Error ?? "Could not parse the flow." }.ToJsonString()));
         if (parsed.Flow.Steps.Count > MaxReplaySteps)
             return (400, "application/json", Encoding.UTF8.GetBytes($"{{\"ok\":false,\"error\":\"Flow too large (max {MaxReplaySteps} steps).\"}}"));
 
         var validation = Flows.FlowValidator.Validate(parsed.Flow);
         if (!validation.Ok)
         {
-            var payload = JsonSerializer.Serialize(new
+            var payload = new JsonObject
             {
-                ok = false,
-                error = "Flow failed validation.",
-                errors = validation.Errors,
-                warnings = validation.Warnings
-            }, CamelCase);
+                ["ok"] = false,
+                ["error"] = "Flow failed validation.",
+                ["errors"] = JsonSerializer.SerializeToNode(validation.Errors, DevFlowCliJsonContext.Default.ListString),
+                ["warnings"] = JsonSerializer.SerializeToNode(validation.Warnings, DevFlowCliJsonContext.Default.ListString)
+            }.ToJsonString();
             return (400, "application/json", Encoding.UTF8.GetBytes(payload));
         }
 
@@ -2901,12 +2913,19 @@ public sealed class InspectorServer : IDisposable
             using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
             var replayer = new Flows.FlowReplayer(_client);
             var report = await replayer.ReplayAsync(parsed.Flow, null, cts.Token);
-            return (200, "application/json", Encoding.UTF8.GetBytes(JsonSerializer.Serialize(report, CamelCase)));
+            return (200, "application/json", Encoding.UTF8.GetBytes(JsonSerializer.Serialize(report, DevFlowCliJsonPreserveNullContext.Default.FlowReplayReport)));
         }
         catch (OperationCanceledException)
         {
             // Surface a timeout as a normal replay failure, not a generic server error.
-            var timeout = JsonSerializer.Serialize(new { ok = false, error = "Replay timed out.", total = parsed.Flow.Steps.Count, passed = 0, failed = parsed.Flow.Steps.Count });
+            var timeout = new JsonObject
+            {
+                ["ok"] = false,
+                ["error"] = "Replay timed out.",
+                ["total"] = parsed.Flow.Steps.Count,
+                ["passed"] = 0,
+                ["failed"] = parsed.Flow.Steps.Count
+            }.ToJsonString();
             return (200, "application/json", Encoding.UTF8.GetBytes(timeout));
         }
         finally
@@ -2948,7 +2967,7 @@ public sealed class InspectorServer : IDisposable
     {
         string? route = null;
         try { route = (await _client.GetStatusAsync())?.Route; } catch { /* best-effort */ }
-        var payload = JsonSerializer.Serialize(new { ok = true, route });
+        var payload = new JsonObject { ["ok"] = true, ["route"] = route }.ToJsonString();
         return (200, "application/json", Encoding.UTF8.GetBytes(payload));
     }
 
@@ -2965,14 +2984,14 @@ public sealed class InspectorServer : IDisposable
         var el = await _client.GetElementAsync(elementId);
         if (el?.SourceFile is null)
             return (200, "application/json", Encoding.UTF8.GetBytes("{\"ok\":false,\"error\":\"No source available for this element.\"}"));
-        var payload = JsonSerializer.Serialize(new
+        var payload = new JsonObject
         {
-            ok = true,
-            file = el.SourceFile,
-            line = el.SourceLine,
-            column = el.SourceColumn,
-            sourceHash = el.SourceHash
-        });
+            ["ok"] = true,
+            ["file"] = el.SourceFile,
+            ["line"] = el.SourceLine,
+            ["column"] = el.SourceColumn,
+            ["sourceHash"] = el.SourceHash
+        }.ToJsonString();
         return (200, "application/json", Encoding.UTF8.GetBytes(payload));
     }
 
@@ -3000,7 +3019,7 @@ public sealed class InspectorServer : IDisposable
     private async Task<(int, string, byte[])> HandleAlertsAsync()
     {
         var result = await _alertController.DetectAsync();
-        return Ok(JsonSerializer.Serialize(result, CamelCase));
+        return Ok(JsonSerializer.Serialize(result, DevFlowCliJsonPreserveNullContext.Default.InspectorAlertResult));
     }
 
     private async Task<(int, string, byte[])> HandleAlertDismissAsync(string? body)
@@ -3009,7 +3028,7 @@ public sealed class InspectorServer : IDisposable
         if (string.IsNullOrWhiteSpace(buttonLabel) || buttonLabel.Length > 256)
             return BadRequest("buttonLabel is required and must be 256 characters or fewer");
         var result = await _alertController.DismissAsync(buttonLabel);
-        return Ok(JsonSerializer.Serialize(result, CamelCase));
+        return Ok(JsonSerializer.Serialize(result, DevFlowCliJsonPreserveNullContext.Default.InspectorAlertResult));
     }
 
     private async Task<(int, string, byte[])> HandleLogsAsync(string? body)
@@ -3034,7 +3053,12 @@ public sealed class InspectorServer : IDisposable
         {
             var requests = await _client.GetNetworkRequestsAsync(limit);
             foreach (var r in requests) RedactNetwork(r);
-            return Ok(JsonSerializer.Serialize(new { ok = true, requests }, CamelCase));
+            var node = new JsonObject
+            {
+                ["ok"] = true,
+                ["requests"] = JsonSerializer.SerializeToNode(requests, DevFlowCliJsonPreserveNullContext.Default.ListNetworkRequest)
+            };
+            return Ok(node.ToJsonString());
         }
         catch { return Ok("{\"ok\":false,\"error\":\"network unavailable\"}"); }
     }
@@ -3049,7 +3073,12 @@ public sealed class InspectorServer : IDisposable
             var detail = await _client.GetNetworkRequestDetailAsync(id);
             if (detail is null) return Ok("{\"ok\":false,\"error\":\"not found\"}");
             RedactNetwork(detail);
-            return Ok(JsonSerializer.Serialize(new { ok = true, request = detail }, CamelCase));
+            var node = new JsonObject
+            {
+                ["ok"] = true,
+                ["request"] = JsonSerializer.SerializeToNode(detail, DevFlowCliJsonPreserveNullContext.Default.NetworkRequest)
+            };
+            return Ok(node.ToJsonString());
         }
         catch { return Ok("{\"ok\":false,\"error\":\"network unavailable\"}"); }
     }
@@ -3062,7 +3091,7 @@ public sealed class InspectorServer : IDisposable
             var prefs = await _client.GetPreferencesAsync(string.IsNullOrWhiteSpace(shared) ? null : shared);
             // Unknown shape across platforms — mask obvious secrets in the serialized text; the client
             // additionally masks values by key heuristic and only reveals on demand.
-            var masked = MaskSecrets(JsonSerializer.Serialize(prefs, CamelCase));
+            var masked = MaskSecrets(CliJson.PrettyPrint(prefs, indented: false));
             return Ok(WrapRaw("preferences", masked));
         }
         catch { return Ok("{\"ok\":false,\"error\":\"preferences unavailable\"}"); }
@@ -3073,13 +3102,13 @@ public sealed class InspectorServer : IDisposable
 
     private async Task<(int, string, byte[])> HandleDeviceAsync(string? body)
     {
-        var result = new Dictionary<string, JsonElement>();
+        var device = new JsonObject();
         foreach (var ep in DeviceEndpoints)
         {
-            try { result[ep] = await _client.GetPlatformInfoAsync(ep); }
+            try { device[ep] = JsonValue.Create(await _client.GetPlatformInfoAsync(ep)); }
             catch { /* unsupported on this platform — omit */ }
         }
-        return Ok(JsonSerializer.Serialize(new { ok = true, device = result }, CamelCase));
+        return Ok(new JsonObject { ["ok"] = true, ["device"] = device }.ToJsonString());
     }
 
     private async Task<(int, string, byte[])> HandleSensorsAsync(string? body)
@@ -3087,7 +3116,7 @@ public sealed class InspectorServer : IDisposable
         try
         {
             var sensors = await _client.GetSensorsAsync();
-            return Ok(JsonSerializer.Serialize(new { ok = true, sensors }, CamelCase));
+            return Ok(new JsonObject { ["ok"] = true, ["sensors"] = JsonValue.Create(sensors) }.ToJsonString());
         }
         catch { return Ok("{\"ok\":false,\"error\":\"sensors unavailable\"}"); }
     }
@@ -3099,7 +3128,7 @@ public sealed class InspectorServer : IDisposable
         try
         {
             var loc = await _client.GetGeolocationAsync(accuracy: "medium", timeoutSeconds: 10);
-            return Ok(JsonSerializer.Serialize(new { ok = true, location = loc }, CamelCase));
+            return Ok(new JsonObject { ["ok"] = true, ["location"] = JsonValue.Create(loc) }.ToJsonString());
         }
         catch { return Ok("{\"ok\":false,\"error\":\"geolocation unavailable\"}"); }
     }
@@ -3109,7 +3138,7 @@ public sealed class InspectorServer : IDisposable
         try
         {
             var roots = await _client.ListStorageRootsAsync();
-            return Ok(JsonSerializer.Serialize(new { ok = true, roots }, CamelCase));
+            return Ok(new JsonObject { ["ok"] = true, ["roots"] = JsonValue.Create(roots) }.ToJsonString());
         }
         catch { return Ok("{\"ok\":false,\"error\":\"storage unavailable\"}"); }
     }
@@ -3129,7 +3158,7 @@ public sealed class InspectorServer : IDisposable
         {
             var files = await _client.ListFilesAsync(string.IsNullOrWhiteSpace(path) ? null : path,
                                                      string.IsNullOrWhiteSpace(root) ? null : root);
-            return Ok(JsonSerializer.Serialize(new { ok = true, files }, CamelCase));
+            return Ok(new JsonObject { ["ok"] = true, ["files"] = JsonValue.Create(files) }.ToJsonString());
         }
         catch { return Ok("{\"ok\":false,\"error\":\"files unavailable\"}"); }
     }
@@ -3138,14 +3167,22 @@ public sealed class InspectorServer : IDisposable
     // existing chobitsu.js CDP bridge.
     private async Task<(int, string, byte[])> HandleCdpWebViewsAsync(string? body)
     {
-        try { var wv = await _client.GetCdpWebViewsAsync(); return Ok(JsonSerializer.Serialize(new { ok = true, webviews = wv }, CamelCase)); }
+        try
+        {
+            var wv = await _client.GetCdpWebViewsAsync();
+            return Ok(new JsonObject { ["ok"] = true, ["webviews"] = JsonValue.Create(wv) }.ToJsonString());
+        }
         catch { return Ok("{\"ok\":false,\"error\":\"no WebViews / CDP unavailable\"}"); }
     }
 
     private async Task<(int, string, byte[])> HandleCdpSourceAsync(string? body)
     {
         var id = ReadStringField(body, "webviewId");
-        try { var src = await _client.GetCdpSourceAsync(string.IsNullOrWhiteSpace(id) ? null : id); return Ok(JsonSerializer.Serialize(new { ok = true, source = src }, CamelCase)); }
+        try
+        {
+            var src = await _client.GetCdpSourceAsync(string.IsNullOrWhiteSpace(id) ? null : id);
+            return Ok(new JsonObject { ["ok"] = true, ["source"] = src }.ToJsonString());
+        }
         catch { return Ok("{\"ok\":false,\"error\":\"source unavailable\"}"); }
     }
 
@@ -3159,7 +3196,7 @@ public sealed class InspectorServer : IDisposable
         {
             var pars = new System.Text.Json.Nodes.JsonObject { ["expression"] = expr, ["returnByValue"] = true };
             var res = await _client.SendCdpCommandAsync("Runtime.evaluate", pars, string.IsNullOrWhiteSpace(id) ? null : id);
-            return Ok(JsonSerializer.Serialize(new { ok = true, result = res }, CamelCase));
+            return Ok(new JsonObject { ["ok"] = true, ["result"] = JsonValue.Create(res) }.ToJsonString());
         }
         catch { return Ok("{\"ok\":false,\"error\":\"evaluate failed\"}"); }
     }
@@ -3168,7 +3205,7 @@ public sealed class InspectorServer : IDisposable
 
     private static (int, string, byte[]) Ok(string json) => (200, "application/json", Encoding.UTF8.GetBytes(json));
     private static (int, string, byte[]) BadRequest(string error)
-        => (400, "application/json", Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { error }, CamelCase)));
+        => (400, "application/json", Encoding.UTF8.GetBytes(new JsonObject { ["error"] = error }.ToJsonString()));
     private static string WrapRaw(string field, string rawJson)
         => "{\"ok\":true,\"" + field + "\":" + (string.IsNullOrWhiteSpace(rawJson) ? "null" : rawJson) + "}";
 
@@ -3279,16 +3316,16 @@ public sealed class InspectorServer : IDisposable
             leaseId,
             holderKind,
             holderLabel);
-        return Ok(JsonSerializer.Serialize(new
+        return Ok(new JsonObject
         {
-            ok = status.Ok,
-            youAreWriter = status.YouHold,
-            heldByOther = status.HeldByOther,
-            holderKind = status.HolderKind,
-            label = status.Label,
-            expiresInMs = status.ExpiresInMs,
-            authority = status.Authority
-        }, CamelCase));
+            ["ok"] = status.Ok,
+            ["youAreWriter"] = status.YouHold,
+            ["heldByOther"] = status.HeldByOther,
+            ["holderKind"] = status.HolderKind,
+            ["label"] = status.Label,
+            ["expiresInMs"] = status.ExpiresInMs,
+            ["authority"] = status.Authority
+        }.ToJsonString());
     }
 
     private static bool ReadBoolField(string? body, string name)

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -17,11 +17,12 @@
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <PackageId>Microsoft.Maui.Cli</PackageId>
     <Description>CLI for .NET MAUI development environment setup and device management</Description>
-    <IsPackable>true</IsPackable>
+    <IsPackable Condition="'$(SkipMauiCliPack)' != 'true'">true</IsPackable>
+    <IsPackable Condition="'$(SkipMauiCliPack)' == 'true'">false</IsPackable>
     <IsShipping>true</IsShipping>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1572;CS1573;IL2026;IL2104;IL3050</NoWarn>
+    <NoWarn>$(NoWarn);CS1572;CS1573;IL2104</NoWarn>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
@@ -55,6 +56,17 @@
     </ItemGroup>
     <Delete Files="@(_PdbsToRemove)" />
     <Delete Files="@(_NativeDebugSymbolsToRemove)" />
+  </Target>
+
+  <!-- NativeAOT cannot run Go's Roslyn compilation in-process. Keep its managed server
+       untrimmed in a subdirectory so the native CLI can launch it through the installed SDK. -->
+  <Target Name="PublishManagedGoServer"
+          AfterTargets="Publish"
+          Condition="'$(DesignTimeBuild)' != 'true'">
+    <MSBuild Projects="..\..\Go\Server\Microsoft.Maui.Go.Server.csproj"
+             Targets="Publish"
+             BuildInParallel="false"
+             Properties="Configuration=$(Configuration);TargetFramework=net10.0;RuntimeIdentifier=;SelfContained=false;PublishAot=false;PublishTrimmed=false;RollForward=Major;PublishDir=$(PublishDir)go-server/" />
   </Target>
 
   <ItemGroup>

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -2,13 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- Multi-target net9.0 and net10.0 so `dotnet tool install` works on both
-         SDKs. dotnet picks the highest compatible TFM at install time. -->
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <!-- RID-specific .NET tool packages require the .NET 10 SDK. -->
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Microsoft.Maui.Cli</RootNamespace>
     <AssemblyName>maui</AssemblyName>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>maui</ToolCommandName>
+    <ToolPackageRuntimeIdentifiers>win-x64;linux-x64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <SelfContained Condition="'$(RuntimeIdentifier)' != '' and '$(RuntimeIdentifier)' != 'any'">true</SelfContained>
+    <!-- Go.Server is consumed in-process even though its project also emits a standalone executable. -->
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <PackageId>Microsoft.Maui.Cli</PackageId>
     <Description>CLI for .NET MAUI development environment setup and device management</Description>
     <IsPackable>true</IsPackable>
@@ -19,9 +24,6 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <!-- Let the latest packaged tool TFM run on newer major runtimes. -->
     <RollForward>Major</RollForward>
   </PropertyGroup>
@@ -36,17 +38,10 @@
     <PackageReference Include="Websocket.Client" />
     <PackageReference Include="Xamarin.Android.Tools.AndroidSdk" />
     <PackageReference Include="Xamarin.Apple.Tools.MaciOS" />
-    <!-- XenoAtom.Terminal.UI requires .NET 10 (uses C# 14 extension members).
-         On net9.0 we fall back to JSON output for the network monitor. -->
-    <PackageReference Include="XenoAtom.Terminal.UI" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="XenoAtom.Terminal.UI" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <!-- Exclude sources that depend on XenoAtom.Terminal.UI on non-net10 targets. -->
-    <Compile Remove="DevFlow\NetworkMonitorTui.cs" />
-  </ItemGroup>
-
-  <!-- Exclude native debug symbols (e.g. SkiaSharp PDBs) from the tool package to reduce size.
+  <!-- Exclude native debug symbols from the tool package to reduce size.
        PackTool globs everything from PublishDir — delete PDBs from there before the glob runs.
        Only runs during 'dotnet pack', not standalone 'dotnet publish'. -->
   <Target Name="RemoveNativeRuntimePdbsBeforeToolPack"
@@ -55,14 +50,16 @@
           Condition="'$(PackAsTool)' == 'true' and '$(IsPackable)' != 'false'">
     <ItemGroup>
       <_PdbsToRemove Include="$(PublishDir)runtimes/**/*.pdb" />
+      <_NativeDebugSymbolsToRemove Include="$(PublishDir)**/*.dSYM/**" />
     </ItemGroup>
     <Delete Files="@(_PdbsToRemove)" />
+    <Delete Files="@(_NativeDebugSymbolsToRemove)" />
   </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Maui.ProfilingHelper\Microsoft.Maui.ProfilingHelper.csproj" />
     <ProjectReference Include="..\..\DevFlow\Microsoft.Maui.DevFlow.Driver\Microsoft.Maui.DevFlow.Driver.csproj" />
-    <ProjectReference Include="..\..\Go\Server\Microsoft.Maui.Go.Server.csproj" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <ProjectReference Include="..\..\Go\Server\Microsoft.Maui.Go.Server.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -9,8 +9,9 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>maui</ToolCommandName>
     <ToolPackageRuntimeIdentifiers>win-x64;linux-x64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
-    <PublishAot>true</PublishAot>
-    <PublishTrimmed>true</PublishTrimmed>
+    <!-- NativeAOT requires a RID, so enable it for packaging rather than ordinary builds. -->
+    <PublishAot Condition="'$(_IsPacking)' == 'true'">true</PublishAot>
+    <PublishTrimmed Condition="'$(_IsPacking)' == 'true'">true</PublishTrimmed>
     <SelfContained Condition="'$(RuntimeIdentifier)' != '' and '$(RuntimeIdentifier)' != 'any'">true</SelfContained>
     <!-- Go.Server is consumed in-process even though its project also emits a standalone executable. -->
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -10,6 +10,8 @@ A command-line tool for .NET MAUI development environment setup and device manag
 |---------|-------------|
 | **Microsoft.Maui.Cli** | Global CLI tool (`maui`) for environment setup, device management, and diagnostics. |
 
+The .NET 10 SDK is required to install the tool. It selects a NativeAOT build on `win-x64`, `linux-x64`, and `osx-arm64`; other platforms use the framework-dependent fallback package.
+
 ## Quick Start
 
 ### 1. Install the CLI tool

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/FlowFormatTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/FlowFormatTests.cs
@@ -96,6 +96,17 @@ public class FlowFormatTests
     }
 
     [Fact]
+    public void Serialize_UnsetMetadata_PreservesNullFields()
+    {
+        var markdown = FlowMarkdown.Serialize(new MauiFlow());
+
+        Assert.Contains("\"app\": null", markdown);
+        Assert.Contains("\"platform\": null", markdown);
+        Assert.Contains("\"recordedAt\": null", markdown);
+        Assert.Contains("\"preconditions\": null", markdown);
+    }
+
+    [Fact]
     public void Validate_ValidFlow_HasNoErrors()
     {
         var flow = FlowMarkdown.Parse(SampleMd).Flow!;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/InspectorAlertControllerTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/InspectorAlertControllerTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Maui.Cli.DevFlow.Android;
+using Microsoft.Maui.Cli.DevFlow;
 using Microsoft.Maui.Cli.DevFlow.Inspector;
 using Microsoft.Maui.DevFlow.Driver;
+using System.Text.Json;
 
 namespace Microsoft.Maui.DevFlow.Tests;
 
@@ -129,6 +131,21 @@ public class InspectorAlertControllerTests
     {
         Assert.True(InspectorServer.IsBlockedDuringReplay("/api/alerts/dismiss"));
         Assert.False(InspectorServer.IsBlockedDuringReplay("/api/alerts"));
+    }
+
+    [Fact]
+    public void JsonContract_UsesCamelCaseAndPreservesNulls()
+    {
+        var result = new InspectorAlertResult(true, true);
+
+        var json = JsonSerializer.Serialize(
+            result,
+            DevFlowCliJsonPreserveNullContext.Default.InspectorAlertResult);
+
+        Assert.Contains("\"ok\":true", json);
+        Assert.Contains("\"alert\":null", json);
+        Assert.Contains("\"error\":null", json);
+        Assert.DoesNotContain("\"Ok\"", json);
     }
 
     private sealed class FakeAlertDriver(AlertInfo? alert) : IAlertDriver


### PR DESCRIPTION
## Summary

- ship RID-specific NativeAOT tool packages for `win-x64`, `linux-x64`, and `osx-arm64`
- retain a framework-dependent `any` fallback for other platforms
- build, sign, register, and publish RID packages from matching operating systems
- publish RID packages before the top-level pointer package and validate package/version completeness
- document the .NET 10 SDK requirement

## Breaking change

The CLI now targets .NET 10 only because RID-aware .NET tool packaging requires the .NET 10 SDK. .NET 9 tool installation is no longer supported.

## Validation

- locally packed the pointer, `osx-arm64`, and `any` packages
- installed the tool from the local package source and confirmed it selected and ran the arm64 Mach-O NativeAOT executable
- validated workflow YAML syntax
- CLI unit tests: 860 passed; `ProcessRunnerTests.RunAsync_CallbackException_DoesNotFailProcess` failed both with and without `PublishAot`, indicating an existing unrelated failure