### PR TITLE
Fix embedded DevFlow skill resource paths

### DIFF
--- a/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
+++ b/src/Cli/Microsoft.Maui.Cli/Microsoft.Maui.Cli.csproj
@@ -77,13 +77,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-onboard\**\*" LogicalName="devflow.skills/maui-devflow-onboard/%(RecursiveDir)%(Filename)%(Extension)">
+    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui-tooling\skills\maui-devflow-onboard\**\*" LogicalName="devflow.skills/maui-devflow-onboard/%(RecursiveDir)%(Filename)%(Extension)">
       <WithCulture>false</WithCulture>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-debug\**\*" LogicalName="devflow.skills/maui-devflow-debug/%(RecursiveDir)%(Filename)%(Extension)">
+    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui-tooling\skills\maui-devflow-debug\**\*" LogicalName="devflow.skills/maui-devflow-debug/%(RecursiveDir)%(Filename)%(Extension)">
       <WithCulture>false</WithCulture>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui\skills\maui-devflow-session-review\**\*" LogicalName="devflow.skills/maui-devflow-session-review/%(RecursiveDir)%(Filename)%(Extension)">
+    <EmbeddedResource Include="..\..\..\plugins\dotnet-maui-tooling\skills\maui-devflow-session-review\**\*" LogicalName="devflow.skills/maui-devflow-session-review/%(RecursiveDir)%(Filename)%(Extension)">
       <WithCulture>false</WithCulture>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
## Summary

- update the CLI's three embedded DevFlow skill inputs to their `dotnet-maui-tooling` locations
- preserve the existing embedded-resource logical names

PR #375 moved these skills between plugins but left the CLI project pointing at the old paths. As a result, the CLI bundle contained no resources for the skills and 26 resource-dependent tests failed with `No embedded DevFlow skill resources found for 'maui-devflow-onboard'`.

This repairs the #375 fallout and unblocks CLI checks on unrelated pull requests.

## Tests

- `dotnet test src\Cli\Microsoft.Maui.Cli.UnitTests\Microsoft.Maui.Cli.UnitTests.csproj --framework net10.0 --filter "FullyQualifiedName~DevFlowSkillManagerTests" --verbosity minimal` (35 passed)
- `git diff --check`