### PR TITLE
Align Android driver with Xamarin.Android.Tools.AndroidSdk

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,7 +3,7 @@
   <ProductDependencies>
     <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.)
          The package is built by dotnet/android which includes android-tools as a submodule. -->
-    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.189-preview.58">
+    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.189-preview.59">
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>2114bc81fed892c4d166aeff637ca2387b0fcd8a</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
     <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.)
          The package is built by dotnet/android which includes android-tools as a submodule. -->
-    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.189-preview.59">
+    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="99.61.4490-ci.main.2352">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>2114bc81fed892c4d166aeff637ca2387b0fcd8a</Sha>
+      <Sha>a199d8f76be961b9c40b7d19e04b9fc8ab14a6ff</Sha>
     </Dependency>
     <!-- dotnet/maui -->
     <Dependency Name="Microsoft.Maui.Controls" Version="10.0.41">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
     <!-- dotnet/android-tools: Android SDK tooling (SdkManager, AdbRunner, JdkInstaller, etc.)
          The package is built by dotnet/android which includes android-tools as a submodule. -->
-    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="99.61.4490-ci.main.2352">
+    <Dependency Name="Xamarin.Android.Tools.AndroidSdk" Version="1.0.189-preview.59">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>a199d8f76be961b9c40b7d19e04b9fc8ab14a6ff</Sha>
+      <Sha>2114bc81fed892c4d166aeff637ca2387b0fcd8a</Sha>
     </Dependency>
     <!-- dotnet/maui -->
     <Dependency Name="Microsoft.Maui.Controls" Version="10.0.41">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   </PropertyGroup>
   <!-- Android platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Android Tools">
-    <XamarinAndroidToolsAndroidSdkVersion>1.0.189-preview.59</XamarinAndroidToolsAndroidSdkVersion>
+    <XamarinAndroidToolsAndroidSdkVersion>99.61.4490-ci.main.2352</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   </PropertyGroup>
   <!-- Android platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Android Tools">
-    <XamarinAndroidToolsAndroidSdkVersion>1.0.189-preview.58</XamarinAndroidToolsAndroidSdkVersion>
+    <XamarinAndroidToolsAndroidSdkVersion>1.0.189-preview.59</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   </PropertyGroup>
   <!-- Android platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Android Tools">
-    <XamarinAndroidToolsAndroidSdkVersion>99.61.4490-ci.main.2352</XamarinAndroidToolsAndroidSdkVersion>
+    <XamarinAndroidToolsAndroidSdkVersion>1.0.189-preview.59</XamarinAndroidToolsAndroidSdkVersion>
   </PropertyGroup>
   <!-- Apple platform tooling (managed via darc/maestro — see eng/Version.Details.xml) -->
   <PropertyGroup Label="Apple Tools">

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Xml.Linq;
+using Xamarin.Android.Tools;
 
 namespace Microsoft.Maui.DevFlow.Driver;
 
