### PR TITLE
feat(devflow): add standalone evidence capture

### DIFF
--- a/.github/extensions/maui-devflow-canvas/shell.mjs
+++ b/.github/extensions/maui-devflow-canvas/shell.mjs
@@ -49,6 +49,7 @@ export function renderShell(inspectorUrl, appName, bridgeId) {
       // Capabilities the canvas contributes: save recordings, receive the human's selection (so the
       // agent can answer about "the selected element"), and push that selection to Copilot as context.
       const capabilities = bridgeId ? ['saveRecording', 'selection', 'copilot', 'copilotContext', 'attachData'] : [];
+      frame.sandbox.add('allow-downloads');
       // Relay a control action to the canvas server (which updates the agent-facing selection store).
       function postControl(payload, cb) {
         try {

--- a/.github/extensions/maui-devflow-canvas/test/evidence-downloads.test.mjs
+++ b/.github/extensions/maui-devflow-canvas/test/evidence-downloads.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+import { renderShell } from "../shell.mjs";
+
+test("Canvas enables evidence downloads before loading the frame, without enabling navigation or popups", () => {
+  const html = renderShell("http://localhost:19223/inspector/app/?embed=fixture", "App", "bridge-fixture");
+  const permissions = new Set(html.match(/sandbox="([^"]+)"/)[1].split(" "));
+  const configured = new Error("Sandbox configured");
+  const frame = {
+    sandbox: { add(value) { permissions.add(value); throw configured; } },
+  };
+  const script = html.match(/<script nonce="[^"]+">([\s\S]+?)<\/script>/)[1];
+  assert.throws(() => vm.runInNewContext(script, {
+    document: { getElementById: () => frame },
+  }), error => error === configured);
+  assert.deepEqual([...permissions].sort(), [
+    "allow-downloads", "allow-forms", "allow-same-origin", "allow-scripts",
+  ]);
+});
+
+test("VS Code applies the same bounded download permission", () => {
+  const source = readFileSync(new URL("../../../../src/DevFlow/js/vscode-inspector/src/extension.ts", import.meta.url), "utf8");
+  assert.match(source, /frame\.sandbox\.add\('allow-downloads'\)/);
+  assert.match(source, /sandbox="allow-scripts allow-forms allow-same-origin"/);
+  assert.doesNotMatch(source, /allow-popups|allow-top-navigation/);
+});

--- a/docs/DevFlow/evidence.md
+++ b/docs/DevFlow/evidence.md
@@ -9,6 +9,7 @@ anything.
 Choose **Evidence** in the Inspector toolbar, or under **More** in a compact host. The same
 dialog is used in the browser, VS Code, and Copilot Canvas. It shows the current app's
 environment, the included entries, exclusions, redaction limits, and warnings.
+Unchanged connection/control polling does not dismiss the **More** menu while choosing Evidence.
 
 Screenshots and loaded workflow text start **off on every opening**. Enabling an attachment
 refreshes the preview and requires a second confirmation before download. Preview never
@@ -85,6 +86,7 @@ The existing recorder already supports AutomationId targets and verifying assert
 Evidence retains structural AutomationIds, but does not repair or promote locators.
 Attached structured workflow values and expected assertion text are redacted, so the
 attachment is diagnostic context, **not a replayable golden test**.
+When a file is loaded before replay validation, an unknown step count is not displayed as zero.
 
 ## Bundle and privacy contract
 
@@ -107,6 +109,8 @@ Tree projection retains at most 5,000 elements and 64 levels. No element Text/Va
 native/framework property dictionaries, view-model object graphs, preferences, secure
 storage, geolocation, app file contents, HTTP headers/bodies, or query-string values are
 collected into the structured entries. Source paths become project-relative or file-name-only.
+The tool version is the CLI's informational product version, not its build-system assembly-version
+placeholder.
 
 Redaction is heuristic, not a guarantee that arbitrary prose contains no private data.
 Review logs and workflow prose before sharing. Screenshot pixels are not redacted and can

--- a/docs/DevFlow/evidence.md
+++ b/docs/DevFlow/evidence.md
@@ -1,0 +1,149 @@
+# Evidence bundles (`.mauitrace`)
+
+Evidence is an on-demand, read-only snapshot for a bug report. It is not a recording,
+a replay result, or a device qualification claim. Capture runs locally and never uploads
+anything.
+
+## Preview and capture
+
+Choose **Evidence** in the Inspector toolbar, or under **More** in a compact host. The same
+dialog is used in the browser, VS Code, and Copilot Canvas. It shows the current app's
+environment, the included entries, exclusions, redaction limits, and warnings.
+
+Screenshots and loaded workflow text start **off on every opening**. Enabling an attachment
+refreshes the preview and requires a second confirmation before download. Preview never
+reads screenshot pixels. Cancel or Escape creates no bundle.
+
+```powershell
+# Inspect the capture plan without writing a file
+maui devflow evidence preview --json
+
+# Write a bundle; add --overwrite only to replace an existing file
+maui devflow evidence capture --output .\maui-traces\issue.mauitrace
+
+# Explicitly include attachments
+maui devflow evidence preview --include-screenshot --workflow .\repro.md
+maui devflow evidence capture --include-screenshot --workflow .\repro.md
+
+# Validate a bundle and regenerate an offline report
+maui devflow evidence view .\maui-traces\issue.mauitrace
+
+# Generate a report without launching a browser
+maui devflow evidence view .\maui-traces\issue.mauitrace --no-open --output-report .\report.html
+```
+
+CLI and MCP captures use a project-local `maui-traces` folder when a project can be resolved,
+or the current directory otherwise. Inspector downloads use the browser/host download
+mechanism; the preview does not expose an absolute host output path.
+
+The MCP tools `maui_evidence_preview` and `maui_evidence_capture` use the same builder,
+redaction rules, and bundle format as the Inspector and CLI. Both accept `workflowFile`
+so the optional attachment can be previewed before capture.
+
+## Environment observations
+
+The preview, `environment.json`, and regenerated report expose the same target-side facts
+when the agent can supply them:
+
+| Fact | Meaning |
+|---|---|
+| App version, build, and package | Reported by the running app, not inferred from a local checkout |
+| OS, manufacturer/model, physical or virtual device | Device names, serials, and personal identifiers are not included |
+| Framework and agent versions | A framework version is **not** a target runtime version |
+| App viewport and density | Default app-window dimensions in logical units (DIP), pixels per DIP, and window count |
+| Display and orientation | Display pixels, display density, orientation, rotation, and refresh rate |
+| Theme | Effective, requested, and app-override theme, when reported |
+| Connectivity | Network-access state and allow-listed transports such as WiFi or Cellular; no SSID or IP address |
+
+The `unavailable` inventory explicitly discloses missing facts. Target runtime version,
+locale, font scale/accessibility text settings, and permission states are not exposed by
+this capture implementation. Connectivity does not measure or enforce latency, bandwidth,
+packet loss, proxy settings, or a simulated offline condition. Capture never requests
+permissions or changes the app/device environment.
+
+Missing viewport values are **not** replaced with display dimensions. Missing app density
+is not replaced with display density. Neither the host's .NET runtime, locale, browser
+theme, nor host font size is substituted for an unknown target value.
+
+Collection uses sequential reads. Preview and capture sample the app separately, so counts
+and current state can change between them. An attached workflow does not make this the
+environment in which that workflow was originally recorded. Multiple-window apps are
+identified explicitly; this capture observes the agent's default window.
+
+## Recording and CI scope
+
+This feature addresses **environment visibility and honest evidence gaps**. It does not
+define or enforce a replay environment contract.
+
+Stable AutomationId/semantic locators, business-visible assertions, environment
+preconditions, reset/seed policies, and a golden journey across a small physical-device/
+emulator matrix belong to recording, replay, and CI changes. Those changes should fail
+closed when a required environment condition cannot be satisfied, rather than treating an
+unknown field, screenshot, or successful gesture as a passing business assertion.
+
+The existing recorder already supports AutomationId targets and verifying assertions.
+Evidence retains structural AutomationIds, but does not repair or promote locators.
+Attached structured workflow values and expected assertion text are redacted, so the
+attachment is diagnostic context, **not a replayable golden test**.
+
+## Bundle and privacy contract
+
+Version 1 is a ZIP with a fixed entry allow-list:
+
+| Entry | Contents |
+|---|---|
+| `manifest.json` | Format/redaction versions, origin surface, counts, limits, exclusions, warnings, entry sizes and SHA-256 hashes |
+| `environment.json` | Target-side observations and explicit environment gaps |
+| `tree.json` | Bounded structure: type, AutomationId, role, geometry, state, and normalized source location |
+| `layout.json` | Existing agent layout findings and coverage, with at most 500 retained findings; excluded when unsupported |
+| `problems.json` | Recognized for reading existing evidence; explicitly excluded from capture because the current agent API has no runtime Problems surface |
+| `logs.json` | Scrubbed log entries: 200 by default, at most 500 |
+| `network.json` | Request summaries: 100 by default, at most 500; query names only |
+| `screenshot.png` | Only after explicit opt-in |
+| `workflow.md` | Only after explicit attachment, at most 1 MiB, with secrets and structured values scrubbed |
+| `device.json` | Recognized v1 workflow/device metadata; not produced or rendered here, with an explicit reader warning when present |
+
+Tree projection retains at most 5,000 elements and 64 levels. No element Text/Value,
+native/framework property dictionaries, view-model object graphs, preferences, secure
+storage, geolocation, app file contents, HTTP headers/bodies, or query-string values are
+collected into the structured entries. Source paths become project-relative or file-name-only.
+
+Redaction is heuristic, not a guarantee that arbitrary prose contains no private data.
+Review logs and workflow prose before sharing. Screenshot pixels are not redacted and can
+show any on-screen information; that is why they are a separate explicit opt-in.
+
+Bundles are written atomically and read back through the validating reader before publication.
+Existing bundles and reports are never overwritten without `--overwrite`. Malformed options
+fail before app reads, and unavailable sections become explicit exclusions rather than empty
+successes.
+
+Imported bundles are untrusted. The reader rejects unknown, nested, traversing, duplicate,
+oversized, or corrupt entries and mismatched manifest hashes. Typed sections have separate
+shape/size limits. Content hashes establish integrity, not producer identity or environment
+truth. No archive entry is extracted or executed.
+
+The offline report is regenerated from encoded values, includes no scripts, and has a
+restrictive Content Security Policy that blocks network requests. Workflow Markdown is shown
+as inert text.
+
+## Contributor checks
+
+The capture, route, CLI, and controller checks require no running app:
+
+```powershell
+dotnet test .\src\Cli\Microsoft.Maui.Cli.UnitTests\Microsoft.Maui.Cli.UnitTests.csproj --filter FullyQualifiedName~Evidence
+node --test .\src\DevFlow\js\test\inspector-evidence.test.mjs
+```
+
+Isolated browser checks use the real Inspector and a loopback fixture. They cover light/dark
+hosts, narrow/short viewports, 200% text, keyboard containment, fresh attachment consent,
+and a real `.mauitrace` download. They are opt-in because normal test runs do not provision
+Chromium. Install Chromium with the test project's generated `playwright.ps1 install chromium`
+if it is not already available, then run:
+
+```powershell
+$env:DEVFLOW_EVIDENCE_BROWSER_TESTS = "1"
+dotnet test .\src\DevFlow\Microsoft.Maui.DevFlow.Inspector.Tests\Microsoft.Maui.DevFlow.Inspector.Tests.csproj --filter FullyQualifiedName~EvidenceInspectorPageTests
+```
+
+Set `EVIDENCE_TEST_ARTIFACTS` to a local directory to retain the browser screenshots.

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceCaptureTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceCaptureTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Maui.Cli.DevFlow.Evidence;
@@ -18,6 +19,14 @@ namespace Microsoft.Maui.Cli.UnitTests;
 /// </summary>
 public class EvidenceCaptureTests : IDisposable
 {
+    [Fact]
+    public void ToolVersion_UsesTheProductVersionRatherThanTheArcadeAssemblyPlaceholder()
+    {
+        var productVersion = typeof(EvidenceCapture).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+        Assert.Equal(productVersion, EvidenceCapture.ToolVersion);
+    }
+
     private readonly string _root = Path.Combine(
         AppContext.BaseDirectory, "evidence-tests", Guid.NewGuid().ToString("N"));
 

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceCaptureTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceCaptureTests.cs
@@ -1,0 +1,1638 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow.Evidence;
+using Microsoft.Maui.Cli.DevFlow.Flows;
+using Microsoft.Maui.DevFlow.Driver;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+/// <summary>
+/// Security and correctness tests for the <c>.mauitrace</c> evidence bundle.
+///
+/// These pin the privacy contract (default-deny projection, redaction at ingestion), the atomic
+/// write behaviour, the hostile-input reader, and the regenerated HTML report. A regression in any
+/// of them would leak app data off a developer's machine or execute untrusted content, so they are
+/// intentionally exhaustive.
+/// </summary>
+public class EvidenceCaptureTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        AppContext.BaseDirectory, "evidence-tests", Guid.NewGuid().ToString("N"));
+
+    public EvidenceCaptureTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch { /* best-effort cleanup */ }
+        GC.SuppressFinalize(this);
+    }
+
+    // ── redaction ────────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("token=eyJhbGciOi.eyJzdWIiOi.SflKxwRJSM", "token=<jwt>")]
+    [InlineData("{\"apiKey\":\"supersecret12345\"}", "{\"apiKey\":\"<redacted>\"}")]
+    [InlineData("{\"access_token\":\"xyz\",\"foo\":\"bar\"}", "{\"access_token\":\"<redacted>\",\"foo\":\"bar\"}")]
+    public void MaskSecrets_RedactsKnownSecretShapes(string input, string expected)
+        => Assert.Equal(expected, EvidenceRedaction.MaskSecrets(input));
+
+    [Fact]
+    public void Scrub_RedactsBearerTokensAndSecretAssignments()
+    {
+        var scrubbed = EvidenceRedaction.Scrub(
+            "auth failed: Bearer abcdefghijklmnop and api_key=zzz-9999 for user alice",
+            EvidenceFormat.MaxLogMessageChars)!;
+
+        Assert.DoesNotContain("abcdefghijklmnop", scrubbed, StringComparison.Ordinal);
+        Assert.DoesNotContain("zzz-9999", scrubbed, StringComparison.Ordinal);
+        Assert.Contains("<redacted>", scrubbed, StringComparison.Ordinal);
+        Assert.Contains("alice", scrubbed, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(@"failed to load C:\Users\alice\src\App\MainPage.xaml", "MainPage.xaml", @"C:\Users\alice")]
+    [InlineData("failed to load /Users/alice/src/App/MainPage.xaml", "MainPage.xaml", "/Users/alice")]
+    [InlineData("failed to load file:///home/alice/App/MainPage.xaml", "MainPage.xaml", "/home/alice")]
+    [InlineData(@"probing \\build-share\drops\team\Alice\app.dll", "app.dll", "build-share")]
+    [InlineData("wsl load /mnt/c/Users/alice/src/App/MainPage.xaml", "MainPage.xaml", "alice")]
+    [InlineData("ci load /workspace/acme/private-project/MainPage.xaml", "MainPage.xaml", "private-project")]
+    [InlineData("gitlab load /builds/acme/private-project/MainPage.xaml", "MainPage.xaml", "private-project")]
+    [InlineData("github load /github/workspace/private-project/MainPage.xaml", "MainPage.xaml", "private-project")]
+    public void Scrub_ReplacesAbsolutePathsWithFileName(string input, string keeps, string drops)
+    {
+        var scrubbed = EvidenceRedaction.Scrub(input, EvidenceFormat.MaxLogMessageChars)!;
+
+        Assert.Contains(keeps, scrubbed, StringComparison.Ordinal);
+        Assert.DoesNotContain(drops, scrubbed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Scrub_DropsControlCharactersAndTruncates()
+    {
+        var scrubbed = EvidenceRedaction.Scrub("a\u0007b" + new string('x', 50), 20)!;
+
+        Assert.DoesNotContain('\u0007', scrubbed);
+        Assert.StartsWith("ab", scrubbed, StringComparison.Ordinal);
+        Assert.EndsWith("[truncated]", scrubbed, StringComparison.Ordinal);
+        Assert.True(scrubbed.Length <= 20);
+    }
+
+    [Fact]
+    public void Scrub_DropsUnicodeFormatCharacters()
+    {
+        var scrubbed = EvidenceRedaction.Scrub("ab\u202Ecd\u200Bef", 20)!;
+
+        Assert.Equal("abcdef", scrubbed);
+    }
+
+    [Theory]
+    [InlineData("sk-live-AAAABBBBCCCCDDDDEEEEFFFF0000")]
+    [InlineData("sk" + "_live_" + "AAAABBBBCCCC" + "DDDDEEEEFFFF0000")]
+    [InlineData("AKIAIOSFODNN7EXAMPLE")]
+    [InlineData("xoxb" + "-1234567890" + "12-abcdefghijklmnop")]
+    [InlineData("https://alice:password@example.com/path")]
+    [InlineData("-----BEGIN RSA PRIVATE KEY-----\nMIIESECRET\n-----END RSA PRIVATE KEY-----")]
+    [InlineData("private_key=super-secret-value")]
+    [InlineData("pwd=super-secret-value")]
+    [InlineData("cookie=session-value")]
+    public void Scrub_MasksCommonBareSecretShapes(string secret)
+    {
+        var scrubbed = EvidenceRedaction.Scrub(secret, EvidenceFormat.MaxLogMessageChars)!;
+
+        Assert.DoesNotContain(secret, scrubbed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NormalizeSourcePath_UsesProjectRelativeFormInsideTheProject()
+    {
+        var projectRoot = Path.Combine(_root, "MyApp");
+        var file = Path.Combine(projectRoot, "Views", "MainPage.xaml");
+
+        Assert.Equal("Views/MainPage.xaml", EvidenceRedaction.NormalizeSourcePath(file, projectRoot));
+    }
+
+    [Fact]
+    public void NormalizeSourcePath_FallsBackToFileNameOutsideTheProject()
+    {
+        var projectRoot = Path.Combine(_root, "MyApp");
+        var outside = OperatingSystem.IsWindows()
+            ? @"D:\shared\packages\Other\Page.xaml"
+            : "/opt/shared/packages/Other/Page.xaml";
+
+        Assert.Equal("Page.xaml", EvidenceRedaction.NormalizeSourcePath(outside, projectRoot));
+    }
+
+    [Theory]
+    [InlineData("Views/MainPage.xaml", "Views/MainPage.xaml")]
+    [InlineData(@"Views\MainPage.xaml", "Views/MainPage.xaml")]
+    [InlineData("../../secrets/MainPage.xaml", "MainPage.xaml")]
+    public void NormalizeSourcePath_KeepsRelativePathsButRejectsTraversal(string input, string expected)
+        => Assert.Equal(expected, EvidenceRedaction.NormalizeSourcePath(input, projectRoot: null));
+
+    [Fact]
+    public void SafeIdentifier_DoesNotRetainAbsolutePaths()
+    {
+        var identifier = EvidenceRedaction.SafeIdentifier(
+            @"control-C:\Users\alice\src\App\MainPage.xaml");
+
+        Assert.DoesNotContain(@"C:\Users\alice", identifier, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("MainPage.xaml", identifier, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SafeIdentifier_RemovesLineAndTabControls()
+        => Assert.Equal("Build42", EvidenceRedaction.SafeIdentifier("Build\n\r\t42"));
+
+    [Fact]
+    public void NormalizeSourcePath_BoundsMetadataAndScrubsSecretsInFileNames()
+    {
+        Assert.True(EvidenceRedaction.NormalizeSourcePath(new string('a', 600) + ".xaml", null)!.Length <= 512);
+        Assert.DoesNotContain("sk-live-AAAABBBBCCCCDDDDEEEEFFFF0000",
+            EvidenceRedaction.NormalizeSourcePath("Views/sk-live-AAAABBBBCCCCDDDDEEEEFFFF0000.xaml", null),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ScrubRoute_RemovesAllQueryValuesAndFragments()
+    {
+        var route = EvidenceRedaction.ScrubRoute(
+            "//orders/detail?customer=alice@example.com&access_token=secret#receipt");
+
+        Assert.Equal("//orders/detail?customer=<redacted>&access_token=<redacted>", route);
+        Assert.DoesNotContain("alice@example.com", route, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret", route, StringComparison.Ordinal);
+        Assert.DoesNotContain("receipt", route, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ScrubRoute_StaysWithinTheEnvironmentFieldLimit()
+    {
+        var route = "//orders?" + string.Join("&", Enumerable.Range(0, 24)
+            .Select(index => $"{index:D2}{new string('a', 62)}=private-value"));
+        var result = EvidenceRedaction.ScrubRoute(route)!;
+        Assert.True(result.Length <= 512);
+        Assert.EndsWith("[truncated]", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("private-value", result, StringComparison.Ordinal);
+    }
+
+    // ── projections ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ProjectTree_OmitsTextValuesAndNativeProperties()
+    {
+        var projectRoot = Path.Combine(_root, "MyApp");
+        var tree = new List<ElementInfo>
+        {
+            new()
+            {
+                Id = "e1",
+                Type = "Entry",
+                AutomationId = "PasswordField",
+                Text = "hunter2-secret-text",
+                Value = "value-secret",
+                NativeType = "UITextField",
+                NativeProperties = new Dictionary<string, string?> { ["placeholder"] = "native-secret" },
+                FrameworkProperties = new Dictionary<string, string?> { ["BindingContext"] = "framework-secret" },
+                Bounds = new BoundsInfo { X = 1, Y = 2, Width = 3, Height = 4 },
+                SourceFile = Path.Combine(projectRoot, "Views", "LoginPage.xaml"),
+                SourceLine = 12,
+                SourceColumn = 5,
+                SourceHash = "abc123",
+                IsVisible = true,
+                IsEnabled = true,
+            },
+        };
+
+        var document = EvidenceBuilder.ProjectTree(tree, projectRoot);
+        var json = EvidenceJson.Serialize(document);
+
+        Assert.Equal(1, document.Count);
+        foreach (var secret in new[] { "hunter2-secret-text", "value-secret", "native-secret", "framework-secret" })
+            Assert.DoesNotContain(secret, json, StringComparison.Ordinal);
+        Assert.DoesNotContain(projectRoot, json, StringComparison.Ordinal);
+
+        var node = document.Roots[0];
+        Assert.Equal("Entry", node.Type);
+        Assert.Equal("PasswordField", node.AutomationId);
+        Assert.Equal("abc123", node.SourceHash);
+        Assert.Equal("Views/LoginPage.xaml", node.SourceFile);
+        Assert.Equal(12, node.SourceLine);
+        Assert.NotNull(node.Bounds);
+    }
+
+    [Fact]
+    public void ProjectTree_StopsAtTheElementBudget()
+    {
+        var roots = new List<ElementInfo>();
+        for (var i = 0; i < EvidenceFormat.MaxTreeElements + 25; i++)
+            roots.Add(new ElementInfo { Id = $"e{i}", Type = "Label" });
+
+        var document = EvidenceBuilder.ProjectTree(roots, projectRoot: null);
+
+        Assert.True(document.Truncated);
+        Assert.Equal(EvidenceFormat.MaxTreeElements, document.Count);
+    }
+
+    [Fact]
+    public void ProjectNetwork_KeepsSummaryMetadataOnly()
+    {
+        var requests = new List<NetworkRequest>
+        {
+            new()
+            {
+                Id = "r1",
+                Method = "GET",
+                Url = "https://api.example.com/users?access_token=super-secret&page=2",
+                Host = "api.example.com",
+                Path = "/users?access_token=super-secret&page=2",
+                StatusCode = 200,
+                DurationMs = 42,
+                RequestSize = 10,
+                ResponseSize = 2048,
+                RequestContentType = "application/json",
+                ResponseContentType = "application/json",
+                RequestHeaders = new Dictionary<string, string[]> { ["Authorization"] = ["Bearer abcdefghijklmnop"] },
+                ResponseHeaders = new Dictionary<string, string[]> { ["Set-Cookie"] = ["session=zzz"] },
+                RequestBody = "{\"password\":\"pw\"}",
+                ResponseBody = "{\"token\":\"tk\"}",
+                Error = @"connect failed for C:\Users\alice\app.db",
+            },
+        };
+
+        var document = EvidenceBuilder.ProjectNetwork(requests, EvidenceFormat.DefaultNetworkLimit);
+        var json = EvidenceJson.Serialize(document);
+
+        foreach (var secret in new[] { "super-secret", "Bearer abcdefghijklmnop", "session=zzz", "password", @"C:\Users\alice" })
+            Assert.DoesNotContain(secret, json, StringComparison.Ordinal);
+
+        var entry = document.Requests[0];
+        Assert.Equal("GET", entry.Method);
+        Assert.Equal("api.example.com", entry.Host);
+        Assert.Equal("/users", entry.Path);
+        Assert.Equal(new[] { "access_token", "page" }, entry.QueryKeys!.ToArray());
+        Assert.Equal(200, entry.StatusCode);
+        Assert.Equal(42, entry.DurationMs);
+        Assert.Equal(2048, entry.ResponseBytes);
+        Assert.Contains("app.db", entry.Error!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProjectLogs_ScrubsAndBounds()
+    {
+        var raw = """
+            [
+              { "t": "2026-07-29T10:00:00Z", "l": "error", "c": "App", "m": "login failed api_key=zzz-999", "s": "native" },
+              { "t": "2026-07-29T10:00:01Z", "l": "info", "c": "App", "m": "second" },
+              { "t": "2026-07-29T10:00:02Z", "l": "info", "c": "App", "m": "third" }
+            ]
+            """;
+
+        var document = EvidenceBuilder.ProjectLogs(raw, limit: 2);
+
+        Assert.Equal(2, document.Count);
+        Assert.True(document.Truncated);
+        Assert.DoesNotContain("zzz-999", document.Entries[0].Message, StringComparison.Ordinal);
+        Assert.Equal("error", document.Entries[0].Level);
+    }
+
+    [Fact]
+    public void ProjectLogs_RejectsMalformedPayloadsRatherThanReportingNoLogs()
+    {
+        Assert.ThrowsAny<JsonException>(() => EvidenceBuilder.ProjectLogs("not json", 10));
+        Assert.Throws<InvalidDataException>(() => EvidenceBuilder.ProjectLogs("{\"not\":\"an array\"}", 10));
+    }
+
+    // ── manifest / plan ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BuildAsync_EnvironmentPreservesTargetFactsAndDisclosesMissingContractFields()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+        var environment = bundle.Plan.Environment!;
+        Assert.Equal("42", environment.App!.Build);
+        Assert.Equal("11", environment.Device!.OsVersion);
+        Assert.Equal(430, environment.Viewport!.Width);
+        Assert.Equal(760, environment.Viewport.Height);
+        Assert.Equal(1.5, environment.Viewport.Density);
+        Assert.Equal(1920, environment.Display!.Width);
+        Assert.Equal(2, environment.Display.Density);
+        Assert.Equal("dark", environment.Theme!.Effective);
+        Assert.Equal("Internet", environment.Connectivity!.NetworkAccess);
+        Assert.Equal(["WiFi"], environment.Connectivity.ConnectionProfiles);
+        foreach (var name in new[] { "runtime", "locale", "fontScale", "permissions", "networkConditions" })
+            Assert.Contains(environment.Unavailable, gap => gap.Name == name);
+        var read = EvidenceBundleReader.Read(new MemoryStream(EvidenceBundleWriter.ToBytes(bundle)));
+        Assert.True(read.Ok, read.Error);
+        Assert.Equal(EvidenceJson.Serialize(environment), EvidenceJson.Serialize(read.Environment));
+        var report = EvidenceReportRenderer.Render(read);
+        Assert.Contains("App viewport (DIP)", report, StringComparison.Ordinal);
+        Assert.Contains("not the original recording environment or an enforced replay contract", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("private-ssid", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("Alice's PC", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsync_DoesNotSubstituteDisplayOrHostDefaultsForMissingTargetFacts()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource
+        {
+            Status = new AgentStatus { Device = new DeviceDescriptor { WindowWidth = 0, WindowHeight = -1, DisplayDensity = 0 } },
+            AppInfo = JsonSerializer.SerializeToElement(new { }),
+            Connectivity = JsonSerializer.SerializeToElement(new { networkAccess = "Unknown" }),
+        }, Options());
+        var environment = bundle.Plan.Environment!;
+        Assert.Null(environment.App);
+        Assert.Null(environment.Viewport!.Width);
+        Assert.Null(environment.Viewport.Height);
+        Assert.Null(environment.Viewport.Density);
+        Assert.Null(environment.Theme);
+        Assert.Equal(1920, environment.Display!.Width);
+        foreach (var name in new[] { "appBuild", "viewport", "density", "theme", "connectivity" })
+            Assert.Contains(environment.Unavailable, gap => gap.Name == name);
+    }
+
+    [Fact]
+    public void ProjectConnectivity_OnlyKeepsKnownAccessAndTransportEnums()
+    {
+        var raw = JsonSerializer.SerializeToElement(new
+        {
+            networkAccess = "Internet",
+            connectionProfiles = new[] { "WiFi", "WiFi", "private-ssid", "Cellular" },
+            ssid = "private-ssid",
+            address = "192.0.2.10",
+        });
+        var projected = EvidenceBuilder.ProjectConnectivity(raw)!;
+        Assert.Equal(["Cellular", "WiFi"], projected.ConnectionProfiles);
+        Assert.DoesNotContain("private-ssid", EvidenceJson.Serialize(projected), StringComparison.Ordinal);
+        Assert.DoesNotContain("192.0.2.10", EvidenceJson.Serialize(projected), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("{\"viewport\":{\"width\":-1,\"height\":20}}")]
+    [InlineData("{\"connectivity\":{\"connectionProfiles\":[\"private-ssid\"]}}")]
+    [InlineData("{\"theme\":{\"effective\":\"not-a-theme\"}}")]
+    [InlineData("{\"unavailable\":null}")]
+    public void Read_InvalidEnvironmentFieldsAreExplicitlyIgnored(string json)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var path = WriteArchive("environment.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ManifestForEntries((EvidenceFormat.EnvironmentEntry, bytes)));
+            AddBytes(archive, EvidenceFormat.EnvironmentEntry, bytes);
+        });
+        var read = EvidenceBundleReader.Read(path);
+        Assert.True(read.Ok, read.Error);
+        Assert.Null(read.Environment);
+        Assert.Contains(read.Warnings, warning => warning.Contains("environment.json", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task BuildAsync_MalformedLogsProduceAnExclusionNotAnEmptySuccess()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource { LogsJson = "{}" }, Options());
+        Assert.DoesNotContain(bundle.Entries, entry => entry.Name == EvidenceFormat.LogsEntry);
+        Assert.Contains(bundle.Plan.Excluded, entry => entry.Name == EvidenceFormat.LogsEntry);
+    }
+
+    [Fact]
+    public void ProjectCapabilities_OmitsExplicitlyUnsupportedFeatures()
+    {
+        var capabilities = JsonSerializer.SerializeToElement(new
+        {
+            capabilities = new { ui = true, screenshots = false, theme = new { supported = false }, network = new { version = 1 } },
+        });
+        Assert.Equal(["network", "ui"], EvidenceBuilder.ProjectCapabilities(capabilities));
+    }
+
+    [Fact]
+    public async Task BuildAsync_OmitsScreenshotUnlessExplicitlyRequested()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+
+        Assert.False(bundle.Manifest.Screenshot.Requested);
+        Assert.False(bundle.Manifest.Screenshot.Included);
+        Assert.DoesNotContain(bundle.Entries, e => e.Name == EvidenceFormat.ScreenshotEntry);
+        Assert.Contains(bundle.Manifest.Excluded, e => e.Name == EvidenceFormat.ScreenshotEntry);
+        Assert.Equal(bundle.Manifest.Counts.TreeElements, bundle.Plan.Counts.TreeElements);
+        Assert.Contains(bundle.Plan.NeverIncluded, entry => entry.Contains("secure storage", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task BuildAsync_IncludesScreenshotOnOptIn()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource(), Options(includeScreenshot: true));
+
+        Assert.True(bundle.Manifest.Screenshot.Requested);
+        Assert.True(bundle.Manifest.Screenshot.Included);
+        Assert.Contains(bundle.Entries, e => e.Name == EvidenceFormat.ScreenshotEntry);
+        Assert.Contains(bundle.Manifest.Warnings, w => w.Contains("screenshot", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task BuildAsync_PreviewSkipsTheScreenshotRead()
+    {
+        var source = new FakeEvidenceSource();
+
+        var bundle = await EvidenceBuilder.BuildAsync(
+            source, Options(includeScreenshot: true, previewOnly: true));
+
+        Assert.Equal(0, source.ScreenshotReads);
+        Assert.True(bundle.Plan.Screenshot.Requested);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ManifestDescribesEveryIncludedEntry()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+
+        Assert.Equal(EvidenceFormat.SchemaId, bundle.Manifest.Schema);
+        Assert.Equal(EvidenceFormat.Version, bundle.Manifest.FormatVersion);
+        Assert.Equal(EvidenceRedaction.Version, bundle.Manifest.RedactionVersion);
+        Assert.All(bundle.Manifest.Entries, entry =>
+        {
+            Assert.Contains(entry.Name, EvidenceFormat.AllowedEntries);
+            Assert.True(entry.Bytes > 0);
+            Assert.False(string.IsNullOrWhiteSpace(entry.Sha256));
+        });
+        // Every non-manifest entry has a manifest record, and vice versa.
+        Assert.Equal(
+            bundle.Entries.Select(e => e.Name).OrderBy(n => n, StringComparer.Ordinal),
+            bundle.Manifest.Entries.Select(e => e.Name).OrderBy(n => n, StringComparer.Ordinal));
+        Assert.Contains(bundle.Plan.Included, entry => entry.Name == EvidenceFormat.ManifestEntry);
+    }
+
+    [Fact]
+    public async Task BuildAsync_TurnsSectionFailuresIntoExclusions()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource { FailNetwork = true }, Options());
+
+        Assert.Contains(bundle.Manifest.Excluded, e => e.Name == EvidenceFormat.NetworkEntry);
+        Assert.DoesNotContain(bundle.Entries, e => e.Name == EvidenceFormat.NetworkEntry);
+        // The rest of the bundle still built.
+        Assert.Contains(bundle.Entries, e => e.Name == EvidenceFormat.TreeEntry);
+    }
+
+    // ── layout.json ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BuildAsync_IncludesLayoutFindingsAndCountsThem()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+
+        Assert.Contains(bundle.Entries, e => e.Name == EvidenceFormat.LayoutEntry);
+        Assert.Equal(1, bundle.Manifest.Counts.LayoutFindings);
+        Assert.Equal(1, bundle.Manifest.Counts.LayoutViolations);
+        Assert.Contains(bundle.Plan.Included, entry => entry.Name == EvidenceFormat.LayoutEntry && entry.Count == 1);
+        Assert.Equal(EvidenceFormat.MaxLayoutFindings, bundle.Manifest.Limits.LayoutFindings);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ExcludesLayoutWhenTheAgentDoesNotSupportIt()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource { LayoutUnsupported = true }, Options());
+
+        Assert.DoesNotContain(bundle.Entries, e => e.Name == EvidenceFormat.LayoutEntry);
+        Assert.Contains(bundle.Manifest.Excluded,
+            e => e.Name == EvidenceFormat.LayoutEntry && e.Reason.Contains("does not support", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, bundle.Manifest.Counts.LayoutFindings);
+    }
+
+    [Fact]
+    public void ProjectLayout_NormalizesSourcePathsAndKeepsNoTextOrValues()
+    {
+        var report = new LayoutInspectionResult
+        {
+            SchemaVersion = "1.0",
+            RuleSetVersion = "1.0",
+            Snapshot = new LayoutSnapshotInfo
+            {
+                Platform = "Windows",
+                Id = "snapshot-1",
+                TreeRevision = "tree-1",
+                DiagnosticsRevision = "diagnostics-1",
+                Stable = true,
+            },
+            Summary = new LayoutInspectionSummary { Violations = 1, Suppressed = 1 },
+            Coverage = new LayoutCoverageInfo { Overall = "partial" },
+            Findings =
+            [
+                new LayoutFinding
+                {
+                    Id = "layout.visible-zero-area:e1:area",
+                    RuleId = "layout.visible-zero-area",
+                    Outcome = "violation",
+                    Confidence = "high",
+                    Severity = "serious",
+                    Actionability = "fix",
+                    SuppressionKey = "suppression-1",
+                    Suppressed = true,
+                    SuppressionReason = "Known fixture",
+                    FixCategories = ["adjust-layout-constraints"],
+                    Message = @"Collapsed in C:\Users\alice\App\MainPage.xaml with token=abcdefghijklmnop",
+                    Element = new LayoutElementReference
+                    {
+                        Id = "e1",
+                        Type = "Label",
+                        SourceFile = Path.Combine(_root, "MyApp", "Views", "MainPage.xaml"),
+                        SourceLine = 7,
+                    },
+                    RelatedElements =
+                    [
+                        new LayoutRelatedElement
+                        {
+                            Relation = "parent",
+                            Element = new LayoutElementReference { Id = "parent", Type = "Grid" },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var projected = EvidenceBuilder.ProjectLayout(report, Path.Combine(_root, "MyApp"));
+        var finding = Assert.Single(projected.Findings);
+
+        Assert.Equal("Views/MainPage.xaml", finding.SourceFile);
+        Assert.DoesNotContain(@"C:\Users\alice", finding.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("abcdefghijklmnop", finding.Message, StringComparison.Ordinal);
+        Assert.Equal("snapshot-1", projected.SnapshotId);
+        Assert.Equal("tree-1", projected.TreeRevision);
+        Assert.Equal("diagnostics-1", projected.DiagnosticsRevision);
+        Assert.True(projected.Stable);
+        Assert.Equal(1, projected.Suppressed);
+        Assert.Equal("serious", finding.Severity);
+        Assert.Equal("fix", finding.Actionability);
+        Assert.True(finding.Suppressed);
+        Assert.Equal("Known fixture", finding.SuppressionReason);
+        Assert.Equal(["parent"], finding.RelatedElementIds);
+        Assert.Equal(["adjust-layout-constraints"], finding.FixCategories);
+
+        var json = EvidenceJson.Serialize(projected);
+        Assert.DoesNotContain("\"text\"", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"value\"", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ProjectLayout_StopsAtTheFindingBudget()
+    {
+        var report = new LayoutInspectionResult
+        {
+            Findings = [.. Enumerable.Range(0, EvidenceFormat.MaxLayoutFindings + 25).Select(index => new LayoutFinding
+            {
+                Id = $"layout.visible-zero-area:e{index}:area",
+                RuleId = "layout.visible-zero-area",
+                Outcome = "violation",
+                Message = "message",
+            })],
+        };
+
+        var projected = EvidenceBuilder.ProjectLayout(report, projectRoot: null);
+
+        Assert.Equal(EvidenceFormat.MaxLayoutFindings, projected.Findings.Count);
+        Assert.True(projected.FindingsTruncated);
+    }
+
+    [Fact]
+    public async Task Bundle_RoundTripsLayoutFindingsThroughTheReader()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+        var path = Path.Combine(_root, "layout-roundtrip.mauitrace");
+        EvidenceBundleWriter.Write(bundle, path, overwrite: true);
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.True(read.Ok, read.Error);
+        Assert.NotNull(read.Layout);
+        Assert.Contains(EvidenceFormat.LayoutEntry, read.Entries);
+        var finding = Assert.Single(read.Layout!.Findings);
+        Assert.Equal("layout.visible-zero-area", finding.RuleId);
+        Assert.Equal("violation", finding.Outcome);
+        Assert.NotEmpty(read.Layout.NeverCaptured);
+
+        var html = EvidenceReportRenderer.Render(read);
+        Assert.Contains("Layout diagnostics", html, StringComparison.Ordinal);
+        Assert.Contains("layout.visible-zero-area", html, StringComparison.Ordinal);
+        Assert.Contains("incomplete", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BuildAsync_RejectsOversizedWorkflow()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource(),
+            Options() with { WorkflowMarkdown = new string('w', (int)EvidenceFormat.MaxWorkflowBytes + 10) });
+
+        Assert.DoesNotContain(bundle.Entries, e => e.Name == EvidenceFormat.WorkflowEntry);
+        Assert.Contains(bundle.Manifest.Excluded,
+            e => e.Name == EvidenceFormat.WorkflowEntry && e.Reason.Contains("limit", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task BuildAsync_ScrubsTheAttachedWorkflowAndWarnsAboutIt()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource(),
+            Options() with
+            {
+                WorkflowMarkdown = "1. Fill Password = \"hunter2\"\n2. Open C:\\Users\\alice\\App\\MainPage.xaml\n3. Use api_key=zzz-9999",
+            });
+
+        var workflow = Encoding.UTF8.GetString(
+            bundle.Entries.Single(e => e.Name == EvidenceFormat.WorkflowEntry).Content);
+
+        Assert.DoesNotContain("zzz-9999", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"C:\Users\alice", workflow, StringComparison.Ordinal);
+        Assert.Contains("MainPage.xaml", workflow, StringComparison.Ordinal);
+        Assert.Contains(bundle.Manifest.Warnings,
+            w => w.Contains("reproduction steps", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task BuildAsync_RedactsStructuredFlowValuesBeforeAttachingWorkflow()
+    {
+        const string secret = "literal-flow-password";
+        var flow = new MauiFlow
+        {
+            Name = "login",
+            Steps =
+            {
+                new FlowStep
+                {
+                    Seq = 1,
+                    Action = FlowActions.Fill,
+                    Target = new FlowSelector { AutomationId = "PasswordEntry", Text = "private label" },
+                    Value = secret,
+                    Args = new FlowStepArgs { Text = secret },
+                    Asserts =
+                    [
+                        new FlowAssert
+                        {
+                            Kind = "propEquals",
+                            Selector = new FlowSelector { AutomationId = "PasswordEntry" },
+                            Name = "Text",
+                            Expected = secret,
+                            Verify = true
+                        }
+                    ]
+                }
+            }
+        };
+
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource(),
+            Options() with { WorkflowMarkdown = FlowMarkdown.Serialize(flow) });
+        var workflow = Encoding.UTF8.GetString(
+            bundle.Entries.Single(entry => entry.Name == EvidenceFormat.WorkflowEntry).Content);
+
+        Assert.DoesNotContain(secret, workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("private label", workflow, StringComparison.Ordinal);
+        Assert.Contains("<redacted>", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsync_RedactsUnexpectedStructuredValueFieldsRegardlessOfAction()
+    {
+        const string secret = "unexpected-action-secret";
+        var flow = new MauiFlow
+        {
+            Steps =
+            {
+                new FlowStep
+                {
+                    Seq = 1,
+                    Action = FlowActions.Tap,
+                    Target = new FlowSelector { AutomationId = "Button" },
+                    Value = secret,
+                    Args = new FlowStepArgs
+                    {
+                        Route = "//account?email=alice@example.com",
+                        Theme = "secret-theme",
+                    },
+                    Asserts =
+                    [
+                        new FlowAssert
+                        {
+                            Kind = "exists",
+                            Selector = new FlowSelector { AutomationId = "Button" },
+                            Expected = secret,
+                            Verify = true
+                        }
+                    ]
+                }
+            }
+        };
+
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource(),
+            Options() with { WorkflowMarkdown = FlowMarkdown.Serialize(flow) });
+        var workflow = Encoding.UTF8.GetString(
+            bundle.Entries.Single(entry => entry.Name == EvidenceFormat.WorkflowEntry).Content);
+
+        Assert.DoesNotContain(secret, workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("alice@example.com", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-theme", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsync_OmitsMalformedStructuredWorkflowBlock()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource(),
+            Options() with
+            {
+                WorkflowMarkdown = "```json maui-test\n{\"steps\":[\n```"
+            });
+
+        Assert.DoesNotContain(
+            bundle.Entries,
+            entry => entry.Name == EvidenceFormat.WorkflowEntry);
+    }
+
+    [Fact]
+    public async Task BuildAsync_PropagatesCancellationInsteadOfWritingAPartialBundle()
+    {
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            EvidenceBuilder.BuildAsync(
+                new FakeEvidenceSource { CancelOnTree = true },
+                Options()));
+    }
+
+    [Fact]
+    public async Task BundleWriter_ObservesCancellationBeforePublishing()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource(),
+            Options());
+        var destination = Path.Combine(_root, "cancelled.mauitrace");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            EvidenceBundleWriter.Write(bundle, destination, overwrite: false, cts.Token));
+        Assert.False(File.Exists(destination));
+    }
+
+    [Fact]
+    public async Task BundleWriter_PreservesGeneratedSectionsAtTheirExactStringLimits()
+    {
+        var longMessage = new string('x', EvidenceFormat.MaxLogMessageChars + 500);
+        var logs = JsonSerializer.Serialize(new[]
+        {
+            new { t = "2026-07-29T10:00:00Z", l = "info", c = "App", m = longMessage, s = "native" }
+        });
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource { LogsJson = logs },
+            Options());
+
+        var bytes = EvidenceBundleWriter.ToBytes(bundle);
+        var read = EvidenceBundleReader.Read(new MemoryStream(bytes));
+
+        Assert.True(read.Ok, read.Error);
+        var entry = Assert.Single(read.Logs!.Entries);
+        Assert.True(entry.Message.Length <= EvidenceFormat.MaxLogMessageChars);
+        Assert.EndsWith("[truncated]", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsync_DeepTreesSurviveSerializationAndReadBack()
+    {
+        // The tree nests two JSON levels per element level, so a 40-level tree needs a serializer
+        // depth well past the 64 default on BOTH the write and read paths.
+        ElementInfo leaf = new() { Id = "leaf", Type = "Label" };
+        for (var depth = 0; depth < 40; depth++)
+            leaf = new ElementInfo { Id = $"n{depth}", Type = "Grid", Children = [leaf] };
+
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource { Tree = [leaf] }, Options());
+        var destination = Path.Combine(_root, "deep.mauitrace");
+        Assert.True(EvidenceBundleWriter.Write(bundle, destination, overwrite: false).Ok);
+
+        var read = EvidenceBundleReader.Read(destination);
+
+        Assert.DoesNotContain(bundle.Manifest.Excluded, e => e.Name == EvidenceFormat.TreeEntry);
+        Assert.True(read.Ok, read.Error);
+        Assert.NotNull(read.Tree);
+        Assert.Equal(41, read.Tree!.Count);
+    }
+
+    // ── atomic write ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Write_ProducesAReadableBundleAndLeavesNoTemporaryFiles()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+        var destination = Path.Combine(_root, "out", "capture.mauitrace");
+
+        var result = EvidenceBundleWriter.Write(bundle, destination, overwrite: false);
+
+        Assert.True(result.Ok, result.Error);
+        Assert.True(File.Exists(destination));
+        Assert.Empty(Directory.GetFiles(Path.GetDirectoryName(destination)!, "*.tmp"));
+        Assert.True(EvidenceBundleReader.Read(destination).Ok);
+    }
+
+    [Fact]
+    public async Task ToBytes_ProducesAValidatedReadableBundle()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+
+        var bytes = EvidenceBundleWriter.ToBytes(bundle);
+        using var stream = new MemoryStream(bytes, writable: false);
+        var read = EvidenceBundleReader.Read(stream);
+
+        Assert.True(read.Ok, read.Error);
+        Assert.Equal(EvidenceFormat.Version, read.Manifest!.FormatVersion);
+    }
+
+    [Fact]
+    public async Task Write_WithoutOverwrite_RefusesAndKeepsTheOriginal()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+        var destination = Path.Combine(_root, "capture.mauitrace");
+        File.WriteAllText(destination, "original");
+
+        var result = EvidenceBundleWriter.Write(bundle, destination, overwrite: false);
+
+        Assert.False(result.Ok);
+        Assert.Contains("already exists", result.Error!, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("original", File.ReadAllText(destination));
+        Assert.Empty(Directory.GetFiles(_root, "*.tmp"));
+    }
+
+    [Fact]
+    public async Task Write_WithOverwrite_ReplacesTheFileAtomically()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+        var destination = Path.Combine(_root, "capture.mauitrace");
+        File.WriteAllText(destination, "original");
+
+        var result = EvidenceBundleWriter.Write(bundle, destination, overwrite: true);
+
+        Assert.True(result.Ok, result.Error);
+        Assert.True(EvidenceBundleReader.Read(destination).Ok);
+        Assert.Empty(Directory.GetFiles(_root, "*.tmp"));
+    }
+
+    [Fact]
+    public async Task Read_RoundTripsEveryProjectedSection()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new FakeEvidenceSource(),
+            Options(includeScreenshot: true) with { WorkflowMarkdown = "# Repro\n1. Tap" });
+        var destination = Path.Combine(_root, "round-trip.mauitrace");
+        Assert.True(EvidenceBundleWriter.Write(bundle, destination, overwrite: false).Ok);
+
+        var read = EvidenceBundleReader.Read(destination);
+
+        Assert.True(read.Ok, read.Error);
+        Assert.NotNull(read.Manifest);
+        Assert.NotNull(read.Environment);
+        Assert.NotNull(read.Tree);
+        Assert.Null(read.Problems);
+        Assert.Contains(read.Manifest.Excluded, entry => entry.Name == EvidenceFormat.ProblemsEntry);
+        Assert.NotNull(read.Logs);
+        Assert.NotNull(read.Network);
+        Assert.NotNull(read.Screenshot);
+        Assert.Contains("# Repro", read.Workflow!, StringComparison.Ordinal);
+    }
+
+    // ── hostile bundles ──────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("../../etc/passwd")]
+    [InlineData("nested/manifest.json")]
+    [InlineData(@"C:\windows\system32\evil.json")]
+    [InlineData("evil.exe")]
+    [InlineData("manifest.json.bak")]
+    public void ValidateEntryName_RejectsAnythingOutsideTheAllowList(string name)
+        => Assert.NotNull(EvidenceBundleReader.ValidateEntryName(name));
+
+    [Fact]
+    public void ValidateEntryName_AcceptsAllowListedNames()
+        => Assert.All(EvidenceFormat.AllowedEntries, name => Assert.Null(EvidenceBundleReader.ValidateEntryName(name)));
+
+    [Fact]
+    public void Read_RejectsTraversingEntries()
+    {
+        var path = WriteArchive("traversal.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ValidManifestJson());
+            AddText(archive, "../evil.json", "{}");
+        });
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.False(read.Ok);
+        Assert.Contains("travers", read.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_RejectsDuplicateEntries()
+    {
+        var path = WriteArchive("duplicate.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ValidManifestJson());
+            AddText(archive, EvidenceFormat.LogsEntry, "{\"entries\":[]}");
+            AddText(archive, EvidenceFormat.LogsEntry, "{\"entries\":[]}");
+        });
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.False(read.Ok);
+        Assert.Contains("duplicate", read.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_RejectsTooManyEntries()
+    {
+        var path = Path.Combine(_root, "many.mauitrace");
+        using (var file = File.Create(path))
+        using (var archive = new ZipArchive(file, ZipArchiveMode.Create))
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ValidManifestJson());
+            for (var i = 0; i < EvidenceFormat.MaxBundleEntries + 4; i++)
+                AddText(archive, $"filler-{i}.json", "{}");
+        }
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.False(read.Ok);
+        Assert.Contains("too many entries", read.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_RejectsZipBombRatios()
+    {
+        var path = WriteArchive("bomb.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ValidManifestJson());
+            // ~3 MB of zeros stays within the logs entry cap but compresses to a few KB — far past
+            // the ratio guard.
+            var entry = archive.CreateEntry(EvidenceFormat.LogsEntry, CompressionLevel.SmallestSize);
+            using var stream = entry.Open();
+            stream.Write(new byte[3 * 1024 * 1024]);
+        });
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.False(read.Ok);
+        Assert.Contains("compression ratio", read.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_RejectsBundlesThatLieAboutTheirDeclaredSize()
+    {
+        // The central directory is attacker-controlled, so the size/ratio guards must not depend on
+        // it alone. Understating the declared size makes the runtime truncate the inflated stream
+        // (so the content no longer validates) and the reader's own accounting works on the bytes
+        // actually read — either way the bundle is refused rather than silently over-expanding.
+        var path = WriteArchive("lying-bomb.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ValidManifestJson());
+            var entry = archive.CreateEntry(EvidenceFormat.LogsEntry, CompressionLevel.SmallestSize);
+            using var stream = entry.Open();
+            stream.Write(new byte[8 * 1024 * 1024]);
+        });
+        PatchDeclaredUncompressedSizes(path);
+
+        using (var probe = new ZipArchive(File.OpenRead(path), ZipArchiveMode.Read))
+            Assert.Equal(0, probe.GetEntry(EvidenceFormat.LogsEntry)!.Length); // the lie is in place
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.False(read.Ok);
+        Assert.False(string.IsNullOrWhiteSpace(read.Error));
+    }
+
+    /// <summary>
+    /// Rewrites every central-directory record's uncompressed-size field to zero, simulating an
+    /// archive that lies about how much it expands to. The central directory is located through the
+    /// end-of-central-directory record, so no signature scanning heuristics are involved.
+    /// </summary>
+    private static void PatchDeclaredUncompressedSizes(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+
+        var eocd = -1;
+        for (var i = bytes.Length - 22; i >= 0; i--)
+        {
+            if (bytes[i] == 0x50 && bytes[i + 1] == 0x4B && bytes[i + 2] == 0x05 && bytes[i + 3] == 0x06)
+            {
+                eocd = i;
+                break;
+            }
+        }
+        Assert.True(eocd >= 0, "end-of-central-directory record not found");
+
+        var count = BitConverter.ToUInt16(bytes, eocd + 10);
+        var offset = (int)BitConverter.ToUInt32(bytes, eocd + 16);
+        for (var i = 0; i < count; i++)
+        {
+            Assert.True(bytes[offset] == 0x50 && bytes[offset + 1] == 0x4B &&
+                        bytes[offset + 2] == 0x01 && bytes[offset + 3] == 0x02,
+                "central directory record not found");
+            var nameLength = BitConverter.ToUInt16(bytes, offset + 28);
+            var extraLength = BitConverter.ToUInt16(bytes, offset + 30);
+            var commentLength = BitConverter.ToUInt16(bytes, offset + 32);
+            BitConverter.GetBytes(0u).CopyTo(bytes, offset + 24); // uncompressed size
+            offset += 46 + nameLength + extraLength + commentLength;
+        }
+
+        File.WriteAllBytes(path, bytes);
+    }
+
+    [Fact]
+    public void Read_RejectsForeignOrUnsupportedManifests()
+    {
+        var wrongSchema = WriteArchive("wrong-schema.mauitrace", archive =>
+            AddText(archive, EvidenceFormat.ManifestEntry, "{\"schema\":\"something-else\",\"formatVersion\":1,\"capturedUtc\":\"now\"}"));
+        var futureVersion = WriteArchive("future.mauitrace", archive =>
+            AddText(archive, EvidenceFormat.ManifestEntry, $"{{\"schema\":\"{EvidenceFormat.SchemaId}\",\"formatVersion\":99,\"capturedUtc\":\"now\"}}"));
+        var notAnObject = WriteArchive("array.mauitrace", archive =>
+            AddText(archive, EvidenceFormat.ManifestEntry, "[]"));
+        var missingManifest = WriteArchive("no-manifest.mauitrace", archive =>
+            AddText(archive, EvidenceFormat.LogsEntry, "{}"));
+
+        Assert.Contains("not a MAUI DevFlow evidence manifest", EvidenceBundleReader.Read(wrongSchema).Error!, StringComparison.Ordinal);
+        Assert.Contains("Unsupported evidence format version", EvidenceBundleReader.Read(futureVersion).Error!, StringComparison.Ordinal);
+        Assert.Contains("must be a JSON object", EvidenceBundleReader.Read(notAnObject).Error!, StringComparison.Ordinal);
+        Assert.Contains("missing manifest.json", EvidenceBundleReader.Read(missingManifest).Error!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Read_RejectsManifestTerminalControlSequences()
+    {
+        var path = WriteArchive("terminal-control.mauitrace", archive =>
+            AddText(
+                archive,
+                EvidenceFormat.ManifestEntry,
+                $$"""{"schema":"{{EvidenceFormat.SchemaId}}","formatVersion":{{EvidenceFormat.Version}},"capturedUtc":"2026-07-29T10:00:00Z","source":"cli\u001b[31m","entries":[]}"""));
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.False(read.Ok);
+        Assert.Contains("invalid source", read.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FormatView_EscapesTerminalControlCharactersDefensively()
+    {
+        var formatted = EvidenceCommands.FormatView(new EvidenceViewResult
+        {
+            Ok = true,
+            Report = "report\u001b[31m.html",
+            Bundle = "bundle\nname.mauitrace",
+            Entries = ["tree.json\u202E"],
+            Manifest = new EvidenceManifest
+            {
+                CapturedUtc = "now\rspoof",
+                Source = "cli\u001b[0m"
+            }
+        });
+
+        Assert.DoesNotContain('\u001b', formatted);
+        Assert.DoesNotContain('\u202E', formatted);
+        Assert.Contains("\\u001B", formatted, StringComparison.Ordinal);
+        Assert.Contains("\\u000A", formatted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Read_IgnoresMalformedSectionsWithoutFailingTheBundle()
+    {
+        const string malformedLogs = "not json";
+        const string invalidScreenshot = "definitely not a png";
+        var path = WriteArchive("bad-section.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ManifestForEntries(
+                (EvidenceFormat.LogsEntry, Encoding.UTF8.GetBytes(malformedLogs)),
+                (EvidenceFormat.ScreenshotEntry, Encoding.UTF8.GetBytes(invalidScreenshot))));
+            AddText(archive, EvidenceFormat.LogsEntry, malformedLogs);
+            AddText(archive, EvidenceFormat.ScreenshotEntry, invalidScreenshot);
+        });
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.True(read.Ok, read.Error);
+        Assert.Null(read.Logs);
+        Assert.Null(read.Screenshot);
+        Assert.Contains(read.Warnings, w => w.Contains("logs.json", StringComparison.Ordinal));
+        Assert.Contains(read.Warnings, w => w.Contains("screenshot.png", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Read_IgnoresSemanticallyInvalidNullCollections()
+    {
+        const string invalidLayout =
+            """{"schemaVersion":"1.0","ruleSetVersion":"1.0","rules":null,"findings":[],"limitations":[],"neverCaptured":[]}""";
+        const string invalidProblems =
+            """{"enabled":true,"revision":1,"count":1,"evicted":0,"problems":null}""";
+        var layoutBytes = Encoding.UTF8.GetBytes(invalidLayout);
+        var problemBytes = Encoding.UTF8.GetBytes(invalidProblems);
+        var path = WriteArchive("null-collections.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ManifestForEntries(
+                (EvidenceFormat.LayoutEntry, layoutBytes),
+                (EvidenceFormat.ProblemsEntry, problemBytes)));
+            AddBytes(archive, EvidenceFormat.LayoutEntry, layoutBytes);
+            AddBytes(archive, EvidenceFormat.ProblemsEntry, problemBytes);
+        });
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.True(read.Ok, read.Error);
+        Assert.Null(read.Layout);
+        Assert.Null(read.Problems);
+        Assert.Contains(read.Warnings, warning => warning.Contains("layout.json", StringComparison.Ordinal));
+        Assert.Contains(read.Warnings, warning => warning.Contains("problems.json", StringComparison.Ordinal));
+        var html = EvidenceReportRenderer.Render(read);
+        Assert.Contains("Content-Security-Policy", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Read_IgnoresLayoutFindingsWithInvalidCollections()
+    {
+        const string invalidLayout =
+            """
+            {
+              "schemaVersion":"1.0",
+              "ruleSetVersion":"1.0",
+              "rules":[],
+              "findings":[{
+                "id":"finding-1",
+                "ruleId":"layout.visible-zero-area",
+                "outcome":"violation",
+                "confidence":"high",
+                "severity":"serious",
+                "actionability":"fix",
+                "message":"message",
+                "explanation":"explanation",
+                "relatedElementIds":null,
+                "fixCategories":[],
+                "limitations":[]
+              }],
+              "limitations":[],
+              "neverCaptured":[]
+            }
+            """;
+        var layoutBytes = Encoding.UTF8.GetBytes(invalidLayout);
+        var path = WriteArchive("invalid-layout.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ManifestForEntries(
+                (EvidenceFormat.LayoutEntry, layoutBytes)));
+            AddBytes(archive, EvidenceFormat.LayoutEntry, layoutBytes);
+        });
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.True(read.Ok, read.Error);
+        Assert.Null(read.Layout);
+        Assert.Contains(read.Warnings, warning => warning.Contains("layout.json", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(EvidenceFormat.WorkflowEntry, EvidenceFormat.MaxWorkflowBytes)]
+    [InlineData(EvidenceFormat.ScreenshotEntry, EvidenceFormat.MaxScreenshotBytes)]
+    public void Read_RejectsEntriesBeyondTheirCaptureSpecificLimit(string entryName, long limit)
+    {
+        var content = new byte[checked((int)limit + 1)];
+        var path = WriteArchive($"oversized-{entryName.Replace('.', '-')}.mauitrace", archive =>
+        {
+            AddText(archive, EvidenceFormat.ManifestEntry, ManifestForEntries((entryName, content)));
+            AddBytes(archive, entryName, content);
+        });
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.False(read.Ok);
+        Assert.Contains("larger than", read.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Read_RejectsEntryWhoseContentDoesNotMatchManifestHash()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+        var path = Path.Combine(_root, "tampered.mauitrace");
+        Assert.True(EvidenceBundleWriter.Write(bundle, path, overwrite: false).Ok);
+
+        byte[] tampered;
+        using (var archive = new ZipArchive(File.OpenRead(path), ZipArchiveMode.Read))
+        using (var source = archive.GetEntry(EvidenceFormat.LogsEntry)!.Open())
+        using (var buffer = new MemoryStream())
+        {
+            source.CopyTo(buffer);
+            tampered = buffer.ToArray();
+        }
+        tampered[^1] ^= 0x01;
+
+        using (var archive = new ZipArchive(
+            new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None),
+            ZipArchiveMode.Update))
+        {
+            archive.GetEntry(EvidenceFormat.LogsEntry)!.Delete();
+            AddBytes(archive, EvidenceFormat.LogsEntry, tampered);
+        }
+
+        var read = EvidenceBundleReader.Read(path);
+
+        Assert.False(read.Ok);
+        Assert.Contains("integrity hash", read.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_RejectsFilesThatAreNotArchives()
+    {
+        var path = Path.Combine(_root, "garbage.mauitrace");
+        File.WriteAllText(path, "this is not a zip");
+
+        Assert.False(EvidenceBundleReader.Read(path).Ok);
+    }
+
+    // ── report ───────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Render_EncodesHostileContentAndDeclaresARestrictiveCsp()
+    {
+        var read = new EvidenceReadResult
+        {
+            Ok = true,
+            Manifest = new EvidenceManifest
+            {
+                CapturedUtc = "2026-07-29T10:00:00Z",
+                App = new EvidenceAppInfo { Name = "<script>alert('xss')</script>" },
+                Entries = [new EvidenceEntryInfo { Name = "tree.json", Description = "<img src=x onerror=alert(1)>", Bytes = 10 }],
+                Warnings = ["</style><script>alert(2)</script>"],
+            },
+            Workflow = "# Repro\n<script>alert('workflow')</script>",
+            Tree = new EvidenceTreeDocument
+            {
+                Count = 1,
+                Roots = [new EvidenceTreeNode { Id = "e1", Type = "<b>Label</b>", AutomationId = "\"onmouseover=alert(3)" }],
+            },
+        };
+
+        var html = EvidenceReportRenderer.Render(read);
+
+        Assert.Contains("Content-Security-Policy", html, StringComparison.Ordinal);
+        Assert.Contains("script-src 'none'", html, StringComparison.Ordinal);
+        Assert.Contains("default-src 'none'", html, StringComparison.Ordinal);
+        // Hostile values survive only as inert, encoded text: no injected tags and no raw quote
+        // that could break out of an attribute.
+        Assert.DoesNotContain("<script", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<img", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<b>Label</b>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"onmouseover", html, StringComparison.Ordinal);
+        Assert.Contains("&lt;script&gt;", html, StringComparison.Ordinal);
+        Assert.Contains("&quot;onmouseover", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_DropsTerminalControlAndFormatCharacters()
+    {
+        var read = new EvidenceReadResult
+        {
+            Ok = true,
+            Manifest = new EvidenceManifest
+            {
+                CapturedUtc = "2026-07-31T10:00:00Z"
+            },
+            Warnings = ["before\u001b[31mred\u0007after\u202E"]
+        };
+
+        var html = EvidenceReportRenderer.Render(read);
+
+        Assert.DoesNotContain('\u001b', html);
+        Assert.DoesNotContain('\u0007', html);
+        Assert.DoesNotContain('\u202E', html);
+        Assert.Contains("before[31mredafter", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task View_RegeneratesAStaticReportWithoutOpeningIt()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+        var destination = Path.Combine(_root, "view.mauitrace");
+        Assert.True(EvidenceBundleWriter.Write(bundle, destination, overwrite: false).Ok);
+        var reportPath = Path.Combine(_root, "report", "report.html");
+
+        var result = EvidenceCapture.View(destination, reportPath, open: false);
+
+        Assert.True(result.Ok, result.Error);
+        Assert.False(result.Opened);
+        Assert.True(File.Exists(reportPath));
+        Assert.Contains(EvidenceFormat.ManifestEntry, result.Entries);
+        Assert.Contains("Content-Security-Policy", File.ReadAllText(reportPath), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task View_RefusesExistingReportUnlessOverwriteIsExplicit()
+    {
+        var bundle = await EvidenceBuilder.BuildAsync(new FakeEvidenceSource(), Options());
+        var destination = Path.Combine(_root, "view-overwrite.mauitrace");
+        Assert.True(EvidenceBundleWriter.Write(bundle, destination, overwrite: false).Ok);
+        var reportPath = Path.Combine(_root, "report.html");
+        File.WriteAllText(reportPath, "original");
+
+        var refused = EvidenceCapture.View(destination, reportPath, open: false);
+        Assert.False(refused.Ok);
+        Assert.Equal("original", File.ReadAllText(reportPath));
+
+        var overwritten = EvidenceCapture.View(
+            destination,
+            reportPath,
+            open: false,
+            overwrite: true);
+
+        Assert.True(overwritten.Ok, overwritten.Error);
+        Assert.Contains("Content-Security-Policy", File.ReadAllText(reportPath), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("report.txt")]
+    [InlineData("report.html:hidden")]
+    [InlineData("NUL")]
+    public void ValidateReportPath_RejectsUnsafeDestinations(string requested)
+    {
+        if (!OperatingSystem.IsWindows() && requested is "report.html:hidden" or "NUL")
+            return;
+
+        var result = EvidencePaths.ValidateReportPath(Path.Combine(_root, requested));
+
+        Assert.False(result.Ok);
+    }
+
+    [Fact]
+    public void View_RejectsAMissingBundle()
+    {
+        var result = EvidenceCapture.View(Path.Combine(_root, "nope.mauitrace"), null, open: false);
+
+        Assert.False(result.Ok);
+        Assert.Contains("not found", result.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── paths ────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveDefaultOutputPath_UsesTheProjectLocalTraceFolder()
+    {
+        var path = EvidencePaths.ResolveDefaultOutputPath(_root, "My App", new DateTime(2026, 7, 29, 11, 22, 33, DateTimeKind.Utc));
+
+        Assert.Equal(Path.Combine(_root, EvidenceFormat.DefaultFolderName), Path.GetDirectoryName(path));
+        Assert.Equal("MyApp-20260729-112233.mauitrace", Path.GetFileName(path));
+    }
+
+    [Fact]
+    public void ResolveDefaultOutputPath_FallsBackToTheCurrentDirectory()
+    {
+        var path = EvidencePaths.ResolveDefaultOutputPath(null, "App", DateTime.UtcNow);
+
+        Assert.Equal(Path.GetFullPath(Directory.GetCurrentDirectory()), Path.GetDirectoryName(path));
+    }
+
+    [Theory]
+    [InlineData("bundle.zip", "extension")]
+    [InlineData("bundle", "extension")]
+    public void ValidateOutputPath_RequiresTheMauitraceExtension(string requested, string expectedFragment)
+    {
+        var result = EvidencePaths.ValidateOutputPath(requested, _root, "App", DateTime.UtcNow);
+
+        Assert.False(result.Ok);
+        Assert.Contains(expectedFragment, result.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateOutputPath_FillsInADefaultNameForADirectory()
+    {
+        var result = EvidencePaths.ValidateOutputPath(_root, _root, "App", DateTime.UtcNow);
+
+        Assert.True(result.Ok);
+        Assert.Equal(_root, Path.GetDirectoryName(result.Path));
+        Assert.EndsWith(EvidenceFormat.FileExtension, result.Path!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateOutputPath_RejectsControlCharacters()
+        => Assert.False(EvidencePaths.ValidateOutputPath("bad\u0000name.mauitrace", _root, "App", DateTime.UtcNow).Ok);
+
+    [Fact]
+    public void CleanupReports_RemovesExpiredReportsOnlyAndKeepsTheDirectory()
+    {
+        var original = EvidencePaths.ReportDirectory;
+        var reportDirectory = Path.Combine(_root, "reports");
+        try
+        {
+            EvidencePaths.ReportDirectory = reportDirectory;
+            Directory.CreateDirectory(reportDirectory);
+
+            var stale = Path.Combine(reportDirectory, "evidence-report-20260701-100000-abcdef12.html");
+            var unrelated = Path.Combine(reportDirectory, "keep-me.txt");
+            var similar = Path.Combine(reportDirectory, "evidence-report-notes.html");
+            File.WriteAllText(stale, "<html></html>");
+            File.WriteAllText(unrelated, "not ours");
+            File.WriteAllText(similar, "not ours");
+            File.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddDays(-3));
+            File.SetLastWriteTimeUtc(similar, DateTime.UtcNow.AddDays(-3));
+
+            var fresh = EvidencePaths.CreateReportPath(DateTime.UtcNow);
+
+            Assert.False(File.Exists(stale));
+            Assert.True(File.Exists(unrelated));
+            Assert.True(File.Exists(similar));
+            Assert.True(Directory.Exists(reportDirectory));
+            Assert.Equal(reportDirectory, Path.GetDirectoryName(fresh));
+        }
+        finally
+        {
+            EvidencePaths.ReportDirectory = original;
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────
+
+    private static EvidenceCaptureOptions Options(bool includeScreenshot = false, bool previewOnly = false) => new()
+    {
+        IncludeScreenshot = includeScreenshot,
+        PreviewOnly = previewOnly,
+        Source = "cli",
+        ToolVersion = "1.2.3",
+        UtcNow = new DateTime(2026, 7, 29, 10, 0, 0, DateTimeKind.Utc),
+    };
+
+    private string WriteArchive(string name, Action<ZipArchive> build)
+    {
+        var path = Path.Combine(_root, name);
+        using var file = File.Create(path);
+        using var archive = new ZipArchive(file, ZipArchiveMode.Create);
+        build(archive);
+        return path;
+    }
+
+    private static void AddText(ZipArchive archive, string name, string content)
+        => AddBytes(archive, name, Encoding.UTF8.GetBytes(content));
+
+    private static void AddBytes(ZipArchive archive, string name, byte[] content)
+    {
+        var entry = archive.CreateEntry(name, CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        stream.Write(content);
+    }
+
+    private static string ValidManifestJson()
+        => $"{{\"schema\":\"{EvidenceFormat.SchemaId}\",\"formatVersion\":{EvidenceFormat.Version},\"capturedUtc\":\"2026-07-29T10:00:00Z\"}}";
+
+    private static string ManifestForEntries(params (string Name, byte[] Content)[] entries)
+        => EvidenceJson.Serialize(new EvidenceManifest
+        {
+            CapturedUtc = "2026-07-29T10:00:00Z",
+            Entries = entries.Select(entry => new EvidenceEntryInfo
+            {
+                Name = entry.Name,
+                Description = "test",
+                Bytes = entry.Content.LongLength,
+                Sha256 = Convert.ToHexString(
+                    System.Security.Cryptography.SHA256.HashData(entry.Content)).ToLowerInvariant(),
+            }).ToList(),
+        });
+
+    private sealed class FakeEvidenceSource : IEvidenceDataSource
+    {
+        public bool FailNetwork { get; init; }
+        public bool LayoutUnsupported { get; init; }
+        public bool CancelOnTree { get; init; }
+        public string? LogsJson { get; init; }
+        public AgentStatus? Status { get; init; }
+        public JsonElement? AppInfo { get; init; }
+        public JsonElement? Connectivity { get; init; }
+        public List<ElementInfo>? Tree { get; init; }
+        public int ScreenshotReads { get; private set; }
+
+        public Task<AgentStatus?> GetStatusAsync(CancellationToken ct) => Task.FromResult<AgentStatus?>(Status ?? new AgentStatus
+        {
+            Agent = new AgentDescriptor { Version = "0.1.0", Framework = "maui", FrameworkVersion = "10.0" },
+            Device = new DeviceDescriptor
+            {
+                Platform = "Windows", DeviceType = "Virtual", Idiom = "Desktop",
+                WindowWidth = 430, WindowHeight = 760, DisplayDensity = 1.5, WindowCount = 1,
+            },
+            App = new AppDescriptor { Name = "Sample App", Version = "1.0", Build = "42", PackageId = "com.example.sample" },
+            Route = "//home",
+        });
+
+        public Task<JsonElement> GetCapabilitiesAsync(CancellationToken ct)
+            => Task.FromResult(Parse("""{"capabilities":{"ui.actions":{"version":1},"ui.events":{"version":1}}}"""));
+
+        public Task<List<ElementInfo>> GetTreeAsync(CancellationToken ct)
+        {
+            if (CancelOnTree)
+                throw new OperationCanceledException(ct);
+            return Task.FromResult(Tree ?? new List<ElementInfo>
+            {
+                new()
+                {
+                    Id = "e1",
+                    Type = "ContentPage",
+                    Children =
+                    [
+                        new ElementInfo { Id = "e2", Type = "Label", Text = "secret label text", AutomationId = "Title" },
+                    ],
+                }
+            });
+        }
+
+        public Task<string> GetLogsAsync(int limit, CancellationToken ct)
+            => Task.FromResult(LogsJson ??
+                """[{"t":"2026-07-29T10:00:00Z","l":"info","c":"App","m":"started","s":"native"}]""");
+
+        public Task<LayoutInspectionResult?> GetLayoutDiagnosticsAsync(CancellationToken ct)
+        {
+            if (LayoutUnsupported)
+                return Task.FromResult<LayoutInspectionResult?>(null);
+
+            return Task.FromResult<LayoutInspectionResult?>(new LayoutInspectionResult
+            {
+                SchemaVersion = "1.0",
+                RuleSetVersion = "1.0",
+                Snapshot = new LayoutSnapshotInfo
+                {
+                    CapturedAt = "2026-07-29T10:00:00.000Z",
+                    Platform = "Windows",
+                    NodeCount = 2,
+                },
+                Summary = new LayoutInspectionSummary { Violations = 1, Observations = 0, Incomplete = 1 },
+                Coverage = new LayoutCoverageInfo
+                {
+                    Overall = "partial",
+                    Rules =
+                    [
+                        new LayoutRuleSupportInfo { RuleId = "layout.visible-zero-area", Support = "full", Confidence = "high" },
+                    ],
+                    Limitations = ["Managed layout state only."],
+                },
+                Findings =
+                [
+                    new LayoutFinding
+                    {
+                        Id = "layout.visible-zero-area:e2:area",
+                        RuleId = "layout.visible-zero-area",
+                        Outcome = "violation",
+                        Confidence = "high",
+                        Message = @"Label collapsed, declared in C:\Users\alice\App\MainPage.xaml",
+                        Element = new LayoutElementReference
+                        {
+                            Id = "e2",
+                            Type = "Label",
+                            AutomationId = "Title",
+                            SourceFile = @"C:\Users\alice\App\MainPage.xaml",
+                            SourceLine = 12,
+                        },
+                        Evidence = new LayoutFindingEvidence
+                        {
+                            FullRegion = new LayoutRegionInfo
+                            {
+                                Bounds = new LayoutRectInfo { X = 1, Y = 2, Width = 0, Height = 20 },
+                            },
+                            Limitations = ["A deliberately collapsed element matches this rule."],
+                        },
+                    },
+                ],
+            });
+        }
+
+        public Task<List<NetworkRequest>> GetNetworkAsync(int limit, CancellationToken ct)
+            => FailNetwork
+                ? Task.FromException<List<NetworkRequest>>(new HttpRequestException("network capture is off"))
+                : Task.FromResult(new List<NetworkRequest>
+                {
+                    new() { Id = "r1", Method = "GET", Url = "https://example.com/a", Host = "example.com", Path = "/a", StatusCode = 200 },
+                });
+
+        public Task<JsonElement> GetPlatformInfoAsync(string endpoint, CancellationToken ct) => Task.FromResult(endpoint switch
+        {
+            "device-info" => Parse("""{"manufacturer":"Contoso","model":"Surface","platform":"Windows","osVersion":"11","name":"Alice's PC"}"""),
+            "device-display" => Parse("""{"width":1920,"height":1080,"density":2,"orientation":"landscape"}"""),
+            "app-info" => AppInfo ?? Parse("""{"effectiveTheme":"dark","requestedTheme":"light","userAppTheme":"dark"}"""),
+            "connectivity" => Connectivity ?? Parse("""{"networkAccess":"Internet","connectionProfiles":["WiFi"],"ssid":"private-ssid"}"""),
+            _ => Parse("{}"),
+        });
+
+        public Task<byte[]?> GetScreenshotAsync(CancellationToken ct)
+        {
+            ScreenshotReads++;
+            // Minimal PNG signature + payload so the reader's format check passes.
+            var png = new byte[64];
+            png[0] = 0x89; png[1] = 0x50; png[2] = 0x4E; png[3] = 0x47;
+            png[4] = 0x0D; png[5] = 0x0A; png[6] = 0x1A; png[7] = 0x0A;
+            return Task.FromResult<byte[]?>(png);
+        }
+
+        private static JsonElement Parse(string json)
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.Clone();
+        }
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceCliTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceCliTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow;
+using Microsoft.Maui.Cli.DevFlow.Broker;
+using Microsoft.Maui.Cli.UnitTests.Fixtures;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+[Collection("CLI")]
+public class EvidenceCliTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        AppContext.BaseDirectory, "evidence-cli-tests", Guid.NewGuid().ToString("N"));
+
+    public EvidenceCliTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        Directory.Delete(_root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task Preview_ReportsEnvironmentAndLimitsWithoutWritingOrTakingAScreenshot()
+    {
+        await using var server = new MockAgentServer();
+        await server.StartAsync();
+        var cli = new CliTestHarness(server.Port);
+        var output = Path.Combine(_root, "preview.mauitrace");
+
+        var result = await cli.InvokeAsync("devflow", "evidence", "preview", "--output", output, "--json");
+
+        Assert.Equal(0, result.ExitCode);
+        var plan = result.ParseJsonOutput();
+        Assert.Equal("cli", plan.GetProperty("source").GetString());
+        Assert.False(plan.GetProperty("screenshot").GetProperty("requested").GetBoolean());
+        Assert.True(plan.GetProperty("environment").GetProperty("unavailable").GetArrayLength() > 0);
+        Assert.True(plan.GetProperty("neverIncluded").GetArrayLength() > 0);
+        Assert.False(File.Exists(output));
+        Assert.DoesNotContain(server.RecordedRequests, request => request.Path == "/api/v1/ui/screenshot");
+        Assert.Single(server.RecordedRequests, request => request.Path == "/api/v1/ui/tree");
+    }
+
+    [Fact]
+    public async Task CaptureAndView_RoundTripABundleAndGenerateAnOfflineReport()
+    {
+        await using var server = new MockAgentServer();
+        await server.StartAsync();
+        var cli = new CliTestHarness(server.Port);
+        var bundle = Path.Combine(_root, "capture.mauitrace");
+        var report = Path.Combine(_root, "report.html");
+
+        var capture = await cli.InvokeAsync("devflow", "evidence", "capture", "--output", bundle, "--json");
+        Assert.True(capture.ExitCode == 0, capture.StdErr);
+        Assert.True(capture.ParseJsonOutput().GetProperty("ok").GetBoolean());
+        Assert.False(capture.ParseJsonOutput().GetProperty("manifest").GetProperty("screenshot").GetProperty("included").GetBoolean());
+
+        var view = await cli.InvokeRawAsync("devflow", "evidence", "view", bundle, "--no-open", "--output-report", report, "--json");
+        Assert.True(view.ExitCode == 0, view.StdErr);
+        Assert.False(view.ParseJsonOutput().GetProperty("opened").GetBoolean());
+        var html = File.ReadAllText(report);
+        Assert.Contains("script-src 'none'", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<script", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Environment", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Preview_ReportsWorkflowConsentAndHumanReadableEnvironment()
+    {
+        await using var server = new MockAgentServer();
+        await server.StartAsync();
+        var cli = new CliTestHarness(server.Port);
+        var workflow = Path.Combine(_root, "repro.md");
+        File.WriteAllText(workflow, "# Repro\n1. Tap");
+        var preview = await cli.InvokeAsync("devflow", "evidence", "preview", "--workflow", workflow, "--json");
+        Assert.Equal(0, preview.ExitCode);
+        Assert.Contains(preview.ParseJsonOutput().GetProperty("included").EnumerateArray(),
+            entry => entry.GetProperty("name").GetString() == "workflow.md");
+        var text = await cli.InvokeAsync("devflow", "evidence", "preview", "--no-json");
+        Assert.Equal(0, text.ExitCode);
+        Assert.Contains("Current environment", text.StdOut, StringComparison.Ordinal);
+        Assert.Contains("Not captured/enforced", text.StdOut, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CaptureAndView_RequireExplicitOverwrite(bool report)
+    {
+        await using var server = new MockAgentServer();
+        await server.StartAsync();
+        var cli = new CliTestHarness(server.Port);
+        var bundle = Path.Combine(_root, "capture.mauitrace");
+        var destination = report ? Path.Combine(_root, "report.html") : bundle;
+        if (report)
+            Assert.Equal(0, (await cli.InvokeAsync("devflow", "evidence", "capture", "--output", bundle, "--json")).ExitCode);
+        File.WriteAllText(destination, "original");
+        var args = report
+            ? new[] { "devflow", "evidence", "view", bundle, "--no-open", "--output-report", destination, "--json" }
+            : new[] { "devflow", "evidence", "capture", "--output", destination, "--json" };
+
+        var refused = report ? await cli.InvokeRawAsync(args) : await cli.InvokeAsync(args);
+        Assert.Equal(1, refused.ExitCode);
+        Assert.Contains("already exists", refused.StdErr, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("original", File.ReadAllText(destination));
+        var replaced = report
+            ? await cli.InvokeRawAsync([.. args, "--overwrite"])
+            : await cli.InvokeAsync([.. args, "--overwrite"]);
+        Assert.Equal(0, replaced.ExitCode);
+        Assert.NotEqual("original", File.ReadAllText(destination));
+    }
+
+    [Fact]
+    public async Task PreviewAndCapture_RejectAnUnreachableAgent()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        var cli = new CliTestHarness(port);
+        var output = Path.Combine(_root, "unreachable.mauitrace");
+        var preview = await cli.InvokeAsync("devflow", "evidence", "preview", "--json");
+        var capture = await cli.InvokeAsync("devflow", "evidence", "capture", "--output", output, "--json");
+        Assert.Equal(1, preview.ExitCode);
+        Assert.Equal(1, capture.ExitCode);
+        Assert.Contains("No DevFlow agent responded", preview.StdErr, StringComparison.Ordinal);
+        Assert.False(File.Exists(output));
+    }
+
+    [Fact]
+    public async Task Capture_RejectsInvalidOutputAndMissingWorkflow()
+    {
+        await using var server = new MockAgentServer();
+        await server.StartAsync();
+        var cli = new CliTestHarness(server.Port);
+        var invalidOutput = await cli.InvokeAsync("devflow", "evidence", "capture", "--output", Path.Combine(_root, "bundle.zip"), "--json");
+        var missingWorkflow = await cli.InvokeAsync("devflow", "evidence", "capture", "--workflow", Path.Combine(_root, "missing.md"), "--json");
+        Assert.Equal(1, invalidOutput.ExitCode);
+        Assert.Contains(".mauitrace", invalidOutput.StdErr, StringComparison.Ordinal);
+        Assert.Equal(1, missingWorkflow.ExitCode);
+        Assert.Contains("Workflow file not found", missingWorkflow.StdErr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Capture_JsonErrorsDoNotContainHumanAgentLabels()
+    {
+        await using var server = new MockAgentServer();
+        await server.StartAsync();
+        var cli = new CliTestHarness(server.Port);
+        var output = Path.Combine(_root, "existing.mauitrace");
+        File.WriteAllText(output, "original");
+        DevFlowCommands.ResolveRunningBrokerPortAsync = () => Task.FromResult<int?>(19223);
+        DevFlowCommands.ListBrokerAgentsAsync = _ => Task.FromResult<AgentRegistration[]?>([
+            new() { Id = "target", AppName = "Target", Platform = "Windows", Port = server.Port },
+            new() { Id = "other", AppName = "Other", Platform = "Android", Port = server.Port + 1 },
+        ]);
+        try
+        {
+            var result = await cli.InvokeAsync("devflow", "evidence", "capture", "--output", output, "--json");
+            Assert.Equal(1, result.ExitCode);
+            using var error = JsonDocument.Parse(result.StdErr);
+            Assert.Equal("InvocationError", error.RootElement.GetProperty("type").GetString());
+        }
+        finally
+        {
+            DevFlowCommands.ResetBrokerClientForTests();
+        }
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceInspectorRouteTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceInspectorRouteTests.cs
@@ -1,0 +1,168 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow.Evidence;
+using Microsoft.Maui.Cli.DevFlow.Inspector;
+using Microsoft.Maui.Cli.UnitTests.Fixtures;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class EvidenceInspectorRouteTests
+{
+    [Theory]
+    [InlineData("/api/evidence/preview")]
+    [InlineData("/api/evidence/capture")]
+    public void EvidenceRoutes_RequireTheReadTokenWithoutClaimingMutationAuthority(string path)
+    {
+        Assert.True(InspectorServer.IsTokenGatedPath(path));
+        Assert.False(InspectorServer.IsMutation(path));
+        Assert.False(InspectorServer.IsBlockedDuringReplay(path));
+    }
+
+    [Theory]
+    [InlineData("/api/evidence/preview")]
+    [InlineData("/api/evidence/capture")]
+    public Task EvidenceRoutes_RejectMissingReadToken(string path)
+        => WithInspectorAsync(async (http, agent) =>
+        {
+            http.DefaultRequestHeaders.Remove("X-DevFlow-Inspector-Token");
+            var response = await http.PostAsync(path, Json("{}"));
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            Assert.Empty(agent.Requests);
+        });
+
+    [Fact]
+    public Task Preview_ReturnsTargetEnvironmentWithoutAHostOutputPathOrScreenshotRead()
+        => WithInspectorAsync(async (http, agent) =>
+        {
+            var response = await http.PostAsync("/api/evidence/preview", Json("""{"elementId":"e1"}"""));
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var plan = body.RootElement.GetProperty("plan");
+            Assert.Equal("inspector", plan.GetProperty("source").GetString());
+            Assert.Equal("e1", plan.GetProperty("selectedElementId").GetString());
+            Assert.False(plan.TryGetProperty("outputPath", out _));
+            Assert.False(plan.GetProperty("screenshot").GetProperty("requested").GetBoolean());
+            Assert.Equal(430, plan.GetProperty("environment").GetProperty("viewport").GetProperty("width").GetDouble());
+            Assert.Equal("dark", plan.GetProperty("environment").GetProperty("theme").GetProperty("effective").GetString());
+            Assert.Equal(0, agent.ScreenshotRequests);
+        });
+
+    [Fact]
+    public Task Preview_ListsRequestedAttachmentsButDoesNotCapturePixels()
+        => WithInspectorAsync(async (http, agent) =>
+        {
+            var response = await http.PostAsync("/api/evidence/preview",
+                Json("""{"includeScreenshot":true,"includeWorkflow":true,"workflow":"# Repro\n1. Tap"}"""));
+            using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var entries = body.RootElement.GetProperty("plan").GetProperty("included").EnumerateArray()
+                .Select(entry => entry.GetProperty("name").GetString()).ToList();
+            Assert.Contains(EvidenceFormat.WorkflowEntry, entries);
+            Assert.Contains(EvidenceFormat.ScreenshotEntry, entries);
+            Assert.Equal(0, agent.ScreenshotRequests);
+        });
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public Task Capture_WritesOnlyExplicitlyRequestedAttachments(bool includeAttachments)
+        => WithInspectorAsync(async (http, agent) =>
+        {
+            var options = includeAttachments
+                ? """{"includeScreenshot":true,"workflow":"# Repro\nOpen C:\\Users\\alice\\App.xaml with api_key=zzz-9999"}"""
+                : "{}";
+            var response = await http.PostAsync("/api/evidence/capture", Json(options));
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/zip", response.Content.Headers.ContentType?.MediaType);
+            using var stream = new MemoryStream(await response.Content.ReadAsByteArrayAsync());
+            var read = EvidenceBundleReader.Read(stream);
+            Assert.True(read.Ok, read.Error);
+            Assert.Equal(includeAttachments, read.Manifest!.Screenshot.Included);
+            Assert.Equal(includeAttachments ? 1 : 0, agent.ScreenshotRequests);
+            Assert.Equal(includeAttachments, read.Screenshot is not null);
+            Assert.Equal(includeAttachments, read.Workflow is not null);
+            if (includeAttachments)
+            {
+                Assert.DoesNotContain("zzz-9999", read.Workflow!, StringComparison.Ordinal);
+                Assert.DoesNotContain(@"C:\Users\alice", read.Workflow!, StringComparison.Ordinal);
+            }
+            var environment = EvidenceJson.Serialize(read.Environment);
+            Assert.DoesNotContain("private device name", environment, StringComparison.Ordinal);
+            Assert.DoesNotContain("private network name", environment, StringComparison.Ordinal);
+            Assert.DoesNotContain("secret-label-text", EvidenceJson.Serialize(read.Tree), StringComparison.Ordinal);
+            Assert.DoesNotContain(agent.Requests, path => path.Contains("permission", StringComparison.Ordinal) ||
+                path.Contains("storage", StringComparison.Ordinal) || path.Contains("geolocation", StringComparison.Ordinal));
+        });
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("null")]
+    [InlineData("{")]
+    [InlineData("{\"includeScreenshot\":\"true\"}")]
+    [InlineData("{\"workflow\":false}")]
+    [InlineData("{\"logLimit\":0}")]
+    [InlineData("{\"networkLimit\":501}")]
+    public Task EvidenceRoutes_RejectMalformedOptionsBeforeReadingTheApp(string json)
+        => WithInspectorAsync(async (http, agent) =>
+        {
+            foreach (var route in new[] { "/api/evidence/preview", "/api/evidence/capture" })
+            {
+                var response = await http.PostAsync(route, Json(json));
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            }
+            Assert.Empty(agent.Requests);
+        });
+
+    [Fact]
+    public Task ExplicitlyDecliningWorkflow_OverridesSuppliedText()
+        => WithInspectorAsync(async (http, _) =>
+        {
+            var response = await http.PostAsync("/api/evidence/capture",
+                Json("""{"includeWorkflow":false,"workflow":"private note"}"""));
+            using var stream = new MemoryStream(await response.Content.ReadAsByteArrayAsync());
+            var read = EvidenceBundleReader.Read(stream);
+            Assert.True(read.Ok, read.Error);
+            Assert.Null(read.Workflow);
+        });
+
+    [Fact]
+    public Task UnavailableNetworkCapture_IsAnExclusionRatherThanNoRequests()
+        => WithInspectorAsync(async (http, _) =>
+        {
+            var response = await http.PostAsync("/api/evidence/capture", Json("{}"));
+            using var stream = new MemoryStream(await response.Content.ReadAsByteArrayAsync());
+            var read = EvidenceBundleReader.Read(stream);
+            Assert.True(read.Ok, read.Error);
+            Assert.Null(read.Network);
+            Assert.Contains(read.Manifest!.Excluded, entry => entry.Name == EvidenceFormat.NetworkEntry);
+        }, networkUnavailable: true);
+
+    private static async Task WithInspectorAsync(
+        Func<HttpClient, EvidenceAgentFixture, Task> action, bool networkUnavailable = false)
+    {
+        await using var agent = new EvidenceAgentFixture(networkUnavailable);
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        using var inspector = new InspectorServer(port, "127.0.0.1", agent.Port);
+        inspector.Start();
+        try
+        {
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}") };
+            var token = (string)typeof(InspectorServer)
+                .GetField("_readToken", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(inspector)!;
+            http.DefaultRequestHeaders.Add("X-DevFlow-Inspector-Token", token);
+            await action(http, agent);
+        }
+        finally
+        {
+            await inspector.StopAsync();
+        }
+    }
+
+    private static StringContent Json(string value) => new(value, Encoding.UTF8, "application/json");
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceMcpTests.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/EvidenceMcpTests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow.Mcp;
+using Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+using Microsoft.Maui.Cli.UnitTests.Fixtures;
+using Microsoft.Maui.DevFlow.Driver;
+using ModelContextProtocol;
+using Xunit;
+
+namespace Microsoft.Maui.Cli.UnitTests;
+
+public class EvidenceMcpTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"devflow-evidence-mcp-{Guid.NewGuid():N}");
+
+    public EvidenceMcpTests() => Directory.CreateDirectory(_root);
+    public void Dispose()
+    {
+        Directory.Delete(_root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task Preview_IncludesTheSameExplicitWorkflowAsCaptureWithoutTakingAScreenshot()
+    {
+        await using var agent = new EvidenceAgentFixture();
+        var session = new McpAgentSession { DefaultAgentHost = "127.0.0.1" };
+        var workflow = Path.Combine(_root, "repro.md");
+        File.WriteAllText(workflow, "# Repro\n1. Tap OrderConfirmation");
+        using var preview = JsonDocument.Parse(await EvidenceTools.Preview(
+            session, agentPort: agent.Port, includeScreenshot: true, workflowFile: workflow));
+        var included = preview.RootElement.GetProperty("included").EnumerateArray()
+            .Select(entry => entry.GetProperty("name").GetString()).ToArray();
+        Assert.Contains("workflow.md", included);
+        Assert.Contains("screenshot.png", included);
+        Assert.Equal(0, agent.ScreenshotRequests);
+        using var captured = JsonDocument.Parse(await EvidenceTools.Capture(session,
+            agentPort: agent.Port, outputPath: Path.Combine(_root, "capture.mauitrace"), workflowFile: workflow));
+        Assert.True(captured.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal("mcp", captured.RootElement.GetProperty("manifest").GetProperty("source").GetString());
+    }
+
+    [Fact]
+    public async Task InvalidWorkflow_IsAToolErrorBeforeAnyAppRead()
+    {
+        await using var agent = new EvidenceAgentFixture();
+        var session = new McpAgentSession { DefaultAgentHost = "127.0.0.1" };
+        var missing = Path.Combine(_root, "missing.md");
+        await Assert.ThrowsAsync<McpException>(() => EvidenceTools.Preview(session, agentPort: agent.Port, workflowFile: missing));
+        await Assert.ThrowsAsync<McpException>(() => EvidenceTools.Capture(session, agentPort: agent.Port, workflowFile: missing));
+        Assert.Empty(agent.Requests);
+    }
+
+    [Fact]
+    public async Task NetworkRead_StrictOverloadSurfacesFailuresWithoutChangingLegacyBehavior()
+    {
+        await using var agent = new EvidenceAgentFixture(networkUnavailable: true);
+        using var client = new AgentClient("127.0.0.1", agent.Port);
+        Assert.Empty(await client.GetNetworkRequestsAsync());
+        await Assert.ThrowsAnyAsync<HttpRequestException>(() => client.GetNetworkRequestsAsync(100, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task NetworkRead_CancellationPreventsTheRequest()
+    {
+        await using var agent = new EvidenceAgentFixture();
+        using var client = new AgentClient("127.0.0.1", agent.Port);
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetNetworkRequestsAsync(100, cancelled.Token));
+        Assert.Empty(agent.Requests);
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/EvidenceAgentFixture.cs
+++ b/src/Cli/Microsoft.Maui.Cli.UnitTests/Fixtures/EvidenceAgentFixture.cs
@@ -1,0 +1,151 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace Microsoft.Maui.Cli.UnitTests.Fixtures;
+
+internal sealed class EvidenceAgentFixture : IAsyncDisposable
+{
+    private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
+    private readonly CancellationTokenSource _cts = new();
+    private readonly ConcurrentBag<Task> _connections = [];
+    private readonly ConcurrentQueue<string> _requests = [];
+    private readonly Task _loop;
+    private readonly bool _networkUnavailable;
+    private int _screenshotRequests;
+
+    internal EvidenceAgentFixture(bool networkUnavailable = false)
+    {
+        _networkUnavailable = networkUnavailable;
+        _listener.Start();
+        _loop = ListenAsync();
+    }
+
+    internal int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+    internal int ScreenshotRequests => Volatile.Read(ref _screenshotRequests);
+    internal string[] Requests => _requests.ToArray();
+
+    private async Task ListenAsync()
+    {
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                _connections.Add(HandleAsync(client, _cts.Token));
+            }
+        }
+        catch (OperationCanceledException) when (_cts.IsCancellationRequested) { }
+        catch (SocketException) when (_cts.IsCancellationRequested) { }
+    }
+
+    private async Task HandleAsync(TcpClient client, CancellationToken ct)
+    {
+        using (client)
+        {
+            try
+            {
+                var stream = client.GetStream();
+                var target = await ReadRequestAsync(stream, ct);
+                var path = target.Split('?')[0];
+                _requests.Enqueue(path);
+                if (path == "/api/v1/network/requests" && _networkUnavailable)
+                {
+                    await WriteAsync(stream, 503, "application/json",
+                        Encoding.UTF8.GetBytes("""{"error":"Network capture is unavailable."}"""), ct);
+                    return;
+                }
+                if (path == "/api/v1/ui/screenshot")
+                {
+                    Interlocked.Increment(ref _screenshotRequests);
+                    await WriteAsync(stream, 200, "image/png", Convert.FromBase64String(
+                        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aA1cAAAAASUVORK5CYII="), ct);
+                    return;
+                }
+
+                var json = path switch
+                {
+                    "/api/v1/agent/status" => """
+                        {"running":true,"agent":{"version":"0.1.0","framework":".NET MAUI","frameworkVersion":"10.0"},
+                         "device":{"platform":"Windows","deviceType":"Physical","idiom":"Desktop","windowWidth":430,"windowHeight":760,"displayDensity":1.5,"windowCount":1},
+                         "app":{"name":"Evidence Sample","version":"1.2","build":"42","packageId":"com.example.evidence"},"route":"//home"}
+                        """,
+                    "/api/v1/agent/capabilities" => """{"capabilities":{"ui.actions":{"version":1},"diagnostics.layout":{"version":1}}}""",
+                    "/api/v1/ui/tree" => """
+                        [{"id":"page","type":"ContentPage","isVisible":true,"isEnabled":true,
+                          "bounds":{"x":0,"y":0,"width":430,"height":760},"windowBounds":{"x":0,"y":0,"width":430,"height":760},
+                          "children":[{"id":"e1","type":"Label","text":"secret-label-text","automationId":"OrderConfirmation",
+                            "isVisible":true,"isEnabled":true,"bounds":{"x":20,"y":20,"width":220,"height":40},
+                            "windowBounds":{"x":20,"y":20,"width":220,"height":40}}]}]
+                        """,
+                    "/api/v1/ui/diagnostics/layout" => """
+                        {"schemaVersion":"1.0","ruleSetVersion":"1.0",
+                         "snapshot":{"id":"snapshot-1","capturedAt":"2026-09-09T10:00:00Z","platform":"Windows","stable":true,"nodeCount":2},
+                         "coverage":{"overall":"partial","rules":[],"limitations":["Managed layout state only."]},
+                         "summary":{"violations":0,"incomplete":1},"findings":[]}
+                        """,
+                    "/api/v1/logs" => """[{"t":"2026-09-09T10:00:00Z","l":"info","c":"App","m":"started"}]""",
+                    "/api/v1/network/requests" => "[]",
+                    "/api/v1/device/info" => """{"manufacturer":"Contoso","model":"Test Tablet","platform":"Windows","osVersion":"11","deviceType":"Physical","name":"private device name"}""",
+                    "/api/v1/device/display" => """{"width":1920,"height":1080,"density":2,"orientation":"Landscape","rotation":"Rotation0"}""",
+                    "/api/v1/device/app" => """{"effectiveTheme":"dark","requestedTheme":"dark","userAppTheme":"system"}""",
+                    "/api/v1/device/connectivity" => """{"networkAccess":"Internet","connectionProfiles":["WiFi"],"ssid":"private network name"}""",
+                    _ => null,
+                };
+                await WriteAsync(stream, json is null ? 404 : 200, "application/json",
+                    Encoding.UTF8.GetBytes(json ?? """{"success":false,"error":"Unsupported fixture endpoint"}"""), ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+            catch (IOException) { /* A browser may abort an in-flight state poll. */ }
+        }
+    }
+
+    private static async Task<string> ReadRequestAsync(NetworkStream stream, CancellationToken ct)
+    {
+        using var received = new MemoryStream();
+        var buffer = new byte[4096];
+        string header;
+        int headerEnd;
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer, ct);
+            if (read == 0) throw new IOException("The request ended before its headers.");
+            received.Write(buffer, 0, read);
+            header = Encoding.ASCII.GetString(received.GetBuffer(), 0, checked((int)received.Length));
+            headerEnd = header.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+            if (headerEnd >= 0) break;
+            if (received.Length > 16_384) throw new IOException("Fixture request headers exceeded their limit.");
+        }
+        var lines = header[..headerEnd].Split("\r\n");
+        var contentLength = lines.FirstOrDefault(line => line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase));
+        var length = contentLength is null ? 0 :
+            int.Parse(contentLength[(contentLength.IndexOf(':') + 1)..], CultureInfo.InvariantCulture);
+        var remaining = length - (received.Length - headerEnd - 4);
+        while (remaining > 0)
+        {
+            var read = await stream.ReadAsync(buffer.AsMemory(0, (int)Math.Min(remaining, buffer.Length)), ct);
+            if (read == 0) throw new IOException("The request body ended early.");
+            remaining -= read;
+        }
+        return lines[0].Split(' ')[1];
+    }
+
+    private static async Task WriteAsync(NetworkStream stream, int status, string type, byte[] body, CancellationToken ct)
+    {
+        var reason = status switch { 200 => "OK", 503 => "Service Unavailable", _ => "Not Found" };
+        var header = $"HTTP/1.1 {status} {reason}\r\nContent-Type: {type}\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n";
+        await stream.WriteAsync(Encoding.ASCII.GetBytes(header), ct);
+        await stream.WriteAsync(body, ct);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync();
+        _listener.Stop();
+        await _loop;
+        await Task.WhenAll(_connections);
+        _cts.Dispose();
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/DevFlowCommands.cs
@@ -1767,6 +1767,9 @@ public class DevFlowCommands
 
         _devflowCommand = devflowCommand;
 
+        devflowCommand.Add(Evidence.EvidenceCommands.Create(
+            jsonOption, noJsonOption, agentHostOption, agentPortOption,
+            output, CreateAgentClientAsync, () => _errorOccurred = true));
         return devflowCommand;
     }
 
@@ -1902,7 +1905,8 @@ public class DevFlowCommands
 
     private static readonly string s_cliMutationLeaseId = Guid.NewGuid().ToString("N");
 
-    private static async Task<Microsoft.Maui.DevFlow.Driver.AgentClient> CreateAgentClientAsync(string host, int port)
+    private static async Task<Microsoft.Maui.DevFlow.Driver.AgentClient> CreateAgentClientAsync(
+        string host, int port, bool announceAgent = true)
     {
         EnsureAgentPortResolved(port);
 
@@ -1916,7 +1920,8 @@ public class DevFlowCommands
                 if (agent is not null && IsAndroidAgent(agent))
                     await EnsureAndroidForwardingForAgentsAsync([agent], deviceId: null, repair: true, emitWarnings: false, CancellationToken.None, brokerPort: brokerPort.Value);
 
-                EmitAgentLabel(host, port, agents);
+                if (announceAgent)
+                    EmitAgentLabel(host, port, agents);
             }
         }
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceBuilder.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceBuilder.cs
@@ -1,0 +1,973 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow.Flows;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>Everything a caller can influence about a capture. Defaults are the privacy defaults.</summary>
+internal sealed record EvidenceCaptureOptions
+{
+    /// <summary>Screenshots are opt-in — never captured unless explicitly requested.</summary>
+    public bool IncludeScreenshot { get; init; }
+
+    /// <summary>Collect and project, but skip the screenshot read (used by preview).</summary>
+    public bool PreviewOnly { get; init; }
+
+    public string? WorkflowMarkdown { get; init; }
+    public string? SelectedElementId { get; init; }
+    public int LogLimit { get; init; } = EvidenceFormat.DefaultLogLimit;
+    public int NetworkLimit { get; init; } = EvidenceFormat.DefaultNetworkLimit;
+
+    /// <summary>Originating surface: <c>cli</c>, <c>mcp</c>, or <c>inspector</c>.</summary>
+    public string Source { get; init; } = "cli";
+
+    /// <summary>Used to turn absolute source paths into project-relative ones.</summary>
+    public string? ProjectRoot { get; init; }
+
+    /// <summary>Destination reported in the plan (not written by the builder).</summary>
+    public string? OutputPath { get; init; }
+
+    public string ToolVersion { get; init; } = "";
+
+    public DateTime? UtcNow { get; init; }
+}
+
+/// <summary>An in-memory bundle: the manifest, the preview plan, and the serialized entries.</summary>
+internal sealed class EvidenceBundle
+{
+    public required EvidenceManifest Manifest { get; init; }
+    public required EvidencePlan Plan { get; init; }
+    /// <summary>Entries excluding <c>manifest.json</c>, in stable write order.</summary>
+    public required IReadOnlyList<EvidenceBundleEntry> Entries { get; init; }
+    public required byte[] ManifestBytes { get; init; }
+}
+
+internal sealed record EvidenceBundleEntry(string Name, byte[] Content);
+
+/// <summary>
+/// Collects evidence from a running app and projects it into the bundle's safe shapes.
+///
+/// Redaction happens HERE, at ingestion: nothing unredacted is ever handed to a serializer,
+/// a renderer, or a browser. Each section is collected defensively — a section the agent cannot
+/// serve becomes an explicit exclusion plus a warning rather than a failed capture.
+/// </summary>
+internal static class EvidenceBuilder
+{
+    public static async Task<EvidenceBundle> BuildAsync(
+        IEvidenceDataSource source,
+        EvidenceCaptureOptions options,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(options);
+        ct.ThrowIfCancellationRequested();
+
+        var utcNow = options.UtcNow ?? DateTime.UtcNow;
+        var capturedUtc = utcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+        var logLimit = Math.Clamp(options.LogLimit, 1, EvidenceFormat.MaxLogLimit);
+        var networkLimit = Math.Clamp(options.NetworkLimit, 1, EvidenceFormat.MaxNetworkLimit);
+
+        var warnings = new List<string>();
+        var exclusions = new List<EvidenceExclusion>();
+        var entries = new List<EvidenceBundleEntry>();
+        var entryInfos = new List<EvidenceEntryInfo>();
+        var counts = new EvidenceCounts();
+
+        // ── environment ──────────────────────────────────────────────────────────────────────
+        AgentStatus? status = null;
+        try { status = await source.GetStatusAsync(ct); }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex)) { warnings.Add($"Agent status unavailable: {Describe(ex)}"); }
+        if (status is null)
+            warnings.Add("Agent status was unavailable; this capture is incomplete.");
+
+        var app = status?.App is null ? null : new EvidenceAppInfo
+        {
+            Name = EvidenceRedaction.SafeIdentifier(status.App.Name),
+            Version = EvidenceRedaction.SafeIdentifier(status.App.Version),
+            Build = EvidenceRedaction.SafeIdentifier(status.App.Build),
+            PackageId = EvidenceRedaction.SafeIdentifier(status.App.PackageId),
+        };
+
+        var platform = status is null ? null : new EvidencePlatformInfo
+        {
+            Name = EvidenceRedaction.SafeIdentifier(status.Device?.Platform),
+            DeviceType = EvidenceRedaction.SafeIdentifier(status.Device?.DeviceType),
+            Idiom = EvidenceRedaction.SafeIdentifier(status.Device?.Idiom),
+            AgentVersion = EvidenceRedaction.SafeIdentifier(status.Agent?.Version),
+            Framework = EvidenceRedaction.SafeIdentifier(status.Agent?.Framework),
+            FrameworkVersion = EvidenceRedaction.SafeIdentifier(status.Agent?.FrameworkVersion),
+        };
+
+        var capabilities = new List<string>();
+        try { capabilities = ProjectCapabilities(await source.GetCapabilitiesAsync(ct)); }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex)) { warnings.Add($"Agent capabilities unavailable: {Describe(ex)}"); }
+
+        EvidenceDeviceInfo? device = null;
+        try { device = ProjectDevice(await source.GetPlatformInfoAsync("device-info", ct)); }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex)) { warnings.Add($"Device info unavailable: {Describe(ex)}"); }
+
+        EvidenceDisplayInfo? display = null;
+        try { display = ProjectDisplay(await source.GetPlatformInfoAsync("device-display", ct)); }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex)) { warnings.Add($"Display info unavailable: {Describe(ex)}"); }
+
+        EvidenceThemeInfo? theme = null;
+        try { theme = ProjectTheme(await source.GetPlatformInfoAsync("app-info", ct)); }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex)) { warnings.Add($"Theme unavailable: {Describe(ex)}"); }
+
+        EvidenceConnectivityInfo? connectivity = null;
+        try { connectivity = ProjectConnectivity(await source.GetPlatformInfoAsync("connectivity", ct)); }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex)) { warnings.Add($"Connectivity unavailable: {Describe(ex)}"); }
+
+        var viewport = status?.Device is { } metrics ? new EvidenceViewportInfo
+        {
+            Width = PositiveNumber(metrics.WindowWidth),
+            Height = PositiveNumber(metrics.WindowHeight),
+            Density = PositiveNumber(metrics.DisplayDensity),
+            WindowCount = metrics.WindowCount is > 0 ? metrics.WindowCount : null,
+        } : null;
+
+        var environment = new EvidenceEnvironment
+        {
+            CapturedUtc = capturedUtc,
+            App = app,
+            Platform = platform,
+            Device = device,
+            Display = display,
+            Viewport = viewport,
+            Theme = theme,
+            Connectivity = connectivity,
+            Capabilities = capabilities,
+            Route = EvidenceRedaction.ScrubRoute(status?.Route),
+        };
+        environment.Unavailable = EnvironmentGaps(environment);
+        AddEntry(entries, entryInfos, EvidenceFormat.EnvironmentEntry,
+            "App build, OS/device, display, app viewport, theme, connectivity, and explicit environment gaps", null,
+            EvidenceJson.SerializeToUtf8(environment));
+
+        // ── tree ─────────────────────────────────────────────────────────────────────────────
+        try
+        {
+            var tree = await source.GetTreeAsync(ct);
+            var projected = ProjectTree(tree, options.ProjectRoot);
+            counts.TreeElements = projected.Count;
+            if (projected.Truncated)
+                warnings.Add($"Visual tree truncated at {EvidenceFormat.MaxTreeElements} elements.");
+            AddEntry(entries, entryInfos, EvidenceFormat.TreeEntry,
+                "Element structure: type, automation id, bounds, state, and source location (no text or property values)",
+                projected.Count, EvidenceJson.SerializeToUtf8(projected));
+        }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex))
+        {
+            exclusions.Add(new EvidenceExclusion(EvidenceFormat.TreeEntry, $"Visual tree unavailable: {Describe(ex)}"));
+        }
+
+        exclusions.Add(new EvidenceExclusion(EvidenceFormat.ProblemsEntry,
+            "The current agent API does not expose runtime Problems. Layout findings and logs are captured separately."));
+
+        // ── layout ───────────────────────────────────────────────────────────────────────────
+        // Additive and capability-gated: an agent that predates layout diagnostics returns null,
+        // which becomes an explicit exclusion instead of a failed capture.
+        try
+        {
+            var report = await source.GetLayoutDiagnosticsAsync(ct);
+            if (report is null)
+            {
+                exclusions.Add(new EvidenceExclusion(EvidenceFormat.LayoutEntry,
+                    "The connected agent does not support layout diagnostics."));
+            }
+            else
+            {
+                var projected = ProjectLayout(report, options.ProjectRoot);
+                counts.LayoutFindings = projected.FindingCount;
+                counts.LayoutViolations = projected.Violations;
+                if (projected.FindingsTruncated)
+                    warnings.Add($"Layout findings truncated at {EvidenceFormat.MaxLayoutFindings}.");
+                AddEntry(entries, entryInfos, EvidenceFormat.LayoutEntry,
+                    "Layout diagnostics: rule outcomes, coverage, and element identity/geometry (no text or property values)",
+                    projected.FindingCount, EvidenceJson.SerializeToUtf8(projected));
+            }
+        }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex))
+        {
+            exclusions.Add(new EvidenceExclusion(EvidenceFormat.LayoutEntry, $"Layout diagnostics unavailable: {Describe(ex)}"));
+        }
+
+        // ── logs ─────────────────────────────────────────────────────────────────────────────
+        try
+        {
+            var raw = await source.GetLogsAsync(logLimit, ct);
+            var projected = ProjectLogs(raw, logLimit);
+            counts.Logs = projected.Count;
+            AddEntry(entries, entryInfos, EvidenceFormat.LogsEntry,
+                $"Most recent {projected.Count} log entries (secrets and absolute paths scrubbed, messages truncated)",
+                projected.Count, EvidenceJson.SerializeToUtf8(projected));
+        }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex))
+        {
+            exclusions.Add(new EvidenceExclusion(EvidenceFormat.LogsEntry, $"Logs unavailable: {Describe(ex)}"));
+        }
+
+        // ── network ──────────────────────────────────────────────────────────────────────────
+        try
+        {
+            var requests = await source.GetNetworkAsync(networkLimit, ct);
+            var projected = ProjectNetwork(requests, networkLimit);
+            counts.NetworkRequests = projected.Count;
+            AddEntry(entries, entryInfos, EvidenceFormat.NetworkEntry,
+                "HTTP request summaries: method, host, path, status, timing, sizes (no headers, bodies, or query values)",
+                projected.Count, EvidenceJson.SerializeToUtf8(projected));
+        }
+        catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex))
+        {
+            exclusions.Add(new EvidenceExclusion(EvidenceFormat.NetworkEntry, $"Network capture unavailable: {Describe(ex)}"));
+        }
+
+        // ── workflow (caller-supplied markdown) ──────────────────────────────────────────────
+        // Scrubbed like every other free-form payload: a recorded or hand-written repro can still
+        // carry a token or a machine path even though a human chose to attach it.
+        var workflowTooLarge = options.WorkflowMarkdown is not null &&
+            Encoding.UTF8.GetByteCount(options.WorkflowMarkdown) > EvidenceFormat.MaxWorkflowBytes;
+        var workflow = workflowTooLarge ? null : EvidenceRedaction.Scrub(
+            SanitizeWorkflow(options.WorkflowMarkdown), (int)EvidenceFormat.MaxWorkflowBytes);
+        if (workflowTooLarge)
+        {
+            exclusions.Add(new EvidenceExclusion(EvidenceFormat.WorkflowEntry,
+                $"Workflow exceeds the {EvidenceFormat.MaxWorkflowBytes / 1024} KB limit."));
+        }
+        else if (!string.IsNullOrWhiteSpace(workflow))
+        {
+            var bytes = Encoding.UTF8.GetBytes(workflow!);
+            if (bytes.LongLength > EvidenceFormat.MaxWorkflowBytes)
+            {
+                exclusions.Add(new EvidenceExclusion(EvidenceFormat.WorkflowEntry,
+                    $"Workflow exceeds the {EvidenceFormat.MaxWorkflowBytes / 1024} KB limit."));
+            }
+            else
+            {
+                counts.WorkflowBytes = bytes.LongLength;
+                AddEntry(entries, entryInfos, EvidenceFormat.WorkflowEntry,
+                    "Reproduction steps supplied with the capture — they may quote text and values from the recorded steps",
+                    null, bytes);
+                warnings.Add("This bundle contains the reproduction steps you attached, which may quote text and values you typed.");
+            }
+        }
+        else
+        {
+            exclusions.Add(new EvidenceExclusion(EvidenceFormat.WorkflowEntry,
+                string.IsNullOrWhiteSpace(options.WorkflowMarkdown)
+                    ? "No reproduction steps were attached."
+                    : "The structured workflow could not be safely parsed and was omitted."));
+        }
+
+        // ── screenshot (opt-in only) ─────────────────────────────────────────────────────────
+        var screenshot = new EvidenceScreenshotStatus { Requested = options.IncludeScreenshot };
+        if (!options.IncludeScreenshot)
+        {
+            screenshot.OmittedReason = "Screenshots are opt-in and were not requested.";
+            exclusions.Add(new EvidenceExclusion(EvidenceFormat.ScreenshotEntry, screenshot.OmittedReason));
+        }
+        else if (options.PreviewOnly)
+        {
+            // Preview never touches the camera path; it only states the intent.
+            screenshot.Included = true;
+            warnings.Add("The screenshot is captured when the bundle is created and may show on-screen data.");
+        }
+        else
+        {
+            try
+            {
+                var png = await source.GetScreenshotAsync(ct);
+                if (png is null || png.Length == 0)
+                {
+                    screenshot.OmittedReason = "The agent returned no screenshot.";
+                    exclusions.Add(new EvidenceExclusion(EvidenceFormat.ScreenshotEntry, screenshot.OmittedReason));
+                    warnings.Add(screenshot.OmittedReason);
+                }
+                else if (png.LongLength > EvidenceFormat.MaxScreenshotBytes)
+                {
+                    screenshot.OmittedReason = "The screenshot exceeded the size limit.";
+                    exclusions.Add(new EvidenceExclusion(EvidenceFormat.ScreenshotEntry, screenshot.OmittedReason));
+                    warnings.Add(screenshot.OmittedReason);
+                }
+                else
+                {
+                    screenshot.Included = true;
+                    counts.ScreenshotBytes = png.LongLength;
+                    AddEntry(entries, entryInfos, EvidenceFormat.ScreenshotEntry,
+                        "Screen capture — included at your explicit request; it may show on-screen data", null, png);
+                    warnings.Add("This bundle contains a screenshot, which may show on-screen data.");
+                }
+            }
+            catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex))
+            {
+                screenshot.OmittedReason = $"Screenshot unavailable: {Describe(ex)}";
+                exclusions.Add(new EvidenceExclusion(EvidenceFormat.ScreenshotEntry, screenshot.OmittedReason));
+                warnings.Add(screenshot.OmittedReason);
+            }
+        }
+
+        var limits = new EvidenceLimits
+        {
+            Logs = logLimit,
+            Network = networkLimit,
+        };
+
+        var manifest = new EvidenceManifest
+        {
+            CapturedUtc = capturedUtc,
+            Source = NormalizeSource(options.Source),
+            Tool = new EvidenceToolInfo { Version = options.ToolVersion },
+            App = app,
+            Platform = platform,
+            Capabilities = capabilities,
+            Entries = entryInfos,
+            Excluded = exclusions,
+            NeverIncluded = [.. EvidenceFormat.NeverIncluded],
+            Counts = counts,
+            Limits = limits,
+            Screenshot = screenshot,
+            SelectedElementId = EvidenceRedaction.SafeIdentifier(options.SelectedElementId),
+            Warnings = warnings,
+        };
+
+        var manifestBytes = EvidenceJson.SerializeToUtf8(manifest);
+
+        var included = new List<EvidenceEntryInfo>
+        {
+            new()
+            {
+                Name = EvidenceFormat.ManifestEntry,
+                Description = "Bundle description: schema, redaction ruleset, contents, and exclusions",
+                Bytes = manifestBytes.LongLength,
+            },
+        };
+        included.AddRange(entryInfos);
+        if (options.PreviewOnly && options.IncludeScreenshot)
+        {
+            included.Add(new EvidenceEntryInfo
+            {
+                Name = EvidenceFormat.ScreenshotEntry,
+                Description = "App screenshot requested for capture; pixels and size are not collected during preview",
+            });
+        }
+
+        var plan = new EvidencePlan
+        {
+            Source = manifest.Source,
+            GeneratedUtc = capturedUtc,
+            App = app,
+            Platform = platform,
+            Environment = environment,
+            Included = included,
+            Excluded = exclusions,
+            NeverIncluded = [.. EvidenceFormat.NeverIncluded],
+            Screenshot = screenshot,
+            Counts = counts,
+            Limits = limits,
+            Warnings = warnings,
+            SuggestedFileName = EvidencePaths.BuildDefaultFileName(app?.Name, utcNow),
+            OutputPath = options.OutputPath,
+            EstimatedBytes = manifestBytes.LongLength + entries.Sum(e => e.Content.LongLength),
+            SelectedElementId = manifest.SelectedElementId,
+        };
+
+        ct.ThrowIfCancellationRequested();
+        return new EvidenceBundle
+        {
+            Manifest = manifest,
+            Plan = plan,
+            Entries = entries,
+            ManifestBytes = manifestBytes,
+        };
+    }
+
+    private static string NormalizeSource(string? source) => source?.ToLowerInvariant() switch
+    {
+        "mcp" => "mcp",
+        "inspector" => "inspector",
+        _ => "cli",
+    };
+
+    // Exception text can carry hosts, ports, and local paths — scrub before it reaches a manifest.
+    private static string Describe(Exception ex)
+        => EvidenceRedaction.Scrub(ex.Message, EvidenceFormat.MaxErrorChars) ?? ex.GetType().Name;
+
+    private static string? SanitizeWorkflow(string? markdown)
+    {
+        if (string.IsNullOrWhiteSpace(markdown))
+            return markdown;
+
+        var parsed = FlowMarkdown.Parse(markdown);
+        if (!parsed.Ok || parsed.Flow is null)
+        {
+            if (markdown.Contains("```json maui-test", StringComparison.Ordinal))
+                return null;
+            return markdown;
+        }
+        if (parsed.Flow.Schema != MauiFlow.CurrentSchema ||
+            parsed.Flow.Steps.Any(step => step is null || step.Asserts?.Any(assertion => assertion is null) == true))
+            return null;
+
+        foreach (var step in parsed.Flow.Steps)
+        {
+            RedactSelectorText(step.Target);
+            var originalArgs = step.Args;
+            RedactSelectorText(originalArgs?.Selector);
+            step.Args = SanitizeStepArgs(step.Action, originalArgs);
+
+            if (step.Action == FlowActions.Navigate)
+            {
+                step.Value = EvidenceRedaction.ScrubRoute(step.Value);
+            }
+            else if (step.Action == FlowActions.SetTheme)
+            {
+                step.Value = SanitizeTheme(step.Value);
+            }
+            else
+            {
+                step.Value = step.Value is null ? null : "<redacted>";
+            }
+            step.Page = EvidenceRedaction.ScrubRoute(step.Page);
+            step.Screenshot = EvidenceRedaction.NormalizeSourcePath(step.Screenshot, projectRoot: null);
+
+            foreach (var assertion in step.Asserts ?? [])
+            {
+                RedactSelectorText(assertion.Selector);
+                if (assertion.Kind == "routeIs")
+                    assertion.Expected = EvidenceRedaction.ScrubRoute(assertion.Expected);
+                else
+                    assertion.Expected = assertion.Expected is null ? null : "<redacted>";
+            }
+        }
+
+        return FlowMarkdown.Serialize(parsed.Flow);
+    }
+
+    private static FlowStepArgs? SanitizeStepArgs(string action, FlowStepArgs? args)
+    {
+        if (args is null)
+            return null;
+
+        var safe = new FlowStepArgs
+        {
+            Selector = args.Selector,
+        };
+        switch (action)
+        {
+            case FlowActions.Fill:
+                safe.Text = args.Text is null ? null : "<redacted>";
+                break;
+            case FlowActions.SetProperty:
+                safe.Name = EvidenceRedaction.SafeIdentifier(args.Name);
+                safe.Value = args.Value is null ? null : "<redacted>";
+                break;
+            case FlowActions.Navigate:
+                safe.Route = EvidenceRedaction.ScrubRoute(args.Route);
+                break;
+            case FlowActions.SetTheme:
+                safe.Theme = SanitizeTheme(args.Theme);
+                break;
+            case FlowActions.Scroll:
+                safe.Element = EvidenceRedaction.SafeIdentifier(args.Element);
+                safe.Dx = args.Dx;
+                safe.Dy = args.Dy;
+                safe.ItemIndex = args.ItemIndex;
+                safe.Position = EvidenceRedaction.SafeIdentifier(args.Position, 32);
+                safe.Animated = args.Animated;
+                break;
+        }
+
+        return safe;
+    }
+
+    private static string? SanitizeTheme(string? value)
+        => value?.Trim().ToLowerInvariant() is "light" or "dark" or "system"
+            ? value.Trim().ToLowerInvariant()
+            : null;
+
+    private static void RedactSelectorText(FlowSelector? selector)
+    {
+        if (selector?.Text is not null)
+            selector.Text = "<redacted>";
+    }
+
+    private static void AddEntry(
+        List<EvidenceBundleEntry> entries,
+        List<EvidenceEntryInfo> infos,
+        string name,
+        string description,
+        int? count,
+        byte[] content)
+    {
+        entries.Add(new EvidenceBundleEntry(name, content));
+        infos.Add(new EvidenceEntryInfo
+        {
+            Name = name,
+            Description = description,
+            Count = count,
+            Bytes = content.LongLength,
+            Sha256 = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant(),
+        });
+    }
+
+    // ── projections ──────────────────────────────────────────────────────────────────────────
+
+    internal static List<string> ProjectCapabilities(JsonElement element)
+    {
+        var result = new List<string>();
+        if (element.ValueKind != JsonValueKind.Object || element.TryGetProperty("error", out _))
+            throw new InvalidDataException("The agent did not return capability metadata.");
+
+        var container = element.TryGetProperty("capabilities", out var caps) && caps.ValueKind == JsonValueKind.Object
+            ? caps
+            : element;
+
+        foreach (var property in container.EnumerateObject())
+        {
+            if (property.Value.ValueKind is not (JsonValueKind.True or JsonValueKind.Object) ||
+                (property.Value.ValueKind == JsonValueKind.Object &&
+                 property.Value.TryGetProperty("supported", out var supported) && supported.ValueKind == JsonValueKind.False))
+                continue;
+            var name = EvidenceRedaction.SafeIdentifier(property.Name, 64);
+            if (name is not null) result.Add(name);
+            if (result.Count >= 64) break;
+        }
+
+        result.Sort(StringComparer.Ordinal);
+        return result;
+    }
+
+    internal static EvidenceDeviceInfo? ProjectDevice(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object) return null;
+        var device = new EvidenceDeviceInfo
+        {
+            Manufacturer = SafeString(element, "manufacturer"),
+            Model = SafeString(element, "model"),
+            Platform = SafeString(element, "platform"),
+            OsVersion = SafeString(element, "osVersion") ?? SafeString(element, "version"),
+            Idiom = SafeString(element, "idiom"),
+            DeviceType = SafeString(element, "deviceType"),
+            Architecture = SafeString(element, "architecture"),
+        };
+        return device.Manufacturer is null && device.Model is null && device.Platform is null &&
+               device.OsVersion is null && device.Idiom is null && device.DeviceType is null &&
+               device.Architecture is null
+            ? null
+            : device;
+    }
+
+    internal static EvidenceDisplayInfo? ProjectDisplay(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object) return null;
+        var display = new EvidenceDisplayInfo
+        {
+            Width = PositiveNumber(SafeNumber(element, "width")),
+            Height = PositiveNumber(SafeNumber(element, "height")),
+            Density = PositiveNumber(SafeNumber(element, "density")),
+            Orientation = SafeString(element, "orientation"),
+            Rotation = SafeString(element, "rotation"),
+            RefreshRate = PositiveNumber(SafeNumber(element, "refreshRate")),
+        };
+        return display.Width is null && display.Height is null && display.Density is null &&
+               display.Orientation is null && display.Rotation is null && display.RefreshRate is null
+            ? null
+            : display;
+    }
+
+    internal static EvidenceThemeInfo? ProjectTheme(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object) return null;
+        var theme = new EvidenceThemeInfo
+        {
+            Effective = SanitizeTheme(ReadString(element, "effectiveTheme")) ??
+                SanitizeTheme(ReadString(element, "theme")),
+            Requested = SanitizeTheme(ReadString(element, "requestedTheme")),
+            AppOverride = SanitizeTheme(ReadString(element, "userAppTheme")),
+        };
+        return theme.Effective is null && theme.Requested is null && theme.AppOverride is null ? null : theme;
+    }
+
+    internal static EvidenceConnectivityInfo? ProjectConnectivity(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object) return null;
+        var access = ReadString(element, "networkAccess");
+        var connectivity = new EvidenceConnectivityInfo
+        {
+            NetworkAccess = access is "Unknown" or "None" or "Local" or "ConstrainedInternet" or "Internet" ? access : null,
+        };
+        if (element.TryGetProperty("connectionProfiles", out var profiles) && profiles.ValueKind == JsonValueKind.Array)
+        {
+            connectivity.ConnectionProfiles = profiles.EnumerateArray()
+                .Where(value => value.ValueKind == JsonValueKind.String)
+                .Select(value => value.GetString())
+                .OfType<string>()
+                .Where(value => value is "Unknown" or "Bluetooth" or "Cellular" or "Ethernet" or "WiFi")
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToList();
+        }
+        return connectivity.NetworkAccess is null && connectivity.ConnectionProfiles.Count == 0 ? null : connectivity;
+    }
+
+    private static double? PositiveNumber(double? value)
+        => value is > 0 && double.IsFinite(value.Value) ? value : null;
+
+    private static List<EvidenceExclusion> EnvironmentGaps(EvidenceEnvironment environment)
+    {
+        var gaps = new List<EvidenceExclusion>
+        {
+            new("runtime", "The target runtime version is not exposed by this agent API. Framework version is not a runtime version."),
+            new("locale", "The target app locale is not exposed by this agent API."),
+            new("fontScale", "The target font scale and accessibility text settings are not exposed by this agent API."),
+            new("permissions", "Permission states are not collected. Capture never requests or changes permissions."),
+            new("networkConditions", "Connectivity is an observation, not a latency, bandwidth, packet-loss, proxy, or offline-test contract."),
+        };
+        if (MissingFact(environment.App?.Build))
+            gaps.Add(new("appBuild", "The agent did not report an app build."));
+        if (MissingFact(environment.Device?.OsVersion))
+            gaps.Add(new("osVersion", "The agent did not report the target OS version."));
+        if (MissingFact(environment.Device?.Model))
+            gaps.Add(new("deviceModel", "The agent did not report a device model."));
+        if (environment.Device?.DeviceType is null && environment.Platform?.DeviceType is null)
+            gaps.Add(new("deviceType", "The agent did not distinguish a physical device from a virtual device."));
+        if (environment.Display?.Width is null || environment.Display.Height is null)
+            gaps.Add(new("display", "The agent did not report valid display dimensions."));
+        if (environment.Display?.Orientation is null)
+            gaps.Add(new("orientation", "The agent did not report display orientation."));
+        if (environment.Display?.Rotation is null)
+            gaps.Add(new("rotation", "The agent did not report display rotation."));
+        if (environment.Viewport?.Width is null || environment.Viewport.Height is null)
+            gaps.Add(new("viewport", "The agent did not report valid app-window dimensions. Display dimensions are not a viewport."));
+        if (environment.Viewport?.Density is null)
+            gaps.Add(new("density", "The agent did not report app-window density. Display density is not substituted."));
+        if (environment.Viewport?.WindowCount is > 1)
+            gaps.Add(new("windowSelection", "Multiple app windows were reported. This capture observes the agent's default window."));
+        if (environment.Theme?.Effective is not ("light" or "dark"))
+            gaps.Add(new("theme", "The agent did not report an effective light or dark app theme."));
+        if (environment.Connectivity?.NetworkAccess is null or "Unknown")
+            gaps.Add(new("connectivity", "The agent did not report a known network-access state."));
+        return gaps;
+    }
+
+    private static bool MissingFact(string? value)
+        => string.IsNullOrWhiteSpace(value) || string.Equals(value, "unknown", StringComparison.OrdinalIgnoreCase);
+
+    private static string? SafeString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? EvidenceRedaction.SafeIdentifier(value.GetString())
+            : null;
+
+    private static double? SafeNumber(JsonElement element, string name)
+        => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Number &&
+           value.TryGetDouble(out var number)
+            ? number
+            : null;
+
+    /// <summary>
+    /// Projects the agent's visual tree into structure-only nodes. Text, Value, native and
+    /// framework property dictionaries, and absolute source paths never leave this method.
+    /// </summary>
+    internal static EvidenceTreeDocument ProjectTree(IEnumerable<ElementInfo>? roots, string? projectRoot)
+    {
+        var document = new EvidenceTreeDocument { MaxDepth = EvidenceFormat.MaxTreeDepth };
+        if (roots is null) return document;
+
+        var budget = EvidenceFormat.MaxTreeElements;
+        document.Roots = ProjectNodes(roots, projectRoot, 0, ref budget, document);
+        document.Count = EvidenceFormat.MaxTreeElements - budget;
+        return document;
+    }
+
+    private static List<EvidenceTreeNode> ProjectNodes(
+        IEnumerable<ElementInfo> elements,
+        string? projectRoot,
+        int depth,
+        ref int budget,
+        EvidenceTreeDocument document)
+    {
+        var result = new List<EvidenceTreeNode>();
+        foreach (var element in elements)
+        {
+            if (budget <= 0)
+            {
+                document.Truncated = true;
+                break;
+            }
+            if (depth >= EvidenceFormat.MaxTreeDepth)
+            {
+                document.Truncated = true;
+                break;
+            }
+
+            budget--;
+            var node = new EvidenceTreeNode
+            {
+                Id = EvidenceRedaction.SafeIdentifier(element.Id) ?? "",
+                Type = EvidenceRedaction.SafeIdentifier(element.Type) ?? "",
+                Framework = EvidenceRedaction.SafeIdentifier(element.Framework),
+                AutomationId = EvidenceRedaction.SafeIdentifier(element.AutomationId),
+                Role = EvidenceRedaction.SafeIdentifier(element.Role),
+                Visible = element.IsVisible,
+                Enabled = element.IsEnabled,
+                Focused = element.IsFocused,
+                Selected = element.IsSelected ? true : null,
+                Bounds = element.Bounds is null ? null : new EvidenceBounds
+                {
+                    X = element.Bounds.X,
+                    Y = element.Bounds.Y,
+                    Width = element.Bounds.Width,
+                    Height = element.Bounds.Height,
+                },
+                SourceFile = EvidenceRedaction.NormalizeSourcePath(element.SourceFile, projectRoot),
+                SourceLine = element.SourceLine,
+                SourceColumn = element.SourceColumn,
+                SourceHash = EvidenceRedaction.SafeIdentifier(element.SourceHash, 64),
+                ChildCount = element.Children?.Count ?? 0,
+            };
+
+            if (element.Children is { Count: > 0 })
+            {
+                var children = ProjectNodes(element.Children, projectRoot, depth + 1, ref budget, document);
+                node.Children = children.Count > 0 ? children : null;
+            }
+
+            result.Add(node);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Projects a layout report into the bundle's safe shape.
+    ///
+    /// The agent's report already carries no text or property values, but this projection is still
+    /// default-deny: only the fields listed here are copied, identifiers are re-checked, source
+    /// paths are made project-relative (or reduced to a file name), and free-form strings are
+    /// scrubbed and truncated exactly like every other bundle payload.
+    /// </summary>
+    internal static EvidenceLayoutDocument ProjectLayout(LayoutInspectionResult? report, string? projectRoot)
+    {
+        var document = new EvidenceLayoutDocument();
+        if (report is null) return document;
+
+        document.SchemaVersion = EvidenceRedaction.SafeIdentifier(report.SchemaVersion, 32) ?? "";
+        document.RuleSetVersion = EvidenceRedaction.SafeIdentifier(report.RuleSetVersion, 32) ?? "";
+        document.CapturedUtc = EvidenceRedaction.SafeIdentifier(report.Snapshot?.CapturedAt, 40);
+        document.Platform = EvidenceRedaction.SafeIdentifier(report.Snapshot?.Platform, 64);
+        document.SnapshotId = EvidenceRedaction.SafeIdentifier(report.Snapshot?.Id, 160);
+        document.TreeRevision = EvidenceRedaction.SafeIdentifier(report.Snapshot?.TreeRevision, 160);
+        document.DiagnosticsRevision = EvidenceRedaction.SafeIdentifier(report.Snapshot?.DiagnosticsRevision, 160);
+        document.Stable = report.Snapshot?.Stable ?? false;
+        document.ElementsExamined = report.Snapshot?.NodeCount ?? 0;
+        document.Violations = report.Summary?.Violations ?? 0;
+        document.Observations = report.Summary?.Observations ?? 0;
+        document.Incomplete = report.Summary?.Incomplete ?? 0;
+        document.Passes = report.Summary?.Passes ?? 0;
+        document.NotApplicable = report.Summary?.NotApplicable ?? 0;
+        document.Suppressed = report.Summary?.Suppressed ?? 0;
+        document.Coverage = EvidenceRedaction.SafeIdentifier(report.Coverage?.Overall, 32) ?? "unavailable";
+
+        foreach (var rule in (report.Coverage?.Rules ?? []).Take(64))
+        {
+            document.Rules.Add(new EvidenceLayoutRule
+            {
+                RuleId = EvidenceRedaction.SafeIdentifier(rule.RuleId, 64) ?? "",
+                Support = EvidenceRedaction.SafeIdentifier(rule.Support, 32) ?? "unavailable",
+                Confidence = EvidenceRedaction.SafeIdentifier(rule.Confidence, 32) ?? "medium",
+            });
+        }
+
+        var findings = report.Findings ?? [];
+        document.FindingsTruncated = findings.Count > EvidenceFormat.MaxLayoutFindings;
+        foreach (var finding in findings.Take(EvidenceFormat.MaxLayoutFindings))
+        {
+            document.Findings.Add(new EvidenceLayoutFinding
+            {
+                Id = EvidenceRedaction.SafeIdentifier(finding.Id, 160) ?? "",
+                RuleId = EvidenceRedaction.SafeIdentifier(finding.RuleId, 64) ?? "",
+                Outcome = EvidenceRedaction.SafeIdentifier(finding.Outcome, 32) ?? "observation",
+                Confidence = EvidenceRedaction.SafeIdentifier(finding.Confidence, 32) ?? "medium",
+                Severity = EvidenceRedaction.SafeIdentifier(finding.Severity, 32) ?? "info",
+                Actionability = EvidenceRedaction.SafeIdentifier(finding.Actionability, 32) ?? "review",
+                SuppressionKey = EvidenceRedaction.SafeIdentifier(finding.SuppressionKey, 160),
+                Suppressed = finding.Suppressed,
+                SuppressionReason = EvidenceRedaction.Scrub(
+                    finding.SuppressionReason,
+                    EvidenceFormat.MaxLayoutTextChars),
+                Message = EvidenceRedaction.Scrub(finding.Message, EvidenceFormat.MaxLayoutTextChars) ?? "",
+                ElementId = EvidenceRedaction.SafeIdentifier(finding.Element?.Id),
+                ElementType = EvidenceRedaction.SafeIdentifier(finding.Element?.Type),
+                AutomationId = EvidenceRedaction.SafeIdentifier(finding.Element?.AutomationId),
+                SourceFile = EvidenceRedaction.NormalizeSourcePath(finding.Element?.SourceFile, projectRoot),
+                SourceLine = finding.Element?.SourceLine,
+                SourceColumn = finding.Element?.SourceColumn,
+                Bounds = ToEvidenceBounds(finding.Evidence?.FullRegion?.Bounds),
+                RelatedElementIds = [.. (finding.RelatedElements ?? [])
+                    .Take(64)
+                    .Select(related => EvidenceRedaction.SafeIdentifier(related.Element?.Id))
+                    .Where(id => id is not null)
+                    .Select(id => id!)],
+                FixCategories = [.. (finding.FixCategories ?? [])
+                    .Take(64)
+                    .Select(category => EvidenceRedaction.SafeIdentifier(category, 64))
+                    .Where(category => category is not null)
+                    .Select(category => category!)],
+                Limitations = [.. (finding.Evidence?.Limitations ?? [])
+                    .Take(64)
+                    .Select(limitation => EvidenceRedaction.Scrub(limitation, EvidenceFormat.MaxLayoutTextChars))
+                    .Where(limitation => !string.IsNullOrEmpty(limitation))
+                    .Select(limitation => limitation!)],
+            });
+        }
+
+        document.FindingCount = document.Findings.Count;
+        document.Limitations = [.. (report.Coverage?.Limitations ?? [])
+            .Take(256)
+            .Select(limitation => EvidenceRedaction.Scrub(limitation, EvidenceFormat.MaxLayoutTextChars))
+            .Where(limitation => !string.IsNullOrEmpty(limitation))
+            .Select(limitation => limitation!)];
+        document.NeverCaptured = ["Element Text/Value content", "Native and framework property dictionaries"];
+        return document;
+    }
+
+    private static EvidenceBounds? ToEvidenceBounds(LayoutRectInfo? rect)
+        => rect is null ? null : new EvidenceBounds
+        {
+            X = rect.X,
+            Y = rect.Y,
+            Width = rect.Width,
+            Height = rect.Height,
+        };
+
+    /// <summary>Parses the agent's compact log array (<c>{t,l,c,m,e,s}</c>) into bounded, scrubbed entries.</summary>
+    internal static EvidenceLogDocument ProjectLogs(string? rawJson, int limit)
+    {
+        var document = new EvidenceLogDocument { Limit = limit };
+        if (string.IsNullOrWhiteSpace(rawJson))
+            throw new InvalidDataException("The agent did not return a log payload.");
+
+        var parsed = JsonDocument.Parse(rawJson);
+        using (parsed)
+        {
+            if (parsed.RootElement.ValueKind != JsonValueKind.Array)
+                throw new InvalidDataException("The agent did not return a log array.");
+
+            foreach (var item in parsed.RootElement.EnumerateArray())
+            {
+                if (document.Entries.Count >= limit)
+                {
+                    document.Truncated = true;
+                    break;
+                }
+                if (item.ValueKind != JsonValueKind.Object)
+                    throw new InvalidDataException("The agent returned an invalid log entry.");
+
+                document.Entries.Add(new EvidenceLogEntry
+                {
+                    Timestamp = SafeString(item, "t"),
+                    Level = SafeString(item, "l"),
+                    Category = EvidenceRedaction.SafeIdentifier(ReadString(item, "c"), 256),
+                    Message = EvidenceRedaction.Scrub(ReadString(item, "m"), EvidenceFormat.MaxLogMessageChars) ?? "",
+                    Exception = EvidenceRedaction.Scrub(ReadString(item, "e"), EvidenceFormat.MaxLogMessageChars),
+                    Source = EvidenceRedaction.SafeIdentifier(ReadString(item, "s"), 32),
+                });
+            }
+        }
+
+        document.Count = document.Entries.Count;
+        return document;
+    }
+
+    private static string? ReadString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    /// <summary>
+    /// Projects captured HTTP traffic to summary metadata. Query VALUES, headers, and bodies are
+    /// dropped entirely; only parameter names survive.
+    /// </summary>
+    internal static EvidenceNetworkDocument ProjectNetwork(IEnumerable<NetworkRequest>? requests, int limit)
+    {
+        var document = new EvidenceNetworkDocument { Limit = limit };
+        if (requests is null) return document;
+
+        var sequence = 0;
+        foreach (var request in requests)
+        {
+            if (document.Requests.Count >= limit) break;
+            sequence++;
+
+            var (path, queryKeys) = SplitPath(request.Path, request.Url);
+            document.Requests.Add(new EvidenceNetworkEntry
+            {
+                Sequence = sequence,
+                Timestamp = request.Timestamp == default
+                    ? null
+                    : request.Timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture),
+                Method = EvidenceRedaction.SafeIdentifier(request.Method, 16) ?? "",
+                Host = EvidenceRedaction.SafeIdentifier(request.Host ?? TryHost(request.Url), 256),
+                Path = path,
+                QueryKeys = queryKeys.Count > 0 ? queryKeys : null,
+                StatusCode = request.StatusCode,
+                StatusText = EvidenceRedaction.SafeIdentifier(request.StatusText, 64),
+                DurationMs = request.DurationMs,
+                RequestBytes = request.RequestSize,
+                ResponseBytes = request.ResponseSize,
+                RequestContentType = EvidenceRedaction.SafeIdentifier(request.RequestContentType, 128),
+                ResponseContentType = EvidenceRedaction.SafeIdentifier(request.ResponseContentType, 128),
+                Error = EvidenceRedaction.Scrub(request.Error, EvidenceFormat.MaxErrorChars),
+            });
+        }
+
+        document.Count = document.Requests.Count;
+        return document;
+    }
+
+    private static string? TryHost(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return null;
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.Host : null;
+    }
+
+    /// <summary>Returns the path without any query, plus the sorted set of query parameter NAMES.</summary>
+    internal static (string? Path, List<string> QueryKeys) SplitPath(string? path, string? url)
+    {
+        var raw = path;
+        if (string.IsNullOrWhiteSpace(raw) && !string.IsNullOrWhiteSpace(url))
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                raw = uri.PathAndQuery;
+            else
+                raw = url;
+        }
+        if (string.IsNullOrWhiteSpace(raw)) return (null, []);
+
+        var value = raw!;
+        var fragment = value.IndexOf('#');
+        if (fragment >= 0) value = value[..fragment];
+
+        var keys = new List<string>();
+        var question = value.IndexOf('?');
+        if (question >= 0)
+        {
+            var query = value[(question + 1)..];
+            value = value[..question];
+            foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (keys.Count >= EvidenceFormat.MaxQueryKeys) break;
+                var equals = pair.IndexOf('=');
+                var key = equals >= 0 ? pair[..equals] : pair;
+                var safe = EvidenceRedaction.SafeIdentifier(key, 64);
+                if (safe is not null && !keys.Contains(safe, StringComparer.Ordinal))
+                    keys.Add(safe);
+            }
+            keys.Sort(StringComparer.Ordinal);
+        }
+
+        return (EvidenceRedaction.SafeIdentifier(value, 512), keys);
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceBundleReader.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceBundleReader.cs
@@ -1,0 +1,799 @@
+using System.IO.Compression;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>Everything a validated bundle yielded. Any field may be null if the entry was absent.</summary>
+internal sealed class EvidenceReadResult
+{
+    public bool Ok { get; init; }
+    public string? Error { get; init; }
+    public string? Path { get; init; }
+    public EvidenceManifest? Manifest { get; init; }
+    public EvidenceEnvironment? Environment { get; init; }
+    public EvidenceTreeDocument? Tree { get; init; }
+    public EvidenceLayoutDocument? Layout { get; init; }
+    public EvidenceProblemDocument? Problems { get; init; }
+    public EvidenceLogDocument? Logs { get; init; }
+    public EvidenceNetworkDocument? Network { get; init; }
+    public string? Workflow { get; init; }
+    public byte[]? Screenshot { get; init; }
+    public List<string> Entries { get; init; } = [];
+    public List<string> Warnings { get; init; } = [];
+
+    public static EvidenceReadResult Fail(string error, string? path = null)
+        => new() { Ok = false, Error = error, Path = path };
+}
+
+/// <summary>
+/// Reads a <c>.mauitrace</c> bundle as HOSTILE input.
+///
+/// Every structural property is checked before any content is decompressed: entry names are
+/// allow-listed and must be flat (no separators, traversal, or rooted paths), entries may not
+/// repeat, and entry count / per-entry size / total size / compression ratio are all bounded.
+/// Content is then parsed with a strict shape check. Nothing in a bundle is ever executed —
+/// <c>workflow.md</c> is treated as inert text and the report is regenerated from scratch.
+/// </summary>
+internal static class EvidenceBundleReader
+{
+    public static EvidenceReadResult Read(string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        FileInfo info;
+        try
+        {
+            info = new FileInfo(path);
+            if (!info.Exists) return EvidenceReadResult.Fail($"Bundle not found: {path}", path);
+            if (info.Length == 0) return EvidenceReadResult.Fail("Bundle is empty.", path);
+            if (info.Length > EvidenceFormat.MaxBundleFileBytes)
+                return EvidenceReadResult.Fail("Bundle is larger than the supported maximum.", path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return EvidenceReadResult.Fail($"Could not open the bundle: {ex.Message}", path);
+        }
+
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return Read(stream, path, cancellationToken);
+        }
+        catch (InvalidDataException)
+        {
+            return EvidenceReadResult.Fail("Bundle is not a readable evidence archive.", path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return EvidenceReadResult.Fail($"Could not read the bundle: {ex.Message}", path);
+        }
+    }
+
+    public static EvidenceReadResult Read(
+        Stream stream,
+        string? path = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!stream.CanSeek)
+        {
+            using var buffered = new MemoryStream();
+            var chunk = new byte[81_920];
+            int read;
+            while ((read = stream.Read(chunk, 0, chunk.Length)) > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (buffered.Length + read > EvidenceFormat.MaxBundleFileBytes)
+                    return EvidenceReadResult.Fail("Bundle is larger than the supported maximum.", path);
+                buffered.Write(chunk, 0, read);
+            }
+            buffered.Position = 0;
+            return Read(buffered, path, cancellationToken);
+        }
+        if (stream.Length - stream.Position > EvidenceFormat.MaxBundleFileBytes)
+            return EvidenceReadResult.Fail("Bundle is larger than the supported maximum.", path);
+
+        ZipArchive archive;
+        try
+        {
+            archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+        }
+        catch (InvalidDataException)
+        {
+            return EvidenceReadResult.Fail("Bundle is not a readable evidence archive.", path);
+        }
+
+        using (archive)
+        {
+            try
+            {
+                return ReadArchive(archive, path, cancellationToken);
+            }
+            catch (EvidenceReadException ex)
+            {
+                return EvidenceReadResult.Fail(ex.Message, path);
+            }
+            catch (InvalidDataException)
+            {
+                // Corrupt deflate stream or CRC mismatch mid-entry.
+                return EvidenceReadResult.Fail("Bundle is not a readable evidence archive.", path);
+            }
+        }
+    }
+
+    private static EvidenceReadResult ReadArchive(
+        ZipArchive archive,
+        string? path,
+        CancellationToken cancellationToken)
+    {
+        {
+            if (archive.Entries.Count == 0)
+                return EvidenceReadResult.Fail("Bundle contains no entries.", path);
+            if (archive.Entries.Count > EvidenceFormat.MaxBundleEntries)
+                return EvidenceReadResult.Fail("Bundle contains too many entries.", path);
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            long declaredTotal = 0;
+
+            // Cheap pre-filter over the central directory. Everything here is attacker-declared, so
+            // the real limits are enforced against the actual decompressed bytes in ReadBounded.
+            foreach (var entry in archive.Entries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var nameError = ValidateEntryName(entry.FullName);
+                if (nameError is not null) return EvidenceReadResult.Fail(nameError, path);
+                if (!seen.Add(entry.FullName))
+                    return EvidenceReadResult.Fail($"Bundle contains duplicate entry '{entry.FullName}'.", path);
+
+                var entryLimit = EntryLimit(entry.FullName);
+                if (entry.Length < 0 || entry.Length > entryLimit)
+                    return EvidenceReadResult.Fail($"Entry '{entry.FullName}' is larger than the supported maximum.", path);
+
+                declaredTotal += entry.Length;
+                if (declaredTotal > EvidenceFormat.MaxTotalUncompressedBytes)
+                    return EvidenceReadResult.Fail("Bundle expands beyond the supported maximum size.", path);
+            }
+
+            var budget = new ReadBudget();
+
+            var manifestEntry = archive.GetEntry(EvidenceFormat.ManifestEntry);
+            if (manifestEntry is null)
+                return EvidenceReadResult.Fail("Bundle is missing manifest.json.", path);
+
+            var manifestJson = DecodeUtf8(ReadBounded(
+                manifestEntry,
+                budget,
+                EntryLimit(EvidenceFormat.ManifestEntry),
+                cancellationToken));
+            if (manifestJson is null) return EvidenceReadResult.Fail("manifest.json is not valid UTF-8 text.", path);
+
+            var manifestError = ValidateManifestShape(manifestJson);
+            if (manifestError is not null) return EvidenceReadResult.Fail(manifestError, path);
+
+            EvidenceManifest? manifest;
+            try { manifest = EvidenceJson.Deserialize<EvidenceManifest>(manifestJson); }
+            catch (JsonException) { return EvidenceReadResult.Fail("manifest.json could not be parsed.", path); }
+            if (manifest is null) return EvidenceReadResult.Fail("manifest.json could not be parsed.", path);
+
+            var warnings = new List<string>();
+            var contents = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            foreach (var entry in archive.Entries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (entry.FullName == EvidenceFormat.ManifestEntry)
+                    continue;
+                contents[entry.FullName] = ReadBounded(
+                    entry,
+                    budget,
+                    EntryLimit(entry.FullName),
+                    cancellationToken);
+            }
+
+            var integrityError = ValidateManifestEntries(manifest, contents);
+            if (integrityError is not null)
+                return EvidenceReadResult.Fail(integrityError, path);
+
+            var environment = ReadJsonEntry<EvidenceEnvironment>(contents, EvidenceFormat.EnvironmentEntry, warnings);
+            var tree = ReadJsonEntry<EvidenceTreeDocument>(contents, EvidenceFormat.TreeEntry, warnings);
+            var layout = ReadJsonEntry<EvidenceLayoutDocument>(contents, EvidenceFormat.LayoutEntry, warnings);
+            var problems = ReadJsonEntry<EvidenceProblemDocument>(contents, EvidenceFormat.ProblemsEntry, warnings);
+            var logs = ReadJsonEntry<EvidenceLogDocument>(contents, EvidenceFormat.LogsEntry, warnings);
+            var network = ReadJsonEntry<EvidenceNetworkDocument>(contents, EvidenceFormat.NetworkEntry, warnings);
+            if (contents.ContainsKey(EvidenceFormat.DeviceEntry))
+                warnings.Add("device.json workflow/device metadata is not rendered by the standalone evidence viewer.");
+
+            string? workflow = null;
+            if (contents.TryGetValue(EvidenceFormat.WorkflowEntry, out var workflowBytes))
+            {
+                if (workflowBytes.LongLength > EvidenceFormat.MaxWorkflowBytes)
+                {
+                    warnings.Add("workflow.md was ignored: it exceeds the workflow size limit.");
+                }
+                else
+                {
+                    workflow = DecodeUtf8(workflowBytes);
+                    if (workflow is null) warnings.Add("workflow.md was ignored: it is not valid UTF-8 text.");
+                }
+            }
+
+            byte[]? screenshot = null;
+            if (contents.TryGetValue(EvidenceFormat.ScreenshotEntry, out var screenshotBytes))
+            {
+                if (screenshotBytes.LongLength > EvidenceFormat.MaxScreenshotBytes)
+                    warnings.Add("screenshot.png was ignored: it exceeds the screenshot size limit.");
+                else if (!IsPng(screenshotBytes)) warnings.Add("screenshot.png was ignored: it is not a PNG image.");
+                else screenshot = screenshotBytes;
+            }
+
+            return new EvidenceReadResult
+            {
+                Ok = true,
+                Path = path,
+                Manifest = manifest,
+                Environment = environment,
+                Tree = tree,
+                Layout = layout,
+                Problems = problems,
+                Logs = logs,
+                Network = network,
+                Workflow = workflow,
+                Screenshot = screenshot,
+                Entries = [.. archive.Entries.Select(e => e.FullName).OrderBy(n => n, StringComparer.Ordinal)],
+                Warnings = warnings,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Entry names must be one of the allow-listed flat names. This rejects traversal
+    /// (<c>../</c>), rooted paths, drive letters, nested directories, and unknown files outright.
+    /// </summary>
+    internal static string? ValidateEntryName(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return "Bundle contains an entry with no name.";
+        if (name.Length > 128)
+            return "Bundle contains an entry name that is too long.";
+        if (name.Contains('\0') || name.Any(char.IsControl))
+            return "Bundle contains an entry name with invalid characters.";
+        if (name.Contains('/') || name.Contains('\\'))
+            return $"Bundle contains a nested or traversing entry '{name}'.";
+        if (name.Contains("..", StringComparison.Ordinal))
+            return $"Bundle contains a traversing entry '{name}'.";
+        if (name.Length >= 2 && name[1] == ':')
+            return $"Bundle contains a rooted entry '{name}'.";
+        if (!EvidenceFormat.AllowedEntries.Contains(name, StringComparer.Ordinal))
+            return $"Bundle contains an unexpected entry '{name}'.";
+        return null;
+    }
+
+    /// <summary>Structural check of manifest.json before it is bound to the typed model.</summary>
+    internal static string? ValidateManifestShape(string json)
+    {
+        JsonDocument document;
+        try { document = JsonDocument.Parse(json, new JsonDocumentOptions { MaxDepth = EvidenceJson.MaxJsonDepth }); }
+        catch (JsonException) { return "manifest.json is not valid JSON."; }
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return "manifest.json must be a JSON object.";
+
+            if (!root.TryGetProperty("schema", out var schema) || schema.ValueKind != JsonValueKind.String ||
+                !string.Equals(schema.GetString(), EvidenceFormat.SchemaId, StringComparison.Ordinal))
+            {
+                return "manifest.json is not a MAUI DevFlow evidence manifest.";
+            }
+
+            if (!root.TryGetProperty("formatVersion", out var version) || version.ValueKind != JsonValueKind.Number ||
+                !version.TryGetInt32(out var formatVersion))
+            {
+                return "manifest.json is missing a numeric formatVersion.";
+            }
+            if (formatVersion != EvidenceFormat.Version)
+                return $"Unsupported evidence format version {formatVersion} (this tool reads version {EvidenceFormat.Version}).";
+
+            if (!root.TryGetProperty("capturedUtc", out var captured) || captured.ValueKind != JsonValueKind.String)
+                return "manifest.json is missing capturedUtc.";
+
+            if (root.TryGetProperty("entries", out var entries) && entries.ValueKind != JsonValueKind.Array)
+                return "manifest.json entries must be an array.";
+        }
+
+        return null;
+    }
+
+    private static string? ValidateManifestEntries(
+        EvidenceManifest manifest,
+        IReadOnlyDictionary<string, byte[]> contents)
+    {
+        if (manifest.Entries is null)
+            return "manifest.json entries are missing.";
+        if (manifest.Capabilities is null || manifest.Excluded is null ||
+            manifest.NeverIncluded is null || manifest.Warnings is null)
+        {
+            return "manifest.json contains null collections.";
+        }
+        if (manifest.Capabilities.Count > 64 || manifest.Excluded.Count > EvidenceFormat.MaxBundleEntries ||
+            manifest.NeverIncluded.Count > 64 || manifest.Warnings.Count > 256)
+        {
+            return "manifest.json contains an oversized collection.";
+        }
+        if (InvalidText(manifest.CapturedUtc, 64) ||
+            !DateTimeOffset.TryParse(
+                manifest.CapturedUtc,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out _) ||
+            manifest.Source is not ("cli" or "mcp" or "inspector") ||
+            InvalidText(manifest.SelectedElementId, EvidenceFormat.MaxIdentifierChars))
+        {
+            return "manifest.json contains invalid source, timestamp, or text metadata.";
+        }
+        if (manifest.Excluded.Any(static exclusion =>
+                exclusion is null ||
+                InvalidText(exclusion.Name, 128) ||
+                InvalidText(exclusion.Reason, 1_000)) ||
+            manifest.Capabilities.Any(static value => InvalidText(value, 128)) ||
+            manifest.NeverIncluded.Any(static value => InvalidText(value, 256)) ||
+            manifest.Warnings.Any(static value => InvalidText(value, 2_000)))
+        {
+            return "manifest.json contains oversized metadata.";
+        }
+        if (!ValidApp(manifest.App) || !ValidPlatform(manifest.Platform))
+            return "manifest.json contains invalid app or platform metadata.";
+
+        var manifestEntries = new Dictionary<string, EvidenceEntryInfo>(StringComparer.Ordinal);
+        foreach (var entry in manifest.Entries)
+        {
+            if (entry is null)
+                return "manifest.json describes a null evidence entry.";
+            if (string.IsNullOrWhiteSpace(entry.Name)
+                || !EvidenceFormat.AllowedEntries.Contains(entry.Name, StringComparer.Ordinal)
+                || entry.Name == EvidenceFormat.ManifestEntry)
+            {
+                return "manifest.json describes an invalid evidence entry.";
+            }
+            if (!manifestEntries.TryAdd(entry.Name, entry))
+                return $"manifest.json describes duplicate entry '{entry.Name}'.";
+            if (entry.Bytes < 0 || entry.Bytes > EntryLimit(entry.Name))
+                return $"manifest.json describes an oversized entry '{entry.Name}'.";
+            if (entry.Count is < 0)
+                return $"manifest.json describes an invalid count for '{entry.Name}'.";
+            if (entry.Description?.Length > 1_000)
+                return $"manifest.json describes an entry with an oversized description.";
+        }
+
+        if (manifestEntries.Count != contents.Count
+            || contents.Keys.Any(name => !manifestEntries.ContainsKey(name)))
+        {
+            return "Bundle contents do not match the entries declared by manifest.json.";
+        }
+
+        foreach (var pair in contents)
+        {
+            var declared = manifestEntries[pair.Key];
+            if (declared.Bytes != pair.Value.LongLength)
+                return $"Entry '{pair.Key}' size does not match manifest.json.";
+            if (declared.Sha256 is not { Length: 64 } ||
+                declared.Sha256.Any(static character => !Uri.IsHexDigit(character)))
+                return $"Entry '{pair.Key}' has an invalid integrity hash.";
+
+            var actualHash = Convert.ToHexString(SHA256.HashData(pair.Value)).ToLowerInvariant();
+            if (!string.Equals(actualHash, declared.Sha256, StringComparison.OrdinalIgnoreCase))
+                return $"Entry '{pair.Key}' integrity hash does not match manifest.json.";
+        }
+
+        return null;
+    }
+
+    private static string? ValidateSection(object? value) => value switch
+    {
+        null => "it could not be deserialized.",
+        EvidenceEnvironment environment => ValidateEnvironment(environment),
+        EvidenceTreeDocument tree => ValidateTree(tree),
+        EvidenceLayoutDocument layout => ValidateLayout(layout),
+        EvidenceProblemDocument problems => ValidateProblems(problems),
+        EvidenceLogDocument logs => ValidateLogs(logs),
+        EvidenceNetworkDocument network => ValidateNetwork(network),
+        _ => null,
+    };
+
+    private static string? ValidateEnvironment(EvidenceEnvironment environment)
+    {
+        if (environment.Capabilities is null)
+            return "capabilities must be an array.";
+        if (environment.Capabilities.Count > 64 ||
+            environment.Capabilities.Any(static value => TooLong(value, 128)))
+        {
+            return "capabilities exceed the supported bounds.";
+        }
+        if (TooLong(environment.CapturedUtc, 64) || TooLong(environment.Route, 512))
+        {
+            return "a string exceeds the supported bounds.";
+        }
+        if (!ValidApp(environment.App) || !ValidPlatform(environment.Platform))
+            return "app or platform metadata exceeds the supported bounds.";
+        if (environment.Unavailable is null || environment.Unavailable.Count > 32 ||
+            environment.Unavailable.Any(item => item is null ||
+                InvalidText(item.Name, 128) || InvalidText(item.Reason, 400)))
+            return "environment gaps exceed the supported bounds.";
+        var device = environment.Device;
+        if (device is not null && new[]
+            {
+                device.Manufacturer, device.Model, device.Platform, device.OsVersion,
+                device.Idiom, device.DeviceType, device.Architecture,
+            }.Any(value => InvalidText(value, EvidenceFormat.MaxIdentifierChars)))
+            return "device metadata exceeds the supported bounds.";
+        var viewport = environment.Viewport;
+        if (viewport is not null &&
+            (!PositiveFinite(viewport.Width) || !PositiveFinite(viewport.Height) ||
+             !PositiveFinite(viewport.Density) || viewport.WindowCount is <= 0 || viewport.Unit != "dip"))
+            return "viewport metrics must be positive, finite, and expressed in DIP.";
+        var theme = environment.Theme;
+        if (theme is not null && new[] { theme.Effective, theme.Requested, theme.AppOverride }
+            .Any(value => value is not (null or "light" or "dark" or "system")))
+            return "theme metadata is invalid.";
+        var connectivity = environment.Connectivity;
+        if (connectivity is not null &&
+            (connectivity.NetworkAccess is not (null or "Unknown" or "None" or "Local" or "ConstrainedInternet" or "Internet") ||
+             connectivity.ConnectionProfiles is null || connectivity.ConnectionProfiles.Count > 5 ||
+             connectivity.ConnectionProfiles.Any(value => value is not ("Unknown" or "Bluetooth" or "Cellular" or "Ethernet" or "WiFi"))))
+            return "connectivity metadata is invalid.";
+        var display = environment.Display;
+        if (display is not null &&
+            (!IsFinite(display.Width) || !IsFinite(display.Height) || !IsFinite(display.Density) ||
+             !IsFinite(display.RefreshRate)))
+        {
+            return "display metrics must be finite.";
+        }
+        return null;
+    }
+
+    private static bool ValidApp(EvidenceAppInfo? app)
+        => app is null || new[] { app.Name, app.Version, app.Build, app.PackageId }
+            .All(value => !InvalidText(value, EvidenceFormat.MaxIdentifierChars));
+
+    private static bool ValidPlatform(EvidencePlatformInfo? platform)
+        => platform is null || new[]
+        {
+            platform.Name, platform.DeviceType, platform.Idiom, platform.AgentVersion,
+            platform.Framework, platform.FrameworkVersion,
+        }.All(value => !InvalidText(value, EvidenceFormat.MaxIdentifierChars));
+
+    private static bool PositiveFinite(double? value)
+        => value is null || (value > 0 && double.IsFinite(value.Value));
+
+    private static string? ValidateTree(EvidenceTreeDocument tree)
+    {
+        if (tree.Roots is null)
+            return "roots must be an array.";
+        if (tree.Count < 0 || tree.Count > EvidenceFormat.MaxTreeElements ||
+            tree.MaxDepth < 0 || tree.MaxDepth > EvidenceFormat.MaxTreeDepth)
+        {
+            return "tree counts exceed the supported bounds.";
+        }
+
+        var count = 0;
+        var stack = new Stack<(EvidenceTreeNode Node, int Depth)>();
+        for (var index = tree.Roots.Count - 1; index >= 0; index--)
+        {
+            var root = tree.Roots[index];
+            if (root is null) return "roots contains a null element.";
+            stack.Push((root, 1));
+        }
+
+        while (stack.Count > 0)
+        {
+            var (node, depth) = stack.Pop();
+            count++;
+            if (count > EvidenceFormat.MaxTreeElements || depth > EvidenceFormat.MaxTreeDepth)
+                return "tree depth or element count exceeds the supported bounds.";
+            if (TooLong(node.Id, EvidenceFormat.MaxIdentifierChars) ||
+                TooLong(node.Type, EvidenceFormat.MaxIdentifierChars) ||
+                TooLong(node.Framework, EvidenceFormat.MaxIdentifierChars) ||
+                TooLong(node.AutomationId, EvidenceFormat.MaxIdentifierChars) ||
+                TooLong(node.Role, EvidenceFormat.MaxIdentifierChars) ||
+                TooLong(node.SourceFile, 512) ||
+                TooLong(node.SourceHash, 128) ||
+                !ValidBounds(node.Bounds))
+            {
+                return "a tree node exceeds the supported bounds.";
+            }
+            if (node.Children is null)
+                continue;
+            for (var index = node.Children.Count - 1; index >= 0; index--)
+            {
+                var child = node.Children[index];
+                if (child is null) return "a tree node contains a null child.";
+                stack.Push((child, depth + 1));
+            }
+        }
+        return null;
+    }
+
+    private static string? ValidateLayout(EvidenceLayoutDocument layout)
+    {
+        if (layout.Rules is null || layout.Findings is null ||
+            layout.Limitations is null || layout.NeverCaptured is null)
+        {
+            return "required collections must be arrays.";
+        }
+        if (layout.Rules.Count > 64 || layout.Findings.Count > EvidenceFormat.MaxLayoutFindings ||
+            layout.Limitations.Count > 256 || layout.NeverCaptured.Count > 128)
+        {
+            return "a collection exceeds the supported bounds.";
+        }
+        if (layout.ElementsExamined < 0 ||
+            layout.Violations < 0 || layout.Observations < 0 || layout.Incomplete < 0 ||
+            layout.Passes < 0 || layout.NotApplicable < 0 || layout.Suppressed < 0 ||
+            layout.FindingCount < 0 || layout.FindingCount > EvidenceFormat.MaxLayoutFindings)
+        {
+            return "layout counts exceed the supported bounds.";
+        }
+        if (layout.Rules.Any(static rule =>
+                rule is null ||
+                TooLong(rule.RuleId, 128) ||
+                TooLong(rule.Support, 32) ||
+                TooLong(rule.Confidence, 32)))
+        {
+            return "a layout rule is invalid.";
+        }
+        foreach (var finding in layout.Findings)
+        {
+            if (finding is null || finding.Limitations is null ||
+                finding.RelatedElementIds is null || finding.FixCategories is null ||
+                finding.Limitations.Count > 64 ||
+                finding.RelatedElementIds.Count > 64 ||
+                finding.FixCategories.Count > 64 ||
+                TooLong(finding.Id, 256) ||
+                TooLong(finding.RuleId, 128) ||
+                TooLong(finding.Outcome, 32) ||
+                TooLong(finding.Confidence, 32) ||
+                TooLong(finding.Severity, 32) ||
+                TooLong(finding.Actionability, 32) ||
+                TooLong(finding.SuppressionKey, 256) ||
+                TooLong(finding.SuppressionReason, EvidenceFormat.MaxLayoutTextChars) ||
+                TooLong(finding.Message, EvidenceFormat.MaxLayoutTextChars) ||
+                TooLong(finding.Explanation, EvidenceFormat.MaxLayoutTextChars) ||
+                TooLong(finding.ElementId, EvidenceFormat.MaxIdentifierChars) ||
+                TooLong(finding.ElementType, EvidenceFormat.MaxIdentifierChars) ||
+                TooLong(finding.AutomationId, EvidenceFormat.MaxIdentifierChars) ||
+                TooLong(finding.SourceFile, 512) ||
+                !ValidBounds(finding.Bounds) ||
+                finding.RelatedElementIds.Any(static id => TooLong(id, EvidenceFormat.MaxIdentifierChars)) ||
+                finding.FixCategories.Any(static category => TooLong(category, 128)) ||
+                finding.Limitations.Any(static text => TooLong(text, EvidenceFormat.MaxLayoutTextChars)))
+            {
+                return "a layout finding exceeds the supported bounds.";
+            }
+        }
+        if (TooLong(layout.SnapshotId, 256) ||
+            TooLong(layout.TreeRevision, 256) ||
+            TooLong(layout.DiagnosticsRevision, 256) ||
+            layout.Limitations.Any(static text => TooLong(text, EvidenceFormat.MaxLayoutTextChars)) ||
+            layout.NeverCaptured.Any(static text => TooLong(text, 256)))
+        {
+            return "layout metadata exceeds the supported bounds.";
+        }
+        return null;
+    }
+
+    private static string? ValidateProblems(EvidenceProblemDocument document)
+    {
+        if (document.Problems is null)
+            return "problems must be an array.";
+        if (document.Problems.Count > EvidenceFormat.MaxProblems)
+            return "problem count exceeds the supported bounds.";
+        foreach (var problem in document.Problems)
+        {
+            if (problem is null ||
+                TooLong(problem.Id, 256) ||
+                TooLong(problem.Kind, 128) ||
+                TooLong(problem.Severity, 32) ||
+                TooLong(problem.Code, 128) ||
+                TooLong(problem.Message, EvidenceFormat.MaxProblemMessageChars) ||
+                TooLong(problem.BindingPath, 512) ||
+                TooLong(problem.SourceFile, 512) ||
+                problem.Count < 0)
+            {
+                return "a problem exceeds the supported bounds.";
+            }
+        }
+        return null;
+    }
+
+    private static string? ValidateLogs(EvidenceLogDocument document)
+    {
+        if (document.Entries is null)
+            return "entries must be an array.";
+        if (document.Entries.Count > EvidenceFormat.MaxLogLimit)
+            return "log count exceeds the supported bounds.";
+        foreach (var entry in document.Entries)
+        {
+            if (entry is null ||
+                TooLong(entry.Timestamp, 64) ||
+                TooLong(entry.Level, 32) ||
+                TooLong(entry.Category, 256) ||
+                TooLong(entry.Message, EvidenceFormat.MaxLogMessageChars) ||
+                TooLong(entry.Exception, EvidenceFormat.MaxLogMessageChars) ||
+                TooLong(entry.Source, 128))
+            {
+                return "a log entry exceeds the supported bounds.";
+            }
+        }
+        return null;
+    }
+
+    private static string? ValidateNetwork(EvidenceNetworkDocument document)
+    {
+        if (document.Requests is null)
+            return "requests must be an array.";
+        if (document.Requests.Count > EvidenceFormat.MaxNetworkLimit)
+            return "network request count exceeds the supported bounds.";
+        foreach (var request in document.Requests)
+        {
+            if (request is null ||
+                TooLong(request.Timestamp, 64) ||
+                TooLong(request.Method, 32) ||
+                TooLong(request.Host, 256) ||
+                TooLong(request.Path, 2_048) ||
+                TooLong(request.StatusText, 256) ||
+                TooLong(request.RequestContentType, 256) ||
+                TooLong(request.ResponseContentType, 256) ||
+                TooLong(request.Error, EvidenceFormat.MaxErrorChars) ||
+                request.QueryKeys is { Count: > EvidenceFormat.MaxQueryKeys } ||
+                request.QueryKeys?.Any(static key => TooLong(key, 64)) == true ||
+                request.DurationMs < 0 ||
+                request.RequestBytes < 0 ||
+                request.ResponseBytes < 0)
+            {
+                return "a network request exceeds the supported bounds.";
+            }
+        }
+        return null;
+    }
+
+    private static bool ValidBounds(EvidenceBounds? bounds)
+        => bounds is null ||
+           (double.IsFinite(bounds.X) &&
+            double.IsFinite(bounds.Y) &&
+            double.IsFinite(bounds.Width) &&
+            double.IsFinite(bounds.Height));
+
+    private static bool IsFinite(double? value)
+        => value is null || double.IsFinite(value.Value);
+
+    private static bool TooLong(string? value, int max)
+        => value?.Length > max;
+
+    private static bool InvalidText(string? value, int max)
+        => TooLong(value, max) ||
+           value?.Any(static character =>
+               char.IsControl(character) ||
+               char.GetUnicodeCategory(character) == UnicodeCategory.Format) == true;
+
+    private static T? ReadJsonEntry<T>(
+        IReadOnlyDictionary<string, byte[]> contents,
+        string name,
+        List<string> warnings)
+        where T : class
+    {
+        if (!contents.TryGetValue(name, out var bytes))
+            return null;
+
+        var json = DecodeUtf8(bytes);
+        if (json is null)
+        {
+            warnings.Add($"{name} was ignored: it is not valid UTF-8 text.");
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json, new JsonDocumentOptions { MaxDepth = EvidenceJson.MaxJsonDepth });
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                warnings.Add($"{name} was ignored: unexpected JSON shape.");
+                return null;
+            }
+            var value = EvidenceJson.Deserialize<T>(json);
+            var semanticError = ValidateSection(value);
+            if (semanticError is not null)
+            {
+                warnings.Add($"{name} was ignored: {semanticError}");
+                return null;
+            }
+            return value;
+        }
+        catch (JsonException)
+        {
+            warnings.Add($"{name} was ignored: it could not be parsed.");
+            return null;
+        }
+    }
+
+    private sealed class ReadBudget
+    {
+        public long TotalBytes;
+    }
+
+    /// <summary>Signals a structural violation that must fail the whole read.</summary>
+    private sealed class EvidenceReadException(string message) : Exception(message);
+
+    /// <summary>
+    /// Copies an entry while enforcing the real limits against the ACTUAL decompressed bytes: the
+    /// declared entry length in the central directory is attacker-controlled, so a bundle that lies
+    /// about its sizes cannot use the cheap pre-filter to smuggle a decompression bomb past the
+    /// per-entry cap, the cumulative cap, or the ratio guard.
+    /// </summary>
+    private static byte[] ReadBounded(
+        ZipArchiveEntry entry,
+        ReadBudget budget,
+        long maxBytes,
+        CancellationToken cancellationToken)
+    {
+        using var source = entry.Open();
+        using var buffer = new MemoryStream();
+
+        var chunk = new byte[81_920];
+        long actual = 0;
+        int read;
+        while ((read = source.Read(chunk, 0, chunk.Length)) > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            actual += read;
+            budget.TotalBytes += read;
+            if (actual > maxBytes)
+                throw new EvidenceReadException($"Entry '{entry.FullName}' is larger than the supported maximum.");
+            if (budget.TotalBytes > EvidenceFormat.MaxTotalUncompressedBytes)
+                throw new EvidenceReadException("Bundle expands beyond the supported maximum size.");
+            buffer.Write(chunk, 0, read);
+        }
+
+        if (entry.CompressedLength >= EvidenceFormat.RatioCheckMinCompressedBytes &&
+            actual / Math.Max(entry.CompressedLength, 1) > EvidenceFormat.MaxCompressionRatio)
+        {
+            throw new EvidenceReadException($"Entry '{entry.FullName}' has a suspicious compression ratio.");
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static long EntryLimit(string name) => name switch
+    {
+        EvidenceFormat.ManifestEntry => EvidenceFormat.MaxManifestBytes,
+        EvidenceFormat.EnvironmentEntry => EvidenceFormat.MaxEnvironmentBytes,
+        EvidenceFormat.TreeEntry => EvidenceFormat.MaxTreeBytes,
+        EvidenceFormat.LayoutEntry => EvidenceFormat.MaxLayoutBytes,
+        EvidenceFormat.ProblemsEntry => EvidenceFormat.MaxProblemsBytes,
+        EvidenceFormat.LogsEntry => EvidenceFormat.MaxLogsBytes,
+        EvidenceFormat.NetworkEntry => EvidenceFormat.MaxNetworkBytes,
+        EvidenceFormat.WorkflowEntry => EvidenceFormat.MaxWorkflowBytes,
+        EvidenceFormat.ScreenshotEntry => EvidenceFormat.MaxScreenshotBytes,
+        _ => EvidenceFormat.MaxEntryUncompressedBytes,
+    };
+
+    private static string? DecodeUtf8(byte[] bytes)
+    {
+        try
+        {
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)
+                .GetString(bytes);
+        }
+        catch (DecoderFallbackException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsPng(byte[] bytes)
+        => bytes.Length > 8 && bytes.AsSpan(0, 8).SequenceEqual(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A });
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceBundleWriter.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceBundleWriter.cs
@@ -1,0 +1,189 @@
+using System.IO.Compression;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+internal sealed record EvidenceWriteResult(bool Ok, string? Path, long Bytes, string? Error);
+
+/// <summary>
+/// Writes a bundle to disk atomically: build the ZIP in a temporary file beside the destination,
+/// validate it by reading it back through the hostile-input reader, and only then move it into
+/// place. A partially written or structurally invalid bundle never appears at the destination.
+/// </summary>
+internal static class EvidenceBundleWriter
+{
+    public static byte[] ToBytes(
+        EvidenceBundle bundle,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+        cancellationToken.ThrowIfCancellationRequested();
+        using var buffer = new MemoryStream();
+        WriteArchive(bundle, buffer, cancellationToken);
+        var bytes = buffer.ToArray();
+        cancellationToken.ThrowIfCancellationRequested();
+        using var validationStream = new MemoryStream(bytes, writable: false);
+        var validation = EvidenceBundleReader.Read(
+            validationStream,
+            cancellationToken: cancellationToken);
+        var validationError = ValidateGeneratedReadback(bundle, validation);
+        if (validationError is not null)
+            throw new InvalidDataException($"The generated bundle failed validation: {validationError}");
+        return bytes;
+    }
+
+    public static EvidenceWriteResult Write(
+        EvidenceBundle bundle,
+        string destinationPath,
+        bool overwrite,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(destinationPath));
+        if (string.IsNullOrEmpty(directory))
+            return new EvidenceWriteResult(false, null, 0, "Output path has no parent directory.");
+
+        if (!overwrite && File.Exists(destinationPath))
+        {
+            return new EvidenceWriteResult(false, null, 0,
+                $"File already exists: {destinationPath} (use --overwrite to replace)");
+        }
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new EvidenceWriteResult(false, null, 0, $"Could not create the output directory: {ex.Message}");
+        }
+
+        var temporaryPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(destinationPath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            using (var file = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                WriteArchive(bundle, file, cancellationToken);
+                file.Flush(flushToDisk: true);
+            }
+
+            // Validate before publishing: the same reader that guards imported bundles.
+            var validation = EvidenceBundleReader.Read(temporaryPath, cancellationToken);
+            var validationError = ValidateGeneratedReadback(bundle, validation);
+            if (validationError is not null)
+            {
+                TryDelete(temporaryPath);
+                return new EvidenceWriteResult(false, null, 0,
+                    $"The generated bundle failed validation: {validationError}");
+            }
+
+            var bytes = new FileInfo(temporaryPath).Length;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (overwrite)
+                File.Move(temporaryPath, destinationPath, overwrite: true);
+            else
+                File.Move(temporaryPath, destinationPath); // fails if another writer won the race
+
+            return new EvidenceWriteResult(true, Path.GetFullPath(destinationPath), bytes, null);
+        }
+        catch (IOException) when (!overwrite && File.Exists(destinationPath))
+        {
+            TryDelete(temporaryPath);
+            return new EvidenceWriteResult(false, null, 0,
+                $"File already exists: {destinationPath} (use --overwrite to replace)");
+        }
+        catch (OperationCanceledException)
+        {
+            TryDelete(temporaryPath);
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            TryDelete(temporaryPath);
+            return new EvidenceWriteResult(false, null, 0, $"Could not write the bundle: {ex.Message}");
+        }
+    }
+
+    private static void WriteArchive(
+        EvidenceBundle bundle,
+        Stream destination,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        using var archive = new ZipArchive(destination, ZipArchiveMode.Create, leaveOpen: true);
+        WriteEntry(
+            archive,
+            EvidenceFormat.ManifestEntry,
+            bundle.ManifestBytes,
+            cancellationToken);
+        foreach (var entry in bundle.Entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            WriteEntry(archive, entry.Name, entry.Content, cancellationToken);
+        }
+    }
+
+    private static void WriteEntry(
+        ZipArchive archive,
+        string name,
+        byte[] content,
+        CancellationToken cancellationToken)
+    {
+        if (!EvidenceFormat.AllowedEntries.Contains(name, StringComparer.Ordinal))
+            throw new InvalidOperationException($"Refusing to write unknown evidence entry '{name}'.");
+
+        var entry = archive.CreateEntry(name, CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        const int chunkSize = 81_920;
+        for (var offset = 0; offset < content.Length; offset += chunkSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var count = Math.Min(chunkSize, content.Length - offset);
+            stream.Write(content, offset, count);
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine("[evidence] Could not remove a temporary bundle file.");
+        }
+    }
+
+    private static string? ValidateGeneratedReadback(
+        EvidenceBundle bundle,
+        EvidenceReadResult validation)
+    {
+        if (!validation.Ok)
+            return validation.Error;
+        if (validation.Warnings.Count > 0)
+            return string.Join("; ", validation.Warnings);
+
+        foreach (var entry in bundle.Entries)
+        {
+            var present = entry.Name switch
+            {
+                EvidenceFormat.EnvironmentEntry => validation.Environment is not null,
+                EvidenceFormat.TreeEntry => validation.Tree is not null,
+                EvidenceFormat.LayoutEntry => validation.Layout is not null,
+                EvidenceFormat.ProblemsEntry => validation.Problems is not null,
+                EvidenceFormat.LogsEntry => validation.Logs is not null,
+                EvidenceFormat.NetworkEntry => validation.Network is not null,
+                EvidenceFormat.WorkflowEntry => validation.Workflow is not null,
+                EvidenceFormat.ScreenshotEntry => validation.Screenshot is not null,
+                _ => false,
+            };
+            if (!present)
+                return $"Entry '{entry.Name}' did not survive typed readback.";
+        }
+        return null;
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceCapture.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceCapture.cs
@@ -13,7 +13,10 @@ internal static class EvidenceCapture
     private static string? s_toolVersion;
 
     public static string ToolVersion =>
-        s_toolVersion ??= Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+        s_toolVersion ??= Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString(3)
+            ?? "unknown";
 
     internal static bool IsExpectedFailure(Exception exception)
         => exception is HttpRequestException or IOException or InvalidDataException or UnauthorizedAccessException or

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceCapture.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceCapture.cs
@@ -1,0 +1,249 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>
+/// The one entry point every surface uses (CLI, MCP, Web Inspector) so preview, capture, and view
+/// behave identically no matter who asked. Surfaces differ only in how they render the result.
+/// </summary>
+internal static class EvidenceCapture
+{
+    private static string? s_toolVersion;
+
+    public static string ToolVersion =>
+        s_toolVersion ??= Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+
+    internal static bool IsExpectedFailure(Exception exception)
+        => exception is HttpRequestException or IOException or InvalidDataException or UnauthorizedAccessException or
+            InvalidOperationException or ArgumentException or NotSupportedException or JsonException or
+            TimeoutException or LayoutDiagnosticsException;
+
+    /// <summary>Collects and projects evidence without writing anything.</summary>
+    public static async Task<EvidencePlan> PreviewAsync(
+        AgentClient client,
+        EvidenceRequest request,
+        CancellationToken ct = default)
+    {
+        await EnsureAgentReachableAsync(client, ct);
+        var utcNow = request.UtcNow ?? DateTime.UtcNow;
+        var projectRoot = request.ProjectRoot ?? EvidencePaths.FindProjectRoot(request.ProjectHint);
+
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new AgentEvidenceDataSource(client),
+            BuildOptions(request, projectRoot, utcNow, previewOnly: true),
+            ct);
+        ct.ThrowIfCancellationRequested();
+
+        if (request.Source == "inspector")
+            return bundle.Plan;
+
+        var destination = EvidencePaths.ValidateOutputPath(
+            request.OutputPath, projectRoot, bundle.Manifest.App?.Name, utcNow);
+        bundle.Plan.OutputPath = destination.Path;
+        if (destination.Error is not null)
+            bundle.Plan.Warnings.Add(destination.Error);
+
+        return bundle.Plan;
+    }
+
+    /// <summary>Collects, projects, and atomically writes the bundle to disk.</summary>
+    public static async Task<EvidenceCaptureResult> CaptureAsync(
+        AgentClient client,
+        EvidenceRequest request,
+        CancellationToken ct = default)
+    {
+        await EnsureAgentReachableAsync(client, ct);
+        var utcNow = request.UtcNow ?? DateTime.UtcNow;
+        var projectRoot = request.ProjectRoot ?? EvidencePaths.FindProjectRoot(request.ProjectHint);
+
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new AgentEvidenceDataSource(client),
+            BuildOptions(request, projectRoot, utcNow, previewOnly: false),
+            ct);
+        ct.ThrowIfCancellationRequested();
+
+        var destination = EvidencePaths.ValidateOutputPath(
+            request.OutputPath, projectRoot, bundle.Manifest.App?.Name, utcNow);
+        if (!destination.Ok)
+            return new EvidenceCaptureResult { Ok = false, Error = destination.Error, Plan = bundle.Plan };
+
+        bundle.Plan.OutputPath = destination.Path;
+
+        ct.ThrowIfCancellationRequested();
+        var write = EvidenceBundleWriter.Write(
+            bundle,
+            destination.Path!,
+            request.Overwrite,
+            ct);
+        if (!write.Ok)
+            return new EvidenceCaptureResult { Ok = false, Error = write.Error, Plan = bundle.Plan };
+
+        return new EvidenceCaptureResult
+        {
+            Ok = true,
+            Path = write.Path,
+            Bytes = write.Bytes,
+            Manifest = bundle.Manifest,
+            Plan = bundle.Plan,
+        };
+    }
+
+    /// <summary>Collects and projects a bundle without touching the filesystem (Inspector download).</summary>
+    public static async Task<(EvidenceBundle Bundle, byte[] Bytes)> CaptureToBytesAsync(
+        AgentClient client,
+        EvidenceRequest request,
+        CancellationToken ct = default)
+    {
+        await EnsureAgentReachableAsync(client, ct);
+        var utcNow = request.UtcNow ?? DateTime.UtcNow;
+        var projectRoot = request.ProjectRoot ?? EvidencePaths.FindProjectRoot(request.ProjectHint);
+        var bundle = await EvidenceBuilder.BuildAsync(
+            new AgentEvidenceDataSource(client),
+            BuildOptions(request, projectRoot, utcNow, previewOnly: false),
+            ct);
+        ct.ThrowIfCancellationRequested();
+        return (bundle, EvidenceBundleWriter.ToBytes(bundle, ct));
+    }
+
+    /// <summary>
+    /// Validates a bundle and regenerates a static HTML report from its parsed contents.
+    /// The bundle's own bytes are never rendered or executed.
+    /// </summary>
+    public static EvidenceViewResult View(
+        string bundlePath,
+        string? reportPath,
+        bool open,
+        DateTime? utcNow = null,
+        bool overwrite = false)
+    {
+        var now = utcNow ?? DateTime.UtcNow;
+
+        var input = EvidencePaths.ValidateInputPath(bundlePath);
+        if (!input.Ok)
+            return new EvidenceViewResult { Ok = false, Error = input.Error, Bundle = bundlePath };
+
+        var read = EvidenceBundleReader.Read(input.Path!);
+        if (!read.Ok)
+            return new EvidenceViewResult { Ok = false, Error = read.Error, Bundle = input.Path };
+
+        string target;
+        if (string.IsNullOrWhiteSpace(reportPath))
+        {
+            target = EvidencePaths.CreateReportPath(now);
+        }
+        else
+        {
+            var report = EvidencePaths.ValidateReportPath(reportPath);
+            if (!report.Ok)
+                return new EvidenceViewResult { Ok = false, Error = report.Error, Bundle = input.Path };
+            target = report.Path!;
+        }
+
+        var temporary = target + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            var directory = Path.GetDirectoryName(target);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+            if (!overwrite && File.Exists(target))
+            {
+                return new EvidenceViewResult
+                {
+                    Ok = false,
+                    Error = $"Report file already exists: {target}. Pass --overwrite to replace it.",
+                    Bundle = input.Path
+                };
+            }
+            File.WriteAllText(temporary, EvidenceReportRenderer.Render(read));
+            File.Move(temporary, target, overwrite);
+            if (string.IsNullOrWhiteSpace(reportPath))
+                EvidencePaths.CleanupReports(now);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            if (!overwrite && File.Exists(target))
+            {
+                return new EvidenceViewResult
+                {
+                    Ok = false,
+                    Error = $"Report file already exists: {target}. Pass --overwrite to replace it.",
+                    Bundle = input.Path
+                };
+            }
+            return new EvidenceViewResult { Ok = false, Error = $"Could not write the report: {ex.Message}", Bundle = input.Path };
+        }
+        finally
+        {
+            try { File.Delete(temporary); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Console.Error.WriteLine("[evidence] Could not remove a temporary report file.");
+            }
+        }
+
+        var opened = open && EvidenceReportLauncher.TryOpen(target);
+        if (open && !opened)
+            read.Warnings.Add("The report was written, but the default browser could not be opened.");
+        return new EvidenceViewResult
+        {
+            Ok = true,
+            Bundle = input.Path,
+            Report = target,
+            Opened = opened,
+            Manifest = read.Manifest,
+            Entries = read.Entries,
+            Warnings = read.Warnings,
+        };
+    }
+
+    private static EvidenceCaptureOptions BuildOptions(
+        EvidenceRequest request,
+        string? projectRoot,
+        DateTime utcNow,
+        bool previewOnly) => new()
+        {
+            IncludeScreenshot = request.IncludeScreenshot,
+            PreviewOnly = previewOnly,
+            WorkflowMarkdown = request.WorkflowMarkdown,
+            SelectedElementId = request.SelectedElementId,
+            LogLimit = request.LogLimit,
+            NetworkLimit = request.NetworkLimit,
+            Source = request.Source,
+            ProjectRoot = projectRoot,
+            ToolVersion = ToolVersion,
+            UtcNow = utcNow,
+        };
+
+    private static async Task EnsureAgentReachableAsync(
+        AgentClient client,
+        CancellationToken ct)
+    {
+        var status = await client.GetStatusAsync().WaitAsync(ct);
+        if (status is null)
+        {
+            throw new HttpRequestException(
+                $"No DevFlow agent responded at {client.BaseUrl}. "
+                + "Start the app or select a reachable agent port.");
+        }
+    }
+}
+
+/// <summary>Caller-facing capture request shared by the CLI, MCP tools, and the Web Inspector.</summary>
+internal sealed class EvidenceRequest
+{
+    public bool IncludeScreenshot { get; init; }
+    public bool Overwrite { get; init; }
+    public string? OutputPath { get; init; }
+    public string? WorkflowMarkdown { get; init; }
+    public string? SelectedElementId { get; init; }
+    public int LogLimit { get; init; } = EvidenceFormat.DefaultLogLimit;
+    public int NetworkLimit { get; init; } = EvidenceFormat.DefaultNetworkLimit;
+    public string Source { get; init; } = "cli";
+    /// <summary>Known project path or directory (the Inspector passes its --project value).</summary>
+    public string? ProjectHint { get; init; }
+    /// <summary>Pre-resolved project root; skips discovery when set.</summary>
+    public string? ProjectRoot { get; init; }
+    public DateTime? UtcNow { get; init; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceCommands.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceCommands.cs
@@ -1,0 +1,445 @@
+using System.CommandLine;
+using System.Text;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>
+/// <c>maui devflow evidence</c>: preview, capture, and view <c>.mauitrace</c> evidence bundles.
+///
+/// Every command follows the DevFlow CLI conventions — the shared <c>--json</c>/<c>--no-json</c>
+/// options, <see cref="IDevFlowOutputWriter"/> for output, and structured errors on stderr.
+/// </summary>
+internal static class EvidenceCommands
+{
+    public static Command Create(
+        Option<bool> jsonOption,
+        Option<bool> noJsonOption,
+        Option<string> agentHostOption,
+        Option<int> agentPortOption,
+        IDevFlowOutputWriter output,
+        Func<string, int, bool, Task<AgentClient>> clientFactory,
+        Action onError)
+    {
+        var command = new Command("evidence",
+            "Capture a shareable, redacted .mauitrace evidence bundle from the running app");
+
+        command.Add(CreatePreviewCommand(jsonOption, noJsonOption, agentHostOption, agentPortOption, output, clientFactory, onError));
+        command.Add(CreateCaptureCommand(jsonOption, noJsonOption, agentHostOption, agentPortOption, output, clientFactory, onError));
+        command.Add(CreateViewCommand(jsonOption, noJsonOption, output, onError));
+        return command;
+    }
+
+    private static Command CreatePreviewCommand(
+        Option<bool> jsonOption,
+        Option<bool> noJsonOption,
+        Option<string> agentHostOption,
+        Option<int> agentPortOption,
+        IDevFlowOutputWriter output,
+        Func<string, int, bool, Task<AgentClient>> clientFactory,
+        Action onError)
+    {
+        var screenshotOption = CreateScreenshotOption();
+        var elementOption = CreateElementOption();
+        var logLimitOption = CreateLogLimitOption();
+        var networkLimitOption = CreateNetworkLimitOption();
+        var workflowOption = CreateWorkflowOption();
+        var outputOption = new Option<string?>("--output", "-o")
+        {
+            Description = $"Destination that 'capture' would use, echoed back in the plan (default: ./{EvidenceFormat.DefaultFolderName}/<app>-<timestamp>{EvidenceFormat.FileExtension})"
+        };
+
+        var command = new Command("preview",
+            "Show exactly what an evidence capture would include and exclude, without writing anything")
+        {
+            screenshotOption,
+            elementOption,
+            logLimitOption,
+            networkLimitOption,
+            outputOption,
+            workflowOption,
+        };
+
+        command.SetAction(async (ctx, ct) =>
+        {
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            try
+            {
+                string? workflow = null;
+                var workflowPath = ctx.GetValue(workflowOption);
+                if (!string.IsNullOrWhiteSpace(workflowPath))
+                {
+                    var read = ReadWorkflowFile(workflowPath);
+                    if (read.Error is not null)
+                    {
+                        output.WriteError(read.Error, isJson, "InvocationError");
+                        onError();
+                        return;
+                    }
+                    workflow = read.Text;
+                }
+                using var client = await clientFactory(
+                    ctx.GetValue(agentHostOption)!,
+                    ctx.GetValue(agentPortOption),
+                    !isJson);
+                var plan = await EvidenceCapture.PreviewAsync(client, new EvidenceRequest
+                {
+                    IncludeScreenshot = ctx.GetValue(screenshotOption),
+                    SelectedElementId = ctx.GetValue(elementOption),
+                    LogLimit = ctx.GetValue(logLimitOption),
+                    NetworkLimit = ctx.GetValue(networkLimitOption),
+                    OutputPath = ctx.GetValue(outputOption),
+                    WorkflowMarkdown = workflow,
+                    Source = "cli",
+                }, ct);
+
+                if (isJson) output.WriteRawJson(EvidenceJson.Serialize(plan, indented: true));
+                else Console.WriteLine(FormatPlan(plan));
+            }
+            catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex))
+            {
+                output.WriteError(ex.Message, isJson, suggestions: ["Run 'maui devflow agent status' to confirm the selected app is connected"]);
+                onError();
+            }
+        });
+
+        return command;
+    }
+
+    private static Command CreateCaptureCommand(
+        Option<bool> jsonOption,
+        Option<bool> noJsonOption,
+        Option<string> agentHostOption,
+        Option<int> agentPortOption,
+        IDevFlowOutputWriter output,
+        Func<string, int, bool, Task<AgentClient>> clientFactory,
+        Action onError)
+    {
+        var outputOption = new Option<string?>("--output", "-o")
+        {
+            Description = $"Bundle path (default: ./{EvidenceFormat.DefaultFolderName}/<app>-<timestamp>{EvidenceFormat.FileExtension} under the project root)"
+        };
+        var overwriteOption = new Option<bool>("--overwrite")
+        {
+            Description = "Overwrite an existing bundle (default: fail if the file exists)",
+            DefaultValueFactory = _ => false,
+        };
+        var screenshotOption = CreateScreenshotOption();
+        var workflowOption = CreateWorkflowOption();
+        var elementOption = CreateElementOption();
+        var logLimitOption = CreateLogLimitOption();
+        var networkLimitOption = CreateNetworkLimitOption();
+
+        var command = new Command("capture", "Write a redacted evidence bundle for the connected app")
+        {
+            outputOption,
+            overwriteOption,
+            screenshotOption,
+            workflowOption,
+            elementOption,
+            logLimitOption,
+            networkLimitOption,
+        };
+
+        command.SetAction(async (ctx, ct) =>
+        {
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            try
+            {
+                var workflowPath = ctx.GetValue(workflowOption);
+                string? workflow = null;
+                if (!string.IsNullOrWhiteSpace(workflowPath))
+                {
+                    var read = ReadWorkflowFile(workflowPath!);
+                    if (read.Error is not null)
+                    {
+                        output.WriteError(read.Error, isJson, "InvocationError");
+                        onError();
+                        return;
+                    }
+                    workflow = read.Text;
+                }
+
+                using var client = await clientFactory(
+                    ctx.GetValue(agentHostOption)!,
+                    ctx.GetValue(agentPortOption),
+                    !isJson);
+                var result = await EvidenceCapture.CaptureAsync(client, new EvidenceRequest
+                {
+                    IncludeScreenshot = ctx.GetValue(screenshotOption),
+                    Overwrite = ctx.GetValue(overwriteOption),
+                    OutputPath = ctx.GetValue(outputOption),
+                    WorkflowMarkdown = workflow,
+                    SelectedElementId = ctx.GetValue(elementOption),
+                    LogLimit = ctx.GetValue(logLimitOption),
+                    NetworkLimit = ctx.GetValue(networkLimitOption),
+                    Source = "cli",
+                }, ct);
+
+                if (!result.Ok)
+                {
+                    output.WriteError(result.Error ?? "Could not capture evidence.", isJson, "InvocationError");
+                    onError();
+                    return;
+                }
+
+                if (isJson) output.WriteRawJson(EvidenceJson.Serialize(result, indented: true));
+                else Console.WriteLine(FormatCapture(result));
+            }
+            catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex))
+            {
+                output.WriteError(ex.Message, isJson, suggestions: ["Run 'maui devflow agent status' to confirm the selected app is connected"]);
+                onError();
+            }
+        });
+
+        return command;
+    }
+
+    private static Command CreateViewCommand(
+        Option<bool> jsonOption,
+        Option<bool> noJsonOption,
+        IDevFlowOutputWriter output,
+        Action onError)
+    {
+        var bundleArgument = new Argument<string>("bundle")
+        {
+            Description = $"Path to a {EvidenceFormat.FileExtension} bundle"
+        };
+        var noOpenOption = new Option<bool>("--no-open")
+        {
+            Description = "Generate the report without opening it in a browser",
+            DefaultValueFactory = _ => false,
+        };
+        var reportOption = new Option<string?>("--output-report")
+        {
+            Description = "Write the generated HTML report to this .html path instead of a temporary file"
+        };
+        var overwriteOption = new Option<bool>("--overwrite")
+        {
+            Description = "Overwrite an existing report file",
+            DefaultValueFactory = _ => false
+        };
+
+        var command = new Command("view",
+            "Validate a bundle and generate a static, self-contained HTML report from its contents")
+        {
+            bundleArgument,
+            noOpenOption,
+            reportOption,
+            overwriteOption,
+        };
+
+        command.SetAction((ctx, ct) =>
+        {
+            var isJson = output.ResolveJsonMode(ctx.GetValue(jsonOption), ctx.GetValue(noJsonOption));
+            try
+            {
+                var result = EvidenceCapture.View(
+                    ctx.GetValue(bundleArgument)!,
+                    ctx.GetValue(reportOption),
+                    open: !ctx.GetValue(noOpenOption),
+                    overwrite: ctx.GetValue(overwriteOption));
+
+                if (!result.Ok)
+                {
+                    output.WriteError(result.Error ?? "Could not read the bundle.", isJson, "InvocationError");
+                    onError();
+                    return Task.CompletedTask;
+                }
+
+                if (isJson) output.WriteRawJson(EvidenceJson.Serialize(result, indented: true));
+                else Console.WriteLine(FormatView(result));
+            }
+            catch (Exception ex) when (EvidenceCapture.IsExpectedFailure(ex))
+            {
+                output.WriteError(ex.Message, isJson);
+                onError();
+            }
+            return Task.CompletedTask;
+        });
+
+        return command;
+    }
+
+    private static Option<bool> CreateScreenshotOption() => new("--include-screenshot")
+    {
+        Description = "Include a screenshot (off by default — a screenshot may show on-screen data)",
+        DefaultValueFactory = _ => false,
+    };
+
+    private static Option<string?> CreateWorkflowOption() => new("--workflow")
+    {
+        Description = "Markdown reproduction steps to attach (max 1 MiB; secrets and structured values are scrubbed)"
+    };
+
+    private static Option<string?> CreateElementOption() => new("--element")
+    {
+        Description = "Element id to highlight in the bundle (metadata only; no text or values are captured)"
+    };
+
+    private static Option<int> CreateLogLimitOption() => new("--log-limit")
+    {
+        Description = $"Maximum log entries to include (1-{EvidenceFormat.MaxLogLimit})",
+        DefaultValueFactory = _ => EvidenceFormat.DefaultLogLimit,
+    };
+
+    private static Option<int> CreateNetworkLimitOption() => new("--network-limit")
+    {
+        Description = $"Maximum network request summaries to include (1-{EvidenceFormat.MaxNetworkLimit})",
+        DefaultValueFactory = _ => EvidenceFormat.DefaultNetworkLimit,
+    };
+
+    internal static (string? Text, string? Error) ReadWorkflowFile(string path)
+    {
+        string full;
+        try { full = Path.GetFullPath(path); }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return (null, "Workflow path is not a valid file path.");
+        }
+
+        if (!full.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            return (null, "Workflow files must be Markdown (.md).");
+        if (!File.Exists(full))
+            return (null, $"Workflow file not found: {full}");
+
+        try
+        {
+            using var input = File.OpenRead(full);
+            if (input.Length > EvidenceFormat.MaxWorkflowBytes)
+                return (null, $"Workflow file is larger than {EvidenceFormat.MaxWorkflowBytes / 1024} KB.");
+            var buffer = new byte[checked((int)EvidenceFormat.MaxWorkflowBytes + 1)];
+            var count = 0;
+            while (count < buffer.Length)
+            {
+                var read = input.Read(buffer, count, buffer.Length - count);
+                if (read == 0) break;
+                count += read;
+            }
+            if (count > EvidenceFormat.MaxWorkflowBytes)
+                return (null, $"Workflow file is larger than {EvidenceFormat.MaxWorkflowBytes / 1024} KB.");
+            using var content = new MemoryStream(buffer, 0, count, writable: false);
+            using var reader = new StreamReader(content, new UTF8Encoding(false, true), detectEncodingFromByteOrderMarks: true);
+            return (reader.ReadToEnd(), null);
+        }
+        catch (DecoderFallbackException)
+        {
+            return (null, "The workflow file contains invalid text encoding.");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return (null, $"Could not read the workflow file: {ex.Message}");
+        }
+    }
+
+    // ── human-readable formatting ────────────────────────────────────────────────────────────
+
+    internal static string FormatPlan(EvidencePlan plan)
+    {
+        var text = new StringBuilder();
+        text.AppendLine($"Evidence preview for {plan.App?.Name ?? "the connected app"} ({plan.Platform?.Name ?? "unknown platform"})");
+        text.AppendLine($"  Format v{plan.FormatVersion} · redaction ruleset v{plan.RedactionVersion} · source {plan.Source}");
+        if (plan.OutputPath is not null)
+            text.AppendLine($"  Would write: {plan.OutputPath} (~{EvidenceReportRenderer.FormatBytes(plan.EstimatedBytes)})");
+
+        if (plan.Environment is { } environment)
+        {
+            text.AppendLine("  Current environment (observations, not an enforced replay contract):");
+            foreach (var (label, value) in EvidenceReportRenderer.EnvironmentFacts(environment))
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                    text.AppendLine($"    {label}: {Terminal(value)}");
+            }
+            foreach (var gap in environment.Unavailable)
+                text.AppendLine($"    Not captured/enforced - {gap.Name}: {Terminal(gap.Reason)}");
+        }
+        text.AppendLine("  Includes:");
+        foreach (var entry in plan.Included)
+        {
+            var count = entry.Count is null ? "" : $" ({entry.Count} items)";
+            text.AppendLine($"    - {entry.Name}{count}: {entry.Description}");
+        }
+
+        if (plan.Excluded.Count > 0)
+        {
+            text.AppendLine("  Excluded:");
+            foreach (var exclusion in plan.Excluded)
+                text.AppendLine($"    - {exclusion.Name}: {exclusion.Reason}");
+        }
+
+        text.AppendLine("  Never captured:");
+        foreach (var item in plan.NeverIncluded)
+            text.AppendLine($"    - {item}");
+
+        text.AppendLine($"  Screenshot: {(plan.Screenshot.Included ? "included (opt-in)" : plan.Screenshot.OmittedReason ?? "not included")}");
+        text.AppendLine($"  Limits: {plan.Limits.Logs} logs · {plan.Limits.Network} requests · {plan.Limits.TreeElements} elements");
+
+        if (plan.Warnings.Count > 0)
+        {
+            text.AppendLine("  Warnings:");
+            foreach (var warning in plan.Warnings)
+                text.AppendLine($"    ! {warning}");
+        }
+
+        return text.ToString().TrimEnd();
+    }
+
+    internal static string FormatCapture(EvidenceCaptureResult result)
+    {
+        var text = new StringBuilder();
+        text.AppendLine($"Evidence bundle written: {Terminal(result.Path)} ({EvidenceReportRenderer.FormatBytes(result.Bytes)})");
+        if (result.Manifest is { } manifest)
+        {
+            foreach (var entry in manifest.Entries.Where(entry => entry.Count is not null))
+                text.AppendLine($"  {entry.Name}: {entry.Count} captured item(s)");
+            foreach (var exclusion in manifest.Excluded)
+                text.AppendLine($"  Omitted {exclusion.Name}: {Terminal(exclusion.Reason)}");
+        }
+        text.AppendLine($"  Screenshot: {(result.Manifest?.Screenshot.Included == true ? "included" : "omitted")}");
+        text.AppendLine($"  Redaction ruleset v{result.Manifest?.RedactionVersion}");
+        if (result.Manifest?.Warnings is { Count: > 0 })
+        {
+            foreach (var warning in result.Manifest.Warnings)
+                text.AppendLine($"  ! {Terminal(warning)}");
+        }
+        text.Append($"  View it with: maui devflow evidence view \"{Terminal(result.Path)}\"");
+        return text.ToString();
+    }
+
+    internal static string FormatView(EvidenceViewResult result)
+    {
+        var text = new StringBuilder();
+        text.AppendLine($"Report generated: {Terminal(result.Report)}");
+        text.AppendLine($"  Bundle: {Terminal(result.Bundle)}");
+        text.AppendLine($"  Entries: {string.Join(", ", result.Entries.Select(Terminal))}");
+        if (result.Manifest is not null)
+        {
+            text.AppendLine($"  Captured {Terminal(result.Manifest.CapturedUtc)} by {Terminal(result.Manifest.Source)} · redaction ruleset v{result.Manifest.RedactionVersion}");
+        }
+        foreach (var warning in result.Warnings)
+            text.AppendLine($"  ! {Terminal(warning)}");
+        text.Append(result.Opened ? "  Opened in your default browser." : "  Open it in a browser to read the report.");
+        return text.ToString();
+    }
+
+    private static string Terminal(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return "";
+        var builder = new StringBuilder(value.Length);
+        foreach (var character in value)
+        {
+            if (char.IsControl(character) ||
+                char.GetUnicodeCategory(character) == System.Globalization.UnicodeCategory.Format)
+            {
+                builder.Append($"\\u{(int)character:X4}");
+            }
+            else
+            {
+                builder.Append(character);
+            }
+        }
+        return builder.ToString();
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceFormat.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceFormat.cs
@@ -1,0 +1,116 @@
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>
+/// Wire constants for the <c>.mauitrace</c> evidence bundle: a small, versioned ZIP of
+/// on-demand diagnostic evidence captured from a running app.
+///
+/// The format is intentionally closed: only the entries in <see cref="AllowedEntries"/> may be
+/// written or read, and every limit here is enforced on BOTH the write path (so we never produce
+/// an unbounded bundle) and the read path (so a hostile bundle can never expand into one).
+/// </summary>
+internal static class EvidenceFormat
+{
+    /// <summary>Schema discriminator written to (and required from) <c>manifest.json</c>.</summary>
+    public const string SchemaId = "maui-devflow-evidence";
+
+    /// <summary>
+    /// Bundle format version. Bump when entry names or required manifest fields change.
+    /// <para>
+    /// The reader requires an exact match, so a bump rejects every previously captured bundle.
+    /// Additive optional entries therefore do not bump it: keeping old evidence readable matters
+    /// more than signalling an addition that older tools would reject anyway.
+    /// </para>
+    /// </summary>
+    public const int Version = 1;
+
+    public const string FileExtension = ".mauitrace";
+
+    /// <summary>Project-local folder used when a project root can be resolved.</summary>
+    public const string DefaultFolderName = "maui-traces";
+
+    public const string ManifestEntry = "manifest.json";
+    public const string EnvironmentEntry = "environment.json";
+    public const string TreeEntry = "tree.json";
+    public const string LayoutEntry = "layout.json";
+    public const string ProblemsEntry = "problems.json";
+    public const string LogsEntry = "logs.json";
+    public const string NetworkEntry = "network.json";
+    public const string ScreenshotEntry = "screenshot.png";
+    public const string WorkflowEntry = "workflow.md";
+    /// <summary>Recognized v1 workflow/device metadata; standalone capture does not produce it.</summary>
+    public const string DeviceEntry = "device.json";
+
+    /// <summary>The complete set of entry names a bundle may contain (ordinal match, flat names only).</summary>
+    public static readonly IReadOnlyList<string> AllowedEntries =
+    [
+        ManifestEntry,
+        EnvironmentEntry,
+        TreeEntry,
+        LayoutEntry,
+        ProblemsEntry,
+        LogsEntry,
+        NetworkEntry,
+        ScreenshotEntry,
+        WorkflowEntry,
+        DeviceEntry,
+    ];
+
+    // ── Capture-side bounds ──────────────────────────────────────────────────────────────────
+
+    public const int DefaultLogLimit = 200;
+    public const int MaxLogLimit = 500;
+    public const int DefaultNetworkLimit = 100;
+    public const int MaxNetworkLimit = 500;
+    public const int MaxProblems = 500;
+    public const int MaxTreeElements = 5_000;
+    public const int MaxTreeDepth = 64;
+
+    /// <summary>Layout findings retained in a bundle. Findings are bounded metadata, but not unbounded.</summary>
+    public const int MaxLayoutFindings = 500;
+
+    /// <summary>Free-form strings inside a layout finding (message, explanation, limitation).</summary>
+    public const int MaxLayoutTextChars = 600;
+    public const int MaxLogMessageChars = 1_000;
+    public const int MaxProblemMessageChars = 1_000;
+    public const int MaxErrorChars = 400;
+    public const int MaxIdentifierChars = 128;
+    public const int MaxQueryKeys = 24;
+
+    /// <summary>Workflow markdown is user-supplied; cap it before it ever reaches the bundle.</summary>
+    public const long MaxWorkflowBytes = 1_048_576; // 1 MB
+
+    public const long MaxScreenshotBytes = 16L * 1024 * 1024;
+
+    // ── Read-side bounds (input is treated as hostile) ───────────────────────────────────────
+
+    public const long MaxBundleFileBytes = 64L * 1024 * 1024;
+    public const int MaxBundleEntries = 16;
+    public const long MaxTotalUncompressedBytes = 128L * 1024 * 1024;
+    public const long MaxEntryUncompressedBytes = 32L * 1024 * 1024;
+    public const long MaxManifestBytes = 1L * 1024 * 1024;
+    public const long MaxEnvironmentBytes = 1L * 1024 * 1024;
+    public const long MaxTreeBytes = 16L * 1024 * 1024;
+    public const long MaxLayoutBytes = 4L * 1024 * 1024;
+    public const long MaxProblemsBytes = 4L * 1024 * 1024;
+    public const long MaxLogsBytes = 4L * 1024 * 1024;
+    public const long MaxNetworkBytes = 4L * 1024 * 1024;
+
+    /// <summary>Maximum uncompressed:compressed ratio tolerated for a single entry (zip-bomb guard).</summary>
+    public const int MaxCompressionRatio = 200;
+
+    /// <summary>Entries smaller than this compress unpredictably, so the ratio guard ignores them.</summary>
+    public const long RatioCheckMinCompressedBytes = 1_024;
+
+    /// <summary>Data classes that are never captured, surfaced verbatim in previews and manifests.</summary>
+    public static readonly IReadOnlyList<string> NeverIncluded =
+    [
+        "Element Text/Value content",
+        "Native and framework property dictionaries",
+        "BindingContext / view-model object graphs",
+        "Preferences and secure storage values",
+        "Geolocation",
+        "File contents from app storage",
+        "Absolute user/machine file paths",
+        "HTTP headers, bodies, and full query strings",
+    ];
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceModels.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceModels.cs
@@ -1,0 +1,485 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+// ── manifest.json ────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The bundle's self-description: what schema/redaction rules produced it, what it contains,
+/// what was deliberately left out, and the bounds that were applied.
+/// </summary>
+internal sealed class EvidenceManifest
+{
+    public string Schema { get; set; } = EvidenceFormat.SchemaId;
+    public int FormatVersion { get; set; } = EvidenceFormat.Version;
+    public int RedactionVersion { get; set; } = EvidenceRedaction.Version;
+    public string CapturedUtc { get; set; } = "";
+    /// <summary>Which surface produced the bundle: <c>cli</c>, <c>mcp</c>, or <c>inspector</c>.</summary>
+    public string Source { get; set; } = "cli";
+    public EvidenceToolInfo Tool { get; set; } = new();
+    public EvidenceAppInfo? App { get; set; }
+    public EvidencePlatformInfo? Platform { get; set; }
+    public List<string> Capabilities { get; set; } = [];
+    public List<EvidenceEntryInfo> Entries { get; set; } = [];
+    public List<EvidenceExclusion> Excluded { get; set; } = [];
+    public List<string> NeverIncluded { get; set; } = [];
+    public EvidenceCounts Counts { get; set; } = new();
+    public EvidenceLimits Limits { get; set; } = new();
+    public EvidenceScreenshotStatus Screenshot { get; set; } = new();
+    public string? SelectedElementId { get; set; }
+    public List<string> Warnings { get; set; } = [];
+}
+
+internal sealed class EvidenceToolInfo
+{
+    public string Name { get; set; } = "maui devflow evidence";
+    public string Version { get; set; } = "";
+}
+
+internal sealed class EvidenceAppInfo
+{
+    public string? Name { get; set; }
+    public string? Version { get; set; }
+    public string? Build { get; set; }
+    public string? PackageId { get; set; }
+}
+
+internal sealed class EvidencePlatformInfo
+{
+    public string? Name { get; set; }
+    public string? DeviceType { get; set; }
+    public string? Idiom { get; set; }
+    public string? AgentVersion { get; set; }
+    public string? Framework { get; set; }
+    public string? FrameworkVersion { get; set; }
+}
+
+/// <summary>One included entry, with its size and content hash so a reader can verify integrity.</summary>
+internal sealed class EvidenceEntryInfo
+{
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public int? Count { get; set; }
+    public long Bytes { get; set; }
+    public string? Sha256 { get; set; }
+}
+
+internal sealed class EvidenceExclusion
+{
+    public EvidenceExclusion() { }
+
+    public EvidenceExclusion(string name, string reason)
+    {
+        Name = name;
+        Reason = reason;
+    }
+
+    public string Name { get; set; } = "";
+    public string Reason { get; set; } = "";
+}
+
+internal sealed class EvidenceCounts
+{
+    public int TreeElements { get; set; }
+    public int Problems { get; set; }
+    public int Logs { get; set; }
+    public int NetworkRequests { get; set; }
+    public int LayoutFindings { get; set; }
+    public int LayoutViolations { get; set; }
+    public long WorkflowBytes { get; set; }
+    public long ScreenshotBytes { get; set; }
+}
+
+internal sealed class EvidenceLimits
+{
+    public int TreeElements { get; set; } = EvidenceFormat.MaxTreeElements;
+    public int TreeDepth { get; set; } = EvidenceFormat.MaxTreeDepth;
+    public int Logs { get; set; } = EvidenceFormat.DefaultLogLimit;
+    public int Network { get; set; } = EvidenceFormat.DefaultNetworkLimit;
+    public int Problems { get; set; } = EvidenceFormat.MaxProblems;
+    public int LayoutFindings { get; set; } = EvidenceFormat.MaxLayoutFindings;
+    public int LogMessageChars { get; set; } = EvidenceFormat.MaxLogMessageChars;
+    public long WorkflowBytes { get; set; } = EvidenceFormat.MaxWorkflowBytes;
+}
+
+internal sealed class EvidenceScreenshotStatus
+{
+    /// <summary>True when the caller explicitly opted in.</summary>
+    public bool Requested { get; set; }
+    public bool Included { get; set; }
+    public string? OmittedReason { get; set; }
+}
+
+// ── environment.json ─────────────────────────────────────────────────────────────────────────
+
+internal sealed class EvidenceEnvironment
+{
+    public string CapturedUtc { get; set; } = "";
+    public EvidenceAppInfo? App { get; set; }
+    public EvidencePlatformInfo? Platform { get; set; }
+    public EvidenceDeviceInfo? Device { get; set; }
+    public EvidenceDisplayInfo? Display { get; set; }
+    public EvidenceViewportInfo? Viewport { get; set; }
+    public EvidenceThemeInfo? Theme { get; set; }
+    public EvidenceConnectivityInfo? Connectivity { get; set; }
+    public List<EvidenceExclusion> Unavailable { get; set; } = [];
+    public List<string> Capabilities { get; set; } = [];
+    public string? Route { get; set; }
+}
+
+internal sealed class EvidenceViewportInfo
+{
+    public double? Width { get; set; }
+    public double? Height { get; set; }
+    public double? Density { get; set; }
+    public int? WindowCount { get; set; }
+    public string Unit { get; set; } = "dip";
+}
+
+internal sealed class EvidenceThemeInfo
+{
+    public string? Effective { get; set; }
+    public string? Requested { get; set; }
+    public string? AppOverride { get; set; }
+}
+
+internal sealed class EvidenceConnectivityInfo
+{
+    public string? NetworkAccess { get; set; }
+    public List<string> ConnectionProfiles { get; set; } = [];
+}
+
+/// <summary>
+/// A safe subset of the agent's device report. Device <em>name</em> is deliberately omitted —
+/// it is frequently personal ("Alex's iPhone").
+/// </summary>
+internal sealed class EvidenceDeviceInfo
+{
+    public string? Manufacturer { get; set; }
+    public string? Model { get; set; }
+    public string? Platform { get; set; }
+    public string? OsVersion { get; set; }
+    public string? Idiom { get; set; }
+    public string? DeviceType { get; set; }
+    public string? Architecture { get; set; }
+}
+
+internal sealed class EvidenceDisplayInfo
+{
+    public double? Width { get; set; }
+    public double? Height { get; set; }
+    public double? Density { get; set; }
+    public string? Orientation { get; set; }
+    public string? Rotation { get; set; }
+    public double? RefreshRate { get; set; }
+}
+
+// ── tree.json ────────────────────────────────────────────────────────────────────────────────
+
+internal sealed class EvidenceTreeDocument
+{
+    public int Count { get; set; }
+    public bool Truncated { get; set; }
+    public int MaxDepth { get; set; }
+    public List<EvidenceTreeNode> Roots { get; set; } = [];
+}
+
+/// <summary>
+/// Structural metadata for one element. Text, Value, native/framework property dictionaries and
+/// absolute source paths are intentionally absent — see <see cref="EvidenceBuilder"/>.
+/// </summary>
+internal sealed class EvidenceTreeNode
+{
+    public string Id { get; set; } = "";
+    public string Type { get; set; } = "";
+    public string? Framework { get; set; }
+    public string? AutomationId { get; set; }
+    public string? Role { get; set; }
+    public bool Visible { get; set; }
+    public bool Enabled { get; set; }
+    public bool Focused { get; set; }
+    public bool? Selected { get; set; }
+    public EvidenceBounds? Bounds { get; set; }
+    public string? SourceFile { get; set; }
+    public int? SourceLine { get; set; }
+    public int? SourceColumn { get; set; }
+    public string? SourceHash { get; set; }
+    public int ChildCount { get; set; }
+    public List<EvidenceTreeNode>? Children { get; set; }
+}
+
+internal sealed class EvidenceBounds
+{
+    public double X { get; set; }
+    public double Y { get; set; }
+    public double Width { get; set; }
+    public double Height { get; set; }
+}
+
+// ── layout.json ──────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The evidence-safe projection of a layout diagnostics report: rule outcomes, coverage, and
+/// element identity/geometry. Findings reference elements by id, type, automation id, and
+/// project-relative source location — never by text, value, or property dictionary.
+/// </summary>
+internal sealed class EvidenceLayoutDocument
+{
+    public string SchemaVersion { get; set; } = "";
+    public string RuleSetVersion { get; set; } = "";
+    public string? CapturedUtc { get; set; }
+    public string? Platform { get; set; }
+    public string? SnapshotId { get; set; }
+    public string? TreeRevision { get; set; }
+    public string? DiagnosticsRevision { get; set; }
+    public bool Stable { get; set; }
+    public int ElementsExamined { get; set; }
+    public bool Truncated { get; set; }
+    public int Violations { get; set; }
+    public int Observations { get; set; }
+    public int Incomplete { get; set; }
+    public int Passes { get; set; }
+    public int NotApplicable { get; set; }
+    public int Suppressed { get; set; }
+    public string Coverage { get; set; } = "unavailable";
+    public int FindingCount { get; set; }
+    public bool FindingsTruncated { get; set; }
+    public List<EvidenceLayoutRule> Rules { get; set; } = [];
+    public List<EvidenceLayoutFinding> Findings { get; set; } = [];
+    public List<string> Limitations { get; set; } = [];
+    public List<string> NeverCaptured { get; set; } = [];
+}
+
+internal sealed class EvidenceLayoutRule
+{
+    public string RuleId { get; set; } = "";
+    public string Support { get; set; } = "unavailable";
+    public string Confidence { get; set; } = "medium";
+}
+
+internal sealed class EvidenceLayoutFinding
+{
+    public string Id { get; set; } = "";
+    public string RuleId { get; set; } = "";
+    public string Outcome { get; set; } = "observation";
+    public string Confidence { get; set; } = "medium";
+    public string Severity { get; set; } = "info";
+    public string Actionability { get; set; } = "review";
+    public string? SuppressionKey { get; set; }
+    public bool Suppressed { get; set; }
+    public string? SuppressionReason { get; set; }
+    public string Message { get; set; } = "";
+    public string Explanation { get; set; } = "";
+    public string? ElementId { get; set; }
+    public string? ElementType { get; set; }
+    public string? AutomationId { get; set; }
+    public string? SourceFile { get; set; }
+    public int? SourceLine { get; set; }
+    public int? SourceColumn { get; set; }
+    public EvidenceBounds? Bounds { get; set; }
+    public List<string> RelatedElementIds { get; set; } = [];
+    public List<string> FixCategories { get; set; } = [];
+    public List<string> Limitations { get; set; } = [];
+}
+
+// ── problems.json ────────────────────────────────────────────────────────────────────────────
+
+internal sealed class EvidenceProblemDocument
+{
+    public bool Enabled { get; set; }
+    public long Revision { get; set; }
+    public int Count { get; set; }
+    public long Evicted { get; set; }
+    public List<EvidenceProblem> Problems { get; set; } = [];
+}
+
+internal sealed class EvidenceProblem
+{
+    public string Id { get; set; } = "";
+    public string Kind { get; set; } = "";
+    public string Severity { get; set; } = "";
+    public string? Code { get; set; }
+    public string Message { get; set; } = "";
+    public int Count { get; set; }
+    public string? FirstSeenUtc { get; set; }
+    public string? LastSeenUtc { get; set; }
+    public string? ElementId { get; set; }
+    public string? ElementType { get; set; }
+    public string? Property { get; set; }
+    public string? BindingType { get; set; }
+    public string? BindingPath { get; set; }
+    public string? BindingMode { get; set; }
+    public string? SourceType { get; set; }
+    public string? ConverterType { get; set; }
+    public string? SourceFile { get; set; }
+    public int? SourceLine { get; set; }
+    public int? SourceColumn { get; set; }
+}
+
+// ── logs.json ────────────────────────────────────────────────────────────────────────────────
+
+internal sealed class EvidenceLogDocument
+{
+    public int Count { get; set; }
+    public int Limit { get; set; }
+    public bool Truncated { get; set; }
+    public List<EvidenceLogEntry> Entries { get; set; } = [];
+}
+
+internal sealed class EvidenceLogEntry
+{
+    public string? Timestamp { get; set; }
+    public string? Level { get; set; }
+    public string? Category { get; set; }
+    public string Message { get; set; } = "";
+    public string? Exception { get; set; }
+    public string? Source { get; set; }
+}
+
+// ── network.json ─────────────────────────────────────────────────────────────────────────────
+
+internal sealed class EvidenceNetworkDocument
+{
+    public int Count { get; set; }
+    public int Limit { get; set; }
+    public List<EvidenceNetworkEntry> Requests { get; set; } = [];
+}
+
+/// <summary>
+/// Summary metadata only: no headers, no bodies, and no query-string VALUES (parameter names are
+/// kept because they describe the call shape without carrying secrets).
+/// </summary>
+internal sealed class EvidenceNetworkEntry
+{
+    public int Sequence { get; set; }
+    public string? Timestamp { get; set; }
+    public string Method { get; set; } = "";
+    public string? Host { get; set; }
+    public string? Path { get; set; }
+    public List<string>? QueryKeys { get; set; }
+    public int? StatusCode { get; set; }
+    public string? StatusText { get; set; }
+    public long DurationMs { get; set; }
+    public long? RequestBytes { get; set; }
+    public long? ResponseBytes { get; set; }
+    public string? RequestContentType { get; set; }
+    public string? ResponseContentType { get; set; }
+    public string? Error { get; set; }
+}
+
+// ── preview / plan ───────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The "what will be shared" contract. Rendered before any bundle leaves the machine —
+/// the Inspector confirmation dialog, <c>evidence preview</c>, and the MCP preview tool all
+/// present this exact object.
+/// </summary>
+internal sealed class EvidencePlan
+{
+    public bool Ok { get; set; } = true;
+    public string Schema { get; set; } = EvidenceFormat.SchemaId;
+    public int FormatVersion { get; set; } = EvidenceFormat.Version;
+    public int RedactionVersion { get; set; } = EvidenceRedaction.Version;
+    public string Source { get; set; } = "cli";
+    public string GeneratedUtc { get; set; } = "";
+    public EvidenceAppInfo? App { get; set; }
+    public EvidencePlatformInfo? Platform { get; set; }
+    public EvidenceEnvironment? Environment { get; set; }
+    public List<EvidenceEntryInfo> Included { get; set; } = [];
+    public List<EvidenceExclusion> Excluded { get; set; } = [];
+    public List<string> NeverIncluded { get; set; } = [];
+    public EvidenceScreenshotStatus Screenshot { get; set; } = new();
+    public EvidenceCounts Counts { get; set; } = new();
+    public EvidenceLimits Limits { get; set; } = new();
+    public List<string> Warnings { get; set; } = [];
+    public string SuggestedFileName { get; set; } = "";
+    /// <summary>Where <c>evidence capture</c> would write with the current options (CLI/MCP only).</summary>
+    public string? OutputPath { get; set; }
+    public long EstimatedBytes { get; set; }
+    public string? SelectedElementId { get; set; }
+}
+
+// ── command results ──────────────────────────────────────────────────────────────────────────
+
+internal sealed class EvidenceCaptureResult
+{
+    public bool Ok { get; set; }
+    public string? Error { get; set; }
+    public string? Path { get; set; }
+    public long Bytes { get; set; }
+    public EvidenceManifest? Manifest { get; set; }
+    public EvidencePlan? Plan { get; set; }
+}
+
+internal sealed class EvidenceViewResult
+{
+    public bool Ok { get; set; }
+    public string? Error { get; set; }
+    public string? Bundle { get; set; }
+    public string? Report { get; set; }
+    public bool Opened { get; set; }
+    public EvidenceManifest? Manifest { get; set; }
+    public List<string> Entries { get; set; } = [];
+    public List<string> Warnings { get; set; } = [];
+}
+
+/// <summary>Web Inspector preview envelope (mirrors the other <c>/api/*</c> responses).</summary>
+internal sealed class EvidencePreviewResponse
+{
+    public bool Ok { get; set; }
+    public string? Error { get; set; }
+    public EvidencePlan? Plan { get; set; }
+}
+
+internal sealed class EvidenceInspectorOptions
+{
+    public bool IncludeScreenshot { get; set; }
+    public bool? IncludeWorkflow { get; set; }
+    public string? Workflow { get; set; }
+    public string? ElementId { get; set; }
+    public int LogLimit { get; set; } = EvidenceFormat.DefaultLogLimit;
+    public int NetworkLimit { get; set; } = EvidenceFormat.DefaultNetworkLimit;
+}
+
+// ── serialization ────────────────────────────────────────────────────────────────────────────
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(EvidenceManifest))]
+[JsonSerializable(typeof(EvidenceEnvironment))]
+[JsonSerializable(typeof(EvidenceTreeDocument))]
+[JsonSerializable(typeof(EvidenceLayoutDocument))]
+[JsonSerializable(typeof(EvidenceProblemDocument))]
+[JsonSerializable(typeof(EvidenceLogDocument))]
+[JsonSerializable(typeof(EvidenceNetworkDocument))]
+[JsonSerializable(typeof(EvidencePlan))]
+[JsonSerializable(typeof(EvidenceCaptureResult))]
+[JsonSerializable(typeof(EvidenceViewResult))]
+[JsonSerializable(typeof(EvidencePreviewResponse))]
+[JsonSerializable(typeof(EvidenceInspectorOptions))]
+internal sealed partial class EvidenceJsonContext : JsonSerializerContext;
+
+/// <summary>Source-generated (AOT-safe) JSON helpers for every evidence payload.</summary>
+internal static class EvidenceJson
+{
+    // The visual tree nests two JSON levels per element level, so the serializer depth must stay
+    // comfortably above 2 × EvidenceFormat.MaxTreeDepth on both the write and read paths —
+    // otherwise a deep (but legitimate) tree would silently fail to serialize.
+    internal const int MaxJsonDepth = 256;
+
+    private static readonly JsonSerializerOptions Compact =
+        new(EvidenceJsonContext.Default.Options) { MaxDepth = MaxJsonDepth };
+    private static readonly JsonSerializerOptions Pretty =
+        new(EvidenceJsonContext.Default.Options) { WriteIndented = true, MaxDepth = MaxJsonDepth };
+
+    public static string Serialize<T>(T value, bool indented = false)
+        => JsonSerializer.Serialize(value, typeof(T), indented ? Pretty : Compact);
+
+    public static byte[] SerializeToUtf8<T>(T value, bool indented = true)
+        => JsonSerializer.SerializeToUtf8Bytes(value, typeof(T), indented ? Pretty : Compact);
+
+    public static T? Deserialize<T>(string json) where T : class
+        => (T?)JsonSerializer.Deserialize(json, typeof(T), Compact);
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidencePaths.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidencePaths.cs
@@ -1,0 +1,292 @@
+using System.Globalization;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>Outcome of validating a requested bundle destination.</summary>
+internal sealed record EvidencePathResult(string? Path, string? Error)
+{
+    public bool Ok => Error is null && Path is not null;
+}
+
+/// <summary>
+/// Filesystem policy for evidence bundles: where a capture goes by default, which destinations are
+/// accepted, and how generated HTML reports are stored and aged out.
+/// </summary>
+internal static class EvidencePaths
+{
+    /// <summary>Directory holding generated (regenerated, never bundled) HTML reports.</summary>
+    internal static string ReportDirectory { get; set; } =
+        Path.Combine(Path.GetTempPath(), "maui-devflow-evidence");
+
+    private const string ReportPrefix = "evidence-report-";
+    private const string ReportSuffix = ".html";
+    private static readonly TimeSpan ReportTtl = TimeSpan.FromHours(24);
+    private const int MaxRetainedReports = 20;
+
+    /// <summary>
+    /// Resolves the project root used for project-relative source paths and the default
+    /// <c>maui-traces</c> output folder. Falls back to walking up from the working directory
+    /// looking for a project file, then returns null.
+    /// </summary>
+    public static string? FindProjectRoot(string? projectHint, string? startDirectory = null)
+    {
+        if (!string.IsNullOrWhiteSpace(projectHint))
+        {
+            try
+            {
+                var full = Path.GetFullPath(projectHint!, startDirectory ?? Directory.GetCurrentDirectory());
+                if (Directory.Exists(full)) return full;
+                if (File.Exists(full)) return Path.GetDirectoryName(full);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException)
+            {
+                Console.Error.WriteLine("[evidence] Could not resolve the project hint; probing the working directory.");
+            }
+        }
+
+        try
+        {
+            var directory = new DirectoryInfo(startDirectory ?? Directory.GetCurrentDirectory());
+            for (var depth = 0; directory is not null && depth < 12; depth++)
+            {
+                if (directory.EnumerateFiles("*.csproj").Any() ||
+                    directory.EnumerateFiles("*.fsproj").Any() ||
+                    directory.EnumerateFiles("*.slnx").Any() ||
+                    directory.EnumerateFiles("*.sln").Any())
+                {
+                    return directory.FullName;
+                }
+                directory = directory.Parent;
+            }
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine("[evidence] Could not inspect the project directory; source paths will use file names only.");
+        }
+
+        return null;
+    }
+
+    /// <summary>Timestamped, filesystem-safe bundle name (e.g. <c>MyApp-20260729-114233.mauitrace</c>).</summary>
+    public static string BuildDefaultFileName(string? appName, DateTime utcNow)
+    {
+        var prefix = SanitizeFileNameComponent(appName);
+        if (prefix.Length == 0) prefix = "devflow";
+        var stamp = utcNow.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
+        return $"{prefix}-{stamp}{EvidenceFormat.FileExtension}";
+    }
+
+    /// <summary>
+    /// Default destination: <c>&lt;projectRoot&gt;/maui-traces/&lt;name&gt;.mauitrace</c> when the
+    /// project root is known, otherwise the same file name in the current directory.
+    /// </summary>
+    public static string ResolveDefaultOutputPath(string? projectRoot, string? appName, DateTime utcNow)
+    {
+        var fileName = BuildDefaultFileName(appName, utcNow);
+        var directory = string.IsNullOrWhiteSpace(projectRoot)
+            ? Directory.GetCurrentDirectory()
+            : Path.Combine(projectRoot!, EvidenceFormat.DefaultFolderName);
+        return Path.GetFullPath(Path.Combine(directory, fileName));
+    }
+
+    /// <summary>
+    /// Validates an explicit <c>--output</c> value. Accepts a full path, a relative path, or an
+    /// existing directory (in which case the default file name is used inside it). Rejects control
+    /// characters, invalid file names, and any extension other than <c>.mauitrace</c>.
+    /// </summary>
+    public static EvidencePathResult ValidateOutputPath(
+        string? requested,
+        string? projectRoot,
+        string? appName,
+        DateTime utcNow)
+    {
+        if (string.IsNullOrWhiteSpace(requested))
+            return new EvidencePathResult(ResolveDefaultOutputPath(projectRoot, appName, utcNow), null);
+
+        var value = requested!.Trim();
+        if (value.Contains('\0') || value.Any(char.IsControl))
+            return new EvidencePathResult(null, "Output path contains invalid characters.");
+        if (value.Length > 1024)
+            return new EvidencePathResult(null, "Output path is too long.");
+
+        string full;
+        try
+        {
+            full = Path.GetFullPath(value);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return new EvidencePathResult(null, "Output path is not a valid file path.");
+        }
+
+        var endsWithSeparator = value.EndsWith('/') || value.EndsWith('\\') ||
+            value.EndsWith(Path.DirectorySeparatorChar) || value.EndsWith(Path.AltDirectorySeparatorChar);
+        if (Directory.Exists(full) || endsWithSeparator)
+            full = Path.Combine(full, BuildDefaultFileName(appName, utcNow));
+
+        var fileName = Path.GetFileName(full);
+        if (string.IsNullOrEmpty(fileName))
+            return new EvidencePathResult(null, "Output path must include a file name.");
+        if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            return new EvidencePathResult(null, "Output file name contains invalid characters.");
+        if (OperatingSystem.IsWindows() && IsReservedWindowsFileName(fileName))
+            return new EvidencePathResult(null, "Output file name is reserved by Windows.");
+        if (!fileName.EndsWith(EvidenceFormat.FileExtension, StringComparison.OrdinalIgnoreCase))
+            return new EvidencePathResult(null, $"Evidence bundles must use the {EvidenceFormat.FileExtension} extension.");
+
+        return new EvidencePathResult(full, null);
+    }
+
+    /// <summary>Validates a bundle path supplied for reading. The file must exist and be a regular file.</summary>
+    public static EvidencePathResult ValidateInputPath(string? requested)
+    {
+        if (string.IsNullOrWhiteSpace(requested))
+            return new EvidencePathResult(null, "A bundle path is required.");
+
+        var value = requested!.Trim();
+        if (value.Contains('\0') || value.Any(char.IsControl))
+            return new EvidencePathResult(null, "Bundle path contains invalid characters.");
+
+        string full;
+        try
+        {
+            full = Path.GetFullPath(value);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return new EvidencePathResult(null, "Bundle path is not a valid file path.");
+        }
+
+        if (Directory.Exists(full))
+            return new EvidencePathResult(null, "Bundle path is a directory.");
+        if (!File.Exists(full))
+            return new EvidencePathResult(null, $"Bundle not found: {full}");
+
+        return new EvidencePathResult(full, null);
+    }
+
+    public static EvidencePathResult ValidateReportPath(string? requested)
+    {
+        if (string.IsNullOrWhiteSpace(requested))
+            return new EvidencePathResult(null, "A report path is required.");
+
+        var value = requested.Trim();
+        if (value.Contains('\0') || value.Any(char.IsControl))
+            return new EvidencePathResult(null, "Report path contains invalid characters.");
+        if (value.Length > 1024)
+            return new EvidencePathResult(null, "Report path is too long.");
+
+        string full;
+        try
+        {
+            full = Path.GetFullPath(value);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return new EvidencePathResult(null, "Report path is not a valid file path.");
+        }
+
+        if (Directory.Exists(full))
+            return new EvidencePathResult(null, "Report path is a directory.");
+
+        var fileName = Path.GetFileName(full);
+        if (string.IsNullOrWhiteSpace(fileName))
+            return new EvidencePathResult(null, "Report path must include a file name.");
+        if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+            (OperatingSystem.IsWindows() && fileName.Contains(':')))
+        {
+            return new EvidencePathResult(null, "Report file name contains invalid characters.");
+        }
+        if (OperatingSystem.IsWindows() && IsReservedWindowsFileName(fileName))
+            return new EvidencePathResult(null, "Report file name is reserved by Windows.");
+        if (!fileName.EndsWith(".html", StringComparison.OrdinalIgnoreCase) &&
+            !fileName.EndsWith(".htm", StringComparison.OrdinalIgnoreCase))
+        {
+            return new EvidencePathResult(null, "Evidence reports must use the .html or .htm extension.");
+        }
+
+        return new EvidencePathResult(full, null);
+    }
+
+    public static string SanitizeFileNameComponent(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        var invalid = Path.GetInvalidFileNameChars();
+        var chars = value.Trim()
+            .Where(c => !char.IsControl(c) && Array.IndexOf(invalid, c) < 0 && c != ' ')
+            .Take(48)
+            .ToArray();
+        return new string(chars).Trim('.', '-');
+    }
+
+    private static bool IsReservedWindowsFileName(string fileName)
+    {
+        var stem = Path.GetFileNameWithoutExtension(fileName)
+            .TrimEnd(' ', '.')
+            .ToUpperInvariant();
+        if (stem is "CON" or "PRN" or "AUX" or "NUL")
+            return true;
+        return stem.Length == 4 &&
+            (stem.StartsWith("COM", StringComparison.Ordinal) ||
+             stem.StartsWith("LPT", StringComparison.Ordinal)) &&
+            stem[3] is >= '1' and <= '9';
+    }
+
+    // ── Generated report files ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Allocates a path for a freshly generated report and ages out old ones. Only files this
+    /// subsystem created (matching the report name pattern) are ever deleted — the directory
+    /// itself is never removed recursively.
+    /// </summary>
+    public static string CreateReportPath(DateTime utcNow)
+    {
+        Directory.CreateDirectory(ReportDirectory);
+        CleanupReports(utcNow);
+        var stamp = utcNow.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
+        var unique = Guid.NewGuid().ToString("N")[..8];
+        return Path.Combine(ReportDirectory, $"{ReportPrefix}{stamp}-{unique}{ReportSuffix}");
+    }
+
+    /// <summary>Deletes generated reports older than the TTL, then trims to the newest N.</summary>
+    public static void CleanupReports(DateTime utcNow)
+    {
+        try
+        {
+            if (!Directory.Exists(ReportDirectory)) return;
+
+            var reports = new DirectoryInfo(ReportDirectory)
+                .GetFiles(ReportPrefix + "*" + ReportSuffix, SearchOption.TopDirectoryOnly)
+                .Where(file => IsGeneratedReportName(file.Name))
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .ToList();
+
+            for (var i = 0; i < reports.Count; i++)
+            {
+                var expired = utcNow - reports[i].LastWriteTimeUtc > ReportTtl;
+                if (expired || i >= MaxRetainedReports)
+                {
+                    try { reports[i].Delete(); }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        Console.Error.WriteLine("[evidence] An inaccessible generated report was retained during cleanup.");
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine("[evidence] Could not clean up generated reports.");
+        }
+    }
+
+    private static bool IsGeneratedReportName(string name)
+    {
+        var suffix = name.AsSpan(ReportPrefix.Length);
+        return suffix.Length == 29 && suffix[8] == '-' && suffix[15] == '-' &&
+            DateTime.TryParseExact(suffix[..15], "yyyyMMdd-HHmmss", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out _) &&
+            suffix.Slice(16, 8).ToString().All(Uri.IsHexDigit) &&
+            suffix[24..].SequenceEqual(ReportSuffix);
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceRedaction.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceRedaction.cs
@@ -1,0 +1,284 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>
+/// The redaction ruleset shared by Inspector, CLI, and MCP evidence capture.
+///
+/// Every rule here is applied at INGESTION — before a value is serialized into a bundle entry or
+/// returned to a host UI — so no downstream renderer can accidentally surface an unredacted value.
+/// <see cref="Version"/> is written into every manifest and preview so a reader knows which
+/// ruleset produced a bundle.
+/// </summary>
+internal static class EvidenceRedaction
+{
+    /// <summary>Ruleset version. Bump whenever the rules below change what is masked or dropped.</summary>
+    public const int Version = 2;
+
+    private const string Redacted = "<redacted>";
+
+    // ── Secret masking ──────────────────────────────────────────────────────────────────────
+
+    private static readonly Regex UrlSecretRegex = new(
+        @"(?i)([?&](?:access_token|refresh_token|id_token|token|api[_-]?key|apikey|key|secret|password|code|sig|signature)=)[^&#\s]+",
+        RegexOptions.Compiled);
+
+    private static readonly Regex JwtRegex = new(
+        @"eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}",
+        RegexOptions.Compiled);
+
+    private static readonly Regex BearerRegex = new(
+        @"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{12,}",
+        RegexOptions.Compiled);
+
+    private static readonly Regex PrefixedSecretRegex = new(
+        @"(?ix)\b(?:
+            sk[-_][a-z0-9_-]{16,} |
+            xox[baprs]-[a-z0-9-]{10,} |
+            gh[pousr]_[a-z0-9]{20,} |
+            github_pat_[a-z0-9_]{20,} |
+            glpat-[a-z0-9_-]{16,} |
+            AIza[a-z0-9_-]{20,} |
+            (?:AKIA|ASIA)[A-Z0-9]{16}
+        )\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex PemPrivateKeyRegex = new(
+        @"(?is)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----",
+        RegexOptions.Compiled);
+
+    private static readonly Regex BasicAuthUrlRegex = new(
+        @"(?i)(https?://)[^/\s:@]+:[^/\s@]+@",
+        RegexOptions.Compiled);
+
+    private static readonly Regex SecretKvRegex = new(
+        "(?i)(\"(?:[a-z0-9_-]*(?:token|secret|password|passwd|pwd|cookie|private[_-]?key|access[_-]?key|signing[_-]?key|apikey|api[_-]?key|authorization)[a-z0-9_-]*)\"\\s*:\\s*)\"[^\"]*\"",
+        RegexOptions.Compiled);
+
+    // key=value / key: value assignments in free-form log text (not JSON).
+    private static readonly Regex SecretAssignmentRegex = new(
+        @"(?i)\b([a-z0-9_-]*(?:token|secret|password|passwd|pwd|cookie|private[_-]?key|access[_-]?key|signing[_-]?key|apikey|api[_-]?key|authorization|credential)[a-z0-9_-]*)\s*[:=]\s*(""[^""]*""|'[^']*'|[^\s,;}{\]]+)",
+        RegexOptions.Compiled);
+
+    // Absolute filesystem paths that would leak the developer's machine layout: drive-rooted,
+    // UNC shares (which also leak internal host names), and the common Unix/WSL roots.
+    private static readonly Regex WindowsPathRegex = new(
+        @"(?i)(\\\\[^\s""'<>|]+|\b[a-z]:[\\/][^\s""'<>|]*)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex UnixPathRegex = new(
+        @"(?<![\w.])/(?:Users|home|root|var|private|Volumes|tmp|opt|data|storage|mnt|media|srv|workspace|workspaces|builds|github/workspace|agent/_work|__w)/[^\s""'<>|]*",
+        RegexOptions.Compiled);
+
+    private static readonly Regex FileUriRegex = new(
+        @"(?i)file:///[^\s""'<>|]*",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Masks JWTs, bearer tokens, and secret-shaped JSON values in free-form text. Replacements
+    /// never introduce a quote, so masking a serialized JSON document keeps it parseable.
+    /// </summary>
+    public static string MaskSecrets(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+        text = PemPrivateKeyRegex.Replace(text, "<private-key>");
+        text = PrefixedSecretRegex.Replace(text, Redacted);
+        text = BasicAuthUrlRegex.Replace(text, "$1" + Redacted + "@");
+        text = JwtRegex.Replace(text, "<jwt>");
+        text = BearerRegex.Replace(text, "$1" + Redacted);
+        text = SecretKvRegex.Replace(text, "$1\"" + Redacted + "\"");
+        return text;
+    }
+
+    /// <summary>Strips secret query-string values from a URL while keeping the rest readable.</summary>
+    public static string MaskUrlSecrets(string url)
+        => string.IsNullOrEmpty(url) ? url : UrlSecretRegex.Replace(url, "$1" + Redacted);
+
+    // ── Bundle-side scrubbing ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Full ingestion scrub for any free-form string entering a bundle: masks secrets and secret
+    /// assignments, replaces absolute paths with their file name, drops control characters, and
+    /// truncates to <paramref name="maxChars"/>.
+    /// </summary>
+    public static string? Scrub(string? text, int maxChars)
+    {
+        if (text is null) return null;
+        if (text.Length == 0) return string.Empty;
+
+        var scrubbed = MaskSecrets(text);
+        scrubbed = SecretAssignmentRegex.Replace(scrubbed, "$1=" + Redacted);
+        scrubbed = MaskUrlSecrets(scrubbed);
+        scrubbed = StripAbsolutePaths(scrubbed);
+        scrubbed = RemoveControlCharacters(scrubbed);
+        return Truncate(scrubbed, maxChars);
+    }
+
+    /// <summary>Replaces absolute Windows/Unix/file-URI paths with their file name only.</summary>
+    public static string StripAbsolutePaths(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+        text = FileUriRegex.Replace(text, m => LastSegment(m.Value));
+        text = WindowsPathRegex.Replace(text, m => LastSegment(m.Value));
+        text = UnixPathRegex.Replace(text, m => LastSegment(m.Value));
+        return text;
+    }
+
+    private static string LastSegment(string path)
+    {
+        var trimmed = path.TrimEnd('/', '\\');
+        var index = trimmed.LastIndexOfAny(['/', '\\']);
+        var segment = index >= 0 && index < trimmed.Length - 1 ? trimmed[(index + 1)..] : trimmed;
+        return string.IsNullOrEmpty(segment) ? "<path>" : segment;
+    }
+
+    private static string RemoveControlCharacters(string text)
+    {
+        var needsWork = false;
+        foreach (var c in text)
+        {
+            if ((char.IsControl(c) && c is not ('\n' or '\r' or '\t')) ||
+                char.GetUnicodeCategory(c) == UnicodeCategory.Format)
+            {
+                needsWork = true;
+                break;
+            }
+        }
+        if (!needsWork) return text;
+
+        var builder = new StringBuilder(text.Length);
+        foreach (var c in text)
+        {
+            if ((!char.IsControl(c) || c is '\n' or '\r' or '\t') &&
+                char.GetUnicodeCategory(c) != UnicodeCategory.Format)
+                builder.Append(c);
+        }
+        return builder.ToString();
+    }
+
+    public static string Truncate(string value, int maxChars)
+    {
+        if (maxChars <= 0) return string.Empty;
+        if (value.Length <= maxChars) return value;
+        const string marker = "…[truncated]";
+        if (maxChars <= marker.Length)
+            return marker[..maxChars];
+        return string.Concat(value.AsSpan(0, maxChars - marker.Length), marker);
+    }
+
+    /// <summary>
+    /// Developer-authored identifiers (AutomationId, element type, category names) are safe to keep,
+    /// but they still get length-capped, control-character stripped, and secret-masked in case an
+    /// app generated one from a token.
+    /// </summary>
+    public static string? SafeIdentifier(string? value, int maxChars = EvidenceFormat.MaxIdentifierChars)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var trimmed = RemoveControlCharacters(value.Trim());
+        trimmed = new string(trimmed.Where(character => !char.IsControl(character)).ToArray());
+        trimmed = MaskSecrets(trimmed);
+        trimmed = SecretAssignmentRegex.Replace(trimmed, "$1=" + Redacted);
+        trimmed = StripAbsolutePaths(trimmed);
+        return trimmed.Length == 0 ? null : Truncate(trimmed, maxChars);
+    }
+
+    /// <summary>
+    /// Keeps the route shape while removing every query value and fragment. Query parameter names
+    /// are developer-authored metadata; values frequently contain user or authentication state.
+    /// </summary>
+    public static string? ScrubRoute(string? route)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+            return null;
+
+        var value = route.Trim();
+        var fragmentIndex = value.IndexOf('#');
+        if (fragmentIndex >= 0)
+            value = value[..fragmentIndex];
+
+        var queryIndex = value.IndexOf('?');
+        var path = queryIndex >= 0 ? value[..queryIndex] : value;
+        var safePath = Scrub(path, EvidenceFormat.MaxIdentifierChars);
+        if (queryIndex < 0 || queryIndex == value.Length - 1)
+            return safePath;
+
+        var keys = value[(queryIndex + 1)..]
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(pair =>
+            {
+                var equals = pair.IndexOf('=');
+                var key = equals >= 0 ? pair[..equals] : pair;
+                key = Uri.UnescapeDataString(key);
+                return SafeIdentifier(key, 64);
+            })
+            .Where(static key => !string.IsNullOrWhiteSpace(key))
+            .Distinct(StringComparer.Ordinal)
+            .Take(EvidenceFormat.MaxQueryKeys)
+            .Select(static key => $"{key}=<redacted>")
+            .ToArray();
+
+        return keys.Length == 0 ? safePath : Truncate($"{safePath}?{string.Join("&", keys)}", 512);
+    }
+
+    /// <summary>
+    /// Converts a source-file path into evidence-safe form: project-relative with forward slashes
+    /// when the file lives under <paramref name="projectRoot"/>, otherwise the file name only.
+    /// Never returns an absolute path, a traversal, or a drive-rooted string.
+    /// </summary>
+    public static string? NormalizeSourcePath(string? path, string? projectRoot)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+
+        var value = path.Trim();
+        if (value.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+        {
+            if (Uri.TryCreate(value, UriKind.Absolute, out var fileUri) && fileUri.IsFile)
+                value = fileUri.LocalPath;
+        }
+
+        if (!string.IsNullOrWhiteSpace(projectRoot) &&
+            (!IsRooted(value) || Path.IsPathFullyQualified(value)))
+        {
+            try
+            {
+                var root = Path.GetFullPath(projectRoot!);
+                var full = Path.GetFullPath(value);
+                var comparison = OperatingSystem.IsWindows()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+                var prefix = root.EndsWith(Path.DirectorySeparatorChar)
+                    ? root
+                    : root + Path.DirectorySeparatorChar;
+                if (full.StartsWith(prefix, comparison))
+                    return SafeIdentifier(ToRelativeForm(full[prefix.Length..]), 512);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                // Unparseable path — fall through to the file-name-only policy.
+            }
+        }
+
+        if (!IsRooted(value))
+        {
+            var relative = ToRelativeForm(value);
+            // A relative path that escapes upward still describes the machine layout — drop to name.
+            if (!relative.Contains("../", StringComparison.Ordinal) && relative != "..")
+                return SafeIdentifier(relative, 512);
+        }
+
+        var name = LastSegment(value);
+        return SafeIdentifier(name, 512);
+    }
+
+    private static bool IsRooted(string value)
+    {
+        if (value.Length == 0) return false;
+        if (value[0] is '/' or '\\') return true;
+        return value.Length >= 2 && value[1] == ':' && char.IsLetter(value[0]);
+    }
+
+    private static string ToRelativeForm(string value)
+        => value.Replace('\\', '/').TrimStart('/');
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceReportLauncher.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceReportLauncher.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>
+/// Opens a generated report with the OS default handler. Only paths this tool just wrote are ever
+/// passed here, and the file is launched by path (never through a shell command line), so a
+/// bundle can never influence what gets executed.
+/// </summary>
+internal static class EvidenceReportLauncher
+{
+    public static bool TryOpen(string reportPath)
+    {
+        if (string.IsNullOrWhiteSpace(reportPath) || !File.Exists(reportPath)) return false;
+
+        try
+        {
+            var full = Path.GetFullPath(reportPath);
+            if (OperatingSystem.IsWindows())
+            {
+                using var shellLaunched = Process.Start(new ProcessStartInfo(full) { UseShellExecute = true });
+                return true;
+            }
+
+            var launcher = OperatingSystem.IsMacOS() ? "open" : "xdg-open";
+            var info = new ProcessStartInfo(launcher) { UseShellExecute = false };
+            info.ArgumentList.Add(full);
+            using var launched = Process.Start(info);
+            return launched is not null;
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException or IOException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceReportRenderer.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/EvidenceReportRenderer.cs
@@ -1,0 +1,566 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>
+/// Renders a validated bundle into a fresh, self-contained, static HTML report.
+///
+/// The report is REGENERATED from parsed data — no markup, script, or style from the bundle is
+/// ever forwarded. Every interpolated value is HTML-encoded and the document declares a
+/// restrictive CSP (no script, no network, images limited to embedded data URIs), so opening a
+/// report produced from an untrusted bundle cannot execute anything or phone home.
+/// </summary>
+internal static class EvidenceReportRenderer
+{
+    internal const string ContentSecurityPolicy =
+        "default-src 'none'; img-src data:; style-src 'unsafe-inline'; font-src 'none'; " +
+        "connect-src 'none'; script-src 'none'; object-src 'none'; base-uri 'none'; " +
+        "form-action 'none'; frame-ancestors 'none'";
+
+    private const int MaxRenderedTreeNodes = 2_000;
+    private const int MaxRenderedRows = 500;
+
+    public static string Render(EvidenceReadResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var manifest = result.Manifest;
+        var appName = manifest?.App?.Name ?? "MAUI app";
+        var title = $"DevFlow evidence — {appName}";
+
+        var html = new StringBuilder(64 * 1024);
+        html.Append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
+        html.Append("<meta charset=\"utf-8\">\n");
+        html.Append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+        html.Append("<meta http-equiv=\"Content-Security-Policy\" content=\"").Append(ContentSecurityPolicy).Append("\">\n");
+        html.Append("<meta name=\"referrer\" content=\"no-referrer\">\n");
+        html.Append("<title>").Append(E(title)).Append("</title>\n");
+        html.Append("<style>").Append(Css).Append("</style>\n");
+        html.Append("</head>\n<body>\n<main>\n");
+
+        html.Append("<h1>").Append(E(title)).Append("</h1>\n");
+        RenderOverview(html, result);
+        RenderEnvironment(html, result.Environment);
+        RenderContents(html, manifest);
+        RenderWarnings(html, result);
+        RenderScreenshot(html, result);
+        RenderProblems(html, result);
+        RenderLayout(html, result);
+        RenderNetwork(html, result);
+        RenderLogs(html, result);
+        RenderTree(html, result);
+        RenderWorkflow(html, result);
+
+        html.Append("<footer><p>Generated locally by the MAUI DevFlow CLI. This report is static: it contains no scripts and makes no network requests.</p></footer>\n");
+        html.Append("</main>\n</body>\n</html>\n");
+        return html.ToString();
+    }
+
+    private static void RenderOverview(StringBuilder html, EvidenceReadResult result)
+    {
+        var manifest = result.Manifest;
+        html.Append("<section><h2>Overview</h2>\n<dl class=\"grid\">\n");
+        Definition(html, "Captured (UTC)", manifest?.CapturedUtc);
+        Definition(html, "Captured by", manifest?.Source);
+        Definition(html, "Tool version", manifest?.Tool?.Version);
+        Definition(html, "Format version", manifest?.FormatVersion.ToString(CultureInfo.InvariantCulture));
+        Definition(html, "Redaction ruleset", manifest?.RedactionVersion.ToString(CultureInfo.InvariantCulture));
+        Definition(html, "App", manifest?.App?.Name);
+        Definition(html, "App version", Join(manifest?.App?.Version, manifest?.App?.Build));
+        Definition(html, "Package", manifest?.App?.PackageId);
+        Definition(html, "Platform", manifest?.Platform?.Name);
+        Definition(html, "Device type", manifest?.Platform?.DeviceType);
+        Definition(html, "Agent", manifest?.Platform?.AgentVersion);
+        Definition(html, "Framework", Join(manifest?.Platform?.Framework, manifest?.Platform?.FrameworkVersion));
+        Definition(html, "Selected element", manifest?.SelectedElementId);
+
+        html.Append("</dl>\n");
+
+        var counts = manifest?.Counts;
+        if (counts is not null)
+        {
+            html.Append("<ul class=\"stats\">\n");
+            if (result.Tree is not null) Stat(html, "Elements", counts.TreeElements);
+            if (result.Problems is not null) Stat(html, "Problems", counts.Problems);
+            if (result.Logs is not null) Stat(html, "Log entries", counts.Logs);
+            if (result.Network is not null) Stat(html, "Network requests", counts.NetworkRequests);
+            if (result.Layout is not null) Stat(html, "Layout findings", counts.LayoutFindings);
+            html.Append("</ul>\n");
+        }
+
+        var capabilities = result.Environment?.Capabilities ?? manifest?.Capabilities;
+        if (capabilities is { Count: > 0 })
+        {
+            html.Append("<p class=\"muted\"><strong>Agent capabilities:</strong> ")
+                .Append(E(string.Join(", ", capabilities)))
+                .Append("</p>\n");
+        }
+
+        html.Append("</section>\n");
+    }
+
+    private static void RenderEnvironment(StringBuilder html, EvidenceEnvironment? environment)
+    {
+        html.Append("<section><h2>Environment</h2>\n");
+        html.Append("<p class=\"muted\">A sequential, read-only snapshot of the current app, not the original recording environment or an enforced replay contract. Missing facts are not inferred from the developer's machine. Imported metadata is untrusted; content hashes verify integrity, not provenance.</p>\n");
+        if (environment is null)
+        {
+            html.Append("<p>Environment metadata was not captured or could not be read.</p></section>\n");
+            return;
+        }
+        html.Append("<dl class=\"grid\">\n");
+        foreach (var (label, value) in EnvironmentFacts(environment))
+            Definition(html, label, value);
+        html.Append("</dl>\n");
+        if (environment.Unavailable.Count > 0)
+        {
+            html.Append("<h3>Not captured or enforced</h3><ul>\n");
+            foreach (var gap in environment.Unavailable)
+                html.Append("<li><strong>").Append(E(gap.Name)).Append(":</strong> ").Append(E(gap.Reason)).Append("</li>\n");
+            html.Append("</ul>\n");
+        }
+        else
+        {
+            html.Append("<p class=\"muted\">No environment-gap inventory was recorded. This is not proof of a complete environment.</p>\n");
+        }
+        html.Append("</section>\n");
+    }
+
+    internal static IEnumerable<(string Label, string? Value)> EnvironmentFacts(EvidenceEnvironment environment) =>
+    [
+        ("App version / build", Join(environment.App?.Version, environment.App?.Build)),
+        ("Device", Join(environment.Device?.Manufacturer, environment.Device?.Model)),
+        ("Device type", environment.Device?.DeviceType ?? environment.Platform?.DeviceType),
+        ("OS", Join(environment.Device?.Platform ?? environment.Platform?.Name, environment.Device?.OsVersion)),
+        ("Architecture", environment.Device?.Architecture),
+        ("Framework (not runtime)", Join(environment.Platform?.Framework, environment.Platform?.FrameworkVersion)),
+        ("Display (px)", Dimensions(environment.Display?.Width, environment.Display?.Height)),
+        ("Display density", Num(environment.Display?.Density)),
+        ("Orientation / rotation", Join(environment.Display?.Orientation, environment.Display?.Rotation)),
+        ("Refresh rate (Hz)", Num(environment.Display?.RefreshRate)),
+        ("App viewport (DIP)", Dimensions(environment.Viewport?.Width, environment.Viewport?.Height)),
+        ("App density (px / DIP)", Num(environment.Viewport?.Density)),
+        ("App windows", environment.Viewport?.WindowCount?.ToString(CultureInfo.InvariantCulture)),
+        ("App theme", environment.Theme?.Effective),
+        ("Requested theme", environment.Theme?.Requested),
+        ("App theme override", environment.Theme?.AppOverride),
+        ("Network access", environment.Connectivity?.NetworkAccess),
+        ("Connection profiles", environment.Connectivity is null ? null : string.Join(", ", environment.Connectivity.ConnectionProfiles)),
+    ];
+
+    private static string? Dimensions(double? width, double? height)
+        => width is null || height is null ? null : $"{Num(width)} x {Num(height)}";
+
+    private static void RenderContents(StringBuilder html, EvidenceManifest? manifest)
+    {
+        html.Append("<section><h2>Contents</h2>\n");
+
+        if (manifest?.Entries is { Count: > 0 })
+        {
+            html.Append("<table><caption>Included</caption><thead><tr><th scope=\"col\">Entry</th><th scope=\"col\">What it holds</th><th scope=\"col\">Items</th><th scope=\"col\">Size</th></tr></thead><tbody>\n");
+            foreach (var entry in manifest.Entries)
+            {
+                html.Append("<tr><td><code>").Append(E(entry.Name)).Append("</code></td><td>")
+                    .Append(E(entry.Description)).Append("</td><td>")
+                    .Append(entry.Count is null ? "—" : E(entry.Count.Value.ToString(CultureInfo.InvariantCulture)))
+                    .Append("</td><td>").Append(E(FormatBytes(entry.Bytes))).Append("</td></tr>\n");
+            }
+            html.Append("</tbody></table>\n");
+        }
+
+        if (manifest?.Excluded is { Count: > 0 })
+        {
+            html.Append("<table><caption>Excluded from this capture</caption><thead><tr><th scope=\"col\">Entry</th><th scope=\"col\">Reason</th></tr></thead><tbody>\n");
+            foreach (var exclusion in manifest.Excluded)
+            {
+                html.Append("<tr><td><code>").Append(E(exclusion.Name)).Append("</code></td><td>")
+                    .Append(E(exclusion.Reason)).Append("</td></tr>\n");
+            }
+            html.Append("</tbody></table>\n");
+        }
+
+        var never = manifest?.NeverIncluded is { Count: > 0 } ? manifest.NeverIncluded : EvidenceFormat.NeverIncluded;
+        html.Append("<h3>Never captured</h3>\n<ul>\n");
+        foreach (var item in never)
+            html.Append("<li>").Append(E(item)).Append("</li>\n");
+        html.Append("</ul>\n");
+
+        var screenshot = manifest?.Screenshot;
+        if (screenshot is not null)
+        {
+            var state = screenshot.Included
+                ? "Included at explicit request."
+                : screenshot.OmittedReason ?? "Not included.";
+            html.Append("<p class=\"muted\"><strong>Screenshot:</strong> ").Append(E(state)).Append("</p>\n");
+        }
+
+        html.Append("</section>\n");
+    }
+
+    private static void RenderWarnings(StringBuilder html, EvidenceReadResult result)
+    {
+        var warnings = new List<string>();
+        if (result.Manifest?.Warnings is { Count: > 0 }) warnings.AddRange(result.Manifest.Warnings);
+        if (result.Warnings.Count > 0) warnings.AddRange(result.Warnings);
+        if (warnings.Count == 0) return;
+
+        html.Append("<section class=\"warn\"><h2>Warnings</h2>\n<ul>\n");
+        foreach (var warning in warnings)
+            html.Append("<li>").Append(E(warning)).Append("</li>\n");
+        html.Append("</ul>\n</section>\n");
+    }
+
+    private static void RenderScreenshot(StringBuilder html, EvidenceReadResult result)
+    {
+        if (result.Screenshot is not { Length: > 0 }) return;
+        html.Append("<section><h2>Screenshot</h2>\n<img alt=\"App screenshot captured with this bundle\" src=\"data:image/png;base64,")
+            .Append(Convert.ToBase64String(result.Screenshot))
+            .Append("\">\n</section>\n");
+    }
+
+    private static void RenderProblems(StringBuilder html, EvidenceReadResult result)
+    {
+        var problems = result.Problems;
+        if (problems is null) return;
+        var items = problems.Problems ?? [];
+
+        html.Append("<section><h2>Problems</h2>\n");
+        if (items.Count == 0)
+        {
+            html.Append("<p class=\"muted\">No problems were recorded.</p>\n</section>\n");
+            return;
+        }
+
+        html.Append("<table><thead><tr><th scope=\"col\">Severity</th><th scope=\"col\">Kind</th><th scope=\"col\">Message</th><th scope=\"col\">Element</th><th scope=\"col\">Binding</th><th scope=\"col\">Source</th><th scope=\"col\">Count</th></tr></thead><tbody>\n");
+        foreach (var problem in items.Take(MaxRenderedRows))
+        {
+            html.Append("<tr><td>").Append(E(problem.Severity)).Append("</td><td>")
+                .Append(E(problem.Kind)).Append("</td><td>")
+                .Append(E(problem.Message)).Append("</td><td>")
+                .Append(E(Join(problem.ElementType, problem.Property))).Append("</td><td>")
+                .Append(E(problem.BindingPath)).Append("</td><td>")
+                .Append(E(FormatSource(problem.SourceFile, problem.SourceLine, problem.SourceColumn))).Append("</td><td>")
+                .Append(problem.Count.ToString(CultureInfo.InvariantCulture)).Append("</td></tr>\n");
+        }
+        html.Append("</tbody></table>\n");
+        AppendTruncationNote(html, items.Count, MaxRenderedRows);
+        html.Append("</section>\n");
+    }
+
+    private static void RenderLayout(StringBuilder html, EvidenceReadResult result)
+    {
+        var layout = result.Layout;
+        if (layout is null) return;
+        var rules = layout.Rules ?? [];
+        var findings = layout.Findings ?? [];
+        var limitations = layout.Limitations ?? [];
+        var neverCaptured = layout.NeverCaptured ?? [];
+
+        html.Append("<section><h2>Layout diagnostics</h2>\n");
+        html.Append("<p class=\"muted\">These are the agent's layout observations, with its reported coverage and limitations. Missing or opaque evidence is <em>incomplete</em>, never a pass.</p>\n");
+        html.Append("<dl class=\"grid\">\n");
+        Definition(html, "Schema", Join(layout.SchemaVersion, layout.RuleSetVersion));
+        Definition(html, "Captured (UTC)", layout.CapturedUtc);
+        Definition(html, "Platform", layout.Platform);
+        Definition(html, "Elements examined",
+            layout.ElementsExamined.ToString(CultureInfo.InvariantCulture) + (layout.Truncated ? " (truncated)" : ""));
+        Definition(html, "Coverage", layout.Coverage);
+        html.Append("</dl>\n");
+
+        html.Append("<ul class=\"stats\">\n");
+        Stat(html, "Violations", layout.Violations);
+        Stat(html, "Observations", layout.Observations);
+        Stat(html, "Incomplete", layout.Incomplete);
+        html.Append("</ul>\n");
+
+        if (rules.Count > 0)
+        {
+            html.Append("<table><caption>Rule coverage</caption><thead><tr><th scope=\"col\">Rule</th><th scope=\"col\">Support</th><th scope=\"col\">Confidence</th></tr></thead><tbody>\n");
+            foreach (var rule in rules)
+            {
+                html.Append("<tr><td><code>").Append(E(rule.RuleId)).Append("</code></td><td>")
+                    .Append(E(rule.Support)).Append("</td><td>")
+                    .Append(E(rule.Confidence)).Append("</td></tr>\n");
+            }
+            html.Append("</tbody></table>\n");
+        }
+
+        if (findings.Count == 0)
+        {
+            html.Append("<p class=\"muted\">No findings were recorded. Read the coverage table above before treating that as a pass.</p>\n");
+        }
+        else
+        {
+            html.Append("<table><caption>Findings</caption><thead><tr><th scope=\"col\">Outcome</th><th scope=\"col\">Rule</th><th scope=\"col\">Confidence</th><th scope=\"col\">Element</th><th scope=\"col\">Source</th><th scope=\"col\">Detail</th></tr></thead><tbody>\n");
+            foreach (var finding in findings.Take(MaxRenderedRows))
+            {
+                html.Append("<tr><td>").Append(E(finding.Outcome)).Append("</td><td><code>")
+                    .Append(E(finding.RuleId)).Append("</code></td><td>")
+                    .Append(E(finding.Confidence)).Append("</td><td>")
+                    .Append(E(Join(finding.ElementType, finding.AutomationId ?? finding.ElementId))).Append("</td><td>")
+                    .Append(E(FormatSource(finding.SourceFile, finding.SourceLine, finding.SourceColumn))).Append("</td><td>")
+                    .Append(E(finding.Message)).Append("<br><span class=\"muted\">").Append(E(finding.Explanation)).Append("</span>");
+                foreach (var limitation in finding.Limitations ?? [])
+                    html.Append("<br><span class=\"muted\">! ").Append(E(limitation)).Append("</span>");
+                html.Append("</td></tr>\n");
+            }
+            html.Append("</tbody></table>\n");
+            AppendTruncationNote(html, findings.Count, MaxRenderedRows);
+            if (layout.FindingsTruncated)
+                html.Append("<p class=\"muted\">Findings were truncated when the bundle was captured.</p>\n");
+        }
+
+        if (limitations.Count > 0)
+        {
+            html.Append("<p class=\"muted\"><strong>Limitations:</strong></p>\n<ul>\n");
+            foreach (var limitation in limitations)
+                html.Append("<li>").Append(E(limitation)).Append("</li>\n");
+            html.Append("</ul>\n");
+        }
+
+        if (neverCaptured.Count > 0)
+        {
+            html.Append("<p class=\"muted\"><strong>Never captured:</strong> ")
+                .Append(E(string.Join(", ", neverCaptured))).Append("</p>\n");
+        }
+
+        html.Append("</section>\n");
+    }
+
+    private static void RenderNetwork(StringBuilder html, EvidenceReadResult result)
+    {
+        var network = result.Network;
+        if (network is null) return;
+        var requests = network.Requests ?? [];
+
+        html.Append("<section><h2>Network</h2>\n<p class=\"muted\">Summaries only — no headers, bodies, or query-string values were captured.</p>\n");
+        if (requests.Count == 0)
+        {
+            html.Append("<p class=\"muted\">No requests were recorded.</p>\n</section>\n");
+            return;
+        }
+
+        html.Append("<table><thead><tr><th scope=\"col\">#</th><th scope=\"col\">Method</th><th scope=\"col\">Host</th><th scope=\"col\">Path</th><th scope=\"col\">Query keys</th><th scope=\"col\">Status</th><th scope=\"col\">Duration</th><th scope=\"col\">Size</th></tr></thead><tbody>\n");
+        foreach (var request in requests.Take(MaxRenderedRows))
+        {
+            var status = request.StatusCode?.ToString(CultureInfo.InvariantCulture) ?? request.Error ?? "—";
+            var size = request.ResponseBytes is null ? "—" : FormatBytes(request.ResponseBytes.Value);
+            html.Append("<tr><td>").Append(request.Sequence.ToString(CultureInfo.InvariantCulture)).Append("</td><td>")
+                .Append(E(request.Method)).Append("</td><td>")
+                .Append(E(request.Host)).Append("</td><td>")
+                .Append(E(request.Path)).Append("</td><td>")
+                .Append(E(request.QueryKeys is null ? null : string.Join(", ", request.QueryKeys))).Append("</td><td>")
+                .Append(E(status)).Append("</td><td>")
+                .Append(E(request.DurationMs.ToString(CultureInfo.InvariantCulture) + " ms")).Append("</td><td>")
+                .Append(E(size)).Append("</td></tr>\n");
+        }
+        html.Append("</tbody></table>\n");
+        AppendTruncationNote(html, requests.Count, MaxRenderedRows);
+        html.Append("</section>\n");
+    }
+
+    private static void RenderLogs(StringBuilder html, EvidenceReadResult result)
+    {
+        var logs = result.Logs;
+        if (logs is null) return;
+        var entries = logs.Entries ?? [];
+
+        html.Append("<section><h2>Logs</h2>\n");
+        if (entries.Count == 0)
+        {
+            html.Append("<p class=\"muted\">No log entries were captured.</p>\n</section>\n");
+            return;
+        }
+
+        html.Append("<table><thead><tr><th scope=\"col\">Time</th><th scope=\"col\">Level</th><th scope=\"col\">Category</th><th scope=\"col\">Message</th></tr></thead><tbody>\n");
+        foreach (var entry in entries.Take(MaxRenderedRows))
+        {
+            var message = entry.Exception is { Length: > 0 }
+                ? entry.Message + "\n" + entry.Exception
+                : entry.Message;
+            html.Append("<tr><td>").Append(E(entry.Timestamp)).Append("</td><td>")
+                .Append(E(entry.Level)).Append("</td><td>")
+                .Append(E(entry.Category)).Append("</td><td><pre>")
+                .Append(E(message)).Append("</pre></td></tr>\n");
+        }
+        html.Append("</tbody></table>\n");
+        AppendTruncationNote(html, entries.Count, MaxRenderedRows);
+        html.Append("</section>\n");
+    }
+
+    private static void RenderTree(StringBuilder html, EvidenceReadResult result)
+    {
+        var tree = result.Tree;
+        if (tree is null) return;
+        var roots = tree.Roots ?? [];
+
+        html.Append("<section><h2>Visual tree</h2>\n<p class=\"muted\">Structure only — element text and property values were not captured.</p>\n");
+        if (roots.Count == 0)
+        {
+            html.Append("<p class=\"muted\">No elements were captured.</p>\n</section>\n");
+            return;
+        }
+
+        var selected = result.Manifest?.SelectedElementId;
+        var budget = MaxRenderedTreeNodes;
+        AppendTreeNodes(html, roots, selected, ref budget);
+        if (budget <= 0)
+            html.Append("<p class=\"muted\">Tree display truncated.</p>\n");
+        html.Append("</section>\n");
+    }
+
+    private static void AppendTreeNodes(StringBuilder html, List<EvidenceTreeNode> nodes, string? selectedId, ref int budget)
+    {
+        html.Append("<ul class=\"tree\">\n");
+        foreach (var node in nodes)
+        {
+            if (budget <= 0) break;
+            budget--;
+
+            var isSelected = selectedId is not null && string.Equals(node.Id, selectedId, StringComparison.Ordinal);
+            html.Append(isSelected ? "<li class=\"sel\">" : "<li>");
+            html.Append("<code>").Append(E(node.Type)).Append("</code>");
+            if (node.AutomationId is { Length: > 0 })
+                html.Append(" <span class=\"aid\">#").Append(E(node.AutomationId)).Append("</span>");
+            if (isSelected)
+                html.Append(" <span class=\"badge\">selected</span>");
+            if (node.Bounds is not null)
+            {
+                html.Append(" <span class=\"muted\">")
+                    .Append(E($"{Num(node.Bounds.X)},{Num(node.Bounds.Y)} {Num(node.Bounds.Width)}×{Num(node.Bounds.Height)}"))
+                    .Append("</span>");
+            }
+            if (!node.Visible) html.Append(" <span class=\"muted\">hidden</span>");
+            if (!node.Enabled) html.Append(" <span class=\"muted\">disabled</span>");
+            var source = FormatSource(node.SourceFile, node.SourceLine, node.SourceColumn);
+            if (source is not null)
+                html.Append(" <span class=\"src\">").Append(E(source)).Append("</span>");
+
+            if (node.Children is { Count: > 0 } && budget > 0)
+                AppendTreeNodes(html, node.Children, selectedId, ref budget);
+
+            html.Append("</li>\n");
+        }
+        html.Append("</ul>\n");
+    }
+
+    private static void RenderWorkflow(StringBuilder html, EvidenceReadResult result)
+    {
+        if (string.IsNullOrWhiteSpace(result.Workflow)) return;
+        // Rendered as inert, encoded text — bundled markdown is never interpreted as markup.
+        html.Append("<section><h2>Workflow</h2>\n<p class=\"muted\">Diagnostic attachment only: structured values are redacted, so this is not a replayable golden test. Author a separate journey with AutomationId or semantic locators and business-visible assertions.</p>\n<pre class=\"doc\">")
+            .Append(E(result.Workflow))
+            .Append("</pre>\n</section>\n");
+    }
+
+    private static void AppendTruncationNote(StringBuilder html, int total, int rendered)
+    {
+        if (total <= rendered) return;
+        html.Append("<p class=\"muted\">Showing the first ")
+            .Append(rendered.ToString(CultureInfo.InvariantCulture))
+            .Append(" of ")
+            .Append(total.ToString(CultureInfo.InvariantCulture))
+            .Append(" rows.</p>\n");
+    }
+
+    private static void Definition(StringBuilder html, string term, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+        html.Append("<dt>").Append(E(term)).Append("</dt><dd>").Append(E(value)).Append("</dd>\n");
+    }
+
+    private static void Stat(StringBuilder html, string label, int value)
+        => html.Append("<li><span class=\"n\">").Append(value.ToString(CultureInfo.InvariantCulture))
+               .Append("</span><span>").Append(E(label)).Append("</span></li>\n");
+
+    private static string? Join(string? first, string? second)
+    {
+        if (string.IsNullOrWhiteSpace(first)) return string.IsNullOrWhiteSpace(second) ? null : second;
+        return string.IsNullOrWhiteSpace(second) ? first : $"{first} {second}";
+    }
+
+    private static string? FormatSource(string? file, int? line, int? column)
+    {
+        if (string.IsNullOrWhiteSpace(file)) return null;
+        if (line is null) return file;
+        return column is null
+            ? $"{file}:{line.Value.ToString(CultureInfo.InvariantCulture)}"
+            : $"{file}:{line.Value.ToString(CultureInfo.InvariantCulture)}:{column.Value.ToString(CultureInfo.InvariantCulture)}";
+    }
+
+    private static string? Num(double? value)
+        => value is null ? null : Math.Round(value.Value, 2).ToString(CultureInfo.InvariantCulture);
+
+    internal static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes.ToString(CultureInfo.InvariantCulture)} B";
+        if (bytes < 1024 * 1024) return $"{(bytes / 1024.0).ToString("0.#", CultureInfo.InvariantCulture)} KB";
+        return $"{(bytes / (1024.0 * 1024.0)).ToString("0.##", CultureInfo.InvariantCulture)} MB";
+    }
+
+    /// <summary>HTML-encodes every interpolated value. Null becomes an empty cell.</summary>
+    private static string E(string? value)
+    {
+        if (value is null)
+            return "";
+        var safe = new string(value.Where(character =>
+            (!char.IsControl(character) || character is '\n' or '\r' or '\t') &&
+            char.GetUnicodeCategory(character) != System.Globalization.UnicodeCategory.Format).ToArray());
+        return WebUtility.HtmlEncode(safe);
+    }
+
+    private const string Css = """
+        :root { color-scheme: light dark; }
+        body { margin: 0; font: 14px/1.5 system-ui, -apple-system, Segoe UI, sans-serif; background: #f6f7f9; color: #1b1b1f; }
+        main { max-width: 1100px; margin: 0 auto; padding: 24px 20px 64px; }
+        h1 { font-size: 22px; margin: 0 0 16px; }
+        h2 { font-size: 17px; margin: 0 0 10px; }
+        h3 { font-size: 15px; margin: 18px 0 6px; }
+        section { background: #fff; border: 1px solid #dfe1e6; border-radius: 8px; padding: 16px 18px; margin: 0 0 16px; }
+        section.warn { border-color: #e0b400; background: #fffbe6; }
+        dl.grid { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; margin: 0; }
+        dt { font-weight: 600; }
+        dd { margin: 0; }
+        dd, td, li { overflow-wrap: anywhere; }
+        ul.stats { display: flex; flex-wrap: wrap; gap: 18px; list-style: none; padding: 0; margin: 14px 0 0; }
+        ul.stats li { display: flex; flex-direction: column; min-width: 110px; }
+        ul.stats .n { font-size: 20px; font-weight: 600; }
+        table { width: 100%; border-collapse: collapse; margin: 8px 0; font-size: 13px; table-layout: fixed; }
+        caption { text-align: left; font-weight: 600; padding: 6px 0; }
+        th, td { border-bottom: 1px solid #e6e8ec; padding: 6px 8px; text-align: left; vertical-align: top; }
+        th { background: #f0f1f4; }
+        pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12px/1.45 ui-monospace, Consolas, monospace; }
+        pre.doc { background: #f0f1f4; padding: 12px; border-radius: 6px; }
+        code { font: 12px/1.45 ui-monospace, Consolas, monospace; }
+        img { max-width: 100%; height: auto; border: 1px solid #dfe1e6; border-radius: 6px; }
+        ul.tree { list-style: none; margin: 4px 0 0; padding-left: 18px; border-left: 1px solid #e6e8ec; }
+        ul.tree li { padding: 1px 0; }
+        li.sel { background: #fff3cd; }
+        .aid { color: #0b6bcb; }
+        .src { color: #6a737d; }
+        .muted { color: #6a737d; }
+        .badge { background: #0b6bcb; color: #fff; border-radius: 4px; padding: 0 6px; font-size: 11px; }
+        footer { color: #6a737d; font-size: 12px; }
+        @media (max-width: 600px) {
+          main { padding: 16px 10px; }
+          section { padding: 12px; overflow-x: auto; }
+          dl.grid { grid-template-columns: 1fr; gap: 2px; }
+          dd { margin-bottom: 8px; }
+          table { min-width: 540px; }
+        }
+        @media (prefers-color-scheme: dark) {
+          body { background: #16181d; color: #e6e6e6; }
+          section { background: #1f2229; border-color: #333842; }
+          section.warn { background: #2b2718; border-color: #7a6410; }
+          th { background: #262a33; }
+          th, td { border-color: #333842; }
+          pre.doc { background: #262a33; }
+          li.sel { background: #3a3418; }
+          img { border-color: #333842; }
+          .muted, .src, footer { color: #aab2bf; }
+          .aid { color: #80bcff; }
+        }
+        """;
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/IEvidenceDataSource.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Evidence/IEvidenceDataSource.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Microsoft.Maui.DevFlow.Driver;
+
+namespace Microsoft.Maui.Cli.DevFlow.Evidence;
+
+/// <summary>
+/// The reads an evidence capture is allowed to perform. Keeping this narrow is part of the
+/// privacy contract: there is no preferences, secure-storage, geolocation, or file-content read
+/// available to the builder at all.
+/// </summary>
+internal interface IEvidenceDataSource
+{
+    Task<AgentStatus?> GetStatusAsync(CancellationToken ct);
+    Task<JsonElement> GetCapabilitiesAsync(CancellationToken ct);
+    Task<List<ElementInfo>> GetTreeAsync(CancellationToken ct);
+    Task<LayoutInspectionResult?> GetLayoutDiagnosticsAsync(CancellationToken ct);
+    Task<string> GetLogsAsync(int limit, CancellationToken ct);
+    Task<List<NetworkRequest>> GetNetworkAsync(int limit, CancellationToken ct);
+    Task<JsonElement> GetPlatformInfoAsync(string endpoint, CancellationToken ct);
+    Task<byte[]?> GetScreenshotAsync(CancellationToken ct);
+}
+
+/// <summary>Adapts a live <see cref="AgentClient"/> to <see cref="IEvidenceDataSource"/>.</summary>
+internal sealed class AgentEvidenceDataSource(AgentClient client) : IEvidenceDataSource
+{
+    public Task<AgentStatus?> GetStatusAsync(CancellationToken ct) => client.GetStatusAsync().WaitAsync(ct);
+
+    public Task<JsonElement> GetCapabilitiesAsync(CancellationToken ct) => client.GetCapabilitiesAsync().WaitAsync(ct);
+
+    public async Task<List<ElementInfo>> GetTreeAsync(CancellationToken ct)
+    {
+        var snapshot = await client.GetTreeSnapshotAsync(maxDepth: EvidenceFormat.MaxTreeDepth).WaitAsync(ct);
+        return snapshot?.Elements ?? throw new InvalidDataException("The agent did not return a visual tree.");
+    }
+
+    public Task<LayoutInspectionResult?> GetLayoutDiagnosticsAsync(CancellationToken ct)
+        => client.AnalyzeLayoutAsync(new LayoutInspectionRequest
+        {
+            Scope = new LayoutInspectionScope { MaxDepth = EvidenceFormat.MaxTreeDepth },
+            Privacy = new LayoutPrivacyOptions { Text = "none" },
+        }, ct);
+
+    public Task<string> GetLogsAsync(int limit, CancellationToken ct) => client.GetLogsAsync(limit).WaitAsync(ct);
+
+    public Task<List<NetworkRequest>> GetNetworkAsync(int limit, CancellationToken ct)
+        => client.GetNetworkRequestsAsync(limit, ct);
+
+    public Task<JsonElement> GetPlatformInfoAsync(string endpoint, CancellationToken ct)
+        => client.GetPlatformInfoAsync(endpoint).WaitAsync(ct);
+
+    public Task<byte[]?> GetScreenshotAsync(CancellationToken ct) => client.ScreenshotAsync().WaitAsync(ct);
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/InspectorServer.Evidence.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/InspectorServer.Evidence.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using Microsoft.Maui.Cli.DevFlow.Evidence;
+
+namespace Microsoft.Maui.Cli.DevFlow.Inspector;
+
+public sealed partial class InspectorServer
+{
+    private async Task<(int, string, byte[])> HandleEvidencePreviewAsync(string? body)
+    {
+        EvidenceRequest request;
+        try { request = ReadEvidenceRequest(body); }
+        catch (Exception ex) when (ex is JsonException or ArgumentException)
+        {
+            return BadRequest("Invalid evidence options. Use boolean consent flags, a workflow string, and limits from 1 to 500.");
+        }
+
+        var plan = await EvidenceCapture.PreviewAsync(_client, request, _lifetimeCts.Token);
+        return Ok(EvidenceJson.Serialize(new EvidencePreviewResponse { Ok = true, Plan = plan }));
+    }
+
+    private async Task<(int, string, byte[])> HandleEvidenceCaptureAsync(string? body)
+    {
+        EvidenceRequest request;
+        try { request = ReadEvidenceRequest(body); }
+        catch (Exception ex) when (ex is JsonException or ArgumentException)
+        {
+            return BadRequest("Invalid evidence options. Use boolean consent flags, a workflow string, and limits from 1 to 500.");
+        }
+
+        var (_, bytes) = await EvidenceCapture.CaptureToBytesAsync(_client, request, _lifetimeCts.Token);
+        return (200, "application/zip", bytes);
+    }
+
+    private EvidenceRequest ReadEvidenceRequest(string? body)
+    {
+        var options = EvidenceJson.Deserialize<EvidenceInspectorOptions>(body ?? "{}")
+            ?? throw new ArgumentException("Evidence options must be an object.");
+        if (options.LogLimit is < 1 or > EvidenceFormat.MaxLogLimit ||
+            options.NetworkLimit is < 1 or > EvidenceFormat.MaxNetworkLimit)
+            throw new ArgumentException("Evidence limits are out of range.");
+
+        return new EvidenceRequest
+        {
+            Source = "inspector",
+            ProjectHint = _project,
+            IncludeScreenshot = options.IncludeScreenshot,
+            WorkflowMarkdown = options.IncludeWorkflow == false ? null : options.Workflow,
+            SelectedElementId = options.ElementId,
+            LogLimit = options.LogLimit,
+            NetworkLimit = options.NetworkLimit,
+        };
+    }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/InspectorServer.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/InspectorServer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Cli.DevFlow.Inspector;
 /// Generates an interactive HTML page representing the native app's visual tree
 /// and proxies interaction commands to the DevFlow agent.
 /// </summary>
-public sealed class InspectorServer : IDisposable
+public sealed partial class InspectorServer : IDisposable
 {
     private TcpListener? _listener;
     private CancellationTokenSource? _cts;
@@ -955,6 +955,8 @@ public sealed class InspectorServer : IDisposable
                     "/inspector-data-context.js" => HandleEmbeddedFile("inspector-data-context.js", "application/javascript"),
                     "/inspector-properties.js" => HandleEmbeddedFile("inspector-properties.js", "application/javascript"),
                     "/inspector-tree.js" => HandleEmbeddedFile("inspector-tree.js", "application/javascript"),
+                    "/inspector-evidence.js" => HandleEmbeddedFile("inspector-evidence.js", "application/javascript"),
+                    "/inspector-evidence.css" => HandleEmbeddedFile("inspector-evidence.css", "text/css"),
                     "/devflow.css" => HandleEmbeddedFile("devflow.css", "text/css"),
                     _ => (404, "text/plain", Encoding.UTF8.GetBytes("Not Found"))
                 },
@@ -985,6 +987,8 @@ public sealed class InspectorServer : IDisposable
                     "/api/logs" => await HandleLogsAsync(request.Body),
                     "/api/network" => await HandleNetworkAsync(request.Body),
                     "/api/network/detail" => await HandleNetworkDetailAsync(request.Body),
+                    "/api/evidence/preview" => await HandleEvidencePreviewAsync(request.Body),
+                    "/api/evidence/capture" => await HandleEvidenceCaptureAsync(request.Body),
                     "/api/preferences" => await HandlePreferencesAsync(request.Body),
                     "/api/device" => await HandleDeviceAsync(request.Body),
                     "/api/sensors" => await HandleSensorsAsync(request.Body),
@@ -2991,6 +2995,7 @@ public sealed class InspectorServer : IDisposable
         "/api/source" or "/api/persistProperty" or "/api/logs" or "/api/network" or "/api/network/detail" or "/api/preferences"
             or "/api/device" or "/api/sensors" or "/api/geolocation"
             or "/api/files/roots" or "/api/files/list"
+            or "/api/evidence/preview" or "/api/evidence/capture"
             or "/api/flows/files/list" or "/api/flows/files/load"
             or "/api/alerts" or "/api/alerts/dismiss"
             or "/api/cdp/webviews" or "/api/cdp/source" or "/api/cdp/eval" => true,

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/devflow.js
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/devflow.js
@@ -5,6 +5,7 @@ import { confirmModal } from './inspector-dialog.js';
 import { createDataSnapshot, isSecretContextKey, supportsDataContextScope } from './inspector-data-context.js';
 import { createPropertyGridController } from './inspector-properties.js';
 import { createElementTreeController } from './inspector-tree.js';
+import { createEvidenceController } from './inspector-evidence.js';
 
 (function () {
   'use strict';
@@ -950,6 +951,7 @@ import { createElementTreeController } from './inspector-tree.js';
   const toolbarActions = tb.secondary ? [...tb.secondary.querySelectorAll(':scope > button')] : [];
   const toolbarPriorities = new Map([
     ['df-goto-checkpoint', 10],
+    ['df-evidence', 15],
     ['df-assert', 20],
     ['df-toggle-bounds', 30],
     ['df-open-source', 50],
@@ -1983,6 +1985,19 @@ import { createElementTreeController } from './inspector-tree.js';
   });
 
   function selectedElement() { return selectedId ? elById(selectedId) : null; }
+
+  const evidence = createEvidenceController({
+    basePath,
+    inspectorToken,
+    api: inspectorApi,
+    setStatus,
+    getSelectedId: () => selectedId,
+    getWorkflow: () => lastMarkdown,
+  });
+  document.getElementById('df-evidence')?.addEventListener('click', () => {
+    setMoreOpen(false, false, document.body.classList.contains('df-more-open'));
+    evidence.open();
+  });
 
   function setExplainedDisabled(button, disabled) {
     if (!button) return;

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/devflow.js
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/devflow.js
@@ -1,11 +1,11 @@
 // DevFlow Web Inspector — Interaction Script
 // Composition root: coordinates browser events, app transport, recording, hosts, and feature modules.
+import { createEvidenceController } from './inspector-evidence.js';
 import { createInspectorApi } from './inspector-api.js';
 import { confirmModal } from './inspector-dialog.js';
 import { createDataSnapshot, isSecretContextKey, supportsDataContextScope } from './inspector-data-context.js';
 import { createPropertyGridController } from './inspector-properties.js';
 import { createElementTreeController } from './inspector-tree.js';
-import { createEvidenceController } from './inspector-evidence.js';
 
 (function () {
   'use strict';

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/devflow.js
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/devflow.js
@@ -1443,10 +1443,13 @@ import { createEvidenceController } from './inspector-evidence.js';
     // (setting textContent here would wipe the .df-btn-label wrapper the toolbar relies on).
     const lbl = recordBtn.querySelector('.df-btn-label');
     const label = recordingStopping ? 'Stopping…' : (recordingId ? `Rec (${recStepCount})` : 'Record');
-    if (lbl) lbl.textContent = label;
-    else recordBtn.textContent = recordingId ? `\u25CF ${label}` : `\u25CF ${label}`;
+    const labelElement = lbl || recordBtn;
+    const nextLabel = lbl ? label : `\u25CF ${label}`;
+    if (labelElement.textContent !== nextLabel) {
+      labelElement.textContent = nextLabel;
+      scheduleToolbarLayout();
+    }
     if (cancelRecordingBtn) cancelRecordingBtn.classList.toggle('df-hidden', !recordingId);
-    scheduleToolbarLayout();
   }
 
   // Highest-precedence DURABLE selector for the element (automationId > text > id). We never send a
@@ -1636,7 +1639,7 @@ import { createEvidenceController } from './inspector-evidence.js';
     }
     if (timelineTitleText) timelineTitleText.textContent = 'Workflow';
     if (timelineMetaEl) {
-      const count = Number.isFinite(Number(steps))
+      const count = steps != null && Number.isFinite(Number(steps))
         ? `${Number(steps)} step${Number(steps) === 1 ? '' : 's'}`
         : null;
       timelineMetaEl.textContent = [lastMarkdownName, count].filter(Boolean).join(' · ');

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/inspector-evidence.css
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/inspector-evidence.css
@@ -1,0 +1,50 @@
+.df-evidence-dialog {
+  margin: auto;
+  padding: 0;
+  width: min(680px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
+  max-height: calc(100dvh - 24px);
+  color: var(--df-fg);
+  background: var(--df-bg);
+  border: 1px solid var(--df-border);
+  border-radius: 10px;
+  box-shadow: var(--df-shadow);
+  font: inherit;
+  line-height: 1.5;
+  overflow: hidden;
+}
+.df-evidence-dialog[open] { display: flex; flex-direction: column; }
+.df-evidence-dialog::backdrop { background: rgb(0 0 0 / 48%); }
+.df-evidence-header { padding: 18px 22px 14px; border-bottom: 1px solid var(--df-border-subtle); }
+.df-evidence-eyebrow { color: var(--df-type); font-weight: 600; margin-bottom: 4px; }
+.df-evidence-dialog h2 { font-size: 1.25em; line-height: 1.3; overflow-wrap: anywhere; }
+.df-evidence-dialog h3, .df-evidence-dialog legend { font-size: 1em; font-weight: 600; margin-bottom: 6px; }
+.df-evidence-desc { margin-top: 6px; color: var(--df-muted); }
+.df-evidence-content { min-height: 0; overflow: auto; overscroll-behavior: contain; padding: 16px 22px; }
+.df-evidence-summary { font-weight: 600; margin-bottom: 16px; }
+.df-evidence-section { margin-bottom: 16px; overflow-wrap: anywhere; }
+.df-evidence-section ul, .df-evidence-gaps ul { margin-top: 6px; padding-left: 20px; }
+.df-evidence-section li, .df-evidence-gaps li { margin-bottom: 4px; }
+.df-evidence-environment { display: grid; grid-template-columns: minmax(110px, 2fr) minmax(0, 3fr); gap: 5px 16px; }
+.df-evidence-environment dt { color: var(--df-muted); }
+.df-evidence-environment dd { margin: 0; overflow-wrap: anywhere; }
+.df-evidence-gaps { margin-top: 10px; padding: 10px 12px; background: var(--df-surface); border-radius: var(--df-radius); }
+.df-evidence-dialog summary { cursor: pointer; font-weight: 600; }
+.df-evidence-warn { color: var(--df-warn); }
+.df-evidence-options { border: 1px solid var(--df-border); border-radius: var(--df-radius); padding: 10px 12px; min-width: 0; }
+.df-evidence-opt { display: flex; align-items: flex-start; gap: 10px; margin: 6px 0 10px; cursor: pointer; }
+.df-evidence-opt input { flex: none; margin-top: 4px; accent-color: var(--df-accent); }
+.df-evidence-actions { display: flex; flex: none; flex-wrap: wrap; justify-content: flex-end; gap: 8px; padding: 12px 22px; border-top: 1px solid var(--df-border-subtle); background: var(--df-surface); }
+.df-evidence-actions .df-tool-btn { padding: 7px 14px; min-height: 34px; white-space: normal; }
+.df-evidence-actions .df-evidence-primary { background: var(--df-accent); color: var(--df-accent-fg); }
+@media (max-width: 380px) {
+  .df-evidence-header, .df-evidence-content { padding: 12px; }
+  .df-evidence-actions { padding: 10px 12px; }
+  .df-evidence-environment { grid-template-columns: 1fr; gap: 2px; }
+  .df-evidence-environment dd { margin-bottom: 7px; }
+}
+@media (max-height: 400px) {
+  .df-evidence-header { padding: 8px 12px; }
+  .df-evidence-header .df-evidence-desc, .df-evidence-eyebrow { display: none; }
+  .df-evidence-actions { padding: 8px 12px; }
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/inspector-evidence.js
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/inspector-evidence.js
@@ -1,0 +1,316 @@
+// Read-only capture: preview options, review attachments, then download locally.
+export function formatEvidencePlan(plan) {
+  const safe = plan && typeof plan === 'object' ? plan : {};
+  const counts = safe.counts || {};
+  const limits = safe.limits || {};
+  const screenshot = safe.screenshot || {};
+  const includedNames = new Set(list(safe.included).map(entry => entry?.name));
+  const summary = [
+    ['treeElements', 'tree.json', 'element', 'elements'],
+    ['layoutFindings', 'layout.json', 'layout finding', 'layout findings'],
+    ['problems', 'problems.json', 'problem', 'problems'],
+    ['logs', 'logs.json', 'log entry', 'log entries'],
+    ['networkRequests', 'network.json', 'request summary', 'request summaries'],
+  ].filter(([key, entry]) => includedNames.has(entry) && Number.isFinite(counts[key]) && counts[key] >= 0)
+    .map(([key, , singular, plural]) => `${counts[key]} ${counts[key] === 1 ? singular : plural}`);
+  const limitText = [
+    ['logs', 'logs'], ['network', 'requests'], ['treeElements', 'elements'],
+  ].filter(([key]) => Number.isFinite(limits[key])).map(([key, label]) => `${limits[key]} ${label}`);
+  const subject = [safe.app?.name, safe.platform?.name].filter(Boolean).join(' \u00b7 ');
+  return {
+    title: subject ? `Share evidence from ${subject}` : 'Share evidence bundle',
+    summary: summary.join(' \u00b7 '),
+    limits: limitText.join(' \u00b7 '),
+    redaction: `Format v${safe.formatVersion || 1} \u00b7 redaction ruleset v${safe.redactionVersion || 1}`,
+    includes: list(safe.included).filter(entry => entry?.name).map(entry => ({
+      name: String(entry.name),
+      detail: String(entry.description || ''),
+      count: Number.isFinite(entry.count) ? entry.count : null,
+    })),
+    excludes: list(safe.excluded).filter(entry => entry?.name).map(entry => ({
+      name: String(entry.name), detail: String(entry.reason || ''),
+    })),
+    never: list(safe.neverIncluded).map(String),
+    warnings: list(safe.warnings).map(String),
+    environment: formatEvidenceEnvironment(safe.environment),
+    screenshotRequested: screenshot.requested === true,
+    screenshotNote: screenshot.included === true
+      ? 'A screenshot was requested for capture and may show on-screen data.'
+      : String(screenshot.omittedReason || 'No screenshot will be included.'),
+    fileName: evidenceFileName(safe),
+  };
+}
+
+export function formatEvidenceEnvironment(environment) {
+  const value = environment && typeof environment === 'object' ? environment : {};
+  const rows = [];
+  const add = (label, text) => { if (text) rows.push({ label, value: String(text) }); };
+  const dimensions = (metrics, unit) =>
+    Number.isFinite(metrics?.width) && metrics.width > 0 && Number.isFinite(metrics?.height) && metrics.height > 0
+      ? `${metrics.width} \u00d7 ${metrics.height} ${unit}` : null;
+  add('App version / build', [value.app?.version, value.app?.build].filter(Boolean).join(' / '));
+  add('OS', [value.device?.platform || value.platform?.name, value.device?.osVersion].filter(Boolean).join(' '));
+  add('Device', [value.device?.manufacturer, value.device?.model, value.device?.deviceType || value.platform?.deviceType].filter(Boolean).join(' \u00b7 '));
+  add('Framework (not runtime)', [value.platform?.framework, value.platform?.frameworkVersion].filter(Boolean).join(' '));
+  add('App viewport', dimensions(value.viewport, 'DIP'));
+  add('App density', Number.isFinite(value.viewport?.density) && value.viewport.density > 0 ? `${value.viewport.density} px / DIP` : null);
+  add('Display', dimensions(value.display, 'px'));
+  add('Orientation / rotation', [value.display?.orientation, value.display?.rotation].filter(Boolean).join(' / '));
+  add('App theme', value.theme?.effective);
+  add('Connectivity', [value.connectivity?.networkAccess, ...list(value.connectivity?.connectionProfiles)].filter(Boolean).join(' \u00b7 '));
+  const gaps = list(value.unavailable).filter(item => item?.name && item?.reason)
+    .map(item => `${item.name}: ${item.reason}`);
+  if (!environment) gaps.push('Environment metadata is unavailable in this preview.');
+  return { rows, gaps };
+}
+
+export function evidenceFileName(plan) {
+  const suggested = typeof plan?.suggestedFileName === 'string' ? plan.suggestedFileName : '';
+  const base = suggested.split(/[\\/]/).pop() || '';
+  const cleaned = base.replace(/[^A-Za-z0-9._-]/g, '-').replace(/^[.-]+/, '');
+  if (cleaned.length <= 160 && cleaned.toLowerCase().endsWith('.mauitrace') &&
+      !/^(con|prn|aux|nul|com[1-9]|lpt[1-9])\./i.test(cleaned)) return cleaned;
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\..+$/, '').replace('T', '-');
+  return `devflow-${stamp}.mauitrace`;
+}
+
+export function buildCaptureBody({ choice, elementId, workflow } = {}) {
+  const body = { includeScreenshot: choice?.includeScreenshot === true };
+  if (elementId) body.elementId = String(elementId);
+  if (choice?.includeWorkflow === true && typeof workflow === 'string' && workflow.trim())
+    body.workflow = workflow;
+  return body;
+}
+
+export function buildPreviewBody(options = {}) {
+  return {
+    ...buildCaptureBody(options),
+    includeWorkflow: options.choice?.includeWorkflow === true,
+  };
+}
+
+export function createEvidenceController(deps) {
+  const {
+    basePath, inspectorToken, api, setStatus, getSelectedId, getWorkflow,
+    showEvidenceDialog: choose = showEvidenceDialog,
+    showEvidenceFinalDialog: confirm = view => showEvidenceDialog(view, { finalReview: true }),
+    downloadBlob: save = downloadBlob,
+  } = deps;
+  let busy = false;
+
+  async function preview(body) {
+    const result = await api.postDetailed('/api/evidence/preview', body);
+    if (!result?.ok || result.body?.ok !== true || !Array.isArray(result.body.plan?.included))
+      throw new Error(result?.body?.error || 'Could not prepare the evidence preview. Check the agent connection and retry.');
+    return formatEvidencePlan(result.body.plan);
+  }
+
+  async function open() {
+    if (busy) return;
+    busy = true;
+    try {
+      setStatus('Preparing evidence preview...');
+      const elementId = getSelectedId?.();
+      const workflow = getWorkflow?.();
+      const hasWorkflow = typeof workflow === 'string' && !!workflow.trim();
+      const initial = await preview(buildPreviewBody({ elementId }));
+      const choice = await choose(initial, { hasWorkflow });
+      if (!choice) {
+        setStatus('Evidence capture cancelled.');
+        return;
+      }
+      let reviewed = initial;
+      if (choice.includeScreenshot === true || choice.includeWorkflow === true) {
+        setStatus('Preparing the attachment preview...');
+        reviewed = await preview(buildPreviewBody({ choice, elementId, workflow }));
+        if (!await confirm(reviewed, { hasWorkflow, choice, finalReview: true })) {
+          setStatus('Evidence capture cancelled.');
+          return;
+        }
+      }
+      setStatus('Capturing evidence...');
+      const headers = { 'Content-Type': 'application/json' };
+      if (inspectorToken) headers['X-DevFlow-Inspector-Token'] = inspectorToken;
+      const response = await fetch(`${basePath}/api/evidence/capture`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(buildCaptureBody({ choice, elementId, workflow })),
+      });
+      if (!response.ok) {
+        const error = await response.json().catch(() => null);
+        throw new Error(error?.error || `Could not capture evidence (HTTP ${response.status}).`);
+      }
+      const blob = await response.blob();
+      if (!blob.size || !response.headers.get('Content-Type')?.startsWith('application/zip'))
+        throw new Error('The server did not return an evidence bundle. No file was downloaded.');
+      await save(blob, reviewed.fileName);
+      setStatus(`Evidence bundle downloaded: ${reviewed.fileName}`);
+    } catch (error) {
+      console.error('Evidence capture failed:', error);
+      setStatus(error instanceof Error ? error.message : 'Could not capture evidence.');
+    } finally {
+      busy = false;
+    }
+  }
+
+  return Object.freeze({ open });
+}
+
+function downloadBlob(blob, fileName) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function showEvidenceDialog(view, { hasWorkflow = false, finalReview = false } = {}) {
+  return new Promise(resolve => {
+    const previousFocus = document.activeElement;
+    const dialog = node('dialog', 'df-evidence-dialog');
+    dialog.setAttribute('aria-labelledby', 'df-evidence-title');
+    dialog.setAttribute('aria-describedby', 'df-evidence-description');
+    const header = node('header', 'df-evidence-header');
+    header.append(node('p', 'df-evidence-eyebrow', finalReview ? 'Review attachments' : 'Local evidence'));
+    const title = node('h2', null, view.title);
+    title.id = 'df-evidence-title';
+    const description = node('p', 'df-evidence-desc',
+      'A read-only snapshot of the current app. Nothing is uploaded or replayed.');
+    description.id = 'df-evidence-description';
+    header.append(title, description);
+
+    const content = node('div', 'df-evidence-content');
+    content.tabIndex = 0;
+    content.setAttribute('aria-label', 'Evidence preview details');
+    content.append(node('p', 'df-evidence-summary', view.summary || 'No app data was available.'));
+    const environment = node('section', 'df-evidence-section');
+    environment.append(node('h3', null, 'Capture environment'));
+    const definitions = node('dl', 'df-evidence-environment');
+    for (const row of view.environment.rows)
+      definitions.append(node('dt', null, row.label), node('dd', null, row.value));
+    environment.append(definitions);
+    environment.append(node('p', 'df-evidence-desc',
+      'These are live observations, not the original recording environment or an enforced replay contract. Preview and capture sample the app separately.'));
+    if (view.environment.gaps.length) {
+      const gaps = node('details', 'df-evidence-gaps');
+      gaps.append(node('summary', null, `Not captured or enforced (${view.environment.gaps.length})`));
+      gaps.append(items(view.environment.gaps));
+      environment.append(gaps);
+    }
+    content.append(environment);
+    content.append(section('Included', view.includes.map(entryLabel)));
+    if (view.excludes.length) content.append(section('Excluded', view.excludes.map(entryLabel)));
+    const privacy = node('details', 'df-evidence-section');
+    privacy.append(node('summary', null, 'Redaction and capture limits'));
+    privacy.append(items(view.never));
+    privacy.append(node('p', 'df-evidence-desc', `${view.redaction}. Limits: ${view.limits || 'See the manifest'}.`));
+    content.append(privacy);
+    if (view.warnings.length) content.append(section('Warnings', view.warnings, 'df-evidence-warn'));
+
+    let screenshot;
+    let workflow;
+    if (!finalReview) {
+      const options = node('fieldset', 'df-evidence-options');
+      options.append(node('legend', null, 'Optional attachments'));
+      screenshot = checkbox(options, 'df-evidence-screenshot',
+        'Include an app screenshot. Pixels may contain private on-screen data.');
+      if (hasWorkflow)
+        workflow = checkbox(options, 'df-evidence-workflow',
+          'Include loaded workflow steps. Prose may contain typed or private information.');
+      options.append(node('p', 'df-evidence-desc', 'Attachments start off every time. Opting in opens a refreshed preview before download.'));
+      content.append(options);
+    } else {
+      content.append(node('p', 'df-evidence-desc', view.screenshotNote));
+    }
+
+    const actions = node('footer', 'df-evidence-actions');
+    const cancel = node('button', 'df-tool-btn', 'Cancel');
+    cancel.type = 'button';
+    const accept = node('button', 'df-tool-btn df-evidence-primary',
+      finalReview ? 'Confirm and download' : 'Download bundle');
+    accept.type = 'button';
+    const updateLabel = () => {
+      accept.textContent = screenshot?.checked || workflow?.checked ? 'Review attachments' : 'Download bundle';
+    };
+    screenshot?.addEventListener('change', updateLabel);
+    workflow?.addEventListener('change', updateLabel);
+    actions.append(cancel, accept);
+    dialog.append(header, content, actions);
+    let settled = false;
+    const finish = result => {
+      if (settled) return;
+      settled = true;
+      dialog.close();
+      dialog.remove();
+      if (previousFocus?.isConnected) previousFocus.focus({ preventScroll: true });
+      resolve(result);
+    };
+    cancel.addEventListener('click', () => finish(null));
+    accept.addEventListener('click', () => finish(finalReview ? true : {
+      includeScreenshot: screenshot.checked,
+      includeWorkflow: workflow?.checked === true,
+    }));
+    dialog.addEventListener('cancel', event => {
+      event.preventDefault();
+      finish(null);
+    });
+    dialog.addEventListener('keydown', event => {
+      event.stopPropagation();
+      if (event.key !== 'Tab') return;
+      const focusable = [...dialog.querySelectorAll('button, input, summary, [tabindex="0"]')]
+        .filter(element => !element.disabled && element.getClientRects().length > 0);
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    });
+    document.body.append(dialog);
+    dialog.showModal();
+    cancel.focus();
+  });
+}
+
+function list(value) { return Array.isArray(value) ? value : []; }
+
+function node(tag, className, text) {
+  const element = document.createElement(tag);
+  if (className) element.className = className;
+  if (text != null) element.textContent = text;
+  return element;
+}
+
+function items(values) {
+  const result = node('ul');
+  for (const value of values) result.append(node('li', null, value));
+  return result;
+}
+
+function section(title, values, extraClass = '') {
+  const result = node('section', `df-evidence-section ${extraClass}`);
+  result.append(node('h3', null, title), items(values));
+  return result;
+}
+
+function checkbox(parent, id, text) {
+  const row = node('label', 'df-evidence-opt');
+  const input = node('input');
+  input.type = 'checkbox';
+  input.id = id;
+  input.checked = false;
+  row.append(input, node('span', null, text));
+  parent.append(row);
+  return input;
+}
+
+function entryLabel(entry) {
+  const count = Number.isFinite(entry.count) ? ` (${entry.count})` : '';
+  return `${entry.name}${count}${entry.detail ? ` - ${entry.detail}` : ''}`;
+}

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/inspector.html
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/inspector.html
@@ -10,6 +10,7 @@
        {id} as a filename) instead of /inspector/{id}/devflow.css. -->
   <base href="./">
   <link rel="stylesheet" href="devflow.css">
+  <link rel="stylesheet" href="inspector-evidence.css">
 </head>
 <body>
   <!-- Inline SVG icon sprite (stroke = currentColor so every icon inherits the button's themed
@@ -75,6 +76,7 @@
         <button id="df-open-source" class="df-tool-btn" aria-disabled="true" title="Open the selected element's XAML source in your editor. Enabled when the selected element is defined in XAML with source mapping available."><svg class="df-ic"><use href="#i-source"/></svg><span class="df-btn-label">Source</span></button>
         <button id="df-send-copilot" class="df-tool-btn" aria-disabled="true" aria-haspopup="menu" aria-expanded="false" aria-controls="df-copilot-menu" title="Choose specific Inspector context to add to Copilot"><svg class="df-ic"><use href="#i-copilot"/></svg><span class="df-btn-label">Copilot</span><svg class="df-ic-xs df-menu-chevron"><use href="#i-chevron"/></svg></button>
         <button id="df-toggle-dock" class="df-tool-btn" title="Show app data: Logs, Network, Preferences, Device, Sensors, Files" aria-pressed="false"><svg class="df-ic"><use href="#i-data"/></svg><span class="df-btn-label">Data</span></button>
+        <button id="df-evidence" class="df-tool-btn" type="button" aria-haspopup="dialog" title="Preview and download a redacted evidence bundle (.mauitrace)"><svg class="df-ic" aria-hidden="true"><use href="#i-attach"/></svg><span class="df-btn-label">Evidence</span></button>
       </div>
       <button id="df-more" class="df-tool-btn df-more-btn df-hidden" title="More inspector actions" aria-haspopup="menu" aria-expanded="false" aria-controls="df-toolbar-overflow"><svg class="df-ic"><use href="#i-more"/></svg><span class="df-btn-label">More</span></button>
       <div id="df-toolbar-overflow" class="df-toolbar-overflow df-hidden" role="menu" aria-label="More inspector actions"></div>

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -48,6 +48,7 @@ public static class McpServerHost
 			.WithTools<ScreenshotTool>()
 			.WithTools<TreeTool>()
 			.WithTools<LayoutDiagnosticsTool>()
+			.WithTools<EvidenceTools>()
 			.WithTools<LogsTool>()
 			.WithTools<NetworkTool>()
 			.WithTools<InteractionTools>()
@@ -67,7 +68,6 @@ public static class McpServerHost
 			.WithTools<BatchTools>()
 			.WithTools<InvokeTools>()
 			.WithTools<ExtensionTools>()
-			.WithTools<EvidenceTools>()
 			.WithTools<Flows.FlowTools>()
 			.WithTools<Flows.FlowRecordTools>();
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/McpServerHost.cs
@@ -67,6 +67,7 @@ public static class McpServerHost
 			.WithTools<BatchTools>()
 			.WithTools<InvokeTools>()
 			.WithTools<ExtensionTools>()
+			.WithTools<EvidenceTools>()
 			.WithTools<Flows.FlowTools>()
 			.WithTools<Flows.FlowRecordTools>();
 

--- a/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/EvidenceTools.cs
+++ b/src/Cli/Microsoft.Maui.Cli/DevFlow/Mcp/Tools/EvidenceTools.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel;
+using Microsoft.Maui.Cli.DevFlow.Evidence;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace Microsoft.Maui.Cli.DevFlow.Mcp.Tools;
+
+/// <summary>
+/// MCP tools for the on-demand <c>.mauitrace</c> evidence bundle: a small, redacted, shareable
+/// snapshot of a bug (structure, diagnostics, bounded logs, network summaries).
+/// </summary>
+[McpServerToolType]
+public sealed class EvidenceTools
+{
+    [McpServerTool(Name = "maui_evidence_preview"),
+     Description("Preview exactly what a DevFlow evidence bundle (.mauitrace) would contain for the running app, WITHOUT writing any file. " +
+                 "Returns the included entries with item counts, the excluded entries with reasons, the data classes that are never captured, " +
+                 "the applied limits, the screenshot status, the redaction ruleset version, and the path a capture would write to. " +
+                 "Always call this before maui_evidence_capture when a human will share the bundle, so they can see what leaves the machine.")]
+    public static async Task<string> Preview(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+        [Description("Whether the capture would include a screenshot. Screenshots are opt-in because they can show on-screen data. Default: false")] bool includeScreenshot = false,
+        [Description("Element id to highlight in the bundle. Only metadata is captured — never element text or property values")] string? elementId = null,
+        [Description("Maximum log entries to include (1-500, default 200)")] int? logLimit = null,
+        [Description("Maximum network request summaries to include (1-500, default 100)")] int? networkLimit = null,
+        [Description("Bundle path a capture would use, echoed back in the plan. Default: ./maui-traces/<app>-<timestamp>.mauitrace under the project root")] string? outputPath = null,
+        CancellationToken cancellationToken = default,
+        [Description("Optional Markdown reproduction file to preview exactly as it would be attached by capture (max 1 MiB; secrets and structured values are scrubbed)")] string? workflowFile = null)
+    {
+        string? workflow = null;
+        if (!string.IsNullOrWhiteSpace(workflowFile))
+        {
+            var read = EvidenceCommands.ReadWorkflowFile(workflowFile);
+            if (read.Error is not null)
+                throw new McpException(read.Error);
+            workflow = read.Text;
+        }
+        using var agent = await session.GetAgentClientAsync(agentPort);
+        var plan = await EvidenceCapture.PreviewAsync(agent, new EvidenceRequest
+        {
+            IncludeScreenshot = includeScreenshot,
+            SelectedElementId = elementId,
+            LogLimit = logLimit ?? EvidenceFormat.DefaultLogLimit,
+            NetworkLimit = networkLimit ?? EvidenceFormat.DefaultNetworkLimit,
+            OutputPath = outputPath,
+            WorkflowMarkdown = workflow,
+            Source = "mcp",
+        }, cancellationToken);
+
+        return EvidenceJson.Serialize(plan, indented: true);
+    }
+
+    [McpServerTool(Name = "maui_evidence_capture"),
+     Description("Capture a DevFlow evidence bundle (.mauitrace) from the running app and write it atomically to disk. " +
+                 "The bundle holds a redacted, bounded snapshot: app/device/platform metadata, the visual tree STRUCTURE (no element text or property values), " +
+                 "binding/property problems, recent log entries with secrets and absolute paths scrubbed, and HTTP request summaries without headers, bodies, or query values. " +
+                 "Screenshots are opt-in. Preferences, secure storage, geolocation, file contents, and view-model object graphs are never captured. " +
+                 "Returns the written path plus the manifest summary describing what was and was not included.")]
+    public static async Task<string> Capture(
+        McpAgentSession session,
+        [Description("Agent HTTP port (optional if only one agent connected)")] int? agentPort = null,
+        [Description("Bundle path to write. Must end in .mauitrace. Default: ./maui-traces/<app>-<timestamp>.mauitrace under the project root")] string? outputPath = null,
+        [Description("Overwrite the file if it already exists. Default: false (the capture fails instead)")] bool overwrite = false,
+        [Description("Include a screenshot of the app. Off by default — only enable when the human explicitly agreed, because a screenshot can show on-screen data")] bool includeScreenshot = false,
+        [Description("Path to a Markdown (.md) file describing the reproduction steps to embed in the bundle (max 1 MB). Its secrets and absolute paths are scrubbed, but it may still quote text and values from the steps — only attach one the human asked for")] string? workflowFile = null,
+        [Description("Element id to highlight in the bundle. Only metadata is captured — never element text or property values")] string? elementId = null,
+        [Description("Maximum log entries to include (1-500, default 200)")] int? logLimit = null,
+        [Description("Maximum network request summaries to include (1-500, default 100)")] int? networkLimit = null,
+        CancellationToken cancellationToken = default)
+    {
+        string? workflow = null;
+        if (!string.IsNullOrWhiteSpace(workflowFile))
+        {
+            var read = EvidenceCommands.ReadWorkflowFile(workflowFile!);
+            if (read.Error is not null)
+                throw new McpException(read.Error);
+            workflow = read.Text;
+        }
+
+        using var agent = await session.GetAgentClientAsync(agentPort);
+        var result = await EvidenceCapture.CaptureAsync(agent, new EvidenceRequest
+        {
+            IncludeScreenshot = includeScreenshot,
+            Overwrite = overwrite,
+            OutputPath = outputPath,
+            WorkflowMarkdown = workflow,
+            SelectedElementId = elementId,
+            LogLimit = logLimit ?? EvidenceFormat.DefaultLogLimit,
+            NetworkLimit = networkLimit ?? EvidenceFormat.DefaultNetworkLimit,
+            Source = "mcp",
+        }, cancellationToken);
+
+        if (!result.Ok)
+            throw new McpException(result.Error ?? "Could not capture evidence.");
+        return EvidenceJson.Serialize(result, indented: true);
+    }
+}

--- a/src/Cli/README.md
+++ b/src/Cli/README.md
@@ -301,6 +301,16 @@ Other `E2106` throw sites (e.g., "no AVD with that name") emit the same code **w
 | Windows | ✅ | Android SDK, JDK, and emulator commands |
 | Linux | ✅ | Android commands |
 
+## DevFlow evidence
+
+Use **Evidence** in the Inspector toolbar or `maui devflow evidence preview` to review
+a redacted, read-only snapshot before capturing it. Bundles include target environment
+observations and explicit gaps, structural UI data, layout findings, bounded logs, and
+network summaries. Screenshots and workflow text require separate opt-in.
+
+See [Evidence bundles](../../docs/DevFlow/evidence.md) for capture/report commands,
+privacy limits, and the distinction between a snapshot and a replay environment contract.
+
 ## Development
 
 ```bash

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Client/AgentClient.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Client/AgentClient.cs
@@ -2684,6 +2684,26 @@ public class AgentClient : IDisposable
 
     // ── Network monitoring ──
 
+    /// <summary>
+    /// Retrieves network summaries with cancellation and explicit HTTP/JSON failures.
+    /// Unlike the legacy overload, an unavailable capture is not reported as an empty result.
+    /// </summary>
+    public async Task<List<NetworkRequest>> GetNetworkRequestsAsync(
+        int limit, CancellationToken cancellationToken)
+    {
+        if (limit < 1)
+            throw new ArgumentOutOfRangeException(nameof(limit));
+        cancellationToken.ThrowIfCancellationRequested();
+        using var response = await SendWithTransientRetriesAsync(
+            HttpMethod.Get,
+            () => _http.GetAsync($"{_baseUrl}{NetworkApi}/requests?limit={limit}", cancellationToken));
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+        return ProtocolJson.Deserialize<List<NetworkRequest>>(body)
+            ?? throw new InvalidDataException("The agent did not return a network request array.");
+    }
+
     public async Task<List<NetworkRequest>> GetNetworkRequestsAsync(
         int limit = 100, string? host = null, string? method = null)
     {

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Client/README.md
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Client/README.md
@@ -43,6 +43,18 @@ await client.FillAsync("NameEntry", "Ada Lovelace");
 var tree = await client.GetTreeAsync(maxDepth: 3);
 ```
 
+## Diagnostic reads
+
+For diagnostic capture, use the cancellation-aware network overload when a failed read
+must not look like an empty request list:
+
+```csharp
+var requests = await client.GetNetworkRequestsAsync(100, cancellationToken);
+```
+
+This overload surfaces HTTP and JSON errors. The existing optional-filter overload retains
+its original behavior for compatibility.
+
 ## Requirements
 
 - A consumer targeting `netstandard2.0` or later (including .NET Framework 4.6.2+)

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Inspector.Tests/EvidenceInspectorPageTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Inspector.Tests/EvidenceInspectorPageTests.cs
@@ -1,0 +1,254 @@
+using System.IO.Compression;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Maui.Cli.DevFlow.Inspector;
+using Microsoft.Maui.Cli.UnitTests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace Microsoft.Maui.DevFlow.Inspector.Tests;
+
+[Trait("Category", "Integration")]
+public class EvidenceInspectorPageTests : IAsyncLifetime
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"devflow-evidence-browser-{Guid.NewGuid():N}");
+    private EvidenceAgentFixture _agent = null!;
+    private InspectorServer _inspector = null!;
+    private IPlaywright _playwright = null!;
+    private IBrowser _browser = null!;
+    private IBrowserContext _context = null!;
+    private IPage _page = null!;
+    private string _url = "";
+
+    public async Task InitializeAsync()
+    {
+        Directory.CreateDirectory(_root);
+        _agent = new EvidenceAgentFixture();
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        var embedToken = Guid.NewGuid().ToString("N");
+        _inspector = new InspectorServer(port, "127.0.0.1", _agent.Port, embedToken);
+        _inspector.Start();
+        _url = $"http://127.0.0.1:{port}/?embed={embedToken}";
+        _playwright = await Playwright.Playwright.CreateAsync();
+        _browser = await _playwright.Chromium.LaunchAsync(new() { Headless = true });
+        _context = await _browser.NewContextAsync(new() { ViewportSize = new() { Width = 1440, Height = 900 } });
+        _page = await _context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_context is not null) await _context.DisposeAsync();
+        if (_browser is not null) await _browser.DisposeAsync();
+        _playwright?.Dispose();
+        if (_inspector is not null)
+        {
+            await _inspector.StopAsync();
+            _inspector.Dispose();
+        }
+        if (_agent is not null) await _agent.DisposeAsync();
+        Directory.Delete(_root, recursive: true);
+    }
+
+    [EvidenceBrowserTheory]
+    [InlineData(1440, 900, "light", 13)]
+    [InlineData(1440, 900, "dark", 13)]
+    [InlineData(375, 812, "light", 13)]
+    [InlineData(320, 568, "dark", 13)]
+    [InlineData(1024, 320, "dark", 13)]
+    [InlineData(800, 600, "light", 26)]
+    public async Task Preview_IsUsableAcrossHostSizesThemesAndLargeText(int width, int height, string theme, int fontSize)
+    {
+        await _page.SetViewportSizeAsync(width, height);
+        await _page.GotoAsync(_url);
+        await _page.EvaluateAsync("([theme, size]) => { document.documentElement.dataset.theme = theme; document.documentElement.style.setProperty('--df-font-size', `${size}px`); }",
+            new object[] { theme, fontSize });
+        await OpenEvidenceAsync();
+        var dialog = _page.Locator("dialog.df-evidence-dialog");
+        await Expect(dialog).ToContainTextAsync("430 \u00d7 760 DIP");
+        await Expect(dialog).ToContainTextAsync("1920 \u00d7 1080 px");
+        await Expect(dialog.Locator("dd").Filter(new() { HasText = "dark" })).ToBeVisibleAsync();
+        await Expect(dialog.Locator("#df-evidence-screenshot")).Not.ToBeCheckedAsync();
+        var bounds = await dialog.BoundingBoxAsync();
+        Assert.NotNull(bounds);
+        Assert.InRange(bounds.X, 0, width);
+        Assert.InRange(bounds.Y, 0, height);
+        Assert.True(bounds.X + bounds.Width <= width + 1);
+        Assert.True(bounds.Y + bounds.Height <= height + 1);
+        Assert.True(await dialog.Locator(".df-evidence-content")
+            .EvaluateAsync<bool>("element => element.scrollWidth <= element.clientWidth + 1"));
+        Assert.Equal(theme == "light" ? "rgb(255, 255, 255)" : "rgb(30, 30, 30)",
+            await dialog.EvaluateAsync<string>("element => getComputedStyle(element).backgroundColor"));
+        var artifacts = Environment.GetEnvironmentVariable("EVIDENCE_TEST_ARTIFACTS");
+        if (!string.IsNullOrWhiteSpace(artifacts))
+        {
+            Directory.CreateDirectory(artifacts);
+            await _page.ScreenshotAsync(new() { Path = Path.Combine(artifacts, $"evidence-overview-{theme}-{width}x{height}-font{fontSize}.png") });
+        }
+        await dialog.Locator(".df-evidence-gaps summary").ClickAsync();
+        await Expect(dialog).ToContainTextAsync("fontScale");
+        await Expect(dialog).ToContainTextAsync("permissions");
+        await dialog.Locator("#df-evidence-screenshot").ScrollIntoViewIfNeededAsync();
+        await Expect(dialog.Locator("#df-evidence-screenshot")).ToBeVisibleAsync();
+        if (!string.IsNullOrWhiteSpace(artifacts))
+        {
+            Directory.CreateDirectory(artifacts);
+            await _page.ScreenshotAsync(new() { Path = Path.Combine(artifacts, $"evidence-{theme}-{width}x{height}-font{fontSize}.png") });
+        }
+        await dialog.GetByRole(AriaRole.Button, new() { Name = "Cancel", Exact = true }).ClickAsync();
+        await Expect(dialog).ToHaveCountAsync(0);
+    }
+
+    [EvidenceBrowserFact]
+    public async Task Attachments_RequireARefreshedPreviewAndExplicitFinalConfirmation()
+    {
+        await _page.GotoAsync(_url);
+        await LoadWorkflowAsync();
+        await OpenEvidenceAsync();
+        await _page.Locator("#df-evidence-screenshot").CheckAsync();
+        await _page.Locator("#df-evidence-workflow").CheckAsync();
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Review attachments", Exact = true }).ClickAsync();
+        var final = _page.GetByRole(AriaRole.Button, new() { Name = "Confirm and download", Exact = true });
+        await Expect(final).ToBeVisibleAsync();
+        await Expect(_page.Locator("dialog")).ToContainTextAsync("screenshot.png");
+        await Expect(_page.Locator("dialog")).ToContainTextAsync("workflow.md");
+        var download = await _page.RunAndWaitForDownloadAsync(() => final.ClickAsync());
+        var path = Path.Combine(_root, download.SuggestedFilename);
+        await download.SaveAsAsync(path);
+        using var archive = ZipFile.OpenRead(path);
+        Assert.NotNull(archive.GetEntry("screenshot.png"));
+        using var workflow = new StreamReader(archive.GetEntry("workflow.md")!.Open());
+        var text = await workflow.ReadToEndAsync();
+        Assert.DoesNotContain("private-typed-value", text, StringComparison.Ordinal);
+        Assert.Contains("OrderConfirmation", text, StringComparison.Ordinal);
+        using var environment = JsonDocument.Parse(archive.GetEntry("environment.json")!.Open());
+        Assert.Equal(430, environment.RootElement.GetProperty("viewport").GetProperty("width").GetDouble());
+        Assert.Equal("42", environment.RootElement.GetProperty("app").GetProperty("build").GetString());
+        await Expect(_page.Locator("#df-status")).ToContainTextAsync("Evidence bundle downloaded");
+        await OpenEvidenceAsync();
+        await Expect(_page.Locator("#df-evidence-screenshot")).Not.ToBeCheckedAsync();
+        await Expect(_page.Locator("#df-evidence-workflow")).Not.ToBeCheckedAsync();
+    }
+
+    [EvidenceBrowserFact]
+    public async Task CancelAndEscape_DoNotCaptureAndKeepKeyboardFocusInsideTheDialog()
+    {
+        var captures = 0;
+        _page.Request += (_, request) =>
+        {
+            if (request.Url.EndsWith("/api/evidence/capture", StringComparison.Ordinal))
+                Interlocked.Increment(ref captures);
+        };
+        await _page.GotoAsync(_url);
+        await OpenEvidenceAsync();
+        await _page.Locator("#df-evidence-screenshot").CheckAsync();
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Review attachments", Exact = true }).ClickAsync();
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Cancel", Exact = true }).ClickAsync();
+        Assert.Equal(0, captures);
+        await OpenEvidenceAsync();
+        await Expect(_page.Locator("#df-evidence-screenshot")).Not.ToBeCheckedAsync();
+        for (var index = 0; index < 8; index++)
+        {
+            await _page.Keyboard.PressAsync("Tab");
+            Assert.True(await _page.EvaluateAsync<bool>("() => document.querySelector('dialog').contains(document.activeElement)"),
+                $"Tab {index}: {await _page.EvaluateAsync<string>("() => document.activeElement?.outerHTML")}");
+        }
+        await _page.Keyboard.PressAsync("Escape");
+        await Expect(_page.Locator("dialog")).ToHaveCountAsync(0);
+        Assert.Equal(0, captures);
+    }
+
+    [EvidenceBrowserTheory]
+    [InlineData(".github\\extensions\\maui-devflow-canvas\\shell.mjs")]
+    [InlineData("src\\DevFlow\\js\\vscode-inspector\\src\\extension.ts")]
+    public async Task SandboxedHosts_AllowConfirmedEvidenceDownloadsWithoutNavigationPermissions(string relativePath)
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        string? sourcePath = null;
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath.Replace('\\', Path.DirectorySeparatorChar));
+            if (File.Exists(candidate)) { sourcePath = candidate; break; }
+            directory = directory.Parent;
+        }
+        Assert.NotNull(sourcePath);
+        var source = File.ReadAllText(sourcePath);
+        var sandbox = Regex.Match(source, "sandbox=\"([^\"]+)\"").Groups[1].Value;
+        var permission = Regex.Match(source, "frame\\.sandbox\\.add\\('([^']+)'\\)").Groups[1].Value;
+        Assert.Equal("allow-downloads", permission);
+        Assert.DoesNotContain("allow-top-navigation", sandbox, StringComparison.Ordinal);
+        Assert.DoesNotContain("allow-popups", sandbox, StringComparison.Ordinal);
+        await _page.RouteAsync("http://evidence-host.invalid/", route => route.FulfillAsync(new()
+        {
+            ContentType = "text/html",
+            Body = $$"""
+                <!doctype html><html><body style="margin:0">
+                <iframe id="frame" sandbox="{{sandbox}}" style="width:100vw;height:100vh;border:0"></iframe>
+                <script>const frame = document.getElementById('frame'); frame.sandbox.add('{{permission}}'); frame.src = '{{_url}}';</script>
+                </body></html>
+                """,
+        }));
+        await _page.GotoAsync("http://evidence-host.invalid/");
+        var frame = _page.FrameLocator("#frame");
+        var evidence = frame.Locator("#df-evidence");
+        await Expect(evidence).ToBeVisibleAsync();
+        await evidence.ClickAsync();
+        var download = await _page.RunAndWaitForDownloadAsync(() =>
+            frame.GetByRole(AriaRole.Button, new() { Name = "Download bundle", Exact = true }).ClickAsync());
+        var path = Path.Combine(_root, download.SuggestedFilename);
+        await download.SaveAsAsync(path);
+        using var archive = ZipFile.OpenRead(path);
+        Assert.NotNull(archive.GetEntry("environment.json"));
+        Assert.Null(archive.GetEntry("screenshot.png"));
+    }
+
+    private async Task OpenEvidenceAsync()
+    {
+        var button = _page.Locator("#df-evidence");
+        if (!await button.IsVisibleAsync())
+            await _page.Locator("#df-more").ClickAsync();
+        await button.ClickAsync();
+        await Expect(_page.Locator("dialog.df-evidence-dialog")).ToBeVisibleAsync();
+    }
+
+    private async Task LoadWorkflowAsync()
+    {
+        const string markdown = """
+            # Order confirmation
+            ```json maui-test
+            {"schema":1,"name":"order","steps":[{"seq":1,"action":"assert","target":{"automationId":"OrderConfirmation"},"asserts":[{"kind":"propEquals","selector":{"automationId":"OrderConfirmation"},"name":"Text","expected":"private-typed-value","verify":true}]}]}
+            ```
+            """;
+        await _page.Locator("#df-workflow-file-input").SetInputFilesAsync(new FilePayload
+        {
+            Name = "order.md",
+            MimeType = "text/markdown",
+            Buffer = Encoding.UTF8.GetBytes(markdown),
+        });
+        await Expect(_page.Locator("#df-timeline")).ToBeVisibleAsync();
+    }
+}
+
+public sealed class EvidenceBrowserFactAttribute : FactAttribute
+{
+    public EvidenceBrowserFactAttribute()
+    {
+        if (Environment.GetEnvironmentVariable("DEVFLOW_EVIDENCE_BROWSER_TESTS") != "1")
+            Skip = "Set DEVFLOW_EVIDENCE_BROWSER_TESTS=1 to run isolated Chromium evidence checks.";
+    }
+}
+
+public sealed class EvidenceBrowserTheoryAttribute : TheoryAttribute
+{
+    public EvidenceBrowserTheoryAttribute()
+    {
+        if (Environment.GetEnvironmentVariable("DEVFLOW_EVIDENCE_BROWSER_TESTS") != "1")
+            Skip = "Set DEVFLOW_EVIDENCE_BROWSER_TESTS=1 to run isolated Chromium evidence checks.";
+    }
+}

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Inspector.Tests/EvidenceInspectorPageTests.cs
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Inspector.Tests/EvidenceInspectorPageTests.cs
@@ -110,6 +110,7 @@ public class EvidenceInspectorPageTests : IAsyncLifetime
     {
         await _page.GotoAsync(_url);
         await LoadWorkflowAsync();
+        await Expect(_page.Locator("#df-timeline-meta")).Not.ToContainTextAsync("0 steps");
         await OpenEvidenceAsync();
         await _page.Locator("#df-evidence-screenshot").CheckAsync();
         await _page.Locator("#df-evidence-workflow").CheckAsync();
@@ -134,6 +135,24 @@ public class EvidenceInspectorPageTests : IAsyncLifetime
         await OpenEvidenceAsync();
         await Expect(_page.Locator("#df-evidence-screenshot")).Not.ToBeCheckedAsync();
         await Expect(_page.Locator("#df-evidence-workflow")).Not.ToBeCheckedAsync();
+    }
+
+    [EvidenceBrowserFact]
+    public async Task EvidenceInOverflow_RemainsAvailableAcrossAnUnchangedControlPoll()
+    {
+        await _page.SetViewportSizeAsync(900, 720);
+        await _page.GotoAsync(_url);
+        await Expect(_page.Locator("#df-more")).ToBeVisibleAsync();
+        var poll = _page.WaitForResponseAsync(response =>
+            response.Url.EndsWith("/api/control", StringComparison.Ordinal) &&
+            response.Request.PostData is { } body &&
+            (body.Contains("\"status\"", StringComparison.Ordinal) || body.Contains("\"heartbeat\"", StringComparison.Ordinal)));
+        await _page.Locator("#df-more").ClickAsync();
+        await (await poll).FinishedAsync();
+        await _page.EvaluateAsync("() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
+        await Expect(_page.Locator("#df-toolbar-overflow")).ToBeVisibleAsync();
+        await _page.Locator("#df-evidence").ClickAsync();
+        await Expect(_page.Locator("dialog.df-evidence-dialog")).ToBeVisibleAsync();
     }
 
     [EvidenceBrowserFact]

--- a/src/DevFlow/Microsoft.Maui.DevFlow.Inspector.Tests/Microsoft.Maui.DevFlow.Inspector.Tests.csproj
+++ b/src/DevFlow/Microsoft.Maui.DevFlow.Inspector.Tests/Microsoft.Maui.DevFlow.Inspector.Tests.csproj
@@ -18,6 +18,8 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <Compile Include="..\..\Cli\Microsoft.Maui.Cli.UnitTests\Fixtures\EvidenceAgentFixture.cs"
+             Link="Fixtures\EvidenceAgentFixture.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/DevFlow/js/test/inspector-evidence.test.mjs
+++ b/src/DevFlow/js/test/inspector-evidence.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildCaptureBody,
+  buildPreviewBody,
+  createEvidenceController,
+  evidenceFileName,
+  formatEvidenceEnvironment,
+  formatEvidencePlan,
+} from "../../../Cli/Microsoft.Maui.Cli/DevFlow/Inspector/Web/inspector-evidence.js";
+
+const plan = {
+  formatVersion: 1,
+  redactionVersion: 2,
+  app: { name: "Sample App" },
+  platform: { name: "Windows" },
+  included: [
+    { name: "manifest.json", description: "Bundle description" }, { name: "tree.json", count: 42 },
+    { name: "problems.json", count: 3 }, { name: "logs.json", count: 120 }, { name: "network.json", count: 8 },
+  ],
+  excluded: [{ name: "screenshot.png", reason: "Screenshots are opt-in." }],
+  neverIncluded: ["Element Text/Value content"],
+  screenshot: { requested: false, included: false, omittedReason: "Screenshots are opt-in." },
+  counts: { treeElements: 42, problems: 3, logs: 120, networkRequests: 8 },
+  limits: { logs: 200, network: 100, treeElements: 5000 },
+  warnings: ["Network capture unavailable."],
+  suggestedFileName: "SampleApp-20260909-112233.mauitrace",
+};
+
+function previewResult(body = {}) {
+  return {
+    ok: true,
+    body: {
+      ok: true,
+      plan: {
+        ...plan,
+        included: [
+          ...plan.included,
+          ...(body.includeScreenshot ? [{ name: "screenshot.png" }] : []),
+          ...(body.includeWorkflow ? [{ name: "workflow.md" }] : []),
+        ],
+        screenshot: { requested: body.includeScreenshot === true, included: body.includeScreenshot === true },
+      },
+    },
+  };
+}
+
+test("plan renders counts, inclusions, exclusions, limits, and redaction", () => {
+  const view = formatEvidencePlan(plan);
+  assert.equal(view.title, "Share evidence from Sample App \u00b7 Windows");
+  assert.match(view.summary, /42 elements.*3 problems.*8 request summaries/);
+  assert.match(view.limits, /200 logs/);
+  assert.match(view.redaction, /redaction ruleset v2/);
+  assert.deepEqual(view.includes.map(entry => entry.name), plan.included.map(entry => entry.name));
+  assert.deepEqual(view.excludes.map(entry => entry.name), ["screenshot.png"]);
+  assert.deepEqual(view.warnings, plan.warnings);
+  assert.equal(view.screenshotRequested, false);
+  assert.match(view.screenshotNote, /opt-in/);
+});
+
+test("unavailable sections never appear as zero-problem or zero-request successes", () => {
+  const view = formatEvidencePlan({
+    ...plan,
+    included: [{ name: "tree.json" }, { name: "logs.json" }],
+    counts: { treeElements: 1, logs: 1, problems: 0, networkRequests: 0 },
+  });
+  assert.equal(view.summary, "1 element \u00b7 1 log entry");
+});
+
+test("opted-in screenshots warn about pixels and malformed plans remain displayable", () => {
+  assert.match(formatEvidencePlan({ screenshot: { included: true } }).screenshotNote, /on-screen data/);
+  const empty = formatEvidencePlan(null);
+  assert.equal(empty.title, "Share evidence bundle");
+  assert.deepEqual(empty.includes, []);
+  assert.deepEqual(empty.excludes, []);
+  assert.deepEqual(empty.never, []);
+});
+
+test("environment distinguishes app viewport from display and preserves unknowns", () => {
+  const view = formatEvidenceEnvironment({
+    app: { version: "1.2", build: "42" },
+    viewport: { width: 400, height: 700, density: 1.5 },
+    display: { width: 1920, height: 1080, orientation: "Portrait" },
+    theme: { effective: "dark" },
+    unavailable: [{ name: "fontScale", reason: "Not exposed by this agent." }],
+  });
+  assert.equal(view.rows.find(row => row.label === "App viewport").value, "400 \u00d7 700 DIP");
+  assert.equal(view.rows.find(row => row.label === "Display").value, "1920 \u00d7 1080 px");
+  assert.equal(view.rows.find(row => row.label === "App theme").value, "dark");
+  assert.match(view.gaps[0], /fontScale/);
+  assert.equal(formatEvidenceEnvironment({ display: { width: 100, height: 200 } }).rows.some(row => row.label === "App viewport"), false);
+  assert.match(formatEvidenceEnvironment(null).gaps[0], /unavailable/);
+});
+
+test("download names are portable and cannot escape a directory", () => {
+  assert.equal(evidenceFileName(plan), plan.suggestedFileName);
+  assert.equal(evidenceFileName({ suggestedFileName: "../../etc/evil.mauitrace" }), "evil.mauitrace");
+  assert.equal(evidenceFileName({ suggestedFileName: "C:\\Windows\\evil.mauitrace" }), "evil.mauitrace");
+  for (const name of ["CON.mauitrace", "report.html", `${"a".repeat(200)}.mauitrace`])
+    assert.match(evidenceFileName({ suggestedFileName: name }), /^devflow-.*\.mauitrace$/);
+});
+
+test("only explicit boolean consent attaches screenshot or workflow", () => {
+  assert.deepEqual(buildCaptureBody(), { includeScreenshot: false });
+  assert.deepEqual(buildPreviewBody(), { includeScreenshot: false, includeWorkflow: false });
+  assert.deepEqual(buildCaptureBody({
+    choice: { includeScreenshot: "true", includeWorkflow: 1 }, workflow: "private",
+  }), { includeScreenshot: false });
+  assert.deepEqual(buildCaptureBody({
+    choice: { includeScreenshot: true, includeWorkflow: true }, elementId: "e1", workflow: "  ",
+  }), { includeScreenshot: true, elementId: "e1" });
+});
+
+test("attachments are re-previewed and confirmed before the token-stamped download", async t => {
+  const events = [];
+  const previews = [];
+  t.mock.method(globalThis, "fetch", async (url, options) => {
+    events.push("capture");
+    assert.equal(url, "/inspector/app/api/evidence/capture");
+    assert.equal(options.headers["X-DevFlow-Inspector-Token"], "test-read-token");
+    assert.deepEqual(JSON.parse(options.body), {
+      includeScreenshot: true, elementId: "e1", workflow: "# Repro",
+    });
+    return new Response("bundle", { headers: { "Content-Type": "application/zip" } });
+  });
+  const controller = createEvidenceController({
+    basePath: "/inspector/app",
+    inspectorToken: "test-read-token",
+    api: { postDetailed: async (path, body) => {
+      assert.equal(path, "/api/evidence/preview");
+      events.push("preview");
+      previews.push(body);
+      return previewResult(body);
+    } },
+    setStatus() {},
+    getSelectedId: () => "e1",
+    getWorkflow: () => "# Repro",
+    showEvidenceDialog: async (view, options) => {
+      events.push("choose");
+      assert.equal(options.hasWorkflow, true);
+      assert.equal(view.screenshotRequested, false);
+      return { includeScreenshot: true, includeWorkflow: true };
+    },
+    showEvidenceFinalDialog: async view => {
+      events.push("confirm");
+      assert.equal(view.screenshotRequested, true);
+      assert.ok(view.includes.some(entry => entry.name === "workflow.md"));
+      assert.ok(view.includes.some(entry => entry.name === "screenshot.png"));
+      return true;
+    },
+    downloadBlob: (blob, name) => {
+      events.push("download");
+      assert.equal(blob.size, 6);
+      assert.equal(name, plan.suggestedFileName);
+    },
+  });
+  await controller.open();
+  assert.deepEqual(events, ["preview", "choose", "preview", "confirm", "capture", "download"]);
+  assert.deepEqual(previews, [
+    { includeScreenshot: false, includeWorkflow: false, elementId: "e1" },
+    { includeScreenshot: true, includeWorkflow: true, elementId: "e1", workflow: "# Repro" },
+  ]);
+});
+
+for (const phase of ["initial", "final"]) {
+  test(`cancelling the ${phase} dialog never captures`, async t => {
+    const fetch = t.mock.method(globalThis, "fetch", async () => { throw new Error("Unexpected capture"); });
+    const statuses = [];
+    const controller = createEvidenceController({
+      api: { postDetailed: async (path, body) => previewResult(body) },
+      setStatus: text => statuses.push(text),
+      showEvidenceDialog: async () => phase === "initial" ? null : { includeScreenshot: true },
+      showEvidenceFinalDialog: async () => false,
+    });
+    await controller.open();
+    assert.equal(fetch.mock.callCount(), 0);
+    assert.equal(statuses.at(-1), "Evidence capture cancelled.");
+  });
+}
+
+test("HTTP failure cannot be turned into a successful preview by its body", async t => {
+  const errors = t.mock.method(console, "error", () => {});
+  let presented = false;
+  const statuses = [];
+  const controller = createEvidenceController({
+    api: { postDetailed: async () => ({ ok: false, status: 403, body: { ok: true, plan, error: "forbidden" } }) },
+    setStatus: text => statuses.push(text),
+    showEvidenceDialog: async () => { presented = true; },
+  });
+  await controller.open();
+  assert.equal(presented, false);
+  assert.equal(statuses.at(-1), "forbidden");
+  assert.equal(errors.mock.callCount(), 1);
+});
+
+test("capture errors are visible and the controller can be retried", async t => {
+  t.mock.method(console, "error", () => {});
+  const statuses = [];
+  let downloads = 0;
+  let fail = true;
+  t.mock.method(globalThis, "fetch", async () => fail
+    ? Response.json({ error: "Agent disconnected" }, { status: 503 })
+    : new Response("bundle", { headers: { "Content-Type": "application/zip" } }));
+  const controller = createEvidenceController({
+    basePath: "/inspector/app",
+    api: { postDetailed: async () => previewResult() },
+    setStatus: text => statuses.push(text),
+    showEvidenceDialog: async () => ({ includeScreenshot: false, includeWorkflow: false }),
+    downloadBlob: () => { downloads++; },
+  });
+  await controller.open();
+  assert.equal(statuses.at(-1), "Agent disconnected");
+  assert.equal(downloads, 0);
+  fail = false;
+  await controller.open();
+  assert.equal(downloads, 1);
+  assert.match(statuses.at(-1), /downloaded/);
+});
+
+test("an HTML error page is never saved as evidence", async t => {
+  t.mock.method(console, "error", () => {});
+  t.mock.method(globalThis, "fetch", async () => new Response("<html>Error</html>", { headers: { "Content-Type": "text/html" } }));
+  const statuses = [];
+  let downloads = 0;
+  const controller = createEvidenceController({
+    api: { postDetailed: async () => previewResult() },
+    setStatus: text => statuses.push(text),
+    showEvidenceDialog: async () => ({}),
+    downloadBlob: () => { downloads++; },
+  });
+  await controller.open();
+  assert.equal(downloads, 0);
+  assert.match(statuses.at(-1), /No file was downloaded/);
+});
+
+test("repeated clicks share one in-flight preview", async () => {
+  let finish;
+  let previews = 0;
+  const pending = new Promise(resolve => { finish = resolve; });
+  const controller = createEvidenceController({
+    api: { postDetailed: async () => { previews++; return pending; } },
+    setStatus() {},
+    showEvidenceDialog: async () => null,
+  });
+  const first = controller.open();
+  await controller.open();
+  assert.equal(previews, 1);
+  finish(previewResult());
+  await first;
+});

--- a/src/DevFlow/js/vscode-inspector/src/extension.ts
+++ b/src/DevFlow/js/vscode-inspector/src/extension.ts
@@ -536,6 +536,7 @@ function renderHost(inspectorUrl: string, title: string, nonce: string, bridgeId
       const bridgeId = ${bridgeLiteral};
       // Capabilities this host contributes to the shared inspector.
       const capabilities = ['copilot', 'copilotContext', 'workflowFilePicker', 'attachData', 'openSource', 'saveRecording', 'selection'];
+      frame.sandbox.add('allow-downloads');
       // Map the shared inspector's semantic theme tokens onto VS Code's theme colors so the panel
       // adopts the user's active color theme (light / dark / high-contrast). getComputedStyle resolves
       // each --vscode-* var to a concrete color; the inspector re-validates every value before use.


### PR DESCRIPTION
## Summary
- Add standalone Evidence capture to the Inspector, with matching CLI and MCP commands for redacted `.mauitrace` snapshots.
- Include supported app/build, device, viewport, theme, and connectivity details; clearly identify unavailable environment fields.
- Keep screenshots and workflows opt-in with preview/confirmation, and provide validated, script-free offline reports.

Replay environment enforcement and CI device matrices remain separate work.

## Validation
Direct Windows Inspector QA covered capture, consent, cancellation, and real downloads. Passed 151 focused .NET checks, 42 JavaScript checks, and 11 browser scenarios.