@@ -10,6 +12,24 @@ namespace Microsoft.Maui.DevFlow.Driver;
 /// </summary>
 public class AndroidAppDriver : AppDriverBase, IAlertDriver
 {
+    private readonly Func<string, AdbRunner> _createAdbRunner;
+    private readonly Func<string?> _getDefaultSerial;
+    private AdbRunner? _adbRunner;
+    private string? _adbRunnerPath;
+
+    public AndroidAppDriver()
+        : this(
+            static adbPath => new AdbRunner(adbPath),
+            static () => Environment.GetEnvironmentVariable("ANDROID_SERIAL"))
+    {
+    }
+
+    internal AndroidAppDriver(Func<string, AdbRunner> createAdbRunner, Func<string?>? getDefaultSerial = null)
+    {
+        _createAdbRunner = createAdbRunner;
+        _getDefaultSerial = getDefaultSerial ?? (static () => null);
+    }
+
     /// <summary>
     /// Optional serial number for targeting a specific device/emulator (adb -s).
     /// </summary>
@@ -22,17 +42,24 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
 
     protected override async Task SetupPlatformAsync(string host, int port)
     {
-        await RunAdbAsync($"reverse tcp:{port} tcp:{port}");
+        var serial = await ResolveSerialAsync().ConfigureAwait(false);
+        var portSpec = new AdbPortSpec(AdbProtocol.Tcp, port);
+        await GetAdbRunner().ReversePortAsync(serial, portSpec, portSpec).ConfigureAwait(false);
     }
 
     public override async Task BackAsync()
     {
-        await RunAdbAsync("shell input keyevent KEYCODE_BACK");
+        await RunAdbAsync("shell", "input", "keyevent", "KEYCODE_BACK").ConfigureAwait(false);
     }
 
     public override async Task PressKeyAsync(string key)
     {
-        var keycode = key.ToUpperInvariant() switch
+        ArgumentNullException.ThrowIfNull(key);
+        var normalizedKey = key.ToUpperInvariant();
+        if (normalizedKey.Any(character => !IsKeyCharacter(character)))
+            throw new ArgumentException("Android key names may contain only ASCII letters, digits, and underscores.", nameof(key));
+
+        var keycode = normalizedKey switch
         {
             "ENTER" or "RETURN" => "KEYCODE_ENTER",
             "BACK" => "KEYCODE_BACK",
@@ -40,10 +67,10 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
             "TAB" => "KEYCODE_TAB",
             "ESCAPE" or "ESC" => "KEYCODE_ESCAPE",
             "DELETE" or "BACKSPACE" => "KEYCODE_DEL",
-            _ => $"KEYCODE_{key.ToUpperInvariant()}"
+            _ => $"KEYCODE_{normalizedKey}"
         };
 
-        await RunAdbAsync($"shell input keyevent {keycode}");
+        await RunAdbAsync("shell", "input", "keyevent", keycode).ConfigureAwait(false);
     }
 
     public override async Task<ThemeResult> SetThemeAsync(DevFlowTheme theme, ThemeSetScope scope = ThemeSetScope.Auto)
@@ -76,7 +103,7 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
 
         try
         {
-            var qemu = await RunAdbWithOutputAsync("shell getprop ro.kernel.qemu").ConfigureAwait(false);
+            var qemu = await RunAdbWithOutputAsync("shell", "getprop", "ro.kernel.qemu").ConfigureAwait(false);
             return qemu.Trim().Equals("1", StringComparison.Ordinal);
         }
         catch
@@ -94,7 +121,7 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
             _ => "auto",
         };
 
-        await RunAdbAsync($"shell cmd uimode night {mode}").ConfigureAwait(false);
+        await RunAdbAsync("shell", "cmd", "uimode", "night", mode).ConfigureAwait(false);
 
         return new ThemeResult
         {
@@ -132,7 +159,7 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
         if (alert is null) throw new InvalidOperationException("No alert detected to dismiss");
 
         var btn = FindButtonToTap(alert, buttonLabel);
-        await RunAdbAsync($"shell input tap {btn.CenterX} {btn.CenterY}");
+        await TapAsync(btn).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -144,7 +171,7 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
         if (alert is null) return null;
 
         var btn = FindButtonToTap(alert, buttonLabel);
-        await RunAdbAsync($"shell input tap {btn.CenterX} {btn.CenterY}");
+        await TapAsync(btn).ConfigureAwait(false);
         return alert;
     }
 
@@ -164,8 +191,8 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
     private async Task<XElement?> DumpUiHierarchyAsync()
     {
         const string devicePath = "/sdcard/window_dump.xml";
-        await RunAdbAsync($"shell uiautomator dump {devicePath}");
-        var content = await RunAdbWithOutputAsync($"shell cat {devicePath}");
+        await RunAdbAsync("shell", "uiautomator", "dump", devicePath).ConfigureAwait(false);
+        var content = await RunAdbWithOutputAsync("shell", "cat", devicePath).ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(content)) return null;
 
         try { return XElement.Parse(content); }
@@ -349,25 +376,33 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
             effectiveTimeout = AdbMaxTimeLimit;
         }
 
-        var args = Serial is not null ? $"-s {Serial} " : "";
-        args += $"shell screenrecord --time-limit {effectiveTimeout} {DeviceRecordingPath}";
+        var arguments = BuildAdbArguments(
+            Serial,
+            "shell",
+            "screenrecord",
+            "--time-limit",
+            effectiveTimeout.ToString(CultureInfo.InvariantCulture),
+            DeviceRecordingPath);
+        var processStartInfo = CreateAdbProcessStartInfo(AdbPath, arguments);
+        int? recordingPid = null;
+        var recordingTask = ProcessUtils.StartProcess(
+            processStartInfo,
+            TextWriter.Null,
+            TextWriter.Null,
+            CancellationToken.None,
+            process => recordingPid = process.Id);
 
-        var psi = new ProcessStartInfo(AdbPath, args)
+        if (recordingPid is null)
         {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
+            await recordingTask.ConfigureAwait(false);
+            throw new InvalidOperationException("Failed to start adb screenrecord");
+        }
 
-        var process = Process.Start(psi)
-            ?? throw new InvalidOperationException("Failed to start adb screenrecord");
-
-        var watchdogPid = SpawnWatchdog(process.Id, effectiveTimeout);
+        var watchdogPid = SpawnWatchdog(recordingPid.Value, effectiveTimeout);
 
         RecordingStateManager.Save(new RecordingState
         {
-            RecordingPid = process.Id,
+            RecordingPid = recordingPid.Value,
             WatchdogPid = watchdogPid,
             OutputFile = Path.GetFullPath(outputFile),
             Platform = "android",
@@ -398,8 +433,8 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
         catch { }
 
         // Pull the file from device
-        await RunAdbAsync($"pull {DeviceRecordingPath} \"{state.OutputFile}\"");
-        try { await RunAdbAsync($"shell rm {DeviceRecordingPath}"); } catch { }
+        await RunAdbAsync("pull", DeviceRecordingPath, state.OutputFile).ConfigureAwait(false);
+        try { await RunAdbAsync("shell", "rm", DeviceRecordingPath).ConfigureAwait(false); } catch { }
 
         RecordingStateManager.Delete();
         return state.OutputFile;
@@ -409,50 +444,106 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
     // adb helpers
     // ──────────────────────────────────────────────
 
-    private async Task RunAdbAsync(string arguments)
+    private AdbRunner GetAdbRunner()
     {
-        var args = Serial is not null ? $"-s {Serial} {arguments}" : arguments;
-        var psi = new ProcessStartInfo(AdbPath, args)
+        if (_adbRunner is null || !string.Equals(_adbRunnerPath, AdbPath, StringComparison.Ordinal))
         {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        using var process = Process.Start(psi);
-        if (process == null) throw new InvalidOperationException("Failed to start adb");
-        await process.WaitForExitAsync();
-
-        if (process.ExitCode != 0)
-        {
-            var error = await process.StandardError.ReadToEndAsync();
-            throw new InvalidOperationException($"adb {arguments} failed: {error}");
-        }
-    }
-
-    private async Task<string> RunAdbWithOutputAsync(string arguments)
-    {
-        var args = Serial is not null ? $"-s {Serial} {arguments}" : arguments;
-        var psi = new ProcessStartInfo(AdbPath, args)
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        using var process = Process.Start(psi);
-        if (process == null) throw new InvalidOperationException("Failed to start adb");
-        var output = await process.StandardOutput.ReadToEndAsync();
-        await process.WaitForExitAsync();
-
-        if (process.ExitCode != 0)
-        {
-            var error = await process.StandardError.ReadToEndAsync();
-            throw new InvalidOperationException($"adb {arguments} failed: {error}");
+            _adbRunner = _createAdbRunner(AdbPath);
+            _adbRunnerPath = AdbPath;
         }
 
-        return output;
+        return _adbRunner;
     }
+
+    private async Task<string> ResolveSerialAsync()
+    {
+        if (Serial is not null)
+            return ValidateSerial(Serial);
+
+        var defaultSerial = _getDefaultSerial();
+        if (!string.IsNullOrWhiteSpace(defaultSerial))
+            return ValidateSerial(defaultSerial);
+
+        var devices = await GetAdbRunner().ListDevicesAsync().ConfigureAwait(false);
+        var connected = devices.Where(device => device.Status == AdbDeviceStatus.Online).ToArray();
+        return connected.Length switch
+        {
+            1 => ValidateSerial(connected[0].Serial),
+            0 => throw new InvalidOperationException("No connected Android devices found."),
+            _ => throw new InvalidOperationException("More than one Android device is connected. Set Serial to select a device."),
+        };
+    }
+
+    private Task TapAsync(AlertButton button)
+        => RunAdbAsync(
+            "shell",
+            "input",
+            "tap",
+            button.CenterX.ToString(CultureInfo.InvariantCulture),
+            button.CenterY.ToString(CultureInfo.InvariantCulture));
+
+    private async Task RunAdbAsync(params string[] arguments)
+        => _ = await RunAdbWithOutputAsync(arguments).ConfigureAwait(false);
+
+    private async Task<string> RunAdbWithOutputAsync(params string[] arguments)
+    {
+        var adbArguments = BuildAdbArguments(Serial, arguments);
+        var processStartInfo = CreateAdbProcessStartInfo(AdbPath, adbArguments);
+        using var output = new StringWriter(CultureInfo.InvariantCulture);
+        using var error = new StringWriter(CultureInfo.InvariantCulture);
+
+        var exitCode = await ProcessUtils.StartProcess(
+            processStartInfo,
+            output,
+            error,
+            CancellationToken.None).ConfigureAwait(false);
+
+        if (exitCode != 0)
+            throw new InvalidOperationException($"adb {string.Join(" ", arguments)} failed: {error}");
+
+        return output.ToString();
+    }
+
+    internal static ProcessStartInfo CreateAdbProcessStartInfo(string adbPath, params string[] arguments)
+    {
+        var processStartInfo = ProcessUtils.CreateProcessStartInfo(adbPath);
+        foreach (var argument in arguments)
+            processStartInfo.ArgumentList.Add(argument);
+        return processStartInfo;
+    }
+
+    internal static string[] BuildAdbArguments(string? serial, params string[] arguments)
+    {
+        if (serial is null)
+            return arguments;
+
+        var result = new string[arguments.Length + 2];
+        result[0] = "-s";
+        result[1] = serial;
+        Array.Copy(arguments, 0, result, 2, arguments.Length);
+        return result;
+    }
+
+    private static string ValidateSerial(string serial)
+    {
+        if (string.IsNullOrWhiteSpace(serial) || serial.Any(character => !IsSerialCharacter(character)))
+        {
+            throw new ArgumentException(
+                "Android device serials may contain only ASCII letters, digits, periods, hyphens, underscores, colons, brackets, and percent signs.",
+                nameof(Serial));
+        }
+
+        return serial;
+    }
+
+    private static bool IsKeyCharacter(char character)
+        => character is >= 'A' and <= 'Z'
+            or >= '0' and <= '9'
+            or '_';
+
+    private static bool IsSerialCharacter(char character)
+        => character is >= 'A' and <= 'Z'
+            or >= 'a' and <= 'z'
+            or >= '0' and <= '9'
+            or '.' or '-' or '_' or ':' or '[' or ']' or '%';
 }

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/AndroidAppDriver.cs
@@ -458,17 +458,17 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
     private async Task<string> ResolveSerialAsync()
     {
         if (Serial is not null)
-            return ValidateSerial(Serial);
+            return ValidateSerial(Serial, nameof(Serial));
 
         var defaultSerial = _getDefaultSerial();
         if (!string.IsNullOrWhiteSpace(defaultSerial))
-            return ValidateSerial(defaultSerial);
+            return ValidateSerial(defaultSerial, "ANDROID_SERIAL");
 
         var devices = await GetAdbRunner().ListDevicesAsync().ConfigureAwait(false);
         var connected = devices.Where(device => device.Status == AdbDeviceStatus.Online).ToArray();
         return connected.Length switch
         {
-            1 => ValidateSerial(connected[0].Serial),
+            1 => ValidateSerial(connected[0].Serial, "deviceSerial"),
             0 => throw new InvalidOperationException("No connected Android devices found."),
             _ => throw new InvalidOperationException("More than one Android device is connected. Set Serial to select a device."),
         };
@@ -524,13 +524,13 @@ public class AndroidAppDriver : AppDriverBase, IAlertDriver
         return result;
     }
 
-    private static string ValidateSerial(string serial)
+    private static string ValidateSerial(string serial, string paramName)
     {
         if (string.IsNullOrWhiteSpace(serial) || serial.Any(character => !IsSerialCharacter(character)))
         {
             throw new ArgumentException(
                 "Android device serials may contain only ASCII letters, digits, periods, hyphens, underscores, colons, brackets, and percent signs.",
-                nameof(Serial));
+                paramName);
         }
 
         return serial;

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Microsoft.Maui.DevFlow.Driver.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Driver/Microsoft.Maui.DevFlow.Driver.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Xamarin.Android.Tools.AndroidSdk" />
     <PackageReference Include="Interop.UIAutomationClient" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AndroidAppDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AndroidAppDriverTests.cs
@@ -99,6 +99,20 @@ public class AndroidAppDriverAdbTests
         Assert.Equal("emulator-5556", Assert.Single(adbRunner.ReversePortCalls).Serial);
     }
 
+    [Fact]
+    public async Task SetupPlatformAsync_UnsafeAndroidSerial_ReportsEnvironmentVariable()
+    {
+        var adbRunner = new RecordingAdbRunner();
+        using var driver = new TestAndroidAppDriver(
+            _ => adbRunner,
+            () => "emulator-5554\" shell rm /sdcard/victim \"");
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => driver.SetupAsync(19223));
+
+        Assert.Equal("ANDROID_SERIAL", exception.ParamName);
+        Assert.Empty(adbRunner.ReversePortCalls);
+    }
+
     private sealed class TestAndroidAppDriver(
         Func<string, AdbRunner> createAdbRunner,
         Func<string?>? getDefaultSerial = null)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AndroidAppDriverTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Tests/AndroidAppDriverTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Maui.DevFlow.Driver;
+using Xamarin.Android.Tools;
+
+namespace Microsoft.Maui.DevFlow.Tests;
+
+public class AndroidAppDriverAdbTests
+{
+    [Fact]
+    public void CreateAdbProcessStartInfo_UntrustedValues_RemainSeparateArguments()
+    {
+        var arguments = AndroidAppDriver.BuildAdbArguments(
+            "emulator-5554\" shell rm /sdcard/victim \"",
+            "pull",
+            "/sdcard/recording.mp4",
+            "output file\" & unwanted-command.mp4");
+        var processStartInfo = AndroidAppDriver.CreateAdbProcessStartInfo("adb", arguments);
+
+        Assert.Equal(
+            [
+                "-s",
+                "emulator-5554\" shell rm /sdcard/victim \"",
+                "pull",
+                "/sdcard/recording.mp4",
+                "output file\" & unwanted-command.mp4",
+            ],
+            processStartInfo.ArgumentList);
+        Assert.Empty(processStartInfo.Arguments);
+    }
+
+    [Fact]
+    public async Task PressKeyAsync_ShellMetacharacters_ThrowsBeforeLaunchingAdb()
+    {
+        using var driver = new AndroidAppDriver();
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => driver.PressKeyAsync("HOME; rm /sdcard/victim"));
+
+        Assert.Equal("key", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task SetupPlatformAsync_UnsafeSerial_ThrowsBeforeLaunchingAdb()
+    {
+        var adbRunner = new RecordingAdbRunner();
+        using var driver = new TestAndroidAppDriver(_ => adbRunner)
+        {
+            Serial = "emulator-5554\" shell rm /sdcard/victim \"",
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => driver.SetupAsync(19223));
+
+        Assert.Equal("Serial", exception.ParamName);
+        Assert.Empty(adbRunner.ReversePortCalls);
+    }
+
+    [Fact]
+    public async Task SetupPlatformAsync_WithSerial_UsesAdbRunnerReversePort()
+    {
+        var adbRunner = new RecordingAdbRunner();
+        using var driver = new TestAndroidAppDriver(_ => adbRunner)
+        {
+            Serial = "emulator-5554",
+        };
+
+        await driver.SetupAsync(19223);
+
+        var call = Assert.Single(adbRunner.ReversePortCalls);
+        Assert.Equal("emulator-5554", call.Serial);
+        Assert.Equal(new AdbPortSpec(AdbProtocol.Tcp, 19223), call.Remote);
+        Assert.Equal(new AdbPortSpec(AdbProtocol.Tcp, 19223), call.Local);
+    }
+
+    [Fact]
+    public async Task SetupPlatformAsync_WithoutSerial_UsesOnlyConnectedDevice()
+    {
+        var adbRunner = new RecordingAdbRunner(
+        [
+            new AdbDeviceInfo
+            {
+                Serial = "emulator-5554",
+                Status = AdbDeviceStatus.Online,
+            },
+        ]);
+        using var driver = new TestAndroidAppDriver(_ => adbRunner);
+
+        await driver.SetupAsync(19223);
+
+        Assert.Equal("emulator-5554", Assert.Single(adbRunner.ReversePortCalls).Serial);
+    }
+
+    [Fact]
+    public async Task SetupPlatformAsync_WithAndroidSerial_UsesEnvironmentSelection()
+    {
+        var adbRunner = new RecordingAdbRunner();
+        using var driver = new TestAndroidAppDriver(_ => adbRunner, () => "emulator-5556");
+
+        await driver.SetupAsync(19223);
+
+        Assert.Equal("emulator-5556", Assert.Single(adbRunner.ReversePortCalls).Serial);
+    }
+
+    private sealed class TestAndroidAppDriver(
+        Func<string, AdbRunner> createAdbRunner,
+        Func<string?>? getDefaultSerial = null)
+        : AndroidAppDriver(createAdbRunner, getDefaultSerial)
+    {
+        public Task SetupAsync(int port) => SetupPlatformAsync("localhost", port);
+    }
+
+    private sealed class RecordingAdbRunner(IReadOnlyList<AdbDeviceInfo>? devices = null)
+        : AdbRunner("adb")
+    {
+        public List<(string Serial, AdbPortSpec Remote, AdbPortSpec Local)> ReversePortCalls { get; } = [];
+
+        public override Task<IReadOnlyList<AdbDeviceInfo>> ListDevicesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(devices ?? (IReadOnlyList<AdbDeviceInfo>)[]);
+
+        public override Task ReversePortAsync(
+            string serial,
+            AdbPortSpec remote,
+            AdbPortSpec local,
+            CancellationToken cancellationToken = default)
+        {
+            ReversePortCalls.Add((serial, remote, local));
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Align the Android DevFlow driver on the public APIs provided by `Xamarin.Android.Tools.AndroidSdk` and update to the latest compatible, timestamp-signed build from the `dotnet11-transport` feed.

## Validation

- Android driver project builds successfully with warnings treated as errors
- Focused Android driver tests pass